### PR TITLE
Added a clientLoad method to elements (F 1.14.4) and custom code elements (F 1.14.4 / 1.15.2)

### DIFF
--- a/plugins/generator-1.14.4/forge-1.14.4/templates/code.java.ftl
+++ b/plugins/generator-1.14.4/forge-1.14.4/templates/code.java.ftl
@@ -67,5 +67,9 @@ package ${package};
 	@Override public void serverLoad(FMLServerStartingEvent event) {
 	}
 
+	@OnlyIn(Dist.CLIENT)
+	@Override public void clientLoad(FMLClientSetupEvent event) {
+    }
+
 }
 <#-- @formatter:on -->

--- a/plugins/generator-1.14.4/forge-1.14.4/templates/modbase/mod.java.ftl
+++ b/plugins/generator-1.14.4/forge-1.14.4/templates/modbase/mod.java.ftl
@@ -79,6 +79,7 @@ public class ${JavaModName} {
 
 	private void clientSetup(FMLClientSetupEvent event) {
         OBJLoader.INSTANCE.addDomain("${modid}");
+        elements.getElements().forEach(element -> element.clientLoad(event));
     }
 
     @SubscribeEvent public void serverLoad(FMLServerStartingEvent event) {

--- a/plugins/generator-1.14.4/forge-1.14.4/templates/modbase/mod.java.ftl
+++ b/plugins/generator-1.14.4/forge-1.14.4/templates/modbase/mod.java.ftl
@@ -79,6 +79,7 @@ public class ${JavaModName} {
 
 	private void clientSetup(FMLClientSetupEvent event) {
         OBJLoader.INSTANCE.addDomain("${modid}");
+	
         elements.getElements().forEach(element -> element.clientLoad(event));
     }
 

--- a/plugins/generator-1.14.4/forge-1.14.4/templates/modbase/modelements.java.ftl
+++ b/plugins/generator-1.14.4/forge-1.14.4/templates/modbase/modelements.java.ftl
@@ -140,6 +140,9 @@ public class ${JavaModName}Elements {
 		public void serverLoad(FMLServerStartingEvent event) {
 		}
 
+		@OnlyIn(Dist.CLIENT) public void clientLoad(FMLClientSetupEvent event) {
+        }
+
 		@Override public int compareTo(ModElement other){
         	return this.sortid - other.sortid;
     	}

--- a/plugins/generator-1.15.2/forge-1.15.2/templates/code.java.ftl
+++ b/plugins/generator-1.15.2/forge-1.15.2/templates/code.java.ftl
@@ -67,5 +67,9 @@ package ${package};
 	@Override public void serverLoad(FMLServerStartingEvent event) {
 	}
 
+	@OnlyIn(Dist.CLIENT)
+	@Override public void clientLoad(FMLClientSetupEvent event) {
+    }
+
 }
 <#-- @formatter:on -->


### PR DESCRIPTION
This PR adds a clientLoad method to custom code elements, called when the client is being loaded. It already existed in the 1.15.2 Forge generator to handle block transparency, but it was missing from code elements. 