### PR TITLE
Small biome fixes

### DIFF
--- a/plugins/generator-1.14.4/forge-1.14.4/templates/biome.java.ftl
+++ b/plugins/generator-1.14.4/forge-1.14.4/templates/biome.java.ftl
@@ -91,10 +91,6 @@ package ${package}.world.biome;
 			DefaultBiomeFeatures.add${generator.map(defaultFeature, "defaultfeatures")}(this);
 			</#list>
 
-			<#if data.generateLakes>
-			DefaultBiomeFeatures.addLakes(this);
-			</#if>
-
 			<#if data.spawnStronghold>
 			this.addStructure(Feature.STRONGHOLD, IFeatureConfig.NO_FEATURE_CONFIG);
 			</#if>

--- a/plugins/generator-1.15.2/forge-1.15.2/templates/biome.java.ftl
+++ b/plugins/generator-1.15.2/forge-1.15.2/templates/biome.java.ftl
@@ -93,10 +93,6 @@ import net.minecraft.block.material.Material;
 			DefaultBiomeFeatures.add${generator.map(defaultFeature, "defaultfeatures")}(this);
 			</#list>
 
-			<#if data.generateLakes>
-			DefaultBiomeFeatures.addLakes(this);
-			</#if>
-
 			<#if data.spawnStronghold>
 			this.addStructure(Feature.STRONGHOLD.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG));
 			</#if>

--- a/src/main/java/net/mcreator/element/types/Biome.java
+++ b/src/main/java/net/mcreator/element/types/Biome.java
@@ -38,6 +38,7 @@ import java.util.List;
 	public String name;
 	public MItemBlock groundBlock;
 	public MItemBlock undergroundBlock;
+	public boolean generateLakes;
 
 	public int treeType;
 	public String vanillaTreeType;

--- a/src/main/java/net/mcreator/element/types/Biome.java
+++ b/src/main/java/net/mcreator/element/types/Biome.java
@@ -108,6 +108,9 @@ import java.util.List;
 
 		// DEFAULT VALUES
 		name = "";
+		spawnStronghold = true;
+		spawnMineshaft = true;
+		spawnPillagerOutpost = true;
 		vanillaTreeType = "Default";
 		villageType = "none";
 		oceanRuinType = "NONE";

--- a/src/main/java/net/mcreator/element/types/Biome.java
+++ b/src/main/java/net/mcreator/element/types/Biome.java
@@ -38,7 +38,6 @@ import java.util.List;
 	public String name;
 	public MItemBlock groundBlock;
 	public MItemBlock undergroundBlock;
-	public boolean generateLakes;
 
 	public int treeType;
 	public String vanillaTreeType;
@@ -130,7 +129,7 @@ import java.util.List;
 	@Override public BufferedImage generateModElementPicture() {
 		return MinecraftImageGenerator.Preview
 				.generateBiomePreviewPicture(getModElement().getWorkspace(), airColor, grassColor, waterColor,
-						groundBlock, undergroundBlock, generateLakes, treesPerChunk, treeType, treeStem, treeBranch);
+						groundBlock, undergroundBlock, treesPerChunk, treeType, treeStem, treeBranch);
 	}
 
 }

--- a/src/main/java/net/mcreator/element/types/Biome.java
+++ b/src/main/java/net/mcreator/element/types/Biome.java
@@ -38,7 +38,6 @@ import java.util.List;
 	public String name;
 	public MItemBlock groundBlock;
 	public MItemBlock undergroundBlock;
-	public boolean generateLakes;
 
 	public int treeType;
 	public String vanillaTreeType;

--- a/src/main/java/net/mcreator/minecraft/MinecraftImageGenerator.java
+++ b/src/main/java/net/mcreator/minecraft/MinecraftImageGenerator.java
@@ -675,7 +675,7 @@ public class MinecraftImageGenerator {
 		}
 
 		public static BufferedImage generateBiomePreviewPicture(Workspace workspace, Color airColor, Color grassColor,
-				Color waterColor, MItemBlock groundBlock, MItemBlock undergroundBlock, boolean lakes, int treesPerChunk,
+				Color waterColor, MItemBlock groundBlock, MItemBlock undergroundBlock, int treesPerChunk,
 				int treeType, MItemBlock treeStem, MItemBlock treeBranch) {
 			BufferedImage icon = new BufferedImage(28, 28, BufferedImage.TYPE_INT_ARGB);
 			Graphics2D graphics2D = icon.createGraphics();
@@ -714,18 +714,8 @@ public class MinecraftImageGenerator {
 
 			//draw grass
 			graphics2D.setColor(topColor);
-			if (lakes) {
-				graphics2D.fillRect(0, 18, 5, 1);
-				graphics2D.fillRect(13, 18, 15, 1);
-				if (waterColor != null)
-					graphics2D.setColor(waterColor);
-				else
-					graphics2D.setColor(new Color(0x2559CB));
-				graphics2D.fillRect(3, 18, 10, 2);
-				graphics2D.fillRect(5, 20, 6, 1);
-			} else {
-				graphics2D.fillRect(0, 18, 28, 1);
-			}
+
+			graphics2D.fillRect(0, 18, 28, 1);
 
 			//draw trees: 0 = vanilla, 1 = modded
 			if (treesPerChunk > 0) {

--- a/src/main/java/net/mcreator/ui/modgui/BiomeGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/BiomeGUI.java
@@ -109,8 +109,6 @@ public class BiomeGUI extends ModElementGUI<Biome> {
 	private final JColor waterColor = new JColor(mcreator, true);
 	private final JColor waterFogColor = new JColor(mcreator, true);
 
-	private final JCheckBox generateLakes = new JCheckBox("Select to enable");
-
 	private final JSpinner biomeWeight = new JSpinner(new SpinnerNumberModel(10, 0, 1024, 1));
 	private final JComboBox<String> biomeType = new JComboBox<>(new String[] { "WARM", "DESERT", "COOL", "ICY" });
 
@@ -363,8 +361,7 @@ public class BiomeGUI extends ModElementGUI<Biome> {
 
 		pane3.add("Center", PanelUtils.totalCenterInPanel(sbbp3));
 
-		JPanel sbbp4 = new JPanel(new GridLayout(10, 2, 0, 2));
-		generateLakes.setOpaque(false);
+		JPanel sbbp4 = new JPanel(new GridLayout(9, 2, 0, 2));
 
 		sbbp4.add(HelpUtils.wrapWithHelpButton(this.withEntry("biome/name"), new JLabel("Name:")));
 		sbbp4.add(name);
@@ -378,10 +375,6 @@ public class BiomeGUI extends ModElementGUI<Biome> {
 				new JLabel("<html>Underground block:<br><small>Tip: Underground block should use EARTH for material"),
 				new Color(179, 94, 26).brighter()));
 		sbbp4.add(PanelUtils.join(undergroundBlock));
-
-		sbbp4.add(HelpUtils
-				.wrapWithHelpButton(this.withEntry("biome/generate_lakes"), new JLabel("Generate small water lakes?")));
-		sbbp4.add(PanelUtils.join(generateLakes));
 
 		sbbp4.add(HelpUtils.wrapWithHelpButton(this.withEntry("biome/air_color"), new JLabel("Air color:")));
 		sbbp4.add(airColor);
@@ -547,7 +540,6 @@ public class BiomeGUI extends ModElementGUI<Biome> {
 		treeStem.setBlock(biome.treeStem);
 		treeBranch.setBlock(biome.treeBranch);
 		treeFruits.setBlock(biome.treeFruits);
-		generateLakes.setSelected(biome.generateLakes);
 
 		if (biome.treeType == biome.TREES_CUSTOM) {
 			vanillaTrees.setSelected(false);
@@ -608,7 +600,6 @@ public class BiomeGUI extends ModElementGUI<Biome> {
 		biome.name = name.getText();
 		biome.groundBlock = groundBlock.getBlock();
 		biome.undergroundBlock = undergroundBlock.getBlock();
-		biome.generateLakes = generateLakes.isSelected();
 		if (customTrees.isSelected())
 			biome.treeType = biome.TREES_CUSTOM;
 		else

--- a/src/test/java/net/mcreator/integration/TestWorkspaceDataProvider.java
+++ b/src/test/java/net/mcreator/integration/TestWorkspaceDataProvider.java
@@ -207,7 +207,6 @@ public class TestWorkspaceDataProvider {
 					ListUtils.getRandomItem(random, ElementUtil.loadBlocks(modElement.getWorkspace())).getName());
 			biome.undergroundBlock = new MItemBlock(modElement.getWorkspace(),
 					ListUtils.getRandomItem(random, ElementUtil.loadBlocks(modElement.getWorkspace())).getName());
-			biome.generateLakes = _true;
 			biome.vanillaTreeType = "Mega spruce trees";
 			biome.airColor = Color.red;
 			if (!emptyLists) {


### PR DESCRIPTION
Small fixes for biomes concerning my previous PRs.
As the checkbox to generate lakes was a Default feature, I removed it, so the code line will not be generated twice. A converter has been made ([in my other PR](https://github.com/MCreator/MCreator/pull/66)) to add the lake into the Default feature field if the user has already defined it.
I also selected by default the generation of strongholds, mineshafts and pillager outposts.