### PR TITLE
Set text inside a text field procedure block

### DIFF
--- a/plugins/generator-1.15.2/forge-1.15.2/procedures/gui_set_text_textfield.java.ftl
+++ b/plugins/generator-1.15.2/forge-1.15.2/procedures/gui_set_text_textfield.java.ftl
@@ -1,0 +1,6 @@
+{
+	TextFieldWidget textField = (TextFieldWidget) guistate.get("text:${field$textfield}");
+	if (textField != null) {
+		textField.setText(${input$text});
+	}
+}

--- a/plugins/generator-1.16.5/forge-1.16.5/procedures/gui_set_text_textfield.java.ftl
+++ b/plugins/generator-1.16.5/forge-1.16.5/procedures/gui_set_text_textfield.java.ftl
@@ -1,0 +1,6 @@
+{
+	TextFieldWidget textField = (TextFieldWidget) guistate.get("text:${field$textfield}");
+	if (textField != null) {
+		textField.setText(${input$text});
+	}
+}

--- a/plugins/mcreator-core/procedures/gui_set_text_textfield.json
+++ b/plugins/mcreator-core/procedures/gui_set_text_textfield.json
@@ -1,0 +1,42 @@
+{
+  "args0": [
+    {
+      "type": "field_input",
+      "name": "textfield",
+      "text": "textFieldName"
+    },
+    {
+      "type": "field_image",
+      "src": "./res/client.png",
+      "width": 8,
+      "height": 24
+    },
+    {
+      "type": "input_value",
+      "name": "text",
+      "check": "String"
+    }
+  ],
+  "inputsInline": true,
+  "previousStatement": null,
+  "nextStatement": null,
+  "colour": 110,
+  "mcreator": {
+    "toolbox_id": "guimanagement",
+    "toolbox_init": [
+      "<value name=\"text\"><block type=\"text\"><field name=\"TEXT\">Text</field></block></value>"
+    ],
+    "fields": [
+      "textfield"
+    ],
+    "inputs": [
+      "text"
+    ],
+    "dependencies": [
+      {
+        "name": "guistate",
+        "type": "map"
+      }
+    ]
+  }
+}

--- a/plugins/mcreator-localization/lang/texts.properties
+++ b/plugins/mcreator-localization/lang/texts.properties
@@ -821,6 +821,7 @@ blockly.block.gui_damage_item=Deal %1 damage to item in slot %2 of the currently
 blockly.block.gui_get_amount_inslot=Get number of items from slot %1 of the currently open GUI of %2
 blockly.block.gui_get_item_inslot=Get item from slot %1 of the currently open GUI of %2
 blockly.block.gui_get_text_textfield=Get text inside textfield %1 %2
+blockly.block.gui_set_text_textfield=Set text inside textfield %1 to %3 %2
 blockly.block.gui_remove_items=Remove %1 items from slot %2 of the currently open GUI of %3
 blockly.block.gui_set_items=Set %1 %3 in slot %2 of the currently open GUI of %4
 blockly.block.item_add_enhancement=Add enchantment with level %1 to %2 type


### PR DESCRIPTION
In procedures, it was possible to get the text of a text field, but we could not change it. This PR adds a new procedure block to set the text of a text field directly inside a procedure. 