### PR TITLE
Added shortcuts for the "Get/Set var" and dependency procedure blocks

### DIFF
--- a/src/main/java/net/mcreator/blockly/data/Dependency.java
+++ b/src/main/java/net/mcreator/blockly/data/Dependency.java
@@ -85,6 +85,48 @@ public class Dependency implements Comparable<Dependency> {
 		return getColor(type);
 	}
 
+	public String getDependencyBlockXml() {
+		StringBuilder blockXml = new StringBuilder("<xml xmlns=\"http://www.w3.org/1999/xhtml\">");
+		switch (name) {
+		case "x":
+			blockXml.append("<block type=\"coord_x\"></block>");
+			break;
+		case "y":
+			blockXml.append("<block type=\"coord_y\"></block>");
+			break;
+		case "z":
+			blockXml.append("<block type=\"coord_z\"></block>");
+			break;
+		case "entity":
+			blockXml.append("<block type=\"entity_from_deps\"></block>");
+			break;
+		case "sourceentity":
+			blockXml.append("<block type=\"source_entity_from_deps\"></block>");
+			break;
+		case "immediatesourceentity":
+			blockXml.append("<block type=\"immediate_source_entity_from_deps\"></block>");
+			break;
+		case "direction":
+			blockXml.append("<block type=\"direction_from_deps\"></block>");
+			break;
+		case "itemstack":
+			blockXml.append("<block type=\"itemstack_to_mcitem\"></block>");
+			break;
+		default:
+			if (VariableElementTypeLoader.INSTANCE.getVariableTypeFromString(type) != null) {
+				blockXml.append("<block type=\"custom_dependency_");
+				blockXml.append(type);
+				blockXml.append("\"><field name=\"NAME\">");
+				blockXml.append(name);
+				blockXml.append("</field></block>");
+			}
+			else
+				return null;
+		}
+		blockXml.append("</xml>");
+		return blockXml.toString();
+	}
+
 	public static Color getColor(String type) {
 		// Check if the type is a loaded variable and then, get its HUE color
 		if (VariableElementTypeLoader.INSTANCE.getVariableTypeFromString(type) != null) {

--- a/src/main/java/net/mcreator/ui/modgui/ProcedureGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/ProcedureGUI.java
@@ -411,7 +411,7 @@ public class ProcedureGUI extends ModElementGUI<net.mcreator.element.types.Proce
 					VariableElement selectedVar = localVarsList.getSelectedValue();
 					VariableElementType type = selectedVar.getType();
 					String blockXml = "<xml xmlns=\"http://www.w3.org/1999/xhtml\"><block type=\"variables_"
-							+ (!e.isAltDown() ? "get_" : "set_") + type.getName() + "\"><field name=\"VAR\">local:"
+							+ (e.isAltDown() ? "set_" : "get_") + type.getName() + "\"><field name=\"VAR\">local:"
 							+ selectedVar.getName() + "</field></block></xml>";
 					blocklyPanel.addBlocksFromXML(blockXml);
 				}

--- a/src/main/java/net/mcreator/ui/modgui/ProcedureGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/ProcedureGUI.java
@@ -54,6 +54,8 @@ import net.mcreator.workspace.elements.VariableElementTypeLoader;
 
 import javax.swing.*;
 import java.awt.*;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
 import java.util.List;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -399,6 +401,41 @@ public class ProcedureGUI extends ModElementGUI<net.mcreator.element.types.Proce
 				if (n == JOptionPane.YES_OPTION) {
 					blocklyPanel.removeLocalVariable(element.getName());
 					localVars.removeElement(element);
+				}
+			}
+		});
+
+		localVarsList.addMouseListener(new MouseAdapter() {
+			@Override public void mouseClicked(MouseEvent e) {
+				if (localVars.getSize() > 0 && e.getClickCount() == 2) {
+					VariableElement selectedVar = localVarsList.getSelectedValue();
+					VariableElementType type = selectedVar.getType();
+					String blockXml = "<xml xmlns=\"http://www.w3.org/1999/xhtml\"><block type=\"variables_"
+							+ (!e.isAltDown() ? "get_" : "set_") + type.getName() + "\"><field name=\"VAR\">local:"
+							+ selectedVar.getName() + "</field></block></xml>";
+					blocklyPanel.addBlocksFromXML(blockXml);
+				}
+			}
+		});
+
+		dependenciesList.addMouseListener(new MouseAdapter() {
+			@Override public void mouseClicked(MouseEvent e) {
+				if (dependencies.getSize() > 0 && e.getClickCount() == 2) {
+					Dependency selectedDep = dependenciesList.getSelectedValue();
+					String blockXml = selectedDep.getDependencyBlockXml();
+					if (blockXml != null)
+						blocklyPanel.addBlocksFromXML(blockXml);
+				}
+			}
+		});
+
+		dependenciesExtTrigList.addMouseListener(new MouseAdapter() {
+			@Override public void mouseClicked(MouseEvent e) {
+				if (dependenciesExtTrigger.getSize() > 0 && e.getClickCount() == 2) {
+					Dependency selectedDep = dependenciesExtTrigList.getSelectedValue();
+					String blockXml = selectedDep.getDependencyBlockXml();
+					if (blockXml != null)
+						blocklyPanel.addBlocksFromXML(blockXml);
 				}
 			}
 		});


### PR DESCRIPTION
This PR adds shortcuts for the "Get/Set variable" and dependency procedure blocks:
- Double-click on a local variable in the variable list adds a "Get variable" procedure block. Alt+Double-click adds a "Set variable" block
- Double-click on a dependency in one of the deps list will try to add one of the default dependency blocks (x, source entity etc.), or the custom dependency block