### PR TITLE
Renamed "missing" biome default features help tip

### DIFF
--- a/plugins/mcreator-localization/help/default/biome/default_feature.md
+++ b/plugins/mcreator-localization/help/default/biome/default_feature.md
@@ -1,1 +1,0 @@
-Default features are pre-configured features (Minecraft features) you can use in your biome.

--- a/plugins/mcreator-localization/help/default/biome/default_features.md
+++ b/plugins/mcreator-localization/help/default/biome/default_features.md
@@ -1,0 +1,1 @@
+Default features are pre-configured features (Minecraft features) you can use in your biome.


### PR DESCRIPTION
I just checked the overview of MCreator 2020.5 features (it is great! :+1:) and noticed biome default features help tip is not found, this PR fixes this bug.