### PR TITLE
[Bugfix] Set saturation block should no longer crash servers.

### DIFF
--- a/plugins/generator-1.14.4/forge-1.14.4/procedures/entity_set_saturation.java.ftl
+++ b/plugins/generator-1.14.4/forge-1.14.4/procedures/entity_set_saturation.java.ftl
@@ -1,3 +1,3 @@
-if ((${input$entity} instanceof PlayerEntity)) {
-    ((PlayerEntity)${input$entity}).getFoodStats().setFoodSaturationLevel((float)${input$amount});
+if (${input$entity} instanceof PlayerEntity) {
+    ObfuscationReflectionHelper.setPrivateValue(FoodStats.class, ((PlayerEntity) ${input$entity}).getFoodStats(), (float)${input$amount}, "field_75125_b");
 }

--- a/plugins/generator-1.15.2/forge-1.15.2/procedures/entity_set_saturation.java.ftl
+++ b/plugins/generator-1.15.2/forge-1.15.2/procedures/entity_set_saturation.java.ftl
@@ -1,3 +1,3 @@
-if ((${input$entity} instanceof PlayerEntity)) {
-    ((PlayerEntity)${input$entity}).getFoodStats().setFoodSaturationLevel((float)${input$amount});
+if (${input$entity} instanceof PlayerEntity) {
+    ObfuscationReflectionHelper.setPrivateValue(FoodStats.class, ((PlayerEntity) ${input$entity}).getFoodStats(), (float)${input$amount}, "field_75125_b");
 }


### PR DESCRIPTION
This PR is to fix a bug shown in #462 that makes the `Set saturation` procedure block crash servers. Now, saturation should be added both in client and server side.