### PR TITLE
Adding an option for blocks description (Localization key)

### DIFF
--- a/plugins/generator-1.14.4/forge-1.14.4/block.definition.yaml
+++ b/plugins/generator-1.14.4/forge-1.14.4/block.definition.yaml
@@ -284,3 +284,6 @@ templates:
 localizationkeys:
   - key: block.@modid.@registryname
     mapto: name
+  - key: block.@modid.@registryname.tooltip.1
+    condition: descriptionLocalized
+    mapto: specialInfo

--- a/plugins/generator-1.14.4/forge-1.14.4/templates/block.java.ftl
+++ b/plugins/generator-1.14.4/forge-1.14.4/templates/block.java.ftl
@@ -163,9 +163,15 @@ public class ${name}Block extends ${JavaModName}Elements.ModElement {
 		<#if data.specialInfo?has_content>
 		@Override @OnlyIn(Dist.CLIENT) public void addInformation(ItemStack itemstack, IBlockReader world, List<ITextComponent> list, ITooltipFlag flag) {
 			super.addInformation(itemstack, world, list, flag);
-			<#list data.specialInfo as entry>
-			list.add(new StringTextComponent("${JavaConventions.escapeStringForJava(entry)}"));
-            </#list>
+			<#if data.descriptionLocalized>
+			    <#list data.specialInfo as entry>
+			    list.add(new TranslationTextComponent("${JavaConventions.escapeStringForJava(entry)}"));
+			    </#list>
+			<#else>
+                <#list data.specialInfo as entry>
+                list.add(new StringTextComponent("${JavaConventions.escapeStringForJava(entry)}"));
+                </#list>
+            </#if>
 		}
         </#if>
 

--- a/plugins/generator-1.14.4/forge-1.14.4/templates/block.java.ftl
+++ b/plugins/generator-1.14.4/forge-1.14.4/templates/block.java.ftl
@@ -164,16 +164,16 @@ public class ${name}Block extends ${JavaModName}Elements.ModElement {
 		@Override @OnlyIn(Dist.CLIENT) public void addInformation(ItemStack itemstack, IBlockReader world, List<ITextComponent> list, ITooltipFlag flag) {
 			super.addInformation(itemstack, world, list, flag);
 			<#if data.descriptionLocalized>
-			    <#list data.specialInfo as entry>
-			    list.add(new TranslationTextComponent("${JavaConventions.escapeStringForJava(entry)}"));
-			    </#list>
+				<#list data.specialInfo as entry>
+				list.add(new TranslationTextComponent("${JavaConventions.escapeStringForJava(entry)}"));
+				</#list>
 			<#else>
-                <#list data.specialInfo as entry>
-                list.add(new StringTextComponent("${JavaConventions.escapeStringForJava(entry)}"));
-                </#list>
-            </#if>
+				<#list data.specialInfo as entry>
+				list.add(new StringTextComponent("${JavaConventions.escapeStringForJava(entry)}"));
+				</#list>
+			</#if>
 		}
-        </#if>
+		</#if>
 
 		<#if data.transparencyType != "SOLID">
 		@OnlyIn(Dist.CLIENT) @Override public BlockRenderLayer getRenderLayer() {

--- a/plugins/generator-1.15.2/forge-1.15.2/block.definition.yaml
+++ b/plugins/generator-1.15.2/forge-1.15.2/block.definition.yaml
@@ -284,3 +284,6 @@ templates:
 localizationkeys:
   - key: block.@modid.@registryname
     mapto: name
+  - key: block.@modid.@registryname.tooltip.1
+    condition: descriptionLocalized
+    mapto: specialInfo

--- a/plugins/generator-1.15.2/forge-1.15.2/templates/block.java.ftl
+++ b/plugins/generator-1.15.2/forge-1.15.2/templates/block.java.ftl
@@ -185,18 +185,18 @@ public class ${name}Block extends ${JavaModName}Elements.ModElement {
 
 		<#if data.specialInfo?has_content>
 		@Override @OnlyIn(Dist.CLIENT) public void addInformation(ItemStack itemstack, IBlockReader world, List<ITextComponent> list, ITooltipFlag flag) {
-        	super.addInformation(itemstack, world, list, flag);
-        	<#if data.descriptionLocalized>
-        	    <#list data.specialInfo as entry>
-        		list.add(new TranslationTextComponent("${JavaConventions.escapeStringForJava(entry)}"));
-        		</#list>
-        	<#else>
-                <#list data.specialInfo as entry>
-                list.add(new StringTextComponent("${JavaConventions.escapeStringForJava(entry)}"));
-                </#list>
-            </#if>
-        }
-        </#if>
+			super.addInformation(itemstack, world, list, flag);
+			<#if data.descriptionLocalized>
+				<#list data.specialInfo as entry>
+				list.add(new TranslationTextComponent("${JavaConventions.escapeStringForJava(entry)}"));
+				</#list>
+			<#else>
+				<#list data.specialInfo as entry>
+				list.add(new StringTextComponent("${JavaConventions.escapeStringForJava(entry)}"));
+				</#list>
+			</#if>
+		}
+		</#if>
 
 		<#if data.emissiveRendering>
         @OnlyIn(Dist.CLIENT) @Override public boolean isEmissiveRendering(BlockState blockState) {

--- a/plugins/generator-1.15.2/forge-1.15.2/templates/block.java.ftl
+++ b/plugins/generator-1.15.2/forge-1.15.2/templates/block.java.ftl
@@ -185,11 +185,17 @@ public class ${name}Block extends ${JavaModName}Elements.ModElement {
 
 		<#if data.specialInfo?has_content>
 		@Override @OnlyIn(Dist.CLIENT) public void addInformation(ItemStack itemstack, IBlockReader world, List<ITextComponent> list, ITooltipFlag flag) {
-			super.addInformation(itemstack, world, list, flag);
-			<#list data.specialInfo as entry>
-			list.add(new StringTextComponent("${JavaConventions.escapeStringForJava(entry)}"));
-            </#list>
-		}
+        	super.addInformation(itemstack, world, list, flag);
+        	<#if data.descriptionLocalized>
+        	    <#list data.specialInfo as entry>
+        		list.add(new TranslationTextComponent("${JavaConventions.escapeStringForJava(entry)}"));
+        		</#list>
+        	<#else>
+                <#list data.specialInfo as entry>
+                list.add(new StringTextComponent("${JavaConventions.escapeStringForJava(entry)}"));
+                </#list>
+            </#if>
+        }
         </#if>
 
 		<#if data.emissiveRendering>

--- a/plugins/mcreator-localization/help/default/item/description_localized.md
+++ b/plugins/mcreator-localization/help/default/item/description_localized.md
@@ -1,0 +1,5 @@
+If you put a translation key in the field above.
+
+It will automatically be added to the translation tab.
+
+Advised format: element.name.description (example: block.furnace.description)

--- a/plugins/mcreator-localization/help/default/item/description_localized.md
+++ b/plugins/mcreator-localization/help/default/item/description_localized.md
@@ -1,5 +1,3 @@
-If you put a translation key in the field above.
+If you check this box, the text in the field above will be localized (and able to be translated)
 
 It will automatically be added to the translation tab.
-
-Advised format: element.name.description (example: block.furnace.description)

--- a/plugins/mcreator-localization/help/fr_FR/item/description_localized.md
+++ b/plugins/mcreator-localization/help/fr_FR/item/description_localized.md
@@ -1,0 +1,5 @@
+Si vous mettez une clef de traduction dans le champ au dessus.
+
+Sera automatiquement ajouté à la l'onglet de traduction.
+
+Format conseillé: element.nom.description (exemple: block.four.description)

--- a/plugins/mcreator-localization/help/fr_FR/item/description_localized.md
+++ b/plugins/mcreator-localization/help/fr_FR/item/description_localized.md
@@ -1,5 +1,3 @@
-Si vous mettez une clef de traduction dans le champ au dessus.
+Si vous cochez la boite, le texte dans le champ au dessus sera localisé (et donc traduisible)
 
-Sera automatiquement ajouté à la l'onglet de traduction.
-
-Format conseillé: element.nom.description (exemple: block.four.description)
+Il sera automatiquement ajouté à la l'onglet de traduction.

--- a/plugins/mcreator-localization/lang/texts.properties
+++ b/plugins/mcreator-localization/lang/texts.properties
@@ -1135,6 +1135,7 @@ elementgui.block.particle_texture=<html>Block particle texture:<br><small>Option
 elementgui.block.block_textures=Block textures
 elementgui.block.special_information_title=Special information
 elementgui.block.special_information_tip=<html>Special information about the block:<br><small>Separate entries with comma, to use comma in description use \\,
+elementgui.block.description_localized=Localized description?
 elementgui.block.transparency_type=Transparency type:
 elementgui.block.has_trasparency=Check this if your block has transparent parts:
 elementgui.block.connected_sides=Check this to enable connected sides:

--- a/src/main/java/net/mcreator/element/types/Block.java
+++ b/src/main/java/net/mcreator/element/types/Block.java
@@ -63,6 +63,7 @@ import java.util.Map;
 
 	public String name;
 	public List<String> specialInfo;
+	public boolean descriptionLocalized;
 	public double hardness;
 	public double resistance;
 	public boolean hasGravity;

--- a/src/main/java/net/mcreator/ui/modgui/BlockGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/BlockGUI.java
@@ -307,6 +307,7 @@ public class BlockGUI extends ModElementGUI<Block> {
 			Mx.setEnabled(true);
 			My.setEnabled(true);
 			Mz.setEnabled(true);
+			descriptionLocalized.setEnabled(true);
 			rotationMode.setEnabled(true);
 			hasGravity.setEnabled(true);
 			hasTransparency.setEnabled(true);
@@ -355,6 +356,7 @@ public class BlockGUI extends ModElementGUI<Block> {
 				Mx.setEnabled(false);
 				My.setEnabled(false);
 				Mz.setEnabled(false);
+				descriptionLocalized.setEnabled(true);
 				hasGravity.setEnabled(false);
 				rotationMode.setEnabled(false);
 				isWaterloggable.setEnabled(false);
@@ -365,6 +367,7 @@ public class BlockGUI extends ModElementGUI<Block> {
 				Mx.setValue(1d);
 				My.setValue(1d);
 				Mz.setValue(1d);
+				descriptionLocalized.setSelected(false);
 				hasGravity.setSelected(false);
 				rotationMode.setSelectedIndex(0);
 				isWaterloggable.setSelected(false);
@@ -1331,6 +1334,8 @@ public class BlockGUI extends ModElementGUI<Block> {
 		specialInfo.setText(
 				block.specialInfo.stream().map(info -> info.replace(",", "\\,")).collect(Collectors.joining(",")));
 
+		descriptionLocalized.setSelected(block.descriptionLocalized);
+
 		refreshFiledsTileEntity();
 
 		tickRate.setEnabled(!tickRandomly.isSelected());
@@ -1460,6 +1465,8 @@ public class BlockGUI extends ModElementGUI<Block> {
 		block.slipperiness = (double) slipperiness.getValue();
 
 		block.specialInfo = StringUtils.splitCommaSeparatedStringListWithEscapes(specialInfo.getText());
+
+		block.descriptionLocalized = descriptionLocalized.isSelected();
 
 		if (blockBase.getSelectedIndex() != 0)
 			block.blockBase = (String) blockBase.getSelectedItem();

--- a/src/main/java/net/mcreator/ui/modgui/BlockGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/BlockGUI.java
@@ -122,6 +122,7 @@ public class BlockGUI extends ModElementGUI<Block> {
 
 	private final JColor beaconColorModifier = new JColor(mcreator, true);
 
+	private final JCheckBox descriptionLocalized = L10N.checkbox("elementgui.common.enable");
 	private final JCheckBox hasGravity = L10N.checkbox("elementgui.common.enable");
 	private final JCheckBox isWaterloggable = L10N.checkbox("elementgui.common.enable");
 	private final JCheckBox tickRandomly = L10N.checkbox("elementgui.common.enable");
@@ -494,9 +495,12 @@ public class BlockGUI extends ModElementGUI<Block> {
 
 		ComponentUtils.deriveFont(specialInfo, 16);
 
-		txblock3.add(HelpUtils.wrapWithHelpButton(this.withEntry("item/special_information"),
-				L10N.label("elementgui.block.special_information_tip")));
-		txblock3.add(specialInfo);
+		txblock3.add("Center", PanelUtils.gridElements(2, 1,
+				HelpUtils.wrapWithHelpButton(this.withEntry("item/special_information"),
+						L10N.label("elementgui.block.special_information_tip")), specialInfo,
+				HelpUtils.wrapWithHelpButton(this.withEntry("item/description_localized"),
+						L10N.label("elementgui.block.description_localized")), descriptionLocalized
+				));
 
 		sbbp2.add("Center", topnbot);
 
@@ -609,6 +613,7 @@ public class BlockGUI extends ModElementGUI<Block> {
 
 		render.setOpaque(false);
 
+		descriptionLocalized.setOpaque(false);
 		hasTransparency.setOpaque(false);
 		connectedSides.setOpaque(false);
 		emissiveRendering.setOpaque(false);


### PR DESCRIPTION
This PR adds an option to allow localized key to be used as block description so it can be translated. I'll do more PRs for Tools and Items.
Closes #69 

It adds a checkbox. If checked, it will make the content of the description localized, and therefore, translatable without custom coding.