### PR TITLE
[dependabot] Bump gradle-tooling-api from 7.0.2 to 7.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,7 @@ dependencies {
     implementation group: 'org.apache.commons', name: 'commons-text', version: '1.9'
     implementation group: 'org.eclipse.jgit', name: 'org.eclipse.jgit', version: '5.11.0.202103091610-r'
     implementation group: 'org.slf4j', name: 'slf4j-nop', version: '1.7.30'
-    implementation group: 'org.gradle', name: 'gradle-tooling-api', version: '7.0.2'
+    implementation group: 'org.gradle', name: 'gradle-tooling-api', version: '7.1'
     implementation group: 'net.java.balloontip', name: 'balloontip', version: '1.2.4.1'
     implementation group: 'com.atlassian.commonmark', name: 'commonmark', version: '0.16.1'
     implementation group: 'com.atlassian.commonmark', name: 'commonmark-ext-autolink', version: '0.16.1'


### PR DESCRIPTION
I guess the letter has been lost in the post, so recreating [this PR](https://github.com/Defeatomizer/MCreator/pull/15) in the right repository.
I'm sorry for not being aware if that's breaking the order of things.