### PR TITLE
Fix language coverage calculation

### DIFF
--- a/src/main/java/net/mcreator/ui/init/L10N.java
+++ b/src/main/java/net/mcreator/ui/init/L10N.java
@@ -71,7 +71,7 @@ public class L10N {
 
 		rb_en = ResourceBundle.getBundle("lang/texts", Locale.ROOT, PluginLoader.INSTANCE, new UTF8Control());
 
-		double countAll = Collections.list(rb_en.getKeys()).size();
+		double countAll = rb_en.keySet().size();
 
 		Set<String> localeFiles = PluginLoader.INSTANCE.getResourcesInPackage("lang");
 		supportedLocales = localeFiles.stream().map(FilenameUtils::getBaseName).filter(e -> e.contains("_"))


### PR DESCRIPTION
I don't know why, but Collections.list(rb_en.getKeys()) contains duplicated items about 700.
So language coverages can't reach 100% and are incorrect.