### PR TITLE
Minor fixes to code error dialog and particle GUI

### DIFF
--- a/src/main/java/net/mcreator/ui/dialogs/CodeErrorDialog.java
+++ b/src/main/java/net/mcreator/ui/dialogs/CodeErrorDialog.java
@@ -120,7 +120,7 @@ public class CodeErrorDialog {
 			mcreator.mv.search.setText("f:err");
 		} else if (n == 1) {
 			mcreator.mcreatorTabs.showTab(mcreator.consoleTab);
-		} else if (n == 2) {
+		} else if (n == 3) {
 			DesktopUtils.browseSafe(MCreatorApplication.SERVER_DOMAIN + "/support");
 		}
 

--- a/src/main/java/net/mcreator/ui/modgui/ParticleGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/ParticleGUI.java
@@ -79,7 +79,8 @@ public class ParticleGUI extends ModElementGUI<Particle> {
 		additionalExpiryCondition = new ProcedureSelector(this.withEntry("particle/additional_expiry_condition"),
 				mcreator, L10N.t("elementgui.particle.expiry_condition"), ProcedureSelector.Side.CLIENT, true,
 				VariableElementType.LOGIC,
-				Dependency.fromString("x:number/y:number/z:number/world:world/age:number/onGround:boolean"));
+				Dependency.fromString("x:number/y:number/z:number/world:world/age:number/onGround:boolean"))
+				.setDefaultName("(no additional condition)");
 
 		JPanel pane3 = new JPanel(new BorderLayout());
 		pane3.setOpaque(false);


### PR DESCRIPTION
Changelog:
- Fixed the "Do nothing" and "Support" buttons being swapped in the code error dialog
- Changed the default text of particle expiry condition to "(no additional condition)"