### PR TITLE
Fix blockly editor charset

### DIFF
--- a/src/main/java/net/mcreator/ui/blockly/BlocklyPanel.java
+++ b/src/main/java/net/mcreator/ui/blockly/BlocklyPanel.java
@@ -43,6 +43,7 @@ import org.w3c.dom.Text;
 import javax.annotation.Nullable;
 import javax.swing.*;
 import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -126,7 +127,7 @@ public class BlocklyPanel extends JFXPanel {
 
 					webEngine.executeScript(FileIO.readResourceToString("/jsdist/blockly_compressed.js"));
 					webEngine.executeScript(FileIO.readResourceToString("/jsdist/msg/messages.js"));
-					webEngine.executeScript(FileIO.readResourceToString("/jsdist/msg/" + L10N.getLangString() + ".js"));
+					webEngine.executeScript(FileIO.readResourceToString("/jsdist/msg/" + L10N.getLangString() + ".js", StandardCharsets.UTF_8));
 					webEngine.executeScript(FileIO.readResourceToString("/jsdist/blocks_compressed.js"));
 
 					webEngine.executeScript(FileIO.readResourceToString("/blockly/js/block_mcitem.js"));


### PR DESCRIPTION
A few blocks of Blockly editor have character corruption.
I tested in Japanese, but I think it happens in other languages does not using ASCII strings.
This fixes it.
Before
![image](https://user-images.githubusercontent.com/39370373/119109928-971dc400-ba5c-11eb-8597-d8c66477a660.png)
After
![image](https://user-images.githubusercontent.com/39370373/119110449-21febe80-ba5d-11eb-8e18-43afb57a0fdf.png)
