### PR TITLE
Fixed the link to GameRuleWiki page

### DIFF
--- a/src/main/java/net/mcreator/ui/modgui/GameRuleGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/GameRuleGUI.java
@@ -167,6 +167,6 @@ public class GameRuleGUI extends ModElementGUI<GameRule> {
 	}
 
 	@Override public @Nullable URI getContextURL() throws URISyntaxException {
-		return new URI(MCreatorApplication.SERVER_DOMAIN + "/wiki/how-make-gamerule");
+		return new URI(MCreatorApplication.SERVER_DOMAIN + "/wiki/how-make-game-rule");
 	}
 }


### PR DESCRIPTION
When max created the Game Rule mod element, he wrote a link for the in-app helps, but NWT creates the Wiki page with another link. This PR only fixes the link for the right wiki page.