### PR TITLE
[Bugfix] Field "Name in GUI" from Music Disc mod element is not opaque

### DIFF
--- a/src/main/java/net/mcreator/ui/modgui/MusicDiscGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/MusicDiscGUI.java
@@ -121,7 +121,7 @@ public class MusicDiscGUI extends ModElementGUI<MusicDisc> {
 		JPanel subpane2 = new JPanel(new GridLayout(6, 2, 45, 8));
 		subpane2.setOpaque(false);
 
-		name.setOpaque(false);
+		name.setOpaque(true);
 		ComponentUtils.deriveFont(name, 16);
 
 		subpane2.add(HelpUtils.wrapWithHelpButton(this.withEntry("musicdisc/sound"),

--- a/src/main/java/net/mcreator/ui/modgui/MusicDiscGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/MusicDiscGUI.java
@@ -121,7 +121,6 @@ public class MusicDiscGUI extends ModElementGUI<MusicDisc> {
 		JPanel subpane2 = new JPanel(new GridLayout(6, 2, 45, 8));
 		subpane2.setOpaque(false);
 
-		name.setOpaque(true);
 		ComponentUtils.deriveFont(name, 16);
 
 		subpane2.add(HelpUtils.wrapWithHelpButton(this.withEntry("musicdisc/sound"),


### PR DESCRIPTION
This PR fixes a bug from the Music Disc mod element, where the "Name in GUI" field isn't opaque.
Closes #474 