### PR TITLE
Fix needed texture for custom portals when disable

### DIFF
--- a/src/main/java/net/mcreator/ui/modgui/DimensionGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/DimensionGUI.java
@@ -292,6 +292,9 @@ public class DimensionGUI extends ModElementGUI<Dimension> {
 		igniterName.enableRealtimeValidation();
 
 		page1group.addValidationElement(igniterName);
+		page1group.addValidationElement(portalTexture);
+		page1group.addValidationElement(texture);
+		page1group.addValidationElement(portalFrame);
 
 		biomesInDimension.setValidator(
 				new ItemListFieldValidator(biomesInDimension, L10N.t("elementgui.dimension.error_select_biome")));
@@ -323,13 +326,6 @@ public class DimensionGUI extends ModElementGUI<Dimension> {
 		portalTexture.setEnabled(enablePortal.isSelected());
 		portalMakeCondition.setEnabled(enablePortal.isSelected());
 		portalUseCondition.setEnabled(enablePortal.isSelected());
-
-		if (portalTexture.isEnabled())
-			page1group.addValidationElement(portalTexture);
-		if (texture.isEnabled())
-			page1group.addValidationElement(texture);
-		if (portalFrame.isEnabled())
-			page1group.addValidationElement(portalFrame);
 	}
 
 	@Override public void reloadDataLists() {

--- a/src/main/java/net/mcreator/ui/modgui/DimensionGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/DimensionGUI.java
@@ -292,9 +292,6 @@ public class DimensionGUI extends ModElementGUI<Dimension> {
 		igniterName.enableRealtimeValidation();
 
 		page1group.addValidationElement(igniterName);
-		page1group.addValidationElement(portalTexture);
-		page1group.addValidationElement(texture);
-		page1group.addValidationElement(portalFrame);
 
 		biomesInDimension.setValidator(
 				new ItemListFieldValidator(biomesInDimension, L10N.t("elementgui.dimension.error_select_biome")));
@@ -326,6 +323,13 @@ public class DimensionGUI extends ModElementGUI<Dimension> {
 		portalTexture.setEnabled(enablePortal.isSelected());
 		portalMakeCondition.setEnabled(enablePortal.isSelected());
 		portalUseCondition.setEnabled(enablePortal.isSelected());
+
+		if (portalTexture.isEnabled())
+			page1group.addValidationElement(portalTexture);
+		if (texture.isEnabled())
+			page1group.addValidationElement(texture);
+		if (portalFrame.isEnabled())
+			page1group.addValidationElement(portalFrame);
 	}
 
 	@Override public void reloadDataLists() {


### PR DESCRIPTION
I was testing the custom dimensions for the Fabric Generator (using files of the 1.16.x data pack generator) when I saved the mod element. However, even if the portal was disabled, MCreator still wanted textures for the igniter, the portal block and the portal frame-block. To fix this problem, I only add a condition checking if enablePortal is enabled before adding the parameter to the validation group.