### PR TITLE
[Bugfix] Integer gamerule crash the game

### DIFF
--- a/plugins/generator-1.16.5/forge-1.16.5/templates/gamerule.java.ftl
+++ b/plugins/generator-1.16.5/forge-1.16.5/templates/gamerule.java.ftl
@@ -48,7 +48,7 @@ public class ${name}GameRule extends ${JavaModName}Elements.ModElement {
 	<#if data.type == "Number">
 		public static GameRules.RuleType<GameRules.IntegerValue> create(int defaultValue) {
 			try {
-				Method createGameruleMethod = ObfuscationReflectionHelper.findMethod(GameRules.IntegerValue.class, "func_223564_a", int.class);
+				Method createGameruleMethod = ObfuscationReflectionHelper.findMethod(GameRules.IntegerValue.class, "func_223559_b", int.class);
 				createGameruleMethod.setAccessible(true);
 				return (GameRules.RuleType<GameRules.IntegerValue>) createGameruleMethod.invoke(null, defaultValue);
 			} catch (Exception e) {


### PR DESCRIPTION
This PR closes #1096 
It fixes the Integer Gamerule that crashes the game when on Minecraft normal client.