### PR TITLE
Ported item event triggers to food element

### DIFF
--- a/plugins/generator-1.15.2/forge-1.15.2/templates/food.java.ftl
+++ b/plugins/generator-1.15.2/forge-1.15.2/templates/food.java.ftl
@@ -112,6 +112,22 @@ public class ${name}Item extends ${JavaModName}Elements.ModElement{
 		}
         </#if>
 
+		<#if hasProcedure(data.onRightClickedOnBlock)>
+		@Override public ActionResultType onItemUseFirst(ItemStack stack, ItemUseContext context) {
+			ActionResultType retval = super.onItemUseFirst(stack, context);
+			World world = context.getWorld();
+      		BlockPos pos = context.getPos();
+      		PlayerEntity entity = context.getPlayer();
+      		Direction direction = context.getFace();
+			int x = pos.getX();
+			int y = pos.getY();
+			int z = pos.getZ();
+			ItemStack itemstack = context.getItem();
+			<@procedureOBJToCode data.onRightClickedOnBlock/>
+			return retval;
+		}
+        </#if>
+
 		<#if hasProcedure(data.onEaten) || (data.resultItem?? && !data.resultItem.isEmpty())>
 		@Override public ItemStack onItemUseFinish(ItemStack itemstack, World world, LivingEntity entity) {
 			ItemStack retval =
@@ -144,6 +160,18 @@ public class ${name}Item extends ${JavaModName}Elements.ModElement{
 		}
         </#if>
 
+		<#if hasProcedure(data.onEntityHitWith)>
+		@Override public boolean hitEntity(ItemStack itemstack, LivingEntity entity, LivingEntity sourceentity) {
+			boolean retval = super.hitEntity(itemstack, entity, sourceentity);
+			double x = entity.getPosX();
+			double y = entity.getPosY();
+			double z = entity.getPosZ();
+			World world = entity.world;
+			<@procedureOBJToCode data.onEntityHitWith/>
+			return retval;
+		}
+        </#if>
+
 		<#if hasProcedure(data.onEntitySwing)>
 		@Override public boolean onEntitySwing(ItemStack itemstack, LivingEntity entity) {
 			boolean retval = super.onEntitySwing(itemstack, entity);
@@ -164,6 +192,31 @@ public class ${name}Item extends ${JavaModName}Elements.ModElement{
 			double z = entity.getPosZ();
 			<@procedureOBJToCode data.onCrafted/>
 		}
+        </#if>
+
+		<#if hasProcedure(data.onItemInUseTick) || hasProcedure(data.onItemInInventoryTick)>
+		@Override public void inventoryTick(ItemStack itemstack, World world, Entity entity, int slot, boolean selected) {
+			super.inventoryTick(itemstack, world, entity, slot, selected);
+			double x = entity.getPosX();
+			double y = entity.getPosY();
+			double z = entity.getPosZ();
+    		<#if hasProcedure(data.onItemInUseTick)>
+			if (selected)
+    	    <@procedureOBJToCode data.onItemInUseTick/>
+    		</#if>
+    		<@procedureOBJToCode data.onItemInInventoryTick/>
+		}
+		</#if>
+
+		<#if hasProcedure(data.onDroppedByPlayer)>
+        @Override public boolean onDroppedByPlayer(ItemStack itemstack, PlayerEntity entity) {
+            double x = entity.getPosX();
+            double y = entity.getPosY();
+            double z = entity.getPosZ();
+            World world = entity.world;
+            <@procedureOBJToCode data.onDroppedByPlayer/>
+            return true;
+        }
         </#if>
 	}
 

--- a/plugins/generator-1.16.4/forge-1.16.4/templates/food.java.ftl
+++ b/plugins/generator-1.16.4/forge-1.16.4/templates/food.java.ftl
@@ -112,6 +112,22 @@ public class ${name}Item extends ${JavaModName}Elements.ModElement{
 		}
         </#if>
 
+		<#if hasProcedure(data.onRightClickedOnBlock)>
+		@Override public ActionResultType onItemUseFirst(ItemStack stack, ItemUseContext context) {
+			ActionResultType retval = super.onItemUseFirst(stack, context);
+			World world = context.getWorld();
+      		BlockPos pos = context.getPos();
+      		PlayerEntity entity = context.getPlayer();
+      		Direction direction = context.getFace();
+			int x = pos.getX();
+			int y = pos.getY();
+			int z = pos.getZ();
+			ItemStack itemstack = context.getItem();
+			<@procedureOBJToCode data.onRightClickedOnBlock/>
+			return retval;
+		}
+        </#if>
+
 		<#if hasProcedure(data.onEaten) || (data.resultItem?? && !data.resultItem.isEmpty())>
 		@Override public ItemStack onItemUseFinish(ItemStack itemstack, World world, LivingEntity entity) {
 			ItemStack retval =
@@ -144,6 +160,18 @@ public class ${name}Item extends ${JavaModName}Elements.ModElement{
 		}
         </#if>
 
+		<#if hasProcedure(data.onEntityHitWith)>
+		@Override public boolean hitEntity(ItemStack itemstack, LivingEntity entity, LivingEntity sourceentity) {
+			boolean retval = super.hitEntity(itemstack, entity, sourceentity);
+			double x = entity.getPosX();
+			double y = entity.getPosY();
+			double z = entity.getPosZ();
+			World world = entity.world;
+			<@procedureOBJToCode data.onEntityHitWith/>
+			return retval;
+		}
+        </#if>
+
 		<#if hasProcedure(data.onEntitySwing)>
 		@Override public boolean onEntitySwing(ItemStack itemstack, LivingEntity entity) {
 			boolean retval = super.onEntitySwing(itemstack, entity);
@@ -164,6 +192,31 @@ public class ${name}Item extends ${JavaModName}Elements.ModElement{
 			double z = entity.getPosZ();
 			<@procedureOBJToCode data.onCrafted/>
 		}
+        </#if>
+
+		<#if hasProcedure(data.onItemInUseTick) || hasProcedure(data.onItemInInventoryTick)>
+		@Override public void inventoryTick(ItemStack itemstack, World world, Entity entity, int slot, boolean selected) {
+			super.inventoryTick(itemstack, world, entity, slot, selected);
+			double x = entity.getPosX();
+			double y = entity.getPosY();
+			double z = entity.getPosZ();
+    		<#if hasProcedure(data.onItemInUseTick)>
+			if (selected)
+    	    <@procedureOBJToCode data.onItemInUseTick/>
+    		</#if>
+    		<@procedureOBJToCode data.onItemInInventoryTick/>
+		}
+		</#if>
+
+		<#if hasProcedure(data.onDroppedByPlayer)>
+        @Override public boolean onDroppedByPlayer(ItemStack itemstack, PlayerEntity entity) {
+            double x = entity.getPosX();
+            double y = entity.getPosY();
+            double z = entity.getPosZ();
+            World world = entity.world;
+            <@procedureOBJToCode data.onDroppedByPlayer/>
+            return true;
+        }
         </#if>
 	}
 

--- a/src/main/java/net/mcreator/element/types/Food.java
+++ b/src/main/java/net/mcreator/element/types/Food.java
@@ -60,9 +60,14 @@ import java.util.Map;
 	public Procedure glowCondition;
 
 	public Procedure onRightClicked;
+	public Procedure onRightClickedOnBlock;
 	public Procedure onEaten;
+	public Procedure onEntityHitWith;
+	public Procedure onItemInInventoryTick;
+	public Procedure onItemInUseTick;
 	public Procedure onCrafted;
 	public Procedure onEntitySwing;
+	public Procedure onDroppedByPlayer;
 
 	private Food() {
 		this(null);

--- a/src/main/java/net/mcreator/ui/modgui/FoodGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/FoodGUI.java
@@ -77,9 +77,14 @@ public class FoodGUI extends ModElementGUI<Food> {
 	private final JCheckBox isAlwaysEdible = L10N.checkbox("elementgui.common.enable");
 
 	private ProcedureSelector onRightClicked;
+	private ProcedureSelector onRightClickedOnBlock;
 	private ProcedureSelector onEaten;
+	private ProcedureSelector onEntityHitWith;
+	private ProcedureSelector onItemInInventoryTick;
+	private ProcedureSelector onItemInUseTick;
 	private ProcedureSelector onCrafted;
 	private ProcedureSelector onEntitySwing;
+	private ProcedureSelector onDroppedByPlayer;
 
 	private final JCheckBox hasGlow = L10N.checkbox("elementgui.common.enable");
 	private ProcedureSelector glowCondition;
@@ -104,14 +109,29 @@ public class FoodGUI extends ModElementGUI<Food> {
 		onRightClicked = new ProcedureSelector(this.withEntry("item/when_right_clicked"), mcreator,
 				L10N.t("elementgui.common.event_right_clicked_air"),
 				Dependency.fromString("x:number/y:number/z:number/world:world/entity:entity/itemstack:itemstack"));
+		onRightClickedOnBlock = new ProcedureSelector(this.withEntry("item/when_right_clicked_block"), mcreator,
+				L10N.t("elementgui.common.event_right_clicked_block"), Dependency.fromString(
+				"x:number/y:number/z:number/world:world/entity:entity/itemstack:itemstack/direction:direction"));
 		onEaten = new ProcedureSelector(this.withEntry("food/when_eaten"), mcreator,
 				L10N.t("elementgui.food.event_on_eaten"),
 				Dependency.fromString("x:number/y:number/z:number/world:world/entity:entity"));
+		onEntityHitWith = new ProcedureSelector(this.withEntry("item/when_entity_hit"), mcreator,
+				L10N.t("elementgui.item.event_entity_hit"), Dependency.fromString(
+				"x:number/y:number/z:number/world:world/entity:entity/sourceentity:entity/itemstack:itemstack"));
+		onItemInInventoryTick = new ProcedureSelector(this.withEntry("item/inventory_tick"), mcreator,
+				L10N.t("elementgui.item.event_inventory_tick"), Dependency
+				.fromString("x:number/y:number/z:number/world:world/entity:entity/itemstack:itemstack/slot:number"));
+		onItemInUseTick = new ProcedureSelector(this.withEntry("item/hand_tick"), mcreator,
+				L10N.t("elementgui.item.event_hand_tick"), Dependency
+				.fromString("x:number/y:number/z:number/world:world/entity:entity/itemstack:itemstack/slot:number"));
 		onCrafted = new ProcedureSelector(this.withEntry("item/on_crafted"), mcreator,
 				L10N.t("elementgui.common.event_on_crafted"),
 				Dependency.fromString("x:number/y:number/z:number/world:world/entity:entity/itemstack:itemstack"));
 		onEntitySwing = new ProcedureSelector(this.withEntry("item/when_entity_swings"), mcreator,
 				L10N.t("elementgui.food.event_on_swing"),
+				Dependency.fromString("x:number/y:number/z:number/world:world/entity:entity/itemstack:itemstack"));
+		onDroppedByPlayer = new ProcedureSelector(this.withEntry("item/on_dropped"), mcreator,
+				L10N.t("elementgui.item.event_on_dropped"),
 				Dependency.fromString("x:number/y:number/z:number/world:world/entity:entity/itemstack:itemstack"));
 		glowCondition = new ProcedureSelector(this.withEntry("item/condition_glow"), mcreator,
 				L10N.t("elementgui.food.event_make_glow"), ProcedureSelector.Side.CLIENT, true,
@@ -227,13 +247,16 @@ public class FoodGUI extends ModElementGUI<Food> {
 		pane1.setOpaque(false);
 
 		JPanel events = new JPanel();
-		events.setLayout(new GridLayout(2, 3, 10, 10));
+		events.setLayout(new GridLayout(3, 3, 10, 10));
 		events.add(onRightClicked);
+		events.add(onRightClickedOnBlock);
 		events.add(onEaten);
+		events.add(onEntityHitWith);
+		events.add(onItemInInventoryTick);
+		events.add(onItemInUseTick);
 		events.add(onCrafted);
 		events.add(onEntitySwing);
-		events.add(new JEmptyBox());
-		events.add(new JEmptyBox());
+		events.add(onDroppedByPlayer);
 		events.setOpaque(false);
 
 		JPanel wrap = new JPanel();
@@ -267,9 +290,14 @@ public class FoodGUI extends ModElementGUI<Food> {
 	@Override public void reloadDataLists() {
 		super.reloadDataLists();
 		onRightClicked.refreshListKeepSelected();
+		onRightClickedOnBlock.refreshListKeepSelected();
 		onEaten.refreshListKeepSelected();
+		onEntityHitWith.refreshListKeepSelected();
+		onItemInInventoryTick.refreshListKeepSelected();
+		onItemInUseTick.refreshListKeepSelected();
 		onCrafted.refreshListKeepSelected();
 		onEntitySwing.refreshListKeepSelected();
+		onDroppedByPlayer.refreshListKeepSelected();
 		glowCondition.refreshListKeepSelected();
 
 		ComboBoxUtil.updateComboBoxContents(creativeTab, ElementUtil.loadAllTabs(mcreator.getWorkspace()),
@@ -296,9 +324,14 @@ public class FoodGUI extends ModElementGUI<Food> {
 		forDogs.setSelected(food.forDogs);
 		isAlwaysEdible.setSelected(food.isAlwaysEdible);
 		onRightClicked.setSelectedProcedure(food.onRightClicked);
+		onRightClickedOnBlock.setSelectedProcedure(food.onRightClickedOnBlock);
 		onEaten.setSelectedProcedure(food.onEaten);
+		onEntityHitWith.setSelectedProcedure(food.onEntityHitWith);
+		onItemInInventoryTick.setSelectedProcedure(food.onItemInInventoryTick);
+		onItemInUseTick.setSelectedProcedure(food.onItemInUseTick);
 		onCrafted.setSelectedProcedure(food.onCrafted);
 		onEntitySwing.setSelectedProcedure(food.onEntitySwing);
+		onDroppedByPlayer.setSelectedProcedure(food.onDroppedByPlayer);
 		stackSize.setValue(food.stackSize);
 		nutritionalValue.setValue(food.nutritionalValue);
 		saturation.setValue(food.saturation);
@@ -332,9 +365,14 @@ public class FoodGUI extends ModElementGUI<Food> {
 		food.isAlwaysEdible = isAlwaysEdible.isSelected();
 		food.animation = (String) animation.getSelectedItem();
 		food.onRightClicked = onRightClicked.getSelectedProcedure();
+		food.onRightClickedOnBlock = onRightClickedOnBlock.getSelectedProcedure();
 		food.onEaten = onEaten.getSelectedProcedure();
+		food.onEntityHitWith = onEntityHitWith.getSelectedProcedure();
+		food.onItemInInventoryTick = onItemInInventoryTick.getSelectedProcedure();
+		food.onItemInUseTick = onItemInUseTick.getSelectedProcedure();
 		food.onCrafted = onCrafted.getSelectedProcedure();
 		food.onEntitySwing = onEntitySwing.getSelectedProcedure();
+		food.onDroppedByPlayer = onDroppedByPlayer.getSelectedProcedure();
 		food.hasGlow = hasGlow.isSelected();
 		food.glowCondition = glowCondition.getSelectedProcedure();
 		food.specialInfo = StringUtils.splitCommaSeparatedStringListWithEscapes(specialInfo.getText());

--- a/src/test/java/net/mcreator/integration/TestWorkspaceDataProvider.java
+++ b/src/test/java/net/mcreator/integration/TestWorkspaceDataProvider.java
@@ -368,9 +368,14 @@ public class TestWorkspaceDataProvider {
 					new String[] { "block", "bow", "crossbow", "drink", "eat", "none", "spear" });
 			food.hasGlow = _true;
 			food.onRightClicked = new Procedure("procedure1");
-			food.onEaten = new Procedure("procedure2");
-			food.onCrafted = new Procedure("procedure3");
+			food.onRightClickedOnBlock = new Procedure("procedure2");
+			food.onEaten = new Procedure("procedure3");
+			food.onEntityHitWith = new Procedure("procedure4");
+			food.onItemInInventoryTick = new Procedure("procedure5");
+			food.onItemInUseTick = new Procedure("procedure6");
+			food.onCrafted = new Procedure("procedure7");
 			food.onEntitySwing = new Procedure("procedure8");
+			food.onDroppedByPlayer = new Procedure("procedure9");
 			food.renderType = 0;
 			food.customModelName = "Normal";
 			return food;


### PR DESCRIPTION
This PR ports these item event triggers to the food element:
- When right clicked on block
- When living entity is hit with item
- When item in inventory tick
- When item in hand tick
- When item is dropped by player

(The new code is the same as the code from the item element files)