### PR TITLE
"Set action result" procedure block and result values map for procedures

### DIFF
--- a/plugins/generator-1.15.2/forge-1.15.2/procedures/_set_action_result.java.ftl
+++ b/plugins/generator-1.15.2/forge-1.15.2/procedures/_set_action_result.java.ftl
@@ -1,0 +1,1 @@
+resultValues.put("actionResult", ActionResultType.${field$resulttype});

--- a/plugins/generator-1.15.2/forge-1.15.2/templates/block.java.ftl
+++ b/plugins/generator-1.15.2/forge-1.15.2/templates/block.java.ftl
@@ -642,7 +642,7 @@ public class ${name}Block extends ${JavaModName}Elements.ModElement {
 		}
         </#if>
 
-        <#if hasProcedure(data.onRightClicked) || data.openGUIOnRightClick>
+        <#if hasProcedure(data.onRightClicked) || data.shouldOpenGUIOnRightClick()>
 		@Override
 		public ActionResultType onBlockActivated(BlockState state, World world, BlockPos pos, PlayerEntity entity, Hand hand, BlockRayTraceResult hit) {
 			super.onBlockActivated(state, world, pos, entity, hand, hit);
@@ -651,7 +651,7 @@ public class ${name}Block extends ${JavaModName}Elements.ModElement {
 			int y = pos.getY();
 			int z = pos.getZ();
 
-			<#if data.guiBoundTo?has_content && data.guiBoundTo != "<NONE>" && data.openGUIOnRightClick && (data.guiBoundTo)?has_content>
+			<#if data.shouldOpenGUIOnRightClick()>
 				if(entity instanceof ServerPlayerEntity) {
 					NetworkHooks.openGui((ServerPlayerEntity) entity, new INamedContainerProvider() {
 						@Override public ITextComponent getDisplayName() {
@@ -666,10 +666,14 @@ public class ${name}Block extends ${JavaModName}Elements.ModElement {
 
 			<#if hasProcedure(data.onRightClicked)>
 				Direction direction = hit.getFace();
-				<@procedureOBJToCode data.onRightClicked/>
+				<@procedureOBJToCodeWithResult data.onRightClicked/>
 			</#if>
 
+			<#if data.shouldOpenGUIOnRightClick()>
 			return ActionResultType.SUCCESS;
+			<#else>
+			return (ActionResultType) $_resultValues.getOrDefault("actionResult", ActionResultType.SUCCESS);
+			</#if>
 		}
         </#if>
 

--- a/plugins/generator-1.15.2/forge-1.15.2/templates/dimension/portaltrigger.java.ftl
+++ b/plugins/generator-1.15.2/forge-1.15.2/templates/dimension/portaltrigger.java.ftl
@@ -53,15 +53,17 @@ public class ${name}Item extends Item {
 			int y = pos.getY();
 			int z = pos.getZ();
 
-			if (world.isAirBlock(pos) && <@procedureOBJToConditionCode data.portalMakeCondition/>)
+			if (world.isAirBlock(pos) && <@procedureOBJToConditionCode data.portalMakeCondition/>) {
 				${name}Dimension.portal.portalSpawn(world, pos);
+				itemstack.damageItem(1, entity, c -> c.sendBreakAnimation(context.getHand()));
+			}
 
 			<#if hasProcedure(data.whenPortaTriggerlUsed)>
-				<@procedureOBJToCode data.whenPortaTriggerlUsed/>
+				<@procedureOBJToCodeWithResult data.whenPortaTriggerlUsed/>
+				return (ActionResultType) $_resultValues.getOrDefault("actionResult", ActionResultType.SUCCESS);
+			<#else>
+				return ActionResultType.SUCCESS;
 			</#if>
-
-			itemstack.damageItem(1, entity, c -> c.sendBreakAnimation(context.getHand()));
-			return ActionResultType.SUCCESS;
 		}
 	}
 }

--- a/plugins/generator-1.15.2/forge-1.15.2/templates/food.java.ftl
+++ b/plugins/generator-1.15.2/forge-1.15.2/templates/food.java.ftl
@@ -123,8 +123,8 @@ public class ${name}Item extends ${JavaModName}Elements.ModElement{
 			int y = pos.getY();
 			int z = pos.getZ();
 			ItemStack itemstack = context.getItem();
-			<@procedureOBJToCode data.onRightClickedOnBlock/>
-			return retval;
+			<@procedureOBJToCodeWithResult data.onRightClickedOnBlock/>
+			return (ActionResultType) $_resultValues.getOrDefault("actionResult", retval);
 		}
         </#if>
 

--- a/plugins/generator-1.15.2/forge-1.15.2/templates/item.java.ftl
+++ b/plugins/generator-1.15.2/forge-1.15.2/templates/item.java.ftl
@@ -212,8 +212,8 @@ package ${package}.item;
 			int y = pos.getY();
 			int z = pos.getZ();
 			ItemStack itemstack = context.getItem();
-			<@procedureOBJToCode data.onRightClickedOnBlock/>
-			return retval;
+			<@procedureOBJToCodeWithResult data.onRightClickedOnBlock/>
+			return (ActionResultType) $_resultValues.getOrDefault("actionResult", retval);
 		}
         </#if>
 

--- a/plugins/generator-1.15.2/forge-1.15.2/templates/mob.java.ftl
+++ b/plugins/generator-1.15.2/forge-1.15.2/templates/mob.java.ftl
@@ -608,11 +608,15 @@ import net.minecraft.block.material.Material;
             sourceentity.startRiding(this);
             </#if>
 
-			double x = this.getPosX();
-			double y = this.getPosY();
-			double z = this.getPosZ();
-			Entity entity = this;
-			<@procedureOBJToCode data.onRightClickedOn/>
+			<#if hasProcedure(data.onRightClickedOn)>
+				double x = this.getPosX();
+				double y = this.getPosY();
+				double z = this.getPosZ();
+				Entity entity = this;
+				<@procedureOBJToCodeWithResult data.onRightClickedOn/>
+				if ($_resultValues.containsKey("actionResult"))
+					return ((ActionResultType) $_resultValues.get("actionResult")).isSuccessOrConsume();
+			</#if>
 			return retval;
 		}
         </#if>

--- a/plugins/generator-1.15.2/forge-1.15.2/templates/musicdisc.java.ftl
+++ b/plugins/generator-1.15.2/forge-1.15.2/templates/musicdisc.java.ftl
@@ -97,8 +97,8 @@ public class ${name}Item extends ${JavaModName}Elements.ModElement{
 			int y = pos.getY();
 			int z = pos.getZ();
 			ItemStack itemstack = context.getItem();
-			<@procedureOBJToCode data.onRightClickedOnBlock/>
-			return retval;
+			<@procedureOBJToCodeWithResult data.onRightClickedOnBlock/>
+			return (ActionResultType) $_resultValues.getOrDefault("actionResult", retval);
 		}
 		</#if>
 

--- a/plugins/generator-1.15.2/forge-1.15.2/templates/plant.java.ftl
+++ b/plugins/generator-1.15.2/forge-1.15.2/templates/plant.java.ftl
@@ -590,8 +590,8 @@ import net.minecraft.block.material.Material;
 			int y = pos.getY();
 			int z = pos.getZ();
 			Direction direction = hit.getFace();
-			<@procedureOBJToCode data.onRightClicked/>
-			return ActionResultType.SUCCESS;
+			<@procedureOBJToCodeWithResult data.onRightClicked/>
+			return (ActionResultType) $_resultValues.getOrDefault("actionResult", ActionResultType.SUCCESS);
 		}
         </#if>
 

--- a/plugins/generator-1.15.2/forge-1.15.2/templates/procedure.java.ftl
+++ b/plugins/generator-1.15.2/forge-1.15.2/templates/procedure.java.ftl
@@ -42,7 +42,7 @@ public class ${name}Procedure extends ${JavaModName}Elements.ModElement{
 	}
 
 	public static <#if return_type??>${return_type.getJavaType(generator.getWorkspace())}<#else>void</#if> executeProcedure(Map<String, Object> dependencies){
-		<#if return_type??>return</#if> executeProcedure(dependencies, Collections.emptyMap());
+		<#if return_type??>return</#if> executeProcedure(dependencies, new HashMap<>());
 	}
 
 	public static <#if return_type??>${return_type.getJavaType(generator.getWorkspace())}<#else>void</#if> executeProcedure(Map<String, Object> dependencies, Map<String, Object> resultValues){

--- a/plugins/generator-1.15.2/forge-1.15.2/templates/procedure.java.ftl
+++ b/plugins/generator-1.15.2/forge-1.15.2/templates/procedure.java.ftl
@@ -42,7 +42,7 @@ public class ${name}Procedure extends ${JavaModName}Elements.ModElement{
 	}
 
 	public static <#if return_type??>${return_type.getJavaType(generator.getWorkspace())}<#else>void</#if> executeProcedure(Map<String, Object> dependencies){
-		<#if return_type??>return</#if> executeProcedure(dependencies, new HashMap<>());
+		<#if return_type??>return</#if> executeProcedure(dependencies, Collections.emptyMap());
 	}
 
 	public static <#if return_type??>${return_type.getJavaType(generator.getWorkspace())}<#else>void</#if> executeProcedure(Map<String, Object> dependencies, Map<String, Object> resultValues){

--- a/plugins/generator-1.15.2/forge-1.15.2/templates/procedure.java.ftl
+++ b/plugins/generator-1.15.2/forge-1.15.2/templates/procedure.java.ftl
@@ -42,6 +42,10 @@ public class ${name}Procedure extends ${JavaModName}Elements.ModElement{
 	}
 
 	public static <#if return_type??>${return_type.getJavaType(generator.getWorkspace())}<#else>void</#if> executeProcedure(Map<String, Object> dependencies){
+		<#if return_type??>return</#if> executeProcedure(dependencies, new HashMap<>());
+	}
+
+	public static <#if return_type??>${return_type.getJavaType(generator.getWorkspace())}<#else>void</#if> executeProcedure(Map<String, Object> dependencies, Map<String, Object> resultValues){
 		<#list dependencies as dependency>
 		if(dependencies.get("${dependency.getName()}") == null) {
 			if(!dependencies.containsKey("${dependency.getName()}"))

--- a/plugins/generator-1.15.2/forge-1.15.2/templates/tool.java.ftl
+++ b/plugins/generator-1.15.2/forge-1.15.2/templates/tool.java.ftl
@@ -162,8 +162,8 @@ public class ${name}Item extends ${JavaModName}Elements.ModElement{
 			int y = pos.getY();
 			int z = pos.getZ();
 			ItemStack itemstack = context.getItem();
-			<@procedureOBJToCode data.onRightClickedOnBlock/>
-			return retval;
+			<@procedureOBJToCodeWithResult data.onRightClickedOnBlock/>
+			return (ActionResultType) $_resultValues.getOrDefault("actionResult", retval);
 		}
 		</#if>
 

--- a/plugins/generator-1.15.2/forge-1.15.2/utils/procedures.java.ftl
+++ b/plugins/generator-1.15.2/forge-1.15.2/utils/procedures.java.ftl
@@ -24,6 +24,31 @@
     </#if>
 </#macro>
 
+<#macro procedureToCodeWithResult name dependencies customVals={}>
+	Map<String, Object> $_resultValues = new HashMap<>();
+    {
+		Map<String, Object> $_dependencies = new HashMap<>();
+
+        <#list dependencies as dependency>
+            <#if !customVals[dependency.getName()]?? >
+	    	    $_dependencies.put("${dependency.getName()}",${dependency.getName()});
+            </#if>
+        </#list>
+
+        <#list customVals as key, value>
+        $_dependencies.put("${key}",${value});
+        </#list>
+
+        ${(name)}Procedure.executeProcedure($_dependencies, $_resultValues);
+	}
+</#macro>
+
+<#macro procedureOBJToCodeWithResult object="">
+    <#if object?? && object?has_content && object.getName() != "null">
+        <@procedureToCodeWithResult name=object.getName() dependencies=object.getDependencies(generator.getWorkspace()) />
+    </#if>
+</#macro>
+
 <#macro procedureToRetvalCode name dependencies customVals={}>
     <#assign depsBuilder = []>
 

--- a/plugins/generator-1.16.5/forge-1.16.5/procedures/_set_action_result.java.ftl
+++ b/plugins/generator-1.16.5/forge-1.16.5/procedures/_set_action_result.java.ftl
@@ -1,0 +1,1 @@
+resultValues.put("actionResult", ActionResultType.${field$resulttype});

--- a/plugins/generator-1.16.5/forge-1.16.5/templates/block.java.ftl
+++ b/plugins/generator-1.16.5/forge-1.16.5/templates/block.java.ftl
@@ -676,7 +676,7 @@ public class ${name}Block extends ${JavaModName}Elements.ModElement {
 		}
         </#if>
 
-        <#if hasProcedure(data.onRightClicked) || data.openGUIOnRightClick>
+        <#if hasProcedure(data.onRightClicked) || data.shouldOpenGUIOnRightClick()>
 		@Override
 		public ActionResultType onBlockActivated(BlockState state, World world, BlockPos pos, PlayerEntity entity, Hand hand, BlockRayTraceResult hit) {
 			super.onBlockActivated(state, world, pos, entity, hand, hit);
@@ -685,7 +685,7 @@ public class ${name}Block extends ${JavaModName}Elements.ModElement {
 			int y = pos.getY();
 			int z = pos.getZ();
 
-			<#if data.guiBoundTo?has_content && data.guiBoundTo != "<NONE>" && data.openGUIOnRightClick && (data.guiBoundTo)?has_content>
+			<#if data.shouldOpenGUIOnRightClick()>
 				if(entity instanceof ServerPlayerEntity) {
 					NetworkHooks.openGui((ServerPlayerEntity) entity, new INamedContainerProvider() {
 						@Override public ITextComponent getDisplayName() {
@@ -700,10 +700,14 @@ public class ${name}Block extends ${JavaModName}Elements.ModElement {
 
 			<#if hasProcedure(data.onRightClicked)>
 				Direction direction = hit.getFace();
-				<@procedureOBJToCode data.onRightClicked/>
+				<@procedureOBJToCodeWithResult data.onRightClicked/>
 			</#if>
 
-			return ActionResultType.SUCCESS;
+			<#if data.shouldOpenGUIOnRightClick()>
+			return ActionResultType.func_233537_a_(world.isRemote());
+			<#else>
+			return (ActionResultType) $_resultValues.getOrDefault("actionResult", ActionResultType.SUCCESS);
+			</#if>
 		}
         </#if>
 

--- a/plugins/generator-1.16.5/forge-1.16.5/templates/dimension/portaltrigger.java.ftl
+++ b/plugins/generator-1.16.5/forge-1.16.5/templates/dimension/portaltrigger.java.ftl
@@ -53,15 +53,17 @@ public class ${name}Item extends Item {
 			int y = pos.getY();
 			int z = pos.getZ();
 
-			if (world.isAirBlock(pos) && <@procedureOBJToConditionCode data.portalMakeCondition/>)
+			if (world.isAirBlock(pos) && <@procedureOBJToConditionCode data.portalMakeCondition/>) {
 				${name}Dimension.portal.portalSpawn(world, pos);
+				itemstack.damageItem(1, entity, c -> c.sendBreakAnimation(context.getHand()));
+			}
 
 			<#if hasProcedure(data.whenPortaTriggerlUsed)>
-				<@procedureOBJToCode data.whenPortaTriggerlUsed/>
+				<@procedureOBJToCodeWithResult data.whenPortaTriggerlUsed/>
+				return (ActionResultType) $_resultValues.getOrDefault("actionResult", ActionResultType.SUCCESS);
+			<#else>
+				return ActionResultType.SUCCESS;
 			</#if>
-
-			itemstack.damageItem(1, entity, c -> c.sendBreakAnimation(context.getHand()));
-			return ActionResultType.SUCCESS;
 		}
 	}
 }

--- a/plugins/generator-1.16.5/forge-1.16.5/templates/food.java.ftl
+++ b/plugins/generator-1.16.5/forge-1.16.5/templates/food.java.ftl
@@ -123,8 +123,8 @@ public class ${name}Item extends ${JavaModName}Elements.ModElement{
 			int y = pos.getY();
 			int z = pos.getZ();
 			ItemStack itemstack = context.getItem();
-			<@procedureOBJToCode data.onRightClickedOnBlock/>
-			return retval;
+			<@procedureOBJToCodeWithResult data.onRightClickedOnBlock/>
+			return (ActionResultType) $_resultValues.getOrDefault("actionResult", retval);
 		}
         </#if>
 

--- a/plugins/generator-1.16.5/forge-1.16.5/templates/item.java.ftl
+++ b/plugins/generator-1.16.5/forge-1.16.5/templates/item.java.ftl
@@ -216,8 +216,8 @@ package ${package}.item;
 			int y = pos.getY();
 			int z = pos.getZ();
 			ItemStack itemstack = context.getItem();
-			<@procedureOBJToCode data.onRightClickedOnBlock/>
-			return retval;
+			<@procedureOBJToCodeWithResult data.onRightClickedOnBlock/>
+			return (ActionResultType) $_resultValues.getOrDefault("actionResult", retval);
 		}
         </#if>
 

--- a/plugins/generator-1.16.5/forge-1.16.5/templates/mob.java.ftl
+++ b/plugins/generator-1.16.5/forge-1.16.5/templates/mob.java.ftl
@@ -581,12 +581,16 @@ import net.minecraft.block.material.Material;
             sourceentity.startRiding(this);
             </#if>
 
-			double x = this.getPosX();
-			double y = this.getPosY();
-			double z = this.getPosZ();
-			Entity entity = this;
-			<@procedureOBJToCode data.onRightClickedOn/>
-			return retval;
+			<#if hasProcedure(data.onRightClickedOn)>
+				double x = this.getPosX();
+				double y = this.getPosY();
+				double z = this.getPosZ();
+				Entity entity = this;
+				<@procedureOBJToCodeWithResult data.onRightClickedOn/>
+				return (ActionResultType) $_resultValues.getOrDefault("actionResult", retval);
+			<#else>
+				return retval;
+			</#if>
 		}
         </#if>
 

--- a/plugins/generator-1.16.5/forge-1.16.5/templates/musicdisc.java.ftl
+++ b/plugins/generator-1.16.5/forge-1.16.5/templates/musicdisc.java.ftl
@@ -97,8 +97,8 @@ public class ${name}Item extends ${JavaModName}Elements.ModElement{
 			int y = pos.getY();
 			int z = pos.getZ();
 			ItemStack itemstack = context.getItem();
-			<@procedureOBJToCode data.onRightClickedOnBlock/>
-			return retval;
+			<@procedureOBJToCodeWithResult data.onRightClickedOnBlock/>
+			return (ActionResultType) $_resultValues.getOrDefault("resultType", retval);
 		}
 		</#if>
 

--- a/plugins/generator-1.16.5/forge-1.16.5/templates/plant.java.ftl
+++ b/plugins/generator-1.16.5/forge-1.16.5/templates/plant.java.ftl
@@ -630,8 +630,8 @@ import net.minecraft.block.material.Material;
 			int y = pos.getY();
 			int z = pos.getZ();
 			Direction direction = hit.getFace();
-			<@procedureOBJToCode data.onRightClicked/>
-			return ActionResultType.SUCCESS;
+			<@procedureOBJToCodeWithResult data.onRightClicked/>
+			return (ActionResultType) $_resultValues.getOrDefault("actionResult", ActionResultType.SUCCESS);
 		}
         </#if>
 

--- a/plugins/generator-1.16.5/forge-1.16.5/templates/procedure.java.ftl
+++ b/plugins/generator-1.16.5/forge-1.16.5/templates/procedure.java.ftl
@@ -35,7 +35,7 @@ public class ${name}Procedure {
 	${trigger_code}
 
 	public static <#if return_type??>${return_type.getJavaType(generator.getWorkspace())}<#else>void</#if> executeProcedure(Map<String, Object> dependencies){
-		<#if return_type??>return</#if> executeProcedure(dependencies, new HashMap<>());
+		<#if return_type??>return</#if> executeProcedure(dependencies, Collections.emptyMap());
 	}
 
 	public static <#if return_type??>${return_type.getJavaType(generator.getWorkspace())}<#else>void</#if> executeProcedure(Map<String, Object> dependencies, Map<String, Object> resultValues){

--- a/plugins/generator-1.16.5/forge-1.16.5/templates/procedure.java.ftl
+++ b/plugins/generator-1.16.5/forge-1.16.5/templates/procedure.java.ftl
@@ -35,7 +35,7 @@ public class ${name}Procedure {
 	${trigger_code}
 
 	public static <#if return_type??>${return_type.getJavaType(generator.getWorkspace())}<#else>void</#if> executeProcedure(Map<String, Object> dependencies){
-		<#if return_type??>return</#if> executeProcedure(dependencies, Collections.emptyMap());
+		<#if return_type??>return</#if> executeProcedure(dependencies, new HashMap<>());
 	}
 
 	public static <#if return_type??>${return_type.getJavaType(generator.getWorkspace())}<#else>void</#if> executeProcedure(Map<String, Object> dependencies, Map<String, Object> resultValues){

--- a/plugins/generator-1.16.5/forge-1.16.5/templates/procedure.java.ftl
+++ b/plugins/generator-1.16.5/forge-1.16.5/templates/procedure.java.ftl
@@ -35,6 +35,10 @@ public class ${name}Procedure {
 	${trigger_code}
 
 	public static <#if return_type??>${return_type.getJavaType(generator.getWorkspace())}<#else>void</#if> executeProcedure(Map<String, Object> dependencies){
+		<#if return_type??>return</#if> executeProcedure(dependencies, new HashMap<>());
+	}
+
+	public static <#if return_type??>${return_type.getJavaType(generator.getWorkspace())}<#else>void</#if> executeProcedure(Map<String, Object> dependencies, Map<String, Object> resultValues){
 		<#list dependencies as dependency>
 		if(dependencies.get("${dependency.getName()}") == null) {
 			if(!dependencies.containsKey("${dependency.getName()}"))

--- a/plugins/generator-1.16.5/forge-1.16.5/templates/tool.java.ftl
+++ b/plugins/generator-1.16.5/forge-1.16.5/templates/tool.java.ftl
@@ -167,8 +167,8 @@ public class ${name}Item extends ${JavaModName}Elements.ModElement{
 			int y = pos.getY();
 			int z = pos.getZ();
 			ItemStack itemstack = context.getItem();
-			<@procedureOBJToCode data.onRightClickedOnBlock/>
-			return retval;
+			<@procedureOBJToCodeWithResult data.onRightClickedOnBlock/>
+			return (ActionResultType) $_resultValues.getOrDefault("actionResult", retval);
 		}
 		</#if>
 

--- a/plugins/generator-1.16.5/forge-1.16.5/utils/procedures.java.ftl
+++ b/plugins/generator-1.16.5/forge-1.16.5/utils/procedures.java.ftl
@@ -24,6 +24,31 @@
     </#if>
 </#macro>
 
+<#macro procedureToCodeWithResult name dependencies customVals={}>
+	Map<String, Object> $_resultValues = new HashMap<>();
+    {
+		Map<String, Object> $_dependencies = new HashMap<>();
+
+        <#list dependencies as dependency>
+            <#if !customVals[dependency.getName()]?? >
+	    	    $_dependencies.put("${dependency.getName()}",${dependency.getName()});
+            </#if>
+        </#list>
+
+        <#list customVals as key, value>
+        $_dependencies.put("${key}",${value});
+        </#list>
+
+        ${(name)}Procedure.executeProcedure($_dependencies, $_resultValues);
+	}
+</#macro>
+
+<#macro procedureOBJToCodeWithResult object="">
+    <#if object?? && object?has_content && object.getName() != "null">
+        <@procedureToCodeWithResult name=object.getName() dependencies=object.getDependencies(generator.getWorkspace()) />
+    </#if>
+</#macro>
+
 <#macro procedureToRetvalCode name dependencies customVals={}>
     <#assign depsBuilder = []>
 

--- a/plugins/mcreator-core/procedures/_set_action_result.json
+++ b/plugins/mcreator-core/procedures/_set_action_result.json
@@ -1,0 +1,36 @@
+{
+  "args0": [
+    {
+      "type": "field_dropdown",
+      "name": "resulttype",
+      "options": [
+        [
+          "SUCCESS",
+          "SUCCESS"
+        ],
+        [
+          "CONSUME",
+          "CONSUME"
+        ],
+        [
+          "PASS",
+          "PASS"
+        ],
+        [
+          "FAIL",
+          "FAIL"
+        ]
+      ]
+    }
+  ],
+  "inputsInline": true,
+  "previousStatement": null,
+  "nextStatement": null,
+  "colour": 90,
+  "mcreator": {
+    "toolbox_id": "advanced",
+    "fields": [
+      "resulttype"
+    ]
+  }
+}

--- a/plugins/mcreator-localization/lang/texts.properties
+++ b/plugins/mcreator-localization/lang/texts.properties
@@ -629,6 +629,7 @@ blockly.category.text=Text
 blockly.category.advanced=Advanced
 blockly.category.return=Return blocks
 blockly.warning.no_side_sync=Block {0} is not synced between client and server automatically, which means it may not work properly in some cases.
+blockly.block._set_action_result=Set action result type to %1
 blockly.block.advancement_isequalto=Is provided advancement equal to
 blockly.block.block_add=Place %1 at x: %2 y: %3 z: %4
 blockly.block.block_pos_x=x%1

--- a/src/main/java/net/mcreator/element/types/Block.java
+++ b/src/main/java/net/mcreator/element/types/Block.java
@@ -212,6 +212,10 @@ import java.util.stream.Collectors;
 		return !"No tint".equals(tintType);
 	}
 
+	public boolean shouldOpenGUIOnRightClick() {
+		return guiBoundTo != null && !guiBoundTo.equals("<NONE>") && openGUIOnRightClick;
+	}
+
 	@Override public Model getItemModel() {
 		Model.Type modelType = Model.Type.BUILTIN;
 		if (renderType == 2)


### PR DESCRIPTION
This PR adds support for procedures to receive "result values", as suggested in #1378 
- Added a "Set action result" procedure block, to use with certain triggers
- The "Right click" trigger of block elements and "Right click on block" trigger of item elements will check if an action result has been specified in the procedure, if it is they return that value