### PR TITLE
Add FrozenTopLayer to default features

### DIFF
--- a/plugins/generator-1.15.2/forge-1.15.2/mappings/defaultfeatures.yaml
+++ b/plugins/generator-1.15.2/forge-1.15.2/mappings/defaultfeatures.yaml
@@ -7,6 +7,7 @@ DesertFeatures: DesertFeatures
 ExtraEmeraldOre: ExtraEmeraldOre
 ExtraGoldOre: ExtraGoldOre
 Fossils: Fossils
+FrozenTopLayer: FreezeTopLayer
 Icebergs: Icebergs
 InfestedStone: InfestedStone
 JungleGrass: JungleGrass

--- a/plugins/generator-1.16.5/forge-1.16.5/mappings/defaultfeatures.yaml
+++ b/plugins/generator-1.16.5/forge-1.16.5/mappings/defaultfeatures.yaml
@@ -7,6 +7,7 @@ DesertFeatures: DesertWells
 ExtraEmeraldOre: EmeraldOre
 ExtraGoldOre: ExtraGoldOre
 Fossils: Fossils
+FrozenTopLayer: FrozenTopLayer
 Icebergs: Icebergs
 InfestedStone: InfestedStone
 JungleGrass: JungleGrass

--- a/plugins/mcreator-core/datalists/defaultfeatures.yaml
+++ b/plugins/mcreator-core/datalists/defaultfeatures.yaml
@@ -6,6 +6,7 @@
 - ExtraEmeraldOre
 - ExtraGoldOre
 - Fossils
+- FrozenTopLayer
 - Icebergs
 - InfestedStone
 - JungleGrass

--- a/src/main/java/net/mcreator/element/GeneratableElement.java
+++ b/src/main/java/net/mcreator/element/GeneratableElement.java
@@ -42,7 +42,7 @@ public abstract class GeneratableElement {
 
 	private transient ModElement element;
 
-	public static final transient int formatVersion = 17;
+	public static final transient int formatVersion = 18;
 
 	public GeneratableElement(ModElement element) {
 		if (element != null)

--- a/src/main/java/net/mcreator/element/converter/ConverterRegistry.java
+++ b/src/main/java/net/mcreator/element/converter/ConverterRegistry.java
@@ -30,6 +30,7 @@ import net.mcreator.element.converter.fv14.PlantLuminanceFixer;
 import net.mcreator.element.converter.fv15.DimensionPortalSelectedFixer;
 import net.mcreator.element.converter.fv16.BlockBoundingBoxFixer;
 import net.mcreator.element.converter.fv17.GameruleDisplayNameFixer;
+import net.mcreator.element.converter.fv18.BiomeFrozenTopLayerConverter;
 import net.mcreator.element.converter.fv4.RecipeTypeConverter;
 import net.mcreator.element.converter.fv5.AchievementFixer;
 import net.mcreator.element.converter.fv6.GUIBindingInverter;
@@ -47,7 +48,8 @@ public class ConverterRegistry {
 		put(ModElementType.GUI, Arrays.asList(new GUIBindingInverter(), new GUICoordinateConverter()));
 		put(ModElementType.PROCEDURE, Arrays.asList(new ProcedureEntityDepFixer(), new OpenGUIProcedureDepFixer(),
 				new ProcedureGlobalTriggerFixer(), new ProcedureSpawnGemPickupDelayFixer()));
-		put(ModElementType.BIOME, Arrays.asList(new BiomeSpawnListConverter(), new BiomeDefaultFeaturesConverter()));
+		put(ModElementType.BIOME, Arrays.asList(new BiomeSpawnListConverter(), new BiomeDefaultFeaturesConverter(),
+				new BiomeFrozenTopLayerConverter()));
 		put(ModElementType.OVERLAY, Collections.singletonList(new OverlayCoordinateConverter()));
 		put(ModElementType.BLOCK, Arrays.asList(new BlockLuminanceFixer(), new BlockBoundingBoxFixer()));
 		put(ModElementType.PLANT, Collections.singletonList(new PlantLuminanceFixer()));

--- a/src/main/java/net/mcreator/element/converter/fv18/BiomeFrozenTopLayerConverter.java
+++ b/src/main/java/net/mcreator/element/converter/fv18/BiomeFrozenTopLayerConverter.java
@@ -34,12 +34,7 @@ public class BiomeFrozenTopLayerConverter implements IConverter {
 	@Override
 	public GeneratableElement convert(Workspace workspace, GeneratableElement input, JsonElement jsonElementInput) {
 		Biome biome = (Biome) input;
-		try {
-			biome.defaultFeatures.add("FrozenTopLayer");
-		} catch (Exception e) {
-			LOG.warn("Could not convert: " + biome.getModElement().getName());
-		}
-
+		biome.defaultFeatures.add("FrozenTopLayer");
 		return biome;
 	}
 

--- a/src/main/java/net/mcreator/element/converter/fv18/BiomeFrozenTopLayerConverter.java
+++ b/src/main/java/net/mcreator/element/converter/fv18/BiomeFrozenTopLayerConverter.java
@@ -1,0 +1,49 @@
+/*
+ * MCreator (https://mcreator.net/)
+ * Copyright (C) 2012-2020, Pylo
+ * Copyright (C) 2020-2021, Pylo, opensource contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package net.mcreator.element.converter.fv18;
+
+import com.google.gson.JsonElement;
+import net.mcreator.element.GeneratableElement;
+import net.mcreator.element.converter.IConverter;
+import net.mcreator.element.converter.fv12.BiomeDefaultFeaturesConverter;
+import net.mcreator.element.types.Biome;
+import net.mcreator.workspace.Workspace;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class BiomeFrozenTopLayerConverter implements IConverter {
+	private static final Logger LOG = LogManager.getLogger(BiomeFrozenTopLayerConverter.class);
+
+	@Override
+	public GeneratableElement convert(Workspace workspace, GeneratableElement input, JsonElement jsonElementInput) {
+		Biome biome = (Biome) input;
+		try {
+			biome.defaultFeatures.add("FrozenTopLayer");
+		} catch (Exception e) {
+			LOG.warn("Could not convert: " + biome.getModElement().getName());
+		}
+
+		return biome;
+	}
+
+	@Override public int getVersionConvertingTo() {
+		return 18;
+	}
+}

--- a/src/main/java/net/mcreator/ui/modgui/BiomeGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/BiomeGUI.java
@@ -557,7 +557,7 @@ public class BiomeGUI extends ModElementGUI<Biome> {
 			String readableNameFromModElement = StringUtils.machineToReadableName(modElement.getName());
 			name.setText(readableNameFromModElement);
 
-			defaultFeatures.setListElements(Arrays.asList("Caves", "Ores"));
+			defaultFeatures.setListElements(Arrays.asList("Caves", "Ores", "FrozenTopLayer"));
 		}
 	}
 


### PR DESCRIPTION
This PR adds the FrozenTopLayer default features to available default features. Fix #1051
I added a converter, so old biomes can also get this default feature without having to add it manually for each of them. I also added the FrozenTopLayer to default features added when we create a new biome as almost all Minecraft biomes have it.