### PR TITLE
useLootTableForDrops option for plants

### DIFF
--- a/plugins/generator-1.14.4/forge-1.14.4/templates/plant.java.ftl
+++ b/plugins/generator-1.14.4/forge-1.14.4/templates/plant.java.ftl
@@ -268,7 +268,7 @@ package ${package}.block;
 		}
 		</#if>
 
-        <#if data.useLootTableForDrops>
+        <#if !data.useLootTableForDrops>
 		    <#if data.dropAmount != 1 && !(data.customDrop?? && !data.customDrop.isEmpty())>
 		    @Override public List<ItemStack> getDrops(BlockState state, LootContext.Builder builder) {
 			    List<ItemStack> dropsOriginal = super.getDrops(state, builder);

--- a/plugins/generator-1.14.4/forge-1.14.4/templates/plant.java.ftl
+++ b/plugins/generator-1.14.4/forge-1.14.4/templates/plant.java.ftl
@@ -268,27 +268,29 @@ package ${package}.block;
 		}
 		</#if>
 
-		<#if data.dropAmount != 1 && !(data.customDrop?? && !data.customDrop.isEmpty())>
-		@Override public List<ItemStack> getDrops(BlockState state, LootContext.Builder builder) {
-			List<ItemStack> dropsOriginal = super.getDrops(state, builder);
-			if(!dropsOriginal.isEmpty())
-				return dropsOriginal;
-			return Collections.singletonList(new ItemStack(this, ${data.dropAmount}));
-		}
-		<#elseif data.customDrop?? && !data.customDrop.isEmpty()>
-		@Override public List<ItemStack> getDrops(BlockState state, LootContext.Builder builder) {
-			List<ItemStack> dropsOriginal = super.getDrops(state, builder);
-			if(!dropsOriginal.isEmpty())
-				return dropsOriginal;
-			return Collections.singletonList(${mappedMCItemToItemStackCode(data.customDrop, data.dropAmount)});
-		}
-		<#else>
-		@Override public List<ItemStack> getDrops(BlockState state, LootContext.Builder builder) {
-			List<ItemStack> dropsOriginal = super.getDrops(state, builder);
-			if(!dropsOriginal.isEmpty())
-				return dropsOriginal;
-			return Collections.singletonList(new ItemStack(this, 1));
-		}
+        <#if data.useLootTableForDrops>
+		    <#if data.dropAmount != 1 && !(data.customDrop?? && !data.customDrop.isEmpty())>
+		    @Override public List<ItemStack> getDrops(BlockState state, LootContext.Builder builder) {
+			    List<ItemStack> dropsOriginal = super.getDrops(state, builder);
+			    if(!dropsOriginal.isEmpty())
+				    return dropsOriginal;
+			    return Collections.singletonList(new ItemStack(this, ${data.dropAmount}));
+		    }
+		    <#elseif data.customDrop?? && !data.customDrop.isEmpty()>
+		    @Override public List<ItemStack> getDrops(BlockState state, LootContext.Builder builder) {
+			    List<ItemStack> dropsOriginal = super.getDrops(state, builder);
+			    if(!dropsOriginal.isEmpty())
+				    return dropsOriginal;
+			    return Collections.singletonList(${mappedMCItemToItemStackCode(data.customDrop, data.dropAmount)});
+		    }
+		    <#else>
+		    @Override public List<ItemStack> getDrops(BlockState state, LootContext.Builder builder) {
+			    List<ItemStack> dropsOriginal = super.getDrops(state, builder);
+			    if(!dropsOriginal.isEmpty())
+				    return dropsOriginal;
+			    return Collections.singletonList(new ItemStack(this, 1));
+		    }
+            </#if>
         </#if>
 
 		@Override public PlantType getPlantType(IBlockReader world, BlockPos pos) {

--- a/plugins/generator-1.15.2/forge-1.15.2/templates/plant.java.ftl
+++ b/plugins/generator-1.15.2/forge-1.15.2/templates/plant.java.ftl
@@ -268,27 +268,29 @@ import net.minecraft.block.material.Material;
     	}
         </#if>
 
-		<#if data.dropAmount != 1 && !(data.customDrop?? && !data.customDrop.isEmpty())>
-		@Override public List<ItemStack> getDrops(BlockState state, LootContext.Builder builder) {
-			List<ItemStack> dropsOriginal = super.getDrops(state, builder);
-			if(!dropsOriginal.isEmpty())
-				return dropsOriginal;
-			return Collections.singletonList(new ItemStack(this, ${data.dropAmount}));
-		}
-		<#elseif data.customDrop?? && !data.customDrop.isEmpty()>
-		@Override public List<ItemStack> getDrops(BlockState state, LootContext.Builder builder) {
-			List<ItemStack> dropsOriginal = super.getDrops(state, builder);
-			if(!dropsOriginal.isEmpty())
-				return dropsOriginal;
-			return Collections.singletonList(${mappedMCItemToItemStackCode(data.customDrop, data.dropAmount)});
-		}
-		<#else>
-		@Override public List<ItemStack> getDrops(BlockState state, LootContext.Builder builder) {
-			List<ItemStack> dropsOriginal = super.getDrops(state, builder);
-			if(!dropsOriginal.isEmpty())
-				return dropsOriginal;
-			return Collections.singletonList(new ItemStack(this, 1));
-		}
+        <#if data.useLootTableForDrops>
+		    <#if data.dropAmount != 1 && !(data.customDrop?? && !data.customDrop.isEmpty())>
+		    @Override public List<ItemStack> getDrops(BlockState state, LootContext.Builder builder) {
+			    List<ItemStack> dropsOriginal = super.getDrops(state, builder);
+			    if(!dropsOriginal.isEmpty())
+				    return dropsOriginal;
+			    return Collections.singletonList(new ItemStack(this, ${data.dropAmount}));
+		    }
+		    <#elseif data.customDrop?? && !data.customDrop.isEmpty()>
+		    @Override public List<ItemStack> getDrops(BlockState state, LootContext.Builder builder) {
+			    List<ItemStack> dropsOriginal = super.getDrops(state, builder);
+			    if(!dropsOriginal.isEmpty())
+				    return dropsOriginal;
+			    return Collections.singletonList(${mappedMCItemToItemStackCode(data.customDrop, data.dropAmount)});
+		    }
+		    <#else>
+		    @Override public List<ItemStack> getDrops(BlockState state, LootContext.Builder builder) {
+			    List<ItemStack> dropsOriginal = super.getDrops(state, builder);
+			    if(!dropsOriginal.isEmpty())
+				    return dropsOriginal;
+			    return Collections.singletonList(new ItemStack(this, 1));
+		    }
+            </#if>
         </#if>
 
 		@Override public PlantType getPlantType(IBlockReader world, BlockPos pos) {

--- a/plugins/generator-1.15.2/forge-1.15.2/templates/plant.java.ftl
+++ b/plugins/generator-1.15.2/forge-1.15.2/templates/plant.java.ftl
@@ -268,7 +268,7 @@ import net.minecraft.block.material.Material;
     	}
         </#if>
 
-        <#if data.useLootTableForDrops>
+        <#if !data.useLootTableForDrops>
 		    <#if data.dropAmount != 1 && !(data.customDrop?? && !data.customDrop.isEmpty())>
 		    @Override public List<ItemStack> getDrops(BlockState state, LootContext.Builder builder) {
 			    List<ItemStack> dropsOriginal = super.getDrops(state, builder);

--- a/src/main/java/net/mcreator/element/types/Plant.java
+++ b/src/main/java/net/mcreator/element/types/Plant.java
@@ -55,6 +55,7 @@ import java.util.Map;
 	public double luminance;
 	public boolean unbreakable;
 	public StepSound soundOnStep;
+	public boolean useLootTableForDrops;
 	public MItemBlock customDrop;
 	public int dropAmount;
 	public boolean forceTicking;

--- a/src/main/java/net/mcreator/ui/modgui/PlantGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/PlantGUI.java
@@ -366,6 +366,11 @@ public class PlantGUI extends ModElementGUI<Plant> {
 
 		selp.setOpaque(false);
 
+		useLootTableForDrops.addActionListener(e -> {
+			customDrop.setEnabled(!useLootTableForDrops.isSelected());
+			dropAmount.setEnabled(!useLootTableForDrops.isSelected());
+		});
+
 		pane3.add("Center", PanelUtils.totalCenterInPanel(PanelUtils
 				.westAndEastElement(PanelUtils.centerInPanel(selp), PanelUtils.centerInPanel(selp2), 20, 20)));
 
@@ -561,11 +566,6 @@ public class PlantGUI extends ModElementGUI<Plant> {
 		plant.specialInfo = StringUtils.splitCommaSeparatedStringListWithEscapes(specialInfo.getText());
 		plant.generateCondition = generateCondition.getSelectedProcedure();
 		plant.emissiveRendering = emissiveRendering.isSelected();
-
-		useLootTableForDrops.addActionListener(e -> {
-			customDrop.setEnabled(!useLootTableForDrops.isSelected());
-			dropAmount.setEnabled(!useLootTableForDrops.isSelected());
-		});
 
 		Model model = Objects.requireNonNull(renderType.getSelectedItem());
 		plant.renderType = 12;

--- a/src/main/java/net/mcreator/ui/modgui/PlantGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/PlantGUI.java
@@ -72,6 +72,7 @@ public class PlantGUI extends ModElementGUI<Plant> {
 	private final JSpinner frequencyOnChunks = new JSpinner(new SpinnerNumberModel(5, 0, 40, 1));
 	private final JSpinner dropAmount = new JSpinner(new SpinnerNumberModel(1, 0, 200, 1));
 
+	private final JCheckBox useLootTableForDrops = new JCheckBox("Use loot table for drops");
 	private final JCheckBox unbreakable = new JCheckBox("Check to enable");
 	private final JCheckBox forceTicking = new JCheckBox("Check to enable");
 	private final JCheckBox hasTileEntity = new JCheckBox("Check to enable");
@@ -270,8 +271,9 @@ public class PlantGUI extends ModElementGUI<Plant> {
 		pane2.add("Center", PanelUtils.totalCenterInPanel(sbbp2));
 
 		JPanel selp = new JPanel(new GridLayout(10, 2, 25, 4));
-		JPanel selp2 = new JPanel(new GridLayout(10, 2, 25, 4));
+		JPanel selp2 = new JPanel(new GridLayout(11, 2, 25, 4));
 
+		useLootTableForDrops.setOpaque(false);
 		unbreakable.setOpaque(false);
 		forceTicking.setOpaque(false);
 		hasTileEntity.setOpaque(false);
@@ -307,12 +309,13 @@ public class PlantGUI extends ModElementGUI<Plant> {
 		selp.add(HelpUtils.wrapWithHelpButton(this.withEntry("plant/type"), new JLabel("Plant type: ")));
 		selp.add(growapableSpawnType);
 
-		selp.add(HelpUtils.wrapWithHelpButton(this.withEntry("block/custom_drop"),
-				new JLabel("<html>Custom drop:<br><small>Leave empty for default drop")));
-		selp.add(PanelUtils.join(FlowLayout.LEFT, customDrop));
+		selp.add(
+				HelpUtils.wrapWithHelpButton(this.withEntry("block/flammability"), new JLabel("Plant flammability:")));
+		selp.add(flammability);
 
-		selp.add(HelpUtils.wrapWithHelpButton(this.withEntry("block/drop_amount"), new JLabel("Drop amount:")));
-		selp.add(dropAmount);
+		selp.add(HelpUtils.wrapWithHelpButton(this.withEntry("block/fire_spread_speed"),
+				new JLabel("<html>Fire spreading speed:<br><small>Leave 0 for vanilla handling")));
+		selp.add(fireSpreadSpeed);
 
 		selp2.add(HelpUtils.wrapWithHelpButton(this.withEntry("block/emissive_rendering"),
 				new JLabel("Enable emissive rendering (glow):")));
@@ -330,17 +333,20 @@ public class PlantGUI extends ModElementGUI<Plant> {
 				HelpUtils.wrapWithHelpButton(this.withEntry("block/replaceable"), new JLabel("Is plant replaceable?")));
 		selp2.add(isReplaceable);
 
-		selp2.add(
-				HelpUtils.wrapWithHelpButton(this.withEntry("block/flammability"), new JLabel("Plant flammability:")));
-		selp2.add(flammability);
-
-		selp2.add(HelpUtils.wrapWithHelpButton(this.withEntry("block/fire_spread_speed"),
-				new JLabel("<html>Fire spreading speed:<br><small>Leave 0 for vanilla handling")));
-		selp2.add(fireSpreadSpeed);
-
 		selp2.add(HelpUtils.wrapWithHelpButton(this.withEntry("block/creative_pick_item"),
 				new JLabel("<html>Creative pick item:<br><small>Leave empty for default creative pick item")));
 		selp2.add(PanelUtils.join(FlowLayout.LEFT, creativePickItem));
+
+		selp2.add(HelpUtils.wrapWithHelpButton(this.withEntry("block/custom_drop"),
+				new JLabel("<html>Custom drop:<br><small>Leave empty for default drop")));
+		selp2.add(PanelUtils.join(FlowLayout.LEFT, customDrop));
+
+		selp2.add(HelpUtils.wrapWithHelpButton(this.withEntry("block/drop_amount"), new JLabel("Drop amount:")));
+		selp2.add(dropAmount);
+
+		selp2.add(HelpUtils.wrapWithHelpButton(this.withEntry("block/use_loot_table_for_drops"),
+				new JLabel("<html>Use loot table for drops:<br><small>If checked, you need to define loot table for drops")));
+		selp2.add(useLootTableForDrops);
 
 		selp2.setOpaque(false);
 
@@ -462,8 +468,9 @@ public class PlantGUI extends ModElementGUI<Plant> {
 		forceTicking.setSelected(plant.forceTicking);
 		hasTileEntity.setSelected(plant.hasTileEntity);
 		frequencyOnChunks.setValue(plant.frequencyOnChunks);
-		customDrop.setBlock(plant.customDrop);
 		emissiveRendering.setSelected(plant.emissiveRendering);
+		useLootTableForDrops.setSelected(plant.useLootTableForDrops);
+		customDrop.setBlock(plant.customDrop);
 		dropAmount.setValue(plant.dropAmount);
 		creativeTab.setSelectedItem(plant.creativeTab);
 		onNeighbourBlockChanges.setSelectedProcedure(plant.onNeighbourBlockChanges);
@@ -528,6 +535,7 @@ public class PlantGUI extends ModElementGUI<Plant> {
 		plant.forceTicking = forceTicking.isSelected();
 		plant.hasTileEntity = hasTileEntity.isSelected();
 		plant.soundOnStep = new StepSound(mcreator.getWorkspace(), soundOnStep.getSelectedItem());
+		plant.useLootTableForDrops = useLootTableForDrops.isSelected();
 		plant.customDrop = customDrop.getBlock();
 		plant.dropAmount = (int) dropAmount.getValue();
 		plant.frequencyOnChunks = (int) frequencyOnChunks.getValue();
@@ -550,6 +558,11 @@ public class PlantGUI extends ModElementGUI<Plant> {
 		plant.specialInfo = StringUtils.splitCommaSeparatedStringListWithEscapes(specialInfo.getText());
 		plant.generateCondition = generateCondition.getSelectedProcedure();
 		plant.emissiveRendering = emissiveRendering.isSelected();
+
+		useLootTableForDrops.addActionListener(e -> {
+			customDrop.setEnabled(!useLootTableForDrops.isSelected());
+			dropAmount.setEnabled(!useLootTableForDrops.isSelected());
+		});
 
 		Model model = Objects.requireNonNull(renderType.getSelectedItem());
 		plant.renderType = 12;

--- a/src/main/java/net/mcreator/ui/modgui/PlantGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/PlantGUI.java
@@ -517,6 +517,11 @@ public class PlantGUI extends ModElementGUI<Plant> {
 			dyn.setIcon(TiledImageCache.plantGrowingYes);
 		else
 			dyn.setIcon(TiledImageCache.plantGrowingNo);
+
+		useLootTableForDrops.addActionListener(e -> {
+			customDrop.setEnabled(!useLootTableForDrops.isSelected());
+			dropAmount.setEnabled(!useLootTableForDrops.isSelected());
+		});
 	}
 
 	@Override public Plant getElementFromGUI() {

--- a/src/main/java/net/mcreator/ui/modgui/PlantGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/PlantGUI.java
@@ -509,6 +509,9 @@ public class PlantGUI extends ModElementGUI<Plant> {
 		growapableSpawnType.setSelectedItem(plant.growapableSpawnType);
 		staticPlantGenerationType.setSelectedItem(plant.staticPlantGenerationType);
 
+		customDrop.setEnabled(!useLootTableForDrops.isSelected());
+		dropAmount.setEnabled(!useLootTableForDrops.isSelected());
+
 		if (normalType.isSelected())
 			stl.setIcon(TiledImageCache.plantStaticYes);
 		else
@@ -517,11 +520,6 @@ public class PlantGUI extends ModElementGUI<Plant> {
 			dyn.setIcon(TiledImageCache.plantGrowingYes);
 		else
 			dyn.setIcon(TiledImageCache.plantGrowingNo);
-
-		useLootTableForDrops.addActionListener(e -> {
-			customDrop.setEnabled(!useLootTableForDrops.isSelected());
-			dropAmount.setEnabled(!useLootTableForDrops.isSelected());
-		});
 	}
 
 	@Override public Plant getElementFromGUI() {

--- a/src/test/java/net/mcreator/integration/TestWorkspaceDataProvider.java
+++ b/src/test/java/net/mcreator/integration/TestWorkspaceDataProvider.java
@@ -1067,7 +1067,6 @@ public class TestWorkspaceDataProvider {
 			block.isNotColidable = _true;
 			block.canProvidePower = _true;
 			block.isBeaconBase = _true;
-			block.isWaterloggable = _true;
 			block.isLadder = _true;
 			block.enchantPowerBonus = 1.2342;
 			block.reactionToPushing = ListUtils

--- a/src/test/java/net/mcreator/integration/TestWorkspaceDataProvider.java
+++ b/src/test/java/net/mcreator/integration/TestWorkspaceDataProvider.java
@@ -884,9 +884,6 @@ public class TestWorkspaceDataProvider {
 			item.destroyAnyBlock = _true;
 			item.inventorySize = 10;
 			item.inventoryStackSize = 42;
-			item.recipeRemainder = new MItemBlock(modElement.getWorkspace(),
-					ListUtils.getRandomItem(random, ElementUtil.loadBlocksAndItems(modElement.getWorkspace()))
-							.getName());
 			item.stayInGridWhenCrafting = _true;
 			item.damageOnCrafting = _true;
 			item.hasGlow = _true;

--- a/src/test/java/net/mcreator/integration/TestWorkspaceDataProvider.java
+++ b/src/test/java/net/mcreator/integration/TestWorkspaceDataProvider.java
@@ -855,6 +855,7 @@ public class TestWorkspaceDataProvider {
 					ListUtils.getRandomItem(random, ElementUtil.loadBlocksAndItems(modElement.getWorkspace()))
 							.getName());
 			plant.dropAmount = 4;
+			plant.useLootTableForDrops = !_true;
 			plant.frequencyOnChunks = 13;
 			plant.flammability = 5;
 			plant.fireSpreadSpeed = 12;
@@ -883,6 +884,9 @@ public class TestWorkspaceDataProvider {
 			item.destroyAnyBlock = _true;
 			item.inventorySize = 10;
 			item.inventoryStackSize = 42;
+			item.recipeRemainder = new MItemBlock(modElement.getWorkspace(),
+					ListUtils.getRandomItem(random, ElementUtil.loadBlocksAndItems(modElement.getWorkspace()))
+							.getName());
 			item.stayInGridWhenCrafting = _true;
 			item.damageOnCrafting = _true;
 			item.hasGlow = _true;
@@ -1066,6 +1070,7 @@ public class TestWorkspaceDataProvider {
 			block.isNotColidable = _true;
 			block.canProvidePower = _true;
 			block.isBeaconBase = _true;
+			block.isWaterloggable = _true;
 			block.isLadder = _true;
 			block.enchantPowerBonus = 1.2342;
 			block.reactionToPushing = ListUtils


### PR DESCRIPTION
Added useLootTableForDrops option to plants (Closes nothing)

Travis CI build will fail because I included the updated TestWorkspaceDataProvider(TWDP) in waterlogging PR
I don't really know what happens if multiple PR's change one file, so I included that only in that PR
If you think it won't create any problems across PR's I can add the field to TWDP in this PR