### PR TITLE
Fixed explode procedure mode always defaulting to "BREAK"

### DIFF
--- a/plugins/mcreator-core/procedures/explode.json
+++ b/plugins/mcreator-core/procedures/explode.json
@@ -57,6 +57,9 @@
       "z",
       "power"
     ],
+    "fields": [
+      "mode"
+    ],
     "dependencies": [
       {
         "name": "world",


### PR DESCRIPTION
This PR fixes an issue with the "Explode at" procedure block, where the mode field is ignored