### PR TITLE
Biome Default features and name converter

### DIFF
--- a/src/main/java/net/mcreator/element/GeneratableElement.java
+++ b/src/main/java/net/mcreator/element/GeneratableElement.java
@@ -40,7 +40,7 @@ public abstract class GeneratableElement {
 
 	private transient ModElement element;
 
-	public static final transient int formatVersion = 11;
+	public static final transient int formatVersion = 12;
 
 	public GeneratableElement(ModElement element) {
 		if (element != null)

--- a/src/main/java/net/mcreator/element/converter/ConverterRegistry.java
+++ b/src/main/java/net/mcreator/element/converter/ConverterRegistry.java
@@ -22,6 +22,7 @@ import net.mcreator.element.ModElementType;
 import net.mcreator.element.converter.fv10.BiomeSpawnListConverter;
 import net.mcreator.element.converter.fv11.GUICoordinateConverter;
 import net.mcreator.element.converter.fv11.OverlayCoordinateConverter;
+import net.mcreator.element.converter.fv12.BiomeDefFeaturesConverter;
 import net.mcreator.element.converter.fv4.RecipeTypeConverter;
 import net.mcreator.element.converter.fv5.AchievementFixer;
 import net.mcreator.element.converter.fv6.GUIBindingInverter;
@@ -41,6 +42,7 @@ public class ConverterRegistry {
 				new ProcedureGlobalTriggerFixer()));
 		put(ModElementType.BIOME, Collections.singletonList(new BiomeSpawnListConverter()));
 		put(ModElementType.OVERLAY, Collections.singletonList(new OverlayCoordinateConverter()));
+		put(ModElementType.BIOME, Collections.singletonList(new BiomeDefFeaturesConverter()));
 	}};
 
 	public static List<IConverter> getConvertersForModElementType(ModElementType modElementType) {

--- a/src/main/java/net/mcreator/element/converter/fv12/BiomeDefFeaturesConverter.java
+++ b/src/main/java/net/mcreator/element/converter/fv12/BiomeDefFeaturesConverter.java
@@ -38,7 +38,7 @@ public class BiomeDefFeaturesConverter implements IConverter {
 			biome.defaultFeatures.add("MonsterRooms");
 			biome.defaultFeatures.add("Structures");
 			biome.defaultFeatures.add("Ores");
-			if(biome.generateLakes){
+			if(jsonElementInput.getAsJsonObject().get("definition").getAsJsonObject().get("generateLakes") != null){
 				biome.defaultFeatures.add("Lakes");
 			}
 			biome.name = input.getModElement().getName();

--- a/src/main/java/net/mcreator/element/converter/fv12/BiomeDefFeaturesConverter.java
+++ b/src/main/java/net/mcreator/element/converter/fv12/BiomeDefFeaturesConverter.java
@@ -1,0 +1,52 @@
+/*
+ * MCreator (https://mcreator.net/)
+ * Copyright (C) 2020 Pylo and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package net.mcreator.element.converter.fv12;
+
+import com.google.gson.JsonElement;
+import net.mcreator.element.GeneratableElement;
+import net.mcreator.element.converter.IConverter;
+import net.mcreator.element.types.Biome;
+import net.mcreator.workspace.Workspace;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class BiomeDefFeaturesConverter implements IConverter {
+	private static final Logger LOG = LogManager.getLogger(BiomeDefFeaturesConverter.class);
+
+	@Override
+	public GeneratableElement convert(Workspace workspace, GeneratableElement input, JsonElement jsonElementInput) {
+		Biome biome = (Biome)input;
+
+		try{
+			biome.defaultFeatures.add("Caves");
+			biome.defaultFeatures.add("MonsterRooms");
+			biome.defaultFeatures.add("Structures");
+			biome.defaultFeatures.add("Ores");
+			biome.name = input.getModElement().getName();
+		} catch(Exception e){
+			LOG.warn("Could not convert: "+ biome.getModElement().getName());
+		}
+
+		return biome;
+	}
+
+	@Override public int getVersionConvertingTo() {
+		return 12;
+	}
+}

--- a/src/main/java/net/mcreator/element/converter/fv12/BiomeDefFeaturesConverter.java
+++ b/src/main/java/net/mcreator/element/converter/fv12/BiomeDefFeaturesConverter.java
@@ -22,6 +22,7 @@ import com.google.gson.JsonElement;
 import net.mcreator.element.GeneratableElement;
 import net.mcreator.element.converter.IConverter;
 import net.mcreator.element.types.Biome;
+import net.mcreator.util.StringUtils;
 import net.mcreator.workspace.Workspace;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -41,7 +42,7 @@ public class BiomeDefFeaturesConverter implements IConverter {
 			if(jsonElementInput.getAsJsonObject().get("definition").getAsJsonObject().get("generateLakes") != null){
 				biome.defaultFeatures.add("Lakes");
 			}
-			biome.name = input.getModElement().getName();
+			biome.name = StringUtils.machineToReadableName(input.getModElement().getName());
 		} catch(Exception e){
 			LOG.warn("Could not convert: "+ biome.getModElement().getName());
 		}

--- a/src/main/java/net/mcreator/element/converter/fv12/BiomeDefFeaturesConverter.java
+++ b/src/main/java/net/mcreator/element/converter/fv12/BiomeDefFeaturesConverter.java
@@ -38,6 +38,9 @@ public class BiomeDefFeaturesConverter implements IConverter {
 			biome.defaultFeatures.add("MonsterRooms");
 			biome.defaultFeatures.add("Structures");
 			biome.defaultFeatures.add("Ores");
+			if(biome.generateLakes){
+				biome.defaultFeatures.add("Lakes");
+			}
 			biome.name = input.getModElement().getName();
 		} catch(Exception e){
 			LOG.warn("Could not convert: "+ biome.getModElement().getName());


### PR DESCRIPTION
When I added the biome name and the default features, I forgot to create a new converter to add a name to existing biomes and don't remove existing default features. I tested with Farm Adventure II, and it works perfectly. However, concerning the name, it takes the mod element name, so a biome named BlueRedMontains will have as name BlueRedMountains. Finally, locked biomes should be unlocked before switching to the new version.