### PR TITLE
Fixed SplashScreen's ProgressBar colorizing

### DIFF
--- a/src/main/java/net/mcreator/ui/SplashScreen.java
+++ b/src/main/java/net/mcreator/ui/SplashScreen.java
@@ -19,6 +19,7 @@
 package net.mcreator.ui;
 
 import net.mcreator.Launcher;
+import net.mcreator.preferences.PreferencesManager;
 import net.mcreator.ui.component.ImagePanel;
 import net.mcreator.ui.component.ProgressBar;
 import net.mcreator.ui.component.util.EDTUtils;
@@ -75,6 +76,7 @@ public class SplashScreen extends JWindow {
 		}
 
 		initloadprogress.setEmptyColor(null);
+		initloadprogress.setBarColor(PreferencesManager.PREFERENCES.ui.interfaceAccentColor);
 		initloadprogress.setOpaque(false);
 		initloadprogress.setForeground(Color.white);
 		initloadprogress.setMaximalValue(100);

--- a/src/main/java/net/mcreator/ui/component/ProgressBar.java
+++ b/src/main/java/net/mcreator/ui/component/ProgressBar.java
@@ -28,7 +28,7 @@ public class ProgressBar extends JPanel {
 	private int wid = -1;
 
 	private Color emptyColor = new Color(80, 80, 80);
-	private Color barColor = (Color) UIManager.get("MCreatorLAF.MAIN_TINT");
+	private Color barColor = Color.white;
 
 	@Override public void paint(Graphics g) {
 		if (emptyColor != null) {


### PR DESCRIPTION
From what I've seen in the code, the ProgressBar tries to set its 'full' color to _MCreatorLAF.MAIN_TINT_, but the only thing to be initialized/loaded **BEFORE** showing the SplashScreen seems to be preferences, so this color always resets to white.

This PR fixes that bug, making the SplashScreen set the ProgressBar's 'full' color via `PREFERENCES.ui.interfaceAccentColor`.