### PR TITLE
Color scheme now change the color of the main button panel

### DIFF
--- a/src/main/java/net/mcreator/ui/workspace/WorkspacePanel.java
+++ b/src/main/java/net/mcreator/ui/workspace/WorkspacePanel.java
@@ -834,18 +834,15 @@ import java.util.stream.Collectors;
 		setOpaque(false);
 
 		JPanel pne = new JPanel(new GridLayout(8, 1, 6, 6));
-		pne.setOpaque(false);
+		pne.setBackground((Color) UIManager.get("MCreatorLAF.DARK_ACCENT"));
 
 		JLabel but1 = new JLabel(TiledImageCache.workspaceAdd);
-		but1.addMouseListener(new
-
-									  MouseAdapter() {
-										  @Override public void mouseClicked(MouseEvent e) {
-											  if (but1.isEnabled())
-												  new ModTypeDropdown(mcreator)
-														  .show(e.getComponent(), e.getComponent().getWidth() + 5, -3);
-										  }
-									  });
+		but1.addMouseListener(new MouseAdapter() {
+			@Override public void mouseClicked(MouseEvent e) {
+				if (but1.isEnabled())
+					new ModTypeDropdown(mcreator).show(e.getComponent(), e.getComponent().getWidth() + 5, -3);
+			}
+		});
 		but1.setToolTipText(L10N.t("workspace.elements.add.tooltip"));
 		but1.setCursor(new
 

--- a/src/main/java/net/mcreator/ui/workspace/WorkspacePanel.java
+++ b/src/main/java/net/mcreator/ui/workspace/WorkspacePanel.java
@@ -837,12 +837,15 @@ import java.util.stream.Collectors;
 		pne.setBackground((Color) UIManager.get("MCreatorLAF.DARK_ACCENT"));
 
 		JLabel but1 = new JLabel(TiledImageCache.workspaceAdd);
-		but1.addMouseListener(new MouseAdapter() {
-			@Override public void mouseClicked(MouseEvent e) {
-				if (but1.isEnabled())
-					new ModTypeDropdown(mcreator).show(e.getComponent(), e.getComponent().getWidth() + 5, -3);
-			}
-		});
+		but1.addMouseListener(new
+
+									  MouseAdapter() {
+										  @Override public void mouseClicked(MouseEvent e) {
+											  if (but1.isEnabled())
+												  new ModTypeDropdown(mcreator)
+														  .show(e.getComponent(), e.getComponent().getWidth() + 5, -3);
+										  }
+									  });
 		but1.setToolTipText(L10N.t("workspace.elements.add.tooltip"));
 		but1.setCursor(new
 


### PR DESCRIPTION
Some people reported to me, there is a panel that isn't affected by the color scheme (look at the red panel in the image below).
![image](https://user-images.githubusercontent.com/38427877/123010483-b2962a80-d38c-11eb-8eab-6bbb7b671368.png)

This PR changes this by giving the panel the DARK_ACCENT color (background color).

(WorkspacePanel has some very weird spacings.)