### PR TITLE
Field exclusions for definition files

### DIFF
--- a/src/main/java/net/mcreator/generator/GeneratorConfiguration.java
+++ b/src/main/java/net/mcreator/generator/GeneratorConfiguration.java
@@ -226,6 +226,21 @@ public class GeneratorConfiguration implements Comparable<GeneratorConfiguration
 		return null;
 	}
 
+	@Nullable public List<String> getUnsupportedDefinitionFields(ModElementType type) {
+		Map<?, ?> map = definitionsProvider.getModElementDefinition(type);
+
+		if (map == null) {
+			LOG.info("Failed to load element definition for mod element type " + type.name());
+			return null;
+		}
+
+		List<?> exclusions = (List<?>) map.get("field_exclusions");
+		if (exclusions != null)
+			return exclusions.stream().map(Object::toString).map(String::trim).collect(Collectors.toList());
+
+		return null;
+	}
+
 	@Override public int compareTo(@Nonnull GeneratorConfiguration o) {
 		if (o.getGeneratorStats().getStatus() == generatorStats.getStatus()) { // same status, sort by version
 			return o.getGeneratorMinecraftVersion().compareTo(getGeneratorMinecraftVersion());

--- a/src/main/java/net/mcreator/ui/component/UnsupportedComponent.java
+++ b/src/main/java/net/mcreator/ui/component/UnsupportedComponent.java
@@ -1,0 +1,57 @@
+/*
+ * MCreator (https://mcreator.net/)
+ * Copyright (C) 2012-2020, Pylo
+ * Copyright (C) 2020-2021, Pylo, opensource contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package net.mcreator.ui.component;
+
+import net.mcreator.ui.init.UIRES;
+
+import javax.swing.*;
+import java.awt.*;
+
+public class UnsupportedComponent extends JPanel {
+
+	private final Image warning = UIRES.get("18px.warning").getImage();
+
+	public UnsupportedComponent(Component origin) {
+		setLayout(new GridLayout());
+		add(origin);
+		setOpaque(false);
+
+		origin.setEnabled(false);
+	}
+
+	@Override public void paint(Graphics g) {
+		super.paint(g);
+
+		g.setColor(new Color(0.3f, 0.3f, 0, 0.4f));
+		g.fillRect(0, 0, getWidth(), getHeight());
+
+		int x = (this.getWidth() - warning.getWidth(null)) / 2;
+		int y = (this.getHeight() - warning.getHeight(null)) / 2;
+
+		if (getWidth() > 100) {
+			g.setFont(g.getFont().deriveFont(12f));
+			g.drawImage(warning, x - g.getFontMetrics().stringWidth("Not supported") / 2, y, null);
+			g.setColor((Color) UIManager.get("MCreatorLAF.BRIGHT_COLOR"));
+			g.drawString("Not supported", x - g.getFontMetrics().stringWidth("Not supported") / 2 + 18 + 4, y + 13);
+		} else {
+			g.drawImage(warning, x, y, null);
+		}
+	}
+}

--- a/src/main/java/net/mcreator/ui/modgui/ModElementGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/ModElementGUI.java
@@ -350,14 +350,19 @@ public abstract class ModElementGUI<GE extends GeneratableElement> extends ViewB
 			Field[] fields = getClass().getDeclaredFields();
 			for (Field field : fields) {
 				if (Component.class.isAssignableFrom(field.getType())) {
-					if (exclusions.contains(field.getName())) {
-						try {
-							field.setAccessible(true);
-							Component obj = (Component) field.get(this);
-							obj.setEnabled(false);
-						} catch (IllegalAccessException e) {
-							LOG.warn("Failed to access field", e);
+					if (!exclusions.contains(field.getName()) && inclusions != null && !inclusions.contains(field.getName())) {
+						if (exclusions.contains(field.getName())) {
+							try {
+								field.setAccessible(true);
+								Component obj = (Component) field.get(this);
+								obj.setEnabled(false);
+							} catch (IllegalAccessException e) {
+								LOG.warn("Failed to access field", e);
+							}
 						}
+					} else {
+						LOG.warn(field.getName()
+								+ " can not be used in both inclusions and exclusions fields at the same time. The field will be enabled.");
 					}
 				}
 			}

--- a/src/main/java/net/mcreator/ui/modgui/ModElementGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/ModElementGUI.java
@@ -342,6 +342,26 @@ public abstract class ModElementGUI<GE extends GeneratableElement> extends ViewB
 				}
 			}
 		}
+
+		List<String> exclusions = mcreator.getGeneratorConfiguration()
+				.getUnsupportedDefinitionFields(modElement.getType());
+
+		if (exclusions != null) {
+			Field[] fields = getClass().getDeclaredFields();
+			for (Field field : fields) {
+				if (Component.class.isAssignableFrom(field.getType())) {
+					if (exclusions.contains(field.getName())) {
+						try {
+							field.setAccessible(true);
+							Component obj = (Component) field.get(this);
+							obj.setEnabled(false);
+						} catch (IllegalAccessException e) {
+							LOG.warn("Failed to access field", e);
+						}
+					}
+				}
+			}
+		}
 	}
 
 	private void showErrorsMessage(AggregatedValidationResult validationResult) {

--- a/src/main/java/net/mcreator/ui/modgui/ModElementGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/ModElementGUI.java
@@ -25,6 +25,7 @@ import net.mcreator.ui.MCreator;
 import net.mcreator.ui.MCreatorTabs;
 import net.mcreator.ui.component.JEmptyBox;
 import net.mcreator.ui.component.JModElementProgressPanel;
+import net.mcreator.ui.component.UnsupportedComponent;
 import net.mcreator.ui.component.util.ComponentUtils;
 import net.mcreator.ui.component.util.PanelUtils;
 import net.mcreator.ui.help.IHelpContext;
@@ -326,6 +327,14 @@ public abstract class ModElementGUI<GE extends GeneratableElement> extends ViewB
 		List<String> inclusions = mcreator.getGeneratorConfiguration()
 				.getSupportedDefinitionFields(modElement.getType());
 
+		List<String> exclusions = mcreator.getGeneratorConfiguration()
+				.getUnsupportedDefinitionFields(modElement.getType());
+
+		if (inclusions != null && exclusions != null) {
+			LOG.warn("Field inclusions and exclusions can not be used at the same time. Skipping them.");
+			return;
+		}
+
 		if (inclusions != null) {
 			Field[] fields = getClass().getDeclaredFields();
 			for (Field field : fields) {
@@ -334,7 +343,11 @@ public abstract class ModElementGUI<GE extends GeneratableElement> extends ViewB
 						try {
 							field.setAccessible(true);
 							Component obj = (Component) field.get(this);
-							obj.setEnabled(false);
+
+							Container parent = obj.getParent();
+							int index = Arrays.asList(parent.getComponents()).indexOf(obj);
+							parent.remove(index);
+							parent.add(new UnsupportedComponent(obj), index);
 						} catch (IllegalAccessException e) {
 							LOG.warn("Failed to access field", e);
 						}
@@ -343,19 +356,20 @@ public abstract class ModElementGUI<GE extends GeneratableElement> extends ViewB
 			}
 		}
 
-		List<String> exclusions = mcreator.getGeneratorConfiguration()
-				.getUnsupportedDefinitionFields(modElement.getType());
-
 		if (exclusions != null) {
 			Field[] fields = getClass().getDeclaredFields();
 			for (Field field : fields) {
 				if (Component.class.isAssignableFrom(field.getType())) {
-					if (!exclusions.contains(field.getName()) && inclusions != null && !inclusions.contains(field.getName())) {
+					if (!exclusions.contains(field.getName())) {
 						if (exclusions.contains(field.getName())) {
 							try {
 								field.setAccessible(true);
 								Component obj = (Component) field.get(this);
-								obj.setEnabled(false);
+
+								Container parent = obj.getParent();
+								int index = Arrays.asList(parent.getComponents()).indexOf(obj);
+								parent.remove(index);
+								parent.add(new UnsupportedComponent(obj), index);
 							} catch (IllegalAccessException e) {
 								LOG.warn("Failed to access field", e);
 							}


### PR DESCRIPTION
This adds a `field_exclusions` list to definition files for mod elements. It works the same way as `field_inclusions`, but instead, to disable fields not included in the list, it will disable fields included in this list. It can seem useless and nobody will use it, but I need to disable only a few fields inside the Fabric generator (because they are not implemented yet). However, with the current list, I need to list between 75% and 99% of fields to simply disable a few ones. It is much easier to disable specific fields than to enable all other fields. 

I added this to save me some hours of searching and writing hundreds of fields.

In the case, someone adds a field in both lists, the field will always be disabled, so we are sure we don't have a problem.