### PR TITLE
[Bug] Some procedure blocks were moved to different tabs

### DIFF
--- a/.idea/.name
+++ b/.idea/.name
@@ -1,0 +1,1 @@
+MCreator

--- a/.idea/.name
+++ b/.idea/.name
@@ -1,1 +1,0 @@
-MCreator

--- a/plugins/mcreator-core/procedures/advancement_isequalto.json
+++ b/plugins/mcreator-core/procedures/advancement_isequalto.json
@@ -4,9 +4,9 @@
   ],
   "inputsInline": true,
   "output": "Boolean",
-  "colour": "%{BKY_LOGIC_HUE}",
+  "colour": "350",
   "mcreator": {
-    "toolbox_id": "logicoperations",
+    "toolbox_id": "worlddata",
     "fields": [
       "achievement"
     ],

--- a/plugins/mcreator-core/procedures/logic_entity_compare.json
+++ b/plugins/mcreator-core/procedures/logic_entity_compare.json
@@ -13,7 +13,7 @@
   "output": "Boolean",
   "colour": "%{BKY_LOGIC_HUE}",
   "mcreator": {
-    "toolbox_id": "logicoperations",
+    "toolbox_id": "entitymanagement",
     "toolbox_init": [
       "<value name=\"compareTo\"><block type=\"entity_from_deps\"></block></value>"
     ],


### PR DESCRIPTION
Procedure block "Is event/target entity (sub)type of ..." was moved from 'entity' tab to 'logic operations' tab, so I'm moving it back to 'entity' tab.
Procedure block "Is provided advancement equals to ..." was moved from 'worlddata' tab to 'logic operations' tab, so I'm moving it back to 'worlddata' tab. I also changed its color back to how it was.