### PR TITLE
Updating custom procedure blocks functionality

### DIFF
--- a/src/main/java/net/mcreator/blockly/data/ExternalBlockLoader.java
+++ b/src/main/java/net/mcreator/blockly/data/ExternalBlockLoader.java
@@ -100,6 +100,35 @@ public class ExternalBlockLoader {
 
 					jsonresult.add("type", new JsonPrimitive(toolboxBlock.machine_name));
 
+					// converts fields & inputs lists to the new format
+					List<Object> fields = gson.fromJson(jsonresult.get("mcreator").getAsJsonObject().get("fields"), List.class);
+					if (fields != null) {
+						for (int fieldNum = 0; fieldNum < fields.size(); fieldNum++) {
+							if (!(fields.get(fieldNum) instanceof BlockArgument)) {
+								JsonObject blockArgument = new JsonObject();
+								blockArgument.addProperty("name", fields.get(fieldNum).toString());
+								blockArgument.addProperty("does_not_error", false);
+								jsonresult.get("mcreator").getAsJsonObject().get("fields").getAsJsonArray()
+									.set(fieldNum, (JsonElement)blockArgument);
+								toolboxBlock.fields.set(fieldNum, new BlockArgument(fields.get(fieldNum).toString(), false));
+							}
+						}
+					}
+
+					List<Object> inputs = gson.fromJson(jsonresult.get("mcreator").getAsJsonObject().get("inputs"), List.class);
+					if (inputs != null) {
+						for (int inputNum = 0; inputNum < inputs.size(); inputNum++) {
+							if (!(inputs.get(inputNum) instanceof BlockArgument)) {
+								JsonObject blockArgument = new JsonObject();
+								blockArgument.addProperty("name", inputs.get(inputNum).toString());
+								blockArgument.addProperty("does_not_error", false);
+								jsonresult.get("mcreator").getAsJsonObject().get("inputs").getAsJsonArray()
+									.set(inputNum, (JsonElement)blockArgument);
+								toolboxBlock.inputs.set(inputNum, new BlockArgument(inputs.get(inputNum).toString(), false));
+							}
+						}
+					}
+
 					toolboxBlock.blocklyJSON = jsonresult;
 					toolboxBlock.type = jsonresult.get("output") == null ?
 							IBlockGenerator.BlockType.PROCEDURAL :
@@ -255,8 +284,8 @@ public class ExternalBlockLoader {
 
 		@Nullable private List<String> toolbox_init;
 
-		@Nullable public List<String> fields;
-		@Nullable public List<String> inputs;
+		@Nullable public List<Object> fields;
+		@Nullable public List<Object> inputs;
 		@Nullable public List<Dependency> dependencies;
 
 		@Nullable public List<String> required_apis;
@@ -296,6 +325,24 @@ public class ExternalBlockLoader {
 
 		@Override public int hashCode() {
 			return machine_name.hashCode();
+		}
+	}
+
+	public static class BlockArgument {
+		public String name;
+		public boolean does_not_error;
+
+		public BlockArgument(String name, boolean doesNotError) {
+			this.name = name;
+			this.does_not_error = doesNotError;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public boolean doesNotError() {
+			return does_not_error;
 		}
 	}
 

--- a/src/main/java/net/mcreator/generator/blockly/BlocklyBlockCodeGenerator.java
+++ b/src/main/java/net/mcreator/generator/blockly/BlocklyBlockCodeGenerator.java
@@ -98,36 +98,40 @@ public class BlocklyBlockCodeGenerator {
 
 		// check for all fields if they exist, if they do, add them to data model
 		if (toolboxBlock.fields != null) {
-			for (String fieldName : toolboxBlock.fields) {
+			for (Object field : toolboxBlock.fields) {
+				ExternalBlockLoader.BlockArgument arg = (ExternalBlockLoader.BlockArgument)field;
 				boolean found = false;
 				for (Element element : elements) {
-					if (element.getNodeName().equals("field") && element.getAttribute("name").equals(fieldName)
+					if (element.getNodeName().equals("field") && element.getAttribute("name").equals(arg.getName())
 							&& !element.getTextContent().equals("")) {
 						found = true;
-						dataModel.put("field$" + fieldName, element.getTextContent());
+						dataModel.put("field$" + arg.getName(), element.getTextContent());
 					}
 				}
 				if (!found) {
-					master.addCompileNote(new BlocklyCompileNote(BlocklyCompileNote.Type.ERROR,
-							"Field " + fieldName + " on block " + type + " is not defined."));
+					master.addCompileNote(new BlocklyCompileNote(
+							arg.doesNotError() ? BlocklyCompileNote.Type.WARNING : BlocklyCompileNote.Type.ERROR,
+							"Field " + arg.getName() + " on block " + type + " is not defined."));
 				}
 			}
 		}
 
 		// next we check for inputs if they exist, we process them and add to data model
 		if (toolboxBlock.inputs != null) {
-			for (String inputName : toolboxBlock.inputs) {
+			for (Object input : toolboxBlock.inputs) {
+				ExternalBlockLoader.BlockArgument arg = (ExternalBlockLoader.BlockArgument)input;
 				boolean found = false;
 				for (Element element : elements) {
-					if (element.getNodeName().equals("value") && element.getAttribute("name").equals(inputName)) {
+					if ((element.getNodeName().equals("value") || element.getNodeName().equals("statement")) && element.getAttribute("name").equals(arg.getName())) {
 						found = true;
 						String generatedCode = BlocklyToCode.directProcessOutputBlock(master, element);
-						dataModel.put("input$" + inputName, generatedCode);
+						dataModel.put("input$" + arg.getName(), generatedCode);
 					}
 				}
 				if (!found) {
-					master.addCompileNote(new BlocklyCompileNote(BlocklyCompileNote.Type.ERROR,
-							"Input " + inputName + " on block " + type + " is empty."));
+					master.addCompileNote(new BlocklyCompileNote(
+							arg.doesNotError() ? BlocklyCompileNote.Type.WARNING : BlocklyCompileNote.Type.ERROR,
+							"Input " + arg.getName() + " on block " + type + " is empty."));
 				}
 			}
 		}


### PR DESCRIPTION
Begins as #213 and #229 (it took 13 commits to make the code work as designed, so I'm reposting it).
This PR adds a couple of new things to Blockly editor: 
- Fixes problem with Blockly thinking statement inputs on custom procedure blocks are always empty;

![The problem](https://user-images.githubusercontent.com/71347607/93895982-0f2ec100-fcf9-11ea-97ee-78ccb228faec.png)

- Adds support for custom procedure blocks with fields and/or inputs that warn user if some of their parameters are not well defined (like built-in procedure blocks do it :arrow_down::arrow_down::arrow_down:).

![What about this](https://user-images.githubusercontent.com/71347607/93896464-9a0fbb80-fcf9-11ea-84ce-c50536c21a06.png)

A little plugin to test the second feature can be found [here](https://github.com/MCreator/MCreator/files/5262452/pr238-test-plugin.zip).