### PR TITLE
Translate in-app tips in French (part 8)

### DIFF
--- a/plugins/mcreator-localization/help/default/armor/knockback_resistance.md
+++ b/plugins/mcreator-localization/help/default/armor/knockback_resistance.md
@@ -1,0 +1,1 @@
+This parameter controls the knockback resistance of the armor.

--- a/plugins/mcreator-localization/help/default/entity/step_sound.md
+++ b/plugins/mcreator-localization/help/default/entity/step_sound.md
@@ -1,1 +1,1 @@
-The sound played when tye entity walks.
+The sound played when the entity walks.

--- a/plugins/mcreator-localization/help/fr_FR/armor/knockback_resistance.md
+++ b/plugins/mcreator-localization/help/fr_FR/armor/knockback_resistance.md
@@ -1,0 +1,1 @@
+Ce paramètre contrôle la résistance au recul de l'armure.

--- a/plugins/mcreator-localization/help/fr_FR/entity/model.md
+++ b/plugins/mcreator-localization/help/fr_FR/entity/model.md
@@ -1,1 +1,1 @@
-This parameter defines the visual model (the visual shape) of the entity.
+Ce paramètre défini le modèle visuel (la forme visuelle) de l'entité.

--- a/plugins/mcreator-localization/help/fr_FR/entity/movement_speed.md
+++ b/plugins/mcreator-localization/help/fr_FR/entity/movement_speed.md
@@ -1,2 +1,3 @@
-Sets the movement speed of the mob.
-Most normal mobs move at the speed around 0.25, while faster ones such as spiders and wolves move at 0.3.
+Définit la vitesse de mouvement de l'entité.
+La plupart des entités normales bougent à une vitesse d'environ 0,25, tandis que les entités plus rapides
+comme les araignées et les loups bougent à 0,3.

--- a/plugins/mcreator-localization/help/fr_FR/entity/name.md
+++ b/plugins/mcreator-localization/help/fr_FR/entity/name.md
@@ -1,3 +1,2 @@
-Mob name is used in death messages,
-is shown in in-game menus and other
-places where visual name display is possible.
+Le nom de l'entité est utilisé dans les messages de mort, est montré dans les menus en jeu et
+les autres endroits où les noms visuels sont affichés si possible.

--- a/plugins/mcreator-localization/help/fr_FR/entity/on_initial_spawn.md
+++ b/plugins/mcreator-localization/help/fr_FR/entity/on_initial_spawn.md
@@ -1,3 +1,4 @@
-Triggers the procedure when the entity spawns.
+Déclenche la procédure quand l'entité apparait.
 
-Keep in mind some procedure blocks might not work properly in this trigger during early world generation.
+Gardez à l'esprit que quelques blocs de procédure peuvent ne pas fonctionner normalement
+dans ce déclencheur durant la génération du monde.

--- a/plugins/mcreator-localization/help/fr_FR/entity/on_tick_update.md
+++ b/plugins/mcreator-localization/help/fr_FR/entity/on_tick_update.md
@@ -1,1 +1,1 @@
-Triggers the procedure each tick the entity exists in the world.
+Déclenche la procédure à chaque tick tant que l'entité existe dans le monde.

--- a/plugins/mcreator-localization/help/fr_FR/entity/particle_condition.md
+++ b/plugins/mcreator-localization/help/fr_FR/entity/particle_condition.md
@@ -1,1 +1,1 @@
-When this conditional procedure is true, the entity will spawn particles based on the settings.
+Quand cette procédure conditionnelle est vraie, l'entité fera apparaitre des particules basées sur les paramètres.

--- a/plugins/mcreator-localization/help/fr_FR/entity/ridable.md
+++ b/plugins/mcreator-localization/help/fr_FR/entity/ridable.md
@@ -1,3 +1,3 @@
-These parameter enables the player to mount to this entity.
+Ces paramètres autorisent le joueur à monter sur l'entité.
 
-You can enable optional controlls too.
+Vous pouvez activer des contrôles optionels aussi.

--- a/plugins/mcreator-localization/help/fr_FR/entity/sound.md
+++ b/plugins/mcreator-localization/help/fr_FR/entity/sound.md
@@ -1,3 +1,3 @@
-The living sound is the ambient sound that the entity will play randomly. 
+Le son vivant est le son ambiant que l'entité jouera aléatoirement.
 
-Leave blank to deactivate its ambient sound.
+Laissez vide pour désactiver le son ambiant.

--- a/plugins/mcreator-localization/help/fr_FR/entity/spawn_egg_options.md
+++ b/plugins/mcreator-localization/help/fr_FR/entity/spawn_egg_options.md
@@ -1,4 +1,4 @@
-If this parameter is checked, the first color will be the background of the egg. 
-The second color will be the circles on the egg. 
+Si ce paramètre est coché, la première couleur sera l'arrière-plan de l'œuf. 
+La deuxième couleur sera les cercles de l'œuf. 
 
-You can choose the creative tab for the spawn egg too.
+Vous pouvez également choisir l'onglet créatif pour l'œuf.

--- a/plugins/mcreator-localization/help/fr_FR/entity/spawn_group_size.md
+++ b/plugins/mcreator-localization/help/fr_FR/entity/spawn_group_size.md
@@ -1,3 +1,3 @@
-The minimum and maximum set here set the size of groups that the mob will spawn in. 
+Le minimum et le maximum fixés ici déterminent la taille des groupes dans lesquels l'entité apparaitra.
 
-Be warned that mobs that try to spawn in groups of over 20 will struggle to do so (mobs will rarely spawn).
+Soyez avertis que les entités qui tentent d'apparaitre en groupes de plus de 20 auront du mal à le faire (les entités apparaitront très rarement).

--- a/plugins/mcreator-localization/help/fr_FR/entity/spawn_in_dungeons.md
+++ b/plugins/mcreator-localization/help/fr_FR/entity/spawn_in_dungeons.md
@@ -1,1 +1,2 @@
-If checked, dungeons (structures with mob spawner) might spawn with your entity in a mob spawner.
+Si coché, les dongeons (les structures avec un générateur d'entités) pourraient apparaitre avec
+votre entité dans un générateur d'entités.

--- a/plugins/mcreator-localization/help/fr_FR/entity/spawn_type.md
+++ b/plugins/mcreator-localization/help/fr_FR/entity/spawn_type.md
@@ -1,10 +1,10 @@
-This parameter controls spawning type for the biomes where his mob is defined to spawn in.
+Ce paramètre contrôle le type d'apparition pour les biomes dans lesquels l'entité est définie pour apparaitre.
 
-* A mob marked as Monster will only spawn in the dark or at night.
-* A mob marked as Creature will spawn under direct sunlight on grass material blocks only. Do not use this spawn type with
-mob type living entities as they will not spawn
-* A mob marked as Ambient will spawn under any conditions except if block type prevents it,
-but this category should be used for mobs with no gameplay effect such as bats
-* WaterCreature will spawn in water, but with no other limitations
+* Une entité marquée comme "Monster" n'apparait que dans l'obscurité ou la nuit.
+* Une entité marquée comme "Creature" n'apparait que sous la lumière directe du soleil, sur des blocs d'herbe seulement.
+N'utilisez pas ce type d'apparition avec les entités vivantes de type "Mob" car elles n'apparaitront pas.
+* Une entité marquée comme "Ambient" apparaitra dans toutes les conditions sauf si le type de bloc l'empêche,
+mais cette catégorie doit être utilisée pour les entités sans effet de jeu comme les chauves-souris
+* "WaterCreature" apparaitra dans l'eau, mais sans autres limitations
 
-Spawn type system is in-depth explained [here](https://mcreator.net/wiki/mob-spawning-parameters)
+Le système d'apparition est expliqué en détail [ici] (https://mcreator.net/wiki/mob-spawning-parameters)

--- a/plugins/mcreator-localization/help/fr_FR/entity/spawn_weight.md
+++ b/plugins/mcreator-localization/help/fr_FR/entity/spawn_weight.md
@@ -1,6 +1,6 @@
-This parameter controls the priority that the mob has over others when the game is choosing what mob to spawn. 
+Ce paramètre contrôle la priorité que l'entité a sur les autres lorsque le jeu choisis quelle entité faire apparaitre. 
 
-A higher weight means more mob spawns in the game will create this mob. 
-Make this lower for animals, compared to monsters.
+Un poids plus élevé signifie qu'un plus grand nombre d'entités apparaissant dans le jeu créeront votre entité. 
+Pour les animaux, le poids nécessaire est plus faible que pour les monstres.
 
-Spawning weight system is in-depth explained [here](https://mcreator.net/wiki/mob-spawning-parameters)
+Le système de poids d'apparition est expliqué en détail [ici] (https://mcreator.net/wiki/mob-spawning-parameters)

--- a/plugins/mcreator-localization/help/fr_FR/entity/step_sound.md
+++ b/plugins/mcreator-localization/help/fr_FR/entity/step_sound.md
@@ -1,1 +1,1 @@
-The sound played when tye entity walks.
+Le son joué quand l'entité marche.

--- a/plugins/mcreator-localization/help/fr_FR/entity/texture.md
+++ b/plugins/mcreator-localization/help/fr_FR/entity/texture.md
@@ -1,3 +1,3 @@
-Texture of your entity. Make sure the texture is compatible with the model you selected.
+La texture de votre entité. Assurez-vous que la texture est compatible avec le modèle selectionné.
 
-Biped models, for example, only support 64x32 biped type textures.
+Les modèles bipèdes, par exemple, ne supportent que des textures de type bipède 64x32.

--- a/plugins/mcreator-localization/help/fr_FR/entity/tracking_range.md
+++ b/plugins/mcreator-localization/help/fr_FR/entity/tracking_range.md
@@ -1,1 +1,1 @@
-This parameter controls how many blocks far the entity can be seen.
+Ce paramètre contrôle de combien de blocs l'entité peut être vue.

--- a/plugins/mcreator-localization/help/fr_FR/entity/water_entity.md
+++ b/plugins/mcreator-localization/help/fr_FR/entity/water_entity.md
@@ -1,3 +1,3 @@
-Checking this parameter makes the entity a water entity.
+Cocher de paramètre rend l'entité une entité marine.
 
-Enabling this parameter will make the entity have water type navigator and motion controller.
+Activer de paramètre fera en sorte que l'entité aie un type de navigateur et de controlleur marin.

--- a/plugins/mcreator-localization/help/fr_FR/entity/when_dies.md
+++ b/plugins/mcreator-localization/help/fr_FR/entity/when_dies.md
@@ -1,1 +1,1 @@
-This trigger triggers the procedure when the entity dies.
+Déclenche la procédure quand l'entité meurt.

--- a/plugins/mcreator-localization/help/fr_FR/entity/when_falls.md
+++ b/plugins/mcreator-localization/help/fr_FR/entity/when_falls.md
@@ -1,1 +1,1 @@
-This trigger triggers the procedure when the entity falls.
+Déclenche la procédure quand l'entité tombe.

--- a/plugins/mcreator-localization/help/fr_FR/entity/when_hurt.md
+++ b/plugins/mcreator-localization/help/fr_FR/entity/when_hurt.md
@@ -1,4 +1,4 @@
-This trigger triggers the procedure when the entity is hurt.
+Déclenche la procédure quand l'entité est blessée.
 
-`sourceentity` dependency in this case is the entity causing the damage to this entity and can be null
-if the damage is caused by a non-entity source.
+La dépendance `sourceentité` est l'entité causant des dégâts à cette entité et peut être nulle si les dégâts sont
+causés par une source qui n'est pas une entité.

--- a/plugins/mcreator-localization/help/fr_FR/entity/when_kills_another.md
+++ b/plugins/mcreator-localization/help/fr_FR/entity/when_kills_another.md
@@ -1,1 +1,1 @@
-This trigger triggers the procedure when this entity kills another entity.
+Déclenche la procédure quand l'entité tue une autre entité.

--- a/plugins/mcreator-localization/help/fr_FR/entity/when_player_collides.md
+++ b/plugins/mcreator-localization/help/fr_FR/entity/when_player_collides.md
@@ -1,1 +1,1 @@
-This trigger triggers the procedure when the player collides with this entity.
+Déclenche la procédure quand le joueur rentre en contact physique avec l'entité.

--- a/plugins/mcreator-localization/help/fr_FR/entity/when_right_clicked.md
+++ b/plugins/mcreator-localization/help/fr_FR/entity/when_right_clicked.md
@@ -1,1 +1,1 @@
-This trigger triggers the procedure when a player right-clicks on this entity.
+Déclenche la procédure quand le joueur fait un clic droit sur l'entité.

--- a/plugins/mcreator-localization/help/fr_FR/entity/when_struck_by_lightning.md
+++ b/plugins/mcreator-localization/help/fr_FR/entity/when_struck_by_lightning.md
@@ -1,1 +1,1 @@
-This trigger triggers the procedure when this entity is struck by a lightning.
+Déclenche la procédure quand l'entité est frappée par un éclair.

--- a/plugins/mcreator-localization/help/fr_FR/entity/xp_amount.md
+++ b/plugins/mcreator-localization/help/fr_FR/entity/xp_amount.md
@@ -1,3 +1,3 @@
-This parameter controls the amount of experience earned from killing the mob. 
+Ce paramètre contrôle le nombre d'expérience gagné quand on tue l'entité.
 
-This parameter is usually 1-3 for an animal and 5 for a monster.
+Ce paramètre varie entre 1 et 3 pour un animal et 5 pour un monstre.


### PR DESCRIPTION
This PR is here to translate in-app tips in French.
Changelog:
- [ARMORS] Added missing in-app tip
- [ARMOR] Fixed english typo
- [ENTITIES] Translated second half of in-app tips in French