### PR TITLE
Save grid settings for GUI and Overlay

### DIFF
--- a/src/main/java/net/mcreator/element/parts/GridSettings.java
+++ b/src/main/java/net/mcreator/element/parts/GridSettings.java
@@ -21,9 +21,9 @@ package net.mcreator.element.parts;
 
 public class GridSettings {
 
-	public static int sx = 18;
-	public static int sy = 18;
-	public static int ox = 11;
-	public static int oy = 15;
-	public static boolean snapOnGrid;
+	public int sx = 18;
+	public int sy = 18;
+	public int ox = 11;
+	public int oy = 15;
+	public boolean snapOnGrid;
 }

--- a/src/main/java/net/mcreator/element/parts/GridSettings.java
+++ b/src/main/java/net/mcreator/element/parts/GridSettings.java
@@ -1,0 +1,29 @@
+/*
+ * MCreator (https://mcreator.net/)
+ * Copyright (C) 2012-2020, Pylo
+ * Copyright (C) 2020-2021, Pylo, opensource contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package net.mcreator.element.parts;
+
+public class GridSettings {
+
+	public static int sx = 18;
+	public static int sy = 18;
+	public static int ox = 11;
+	public static int oy = 15;
+	public static boolean snapOnGrid;
+}

--- a/src/main/java/net/mcreator/element/types/GUI.java
+++ b/src/main/java/net/mcreator/element/types/GUI.java
@@ -50,12 +50,6 @@ import java.util.List;
 	public Procedure onTick;
 	public Procedure onClosed;
 
-	public int sx = 18;
-	public int sy = 18;
-	public int ox = 11;
-	public int oy = 15;
-	public boolean snapOnGrid;
-
 	public final transient int W;
 	public final transient int H;
 

--- a/src/main/java/net/mcreator/element/types/GUI.java
+++ b/src/main/java/net/mcreator/element/types/GUI.java
@@ -66,6 +66,7 @@ import java.util.List;
 		this.W = WYSIWYG.W;
 		this.H = WYSIWYG.H;
 		this.renderBgLayer = true;
+		this.gridSettings = new GridSettings();
 	}
 
 	public int getMaxSlotID() {

--- a/src/main/java/net/mcreator/element/types/GUI.java
+++ b/src/main/java/net/mcreator/element/types/GUI.java
@@ -50,6 +50,12 @@ import java.util.List;
 	public Procedure onTick;
 	public Procedure onClosed;
 
+	public int sx = 18;
+	public int sy = 18;
+	public int ox = 11;
+	public int oy = 15;
+	public boolean snapOnGrid;
+
 	public final transient int W;
 	public final transient int H;
 

--- a/src/main/java/net/mcreator/element/types/GUI.java
+++ b/src/main/java/net/mcreator/element/types/GUI.java
@@ -19,6 +19,7 @@
 package net.mcreator.element.types;
 
 import net.mcreator.element.GeneratableElement;
+import net.mcreator.element.parts.GridSettings;
 import net.mcreator.element.parts.Procedure;
 import net.mcreator.element.parts.gui.GUIComponent;
 import net.mcreator.element.parts.gui.Slot;
@@ -49,6 +50,8 @@ import java.util.List;
 	public Procedure onOpen;
 	public Procedure onTick;
 	public Procedure onClosed;
+
+	public GridSettings gridSettings;
 
 	public final transient int W;
 	public final transient int H;

--- a/src/main/java/net/mcreator/element/types/Overlay.java
+++ b/src/main/java/net/mcreator/element/types/Overlay.java
@@ -44,6 +44,12 @@ import java.util.List;
 
 	public GridSettings gridSettings;
 
+	private Overlay() {
+		this(null);
+
+		this.gridSettings = new GridSettings();
+	}
+
 	public Overlay(ModElement element) {
 		super(element);
 	}

--- a/src/main/java/net/mcreator/element/types/Overlay.java
+++ b/src/main/java/net/mcreator/element/types/Overlay.java
@@ -19,6 +19,7 @@
 package net.mcreator.element.types;
 
 import net.mcreator.element.GeneratableElement;
+import net.mcreator.element.parts.GridSettings;
 import net.mcreator.element.parts.Procedure;
 import net.mcreator.element.parts.gui.GUIComponent;
 import net.mcreator.workspace.elements.ModElement;
@@ -40,6 +41,8 @@ import java.util.List;
 	public String baseTexture;
 
 	public Procedure displayCondition;
+
+	public GridSettings gridSettings;
 
 	public Overlay(ModElement element) {
 		super(element);

--- a/src/main/java/net/mcreator/element/types/Overlay.java
+++ b/src/main/java/net/mcreator/element/types/Overlay.java
@@ -46,12 +46,12 @@ import java.util.List;
 
 	private Overlay() {
 		this(null);
-
-		this.gridSettings = new GridSettings();
 	}
 
 	public Overlay(ModElement element) {
 		super(element);
+
+		this.gridSettings = new GridSettings();
 	}
 
 	public int getBaseTextureWidth() {

--- a/src/main/java/net/mcreator/ui/modgui/CustomGUIGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/CustomGUIGUI.java
@@ -19,6 +19,7 @@
 package net.mcreator.ui.modgui;
 
 import net.mcreator.blockly.data.Dependency;
+import net.mcreator.element.parts.GridSettings;
 import net.mcreator.element.types.GUI;
 import net.mcreator.preferences.PreferencesManager;
 import net.mcreator.ui.MCreator;
@@ -106,12 +107,12 @@ public class CustomGUIGUI extends ModElementGUI<GUI> {
 			editor.slot2.setEnabled(true);
 		}
 
-		editor.sx.setValue(gui.sx);
-		editor.sy.setValue(gui.sy);
-		editor.ox.setValue(gui.ox);
-		editor.oy.setValue(gui.oy);
-		editor.snapOnGrid.setSelected(gui.snapOnGrid);
-		if (gui.snapOnGrid) {
+		editor.sx.setValue(GridSettings.sx);
+		editor.sy.setValue(GridSettings.sy);
+		editor.ox.setValue(GridSettings.ox);
+		editor.oy.setValue(GridSettings.oy);
+		editor.snapOnGrid.setSelected(GridSettings.snapOnGrid);
+		if (GridSettings.snapOnGrid) {
 			editor.editor.showGrid = true;
 			editor.editor.repaint();
 		}
@@ -133,11 +134,11 @@ public class CustomGUIGUI extends ModElementGUI<GUI> {
 		gui.onTick = onTick.getSelectedProcedure();
 		gui.onClosed = onClosed.getSelectedProcedure();
 
-		gui.sx = (int) editor.sx.getValue();
-		gui.sy = (int) editor.sy.getValue();
-		gui.ox = (int) editor.ox.getValue();
-		gui.oy = (int) editor.oy.getValue();
-		gui.snapOnGrid = editor.snapOnGrid.isSelected();
+		GridSettings.sx = (int) editor.sx.getValue();
+		GridSettings.sy = (int) editor.sy.getValue();
+		GridSettings.ox = (int) editor.ox.getValue();
+		GridSettings.oy = (int) editor.oy.getValue();
+		GridSettings.snapOnGrid = editor.snapOnGrid.isSelected();
 		return gui;
 	}
 

--- a/src/main/java/net/mcreator/ui/modgui/CustomGUIGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/CustomGUIGUI.java
@@ -106,6 +106,16 @@ public class CustomGUIGUI extends ModElementGUI<GUI> {
 			editor.slot2.setEnabled(true);
 		}
 
+		editor.sx.setValue(gui.sx);
+		editor.sy.setValue(gui.sy);
+		editor.ox.setValue(gui.ox);
+		editor.oy.setValue(gui.oy);
+		editor.snapOnGrid.setSelected(gui.snapOnGrid);
+		if (gui.snapOnGrid) {
+			editor.editor.showGrid = true;
+			editor.editor.repaint();
+		}
+
 		editor.setOpening(false);
 	}
 
@@ -122,6 +132,12 @@ public class CustomGUIGUI extends ModElementGUI<GUI> {
 		gui.onOpen = onOpen.getSelectedProcedure();
 		gui.onTick = onTick.getSelectedProcedure();
 		gui.onClosed = onClosed.getSelectedProcedure();
+
+		gui.sx = (int) editor.sx.getValue();
+		gui.sy = (int) editor.sy.getValue();
+		gui.ox = (int) editor.ox.getValue();
+		gui.oy = (int) editor.oy.getValue();
+		gui.snapOnGrid = editor.snapOnGrid.isSelected();
 		return gui;
 	}
 

--- a/src/main/java/net/mcreator/ui/modgui/CustomGUIGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/CustomGUIGUI.java
@@ -37,6 +37,7 @@ import java.awt.*;
 public class CustomGUIGUI extends ModElementGUI<GUI> {
 
 	private WYSIWYGEditor editor;
+	private GridSettings gridSettings;
 
 	private ProcedureSelector onOpen;
 	private ProcedureSelector onTick;
@@ -107,12 +108,12 @@ public class CustomGUIGUI extends ModElementGUI<GUI> {
 			editor.slot2.setEnabled(true);
 		}
 
-		editor.sx.setValue(GridSettings.sx);
-		editor.sy.setValue(GridSettings.sy);
-		editor.ox.setValue(GridSettings.ox);
-		editor.oy.setValue(GridSettings.oy);
-		editor.snapOnGrid.setSelected(GridSettings.snapOnGrid);
-		if (GridSettings.snapOnGrid) {
+		editor.sx.setValue(gridSettings.sx);
+		editor.sy.setValue(gridSettings.sy);
+		editor.ox.setValue(gridSettings.ox);
+		editor.oy.setValue(gridSettings.oy);
+		editor.snapOnGrid.setSelected(gridSettings.snapOnGrid);
+		if (gridSettings.snapOnGrid) {
 			editor.editor.showGrid = true;
 			editor.editor.repaint();
 		}
@@ -134,11 +135,11 @@ public class CustomGUIGUI extends ModElementGUI<GUI> {
 		gui.onTick = onTick.getSelectedProcedure();
 		gui.onClosed = onClosed.getSelectedProcedure();
 
-		GridSettings.sx = (int) editor.sx.getValue();
-		GridSettings.sy = (int) editor.sy.getValue();
-		GridSettings.ox = (int) editor.ox.getValue();
-		GridSettings.oy = (int) editor.oy.getValue();
-		GridSettings.snapOnGrid = editor.snapOnGrid.isSelected();
+		gridSettings.sx = (int) editor.sx.getValue();
+		gridSettings.sy = (int) editor.sy.getValue();
+		gridSettings.ox = (int) editor.ox.getValue();
+		gridSettings.oy = (int) editor.oy.getValue();
+		gridSettings.snapOnGrid = editor.snapOnGrid.isSelected();
 		return gui;
 	}
 

--- a/src/main/java/net/mcreator/ui/modgui/CustomGUIGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/CustomGUIGUI.java
@@ -19,7 +19,6 @@
 package net.mcreator.ui.modgui;
 
 import net.mcreator.blockly.data.Dependency;
-import net.mcreator.element.parts.GridSettings;
 import net.mcreator.element.types.GUI;
 import net.mcreator.preferences.PreferencesManager;
 import net.mcreator.ui.MCreator;
@@ -37,7 +36,6 @@ import java.awt.*;
 public class CustomGUIGUI extends ModElementGUI<GUI> {
 
 	private WYSIWYGEditor editor;
-	private GridSettings gridSettings;
 
 	private ProcedureSelector onOpen;
 	private ProcedureSelector onTick;
@@ -108,12 +106,12 @@ public class CustomGUIGUI extends ModElementGUI<GUI> {
 			editor.slot2.setEnabled(true);
 		}
 
-		editor.sx.setValue(gridSettings.sx);
-		editor.sy.setValue(gridSettings.sy);
-		editor.ox.setValue(gridSettings.ox);
-		editor.oy.setValue(gridSettings.oy);
-		editor.snapOnGrid.setSelected(gridSettings.snapOnGrid);
-		if (gridSettings.snapOnGrid) {
+		editor.sx.setValue(gui.gridSettings.sx);
+		editor.sy.setValue(gui.gridSettings.sy);
+		editor.ox.setValue(gui.gridSettings.ox);
+		editor.oy.setValue(gui.gridSettings.oy);
+		editor.snapOnGrid.setSelected(gui.gridSettings.snapOnGrid);
+		if (gui.gridSettings.snapOnGrid) {
 			editor.editor.showGrid = true;
 			editor.editor.repaint();
 		}
@@ -135,11 +133,11 @@ public class CustomGUIGUI extends ModElementGUI<GUI> {
 		gui.onTick = onTick.getSelectedProcedure();
 		gui.onClosed = onClosed.getSelectedProcedure();
 
-		gridSettings.sx = (int) editor.sx.getValue();
-		gridSettings.sy = (int) editor.sy.getValue();
-		gridSettings.ox = (int) editor.ox.getValue();
-		gridSettings.oy = (int) editor.oy.getValue();
-		gridSettings.snapOnGrid = editor.snapOnGrid.isSelected();
+		gui.gridSettings.sx = (int) editor.sx.getValue();
+		gui.gridSettings.sy = (int) editor.sy.getValue();
+		gui.gridSettings.ox = (int) editor.ox.getValue();
+		gui.gridSettings.oy = (int) editor.oy.getValue();
+		gui.gridSettings.snapOnGrid = editor.snapOnGrid.isSelected();
 		return gui;
 	}
 

--- a/src/main/java/net/mcreator/ui/modgui/OverlayGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/OverlayGUI.java
@@ -19,7 +19,6 @@
 package net.mcreator.ui.modgui;
 
 import net.mcreator.blockly.data.Dependency;
-import net.mcreator.element.parts.GridSettings;
 import net.mcreator.element.types.Overlay;
 import net.mcreator.ui.MCreator;
 import net.mcreator.ui.component.util.ComboBoxUtil;
@@ -42,7 +41,6 @@ import java.util.stream.Collectors;
 public class OverlayGUI extends ModElementGUI<Overlay> {
 
 	private WYSIWYGEditor editor;
-	private GridSettings gridSettings;
 
 	private ProcedureSelector displayCondition;
 
@@ -98,12 +96,12 @@ public class OverlayGUI extends ModElementGUI<Overlay> {
 		editor.overlayBaseTexture.setSelectedItem(overlay.baseTexture);
 		displayCondition.setSelectedProcedure(overlay.displayCondition);
 
-		editor.sx.setValue(gridSettings.sx);
-		editor.sy.setValue(gridSettings.sy);
-		editor.ox.setValue(gridSettings.ox);
-		editor.oy.setValue(gridSettings.oy);
-		editor.snapOnGrid.setSelected(gridSettings.snapOnGrid);
-		if (gridSettings.snapOnGrid) {
+		editor.sx.setValue(overlay.gridSettings.sx);
+		editor.sy.setValue(overlay.gridSettings.sy);
+		editor.ox.setValue(overlay.gridSettings.ox);
+		editor.oy.setValue(overlay.gridSettings.oy);
+		editor.snapOnGrid.setSelected(overlay.gridSettings.snapOnGrid);
+		if (overlay.gridSettings.snapOnGrid) {
 			editor.editor.showGrid = true;
 			editor.editor.repaint();
 		}
@@ -116,11 +114,11 @@ public class OverlayGUI extends ModElementGUI<Overlay> {
 		overlay.baseTexture = editor.overlayBaseTexture.getSelectedItem();
 		overlay.displayCondition = displayCondition.getSelectedProcedure();
 
-		gridSettings.sx = (int) editor.sx.getValue();
-		gridSettings.sy = (int) editor.sy.getValue();
-		gridSettings.ox = (int) editor.ox.getValue();
-		gridSettings.oy = (int) editor.oy.getValue();
-		gridSettings.snapOnGrid = editor.snapOnGrid.isSelected();
+		overlay.gridSettings.sx = (int) editor.sx.getValue();
+		overlay.gridSettings.sy = (int) editor.sy.getValue();
+		overlay.gridSettings.ox = (int) editor.ox.getValue();
+		overlay.gridSettings.oy = (int) editor.oy.getValue();
+		overlay.gridSettings.snapOnGrid = editor.snapOnGrid.isSelected();
 		return overlay;
 	}
 

--- a/src/main/java/net/mcreator/ui/modgui/OverlayGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/OverlayGUI.java
@@ -42,6 +42,7 @@ import java.util.stream.Collectors;
 public class OverlayGUI extends ModElementGUI<Overlay> {
 
 	private WYSIWYGEditor editor;
+	private GridSettings gridSettings;
 
 	private ProcedureSelector displayCondition;
 
@@ -97,12 +98,12 @@ public class OverlayGUI extends ModElementGUI<Overlay> {
 		editor.overlayBaseTexture.setSelectedItem(overlay.baseTexture);
 		displayCondition.setSelectedProcedure(overlay.displayCondition);
 
-		editor.sx.setValue(GridSettings.sx);
-		editor.sy.setValue(GridSettings.sy);
-		editor.ox.setValue(GridSettings.ox);
-		editor.oy.setValue(GridSettings.oy);
-		editor.snapOnGrid.setSelected(GridSettings.snapOnGrid);
-		if (GridSettings.snapOnGrid) {
+		editor.sx.setValue(gridSettings.sx);
+		editor.sy.setValue(gridSettings.sy);
+		editor.ox.setValue(gridSettings.ox);
+		editor.oy.setValue(gridSettings.oy);
+		editor.snapOnGrid.setSelected(gridSettings.snapOnGrid);
+		if (gridSettings.snapOnGrid) {
 			editor.editor.showGrid = true;
 			editor.editor.repaint();
 		}
@@ -115,11 +116,11 @@ public class OverlayGUI extends ModElementGUI<Overlay> {
 		overlay.baseTexture = editor.overlayBaseTexture.getSelectedItem();
 		overlay.displayCondition = displayCondition.getSelectedProcedure();
 
-		GridSettings.sx = (int) editor.sx.getValue();
-		GridSettings.sy = (int) editor.sy.getValue();
-		GridSettings.ox = (int) editor.ox.getValue();
-		GridSettings.oy = (int) editor.oy.getValue();
-		GridSettings.snapOnGrid = editor.snapOnGrid.isSelected();
+		gridSettings.sx = (int) editor.sx.getValue();
+		gridSettings.sy = (int) editor.sy.getValue();
+		gridSettings.ox = (int) editor.ox.getValue();
+		gridSettings.oy = (int) editor.oy.getValue();
+		gridSettings.snapOnGrid = editor.snapOnGrid.isSelected();
 		return overlay;
 	}
 

--- a/src/main/java/net/mcreator/ui/modgui/OverlayGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/OverlayGUI.java
@@ -19,6 +19,7 @@
 package net.mcreator.ui.modgui;
 
 import net.mcreator.blockly.data.Dependency;
+import net.mcreator.element.parts.GridSettings;
 import net.mcreator.element.types.Overlay;
 import net.mcreator.ui.MCreator;
 import net.mcreator.ui.component.util.ComboBoxUtil;
@@ -95,6 +96,16 @@ public class OverlayGUI extends ModElementGUI<Overlay> {
 		editor.setComponentList(overlay.components);
 		editor.overlayBaseTexture.setSelectedItem(overlay.baseTexture);
 		displayCondition.setSelectedProcedure(overlay.displayCondition);
+
+		editor.sx.setValue(GridSettings.sx);
+		editor.sy.setValue(GridSettings.sy);
+		editor.ox.setValue(GridSettings.ox);
+		editor.oy.setValue(GridSettings.oy);
+		editor.snapOnGrid.setSelected(GridSettings.snapOnGrid);
+		if (GridSettings.snapOnGrid) {
+			editor.editor.showGrid = true;
+			editor.editor.repaint();
+		}
 	}
 
 	@Override public Overlay getElementFromGUI() {
@@ -103,6 +114,12 @@ public class OverlayGUI extends ModElementGUI<Overlay> {
 		overlay.components = editor.getComponentList();
 		overlay.baseTexture = editor.overlayBaseTexture.getSelectedItem();
 		overlay.displayCondition = displayCondition.getSelectedProcedure();
+
+		GridSettings.sx = (int) editor.sx.getValue();
+		GridSettings.sy = (int) editor.sy.getValue();
+		GridSettings.ox = (int) editor.ox.getValue();
+		GridSettings.oy = (int) editor.oy.getValue();
+		GridSettings.snapOnGrid = editor.snapOnGrid.isSelected();
 		return overlay;
 	}
 

--- a/src/main/java/net/mcreator/ui/wysiwyg/WYSIWYG.java
+++ b/src/main/java/net/mcreator/ui/wysiwyg/WYSIWYG.java
@@ -58,7 +58,7 @@ public class WYSIWYG extends JComponent implements MouseMotionListener, MouseLis
 	private boolean componentMoveMode;
 	private boolean componentDragMode;
 
-	boolean showGrid = false;
+	public boolean showGrid = false;
 
 	@Nullable private GUIComponent selected;
 

--- a/src/main/java/net/mcreator/ui/wysiwyg/WYSIWYGEditor.java
+++ b/src/main/java/net/mcreator/ui/wysiwyg/WYSIWYGEditor.java
@@ -65,6 +65,13 @@ public class WYSIWYGEditor extends JPanel {
 	public JSpinner invOffX = new JSpinner(new SpinnerNumberModel(0, -256, 256, 1));
 	public JSpinner invOffY = new JSpinner(new SpinnerNumberModel(0, -256, 256, 1));
 
+	public JSpinner sx = new JSpinner(new SpinnerNumberModel(18, 1, 100, 1));
+	public JSpinner sy = new JSpinner(new SpinnerNumberModel(18, 1, 100, 1));
+	public JSpinner ox = new JSpinner(new SpinnerNumberModel(11, 1, 100, 1));
+	public JSpinner oy = new JSpinner(new SpinnerNumberModel(15, 1, 100, 1));
+
+	public JCheckBox snapOnGrid = new JCheckBox((L10N.t("elementgui.gui.snap_components_on_grid")));
+
 	public JButton button = new JButton(UIRES.get("32px.addbutton"));
 	public JButton text = new JButton(UIRES.get("32px.addtextinput"));
 	public JButton slot1 = new JButton(UIRES.get("32px.addinslot"));
@@ -251,17 +258,11 @@ public class WYSIWYGEditor extends JPanel {
 		slot1.addActionListener(e -> new InputSlotDialog(this, null));
 		slot2.addActionListener(e -> new OutputSlotDialog(this, null));
 
-		JCheckBox snapOnGrid = new JCheckBox((L10N.t("elementgui.gui.snap_components_on_grid")));
 		snapOnGrid.setOpaque(false);
 		snapOnGrid.addActionListener(event -> {
 			editor.showGrid = snapOnGrid.isSelected();
 			editor.repaint();
 		});
-
-		JSpinner sx = new JSpinner(new SpinnerNumberModel(18, 1, 100, 1));
-		JSpinner sy = new JSpinner(new SpinnerNumberModel(18, 1, 100, 1));
-		JSpinner ox = new JSpinner(new SpinnerNumberModel(11, 1, 100, 1));
-		JSpinner oy = new JSpinner(new SpinnerNumberModel(15, 1, 100, 1));
 
 		sx.addChangeListener(e -> {
 			editor.grid_x_spacing = (int) sx.getValue();

--- a/src/main/java/net/mcreator/ui/wysiwyg/WYSIWYGEditor.java
+++ b/src/main/java/net/mcreator/ui/wysiwyg/WYSIWYGEditor.java
@@ -70,7 +70,7 @@ public class WYSIWYGEditor extends JPanel {
 	public JSpinner ox = new JSpinner(new SpinnerNumberModel(11, 1, 100, 1));
 	public JSpinner oy = new JSpinner(new SpinnerNumberModel(15, 1, 100, 1));
 
-	public JCheckBox snapOnGrid = new JCheckBox((L10N.t("elementgui.gui.snap_components_on_grid")));
+	public JCheckBox snapOnGrid = L10N.checkbox("elementgui.gui.snap_components_on_grid");
 
 	public JButton button = new JButton(UIRES.get("32px.addbutton"));
 	public JButton text = new JButton(UIRES.get("32px.addtextinput"));


### PR DESCRIPTION
This PR adds an auto save for the grid settings. When a GUI mod element is saved, grid settings are saved in the same JSOn file than the mod element, so when we re-open this GUI, grid settings are changed for the saved settings.