### PR TITLE
Minor fixes to class finder for the code editor

### DIFF
--- a/src/main/java/net/mcreator/java/ClassFinder.java
+++ b/src/main/java/net/mcreator/java/ClassFinder.java
@@ -39,29 +39,31 @@ public class ClassFinder {
 
 	private static final Logger LOG = LogManager.getLogger("Class Finder");
 
-	public static DeclarationFinder.InClassPosition fqdnToInClassPosition(Workspace workspace, String classfqdn,
+	public static DeclarationFinder.InClassPosition fqdnToInClassPosition(Workspace workspace, String classIn,
 			String packagefqdn, JarManager jarManager) {
 		DeclarationFinder.InClassPosition position = new DeclarationFinder.InClassPosition();
+		String classFQDN;
 
 		// if there is no package, it is a class in the current package
-		if (!classfqdn.contains(".")) {
+		if (!classIn.contains(".")) {
 			if (new File(workspace.getGenerator().getSourceRoot(),
-					packagefqdn.replace(".", "/") + "/" + classfqdn + ".java").isFile()) {
+					packagefqdn.replace(".", "/") + "/" + classIn + ".java").isFile()) {
 				position.classFileNode = new File(workspace.getGenerator().getSourceRoot(),
-						packagefqdn.replace(".", "/") + "/" + classfqdn + ".java");
+						packagefqdn.replace(".", "/") + "/" + classIn + ".java");
 				position.openInReadOnly = false;
 				position.virtualFile = position.classFileNode;
 				return position;
 			}
 
-			// if there was no package, but the class was not found in SRCROOT, add package declatation to it
-			classfqdn = packagefqdn + "." + classfqdn;
-		}
+			// if there was no package, but the class was not found in SRCROOT, add package declaration to it
+			classFQDN = packagefqdn + "." + classIn;
+		} else
+			classFQDN = classIn;
 
-		// next we check if the class might be located in the src direcotry of the project under the given fqdn
-		if (new File(workspace.getGenerator().getSourceRoot(), classfqdn.replace(".", "/") + ".java").isFile()) {
+		// next we check if the class might be located in the src directory of the project under the given fqdn
+		if (new File(workspace.getGenerator().getSourceRoot(), classFQDN.replace(".", "/") + ".java").isFile()) {
 			position.classFileNode = new File(workspace.getGenerator().getSourceRoot(),
-					classfqdn.replace(".", "/") + ".java");
+					classFQDN.replace(".", "/") + ".java");
 			position.openInReadOnly = false;
 			position.virtualFile = position.classFileNode;
 			return position;
@@ -69,16 +71,16 @@ public class ClassFinder {
 
 		// next we try to find the declaration using JarManager to check
 		// if the class we are looking for is loaded with source
-		SourceLocation sourceLocation = jarManager.getSourceLocForClass(classfqdn);
-		DeclarationFinder.InClassPosition position1 = sourceLocationToInClassPosition(sourceLocation, classfqdn);
+		SourceLocation sourceLocation = jarManager.getSourceLocForClass(classFQDN);
+		DeclarationFinder.InClassPosition position1 = sourceLocationToInClassPosition(sourceLocation, classFQDN);
 		if (position1 != null)
 			return position1;
 
 		// next we try to find the declaration using JarManager to check
 		// if the class we are looking for is loaded with source
 		// this time in default java lang package
-		sourceLocation = jarManager.getSourceLocForClass("java.lang." + classfqdn);
-		position1 = sourceLocationToInClassPosition(sourceLocation, "java.lang." + classfqdn);
+		sourceLocation = jarManager.getSourceLocForClass("java.lang." + classIn);
+		position1 = sourceLocationToInClassPosition(sourceLocation, "java.lang." + classIn);
 
 		return position1; // position1 can be null if position was not found
 	}

--- a/src/main/java/net/mcreator/java/DeclarationFinder.java
+++ b/src/main/java/net/mcreator/java/DeclarationFinder.java
@@ -43,7 +43,7 @@ public class DeclarationFinder {
 		for (int i = 1; true; i++) {
 			try {
 				String curr = textArea.getText(caret - i, i);
-				if (isValidSeparatorContained(curr)) {
+				if (isValidSeparatorContained(curr, true)) {
 					startexp = caret - i + 1;
 					break;
 				}
@@ -56,7 +56,7 @@ public class DeclarationFinder {
 		for (int i = 1; true; i++) {
 			try {
 				String curr = textArea.getText(caret, i);
-				if (isValidSeparatorContained(curr)) {
+				if (isValidSeparatorContained(curr, false)) {
 					endexp = caret + i - 1;
 					break;
 				}
@@ -123,8 +123,8 @@ public class DeclarationFinder {
 		}
 	}
 
-	private static boolean isValidSeparatorContained(String code) {
-		Pattern r = Pattern.compile("[^a-zA-Z_$]");
+	private static boolean isValidSeparatorContained(String code, boolean behind) {
+		Pattern r = behind ? Pattern.compile("[^a-zA-Z0-9_$.]") : Pattern.compile("[^a-zA-Z0-9_$]");
 		Matcher m = r.matcher(code);
 		return m.find();
 	}

--- a/src/main/java/net/mcreator/java/DeclarationFinder.java
+++ b/src/main/java/net/mcreator/java/DeclarationFinder.java
@@ -31,6 +31,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class DeclarationFinder {
+	public static final Pattern SEPARATORS_BEHIND = Pattern.compile("[^a-zA-Z0-9_$.]");
+	public static final Pattern SEPARATORS_AHEAD = Pattern.compile("[^a-zA-Z0-9_$]");
 
 	public static DeclarationFinder.InClassPosition getDeclarationOnPos(Workspace workspace, JavaParser parser,
 			RSyntaxTextArea textArea, JarManager jarManager) {
@@ -124,7 +126,7 @@ public class DeclarationFinder {
 	}
 
 	private static boolean isValidSeparatorContained(String code, boolean behind) {
-		Pattern r = behind ? Pattern.compile("[^a-zA-Z0-9_$.]") : Pattern.compile("[^a-zA-Z0-9_$]");
+		Pattern r = behind ? SEPARATORS_BEHIND : SEPARATORS_AHEAD;
 		Matcher m = r.matcher(code);
 		return m.find();
 	}


### PR DESCRIPTION
This PR makes ctrl+clicking a class name work in these situations:
- The class name has digits in it (such as in `Vector3d`)
- The class isn't in the imports because the fqdn is used
- The class is in `java.lang`