### PR TITLE
Fixed non-translatable Living Entity mod element registry name

### DIFF
--- a/src/main/java/net/mcreator/element/ModElementType.java
+++ b/src/main/java/net/mcreator/element/ModElementType.java
@@ -39,7 +39,7 @@ public enum ModElementType {
 
 	@SerializedName("fuel") FUEL(BaseType.FUEL, RecipeType.NONE),
 
-	@SerializedName("mob") LIVINGENTITY(BaseType.ENTITY, RecipeType.NONE),
+	@SerializedName("livingentity") LIVINGENTITY(BaseType.ENTITY, RecipeType.NONE),
 
 	@SerializedName("food") FOOD(BaseType.ITEM, RecipeType.ITEM),
 


### PR DESCRIPTION
>On June 16th, the Mob internally turned into Living Entity. However, one of its parts didn't transform along others, and it remains unknown whether anybody noticed that accident or not...

This PR updates registry name of `LivingEntity` mod element thus making its `readableName` translatable again.