### PR TITLE
Fixed custom log rotation not matching vanilla log rotation

### DIFF
--- a/plugins/generator-1.15.2/forge-1.15.2/templates/block.java.ftl
+++ b/plugins/generator-1.15.2/forge-1.15.2/templates/block.java.ftl
@@ -140,8 +140,10 @@ public class ${name}Block extends ${JavaModName}Elements.ModElement {
 
 		<#if data.rotationMode == 1 || data.rotationMode == 3>
 		public static final DirectionProperty FACING = HorizontalBlock.HORIZONTAL_FACING;
-		<#elseif data.rotationMode == 2 || data.rotationMode == 4 || data.rotationMode == 5>
+		<#elseif data.rotationMode == 2 || data.rotationMode == 4>
 		public static final DirectionProperty FACING = DirectionalBlock.FACING;
+		<#elseif data.rotationMode == 5>
+		public static final EnumProperty<Direction.Axis> AXIS = BlockStateProperties.AXIS;
         </#if>
         <#if data.isWaterloggable>
         public static final BooleanProperty WATERLOGGED = BlockStateProperties.WATERLOGGED;
@@ -212,7 +214,7 @@ public class ${name}Block extends ${JavaModName}Elements.ModElement {
                                      <#elseif data.rotationMode == 2 || data.rotationMode == 4>
                                      .with(FACING, Direction.NORTH)
                                      <#elseif data.rotationMode == 5>
-                                     .with(FACING, Direction.SOUTH)
+                                     .with(AXIS, Direction.Axis.Y)
                                      </#if>
                                      <#if data.isWaterloggable>
                                      .with(WATERLOGGED, false)
@@ -308,11 +310,17 @@ public class ${name}Block extends ${JavaModName}Elements.ModElement {
 
 		<#if data.rotationMode != 0>
 		@Override protected void fillStateContainer(StateContainer.Builder<Block, BlockState> builder) {
-		    <#if data.isWaterloggable>
-      		    builder.add(FACING, WATERLOGGED);
-      		<#else>
-      		    builder.add(FACING);
-      		</#if>
+		<#if data.isWaterloggable>
+			<#if data.rotationMode == 5>
+	  		builder.add(AXIS, WATERLOGGED);
+	  		<#else>
+	  		builder.add(FACING, WATERLOGGED);
+	  		</#if>
+	  	<#elseif data.rotationMode == 5>
+	  		builder.add(AXIS);
+	  	<#else>
+	  		builder.add(FACING);
+	  	</#if>
    		}
 
 			<#if data.rotationMode != 5>
@@ -326,10 +334,10 @@ public class ${name}Block extends ${JavaModName}Elements.ModElement {
    			<#else>
 			@Override public BlockState rotate(BlockState state, Rotation rot) {
 				if(rot == Rotation.CLOCKWISE_90 || rot == Rotation.COUNTERCLOCKWISE_90) {
-					if((Direction) state.get(FACING) == Direction.WEST || (Direction) state.get(FACING) == Direction.EAST) {
-						return state.with(FACING, Direction.UP);
-					} else if((Direction) state.get(FACING) == Direction.UP || (Direction) state.get(FACING) == Direction.DOWN) {
-						return state.with(FACING, Direction.WEST);
+					if ((Direction.Axis) state.get(AXIS) == Direction.Axis.X) {
+						return state.with(AXIS, Direction.Axis.Z);
+					} else if ((Direction.Axis) state.get(AXIS) == Direction.Axis.Z) {
+						return state.with(AXIS, Direction.Axis.X);
 					}
 				}
 				return state;
@@ -342,13 +350,7 @@ public class ${name}Block extends ${JavaModName}Elements.ModElement {
 		    Direction facing = context.getFace();
 		    </#if>
 		    <#if data.rotationMode == 5>
-            Direction facing = context.getFace();
-            if (facing == Direction.WEST || facing == Direction.EAST)
-                facing = Direction.UP;
-            else if (facing == Direction.NORTH || facing == Direction.SOUTH)
-                facing = Direction.EAST;
-            else
-                facing = Direction.SOUTH;
+            Direction.Axis axis = context.getFace().getAxis();
             </#if>
             <#if data.isWaterloggable>
             boolean flag = context.getWorld().getFluidState(context.getPos()).getFluid() == Fluids.WATER;
@@ -359,8 +361,10 @@ public class ${name}Block extends ${JavaModName}Elements.ModElement {
 			        .with(FACING, context.getPlacementHorizontalFacing().getOpposite())
 			        <#elseif data.rotationMode == 2>
 			        .with(FACING, context.getNearestLookingDirection().getOpposite())
-                    <#elseif data.rotationMode == 4 || data.rotationMode == 5>
+                    <#elseif data.rotationMode == 4>
 			        .with(FACING, facing)
+                    <#elseif data.rotationMode == 5>
+                    .with(AXIS, axis)
 			        </#if>
 			        <#if data.isWaterloggable>
 			        .with(WATERLOGGED, flag)

--- a/plugins/generator-1.15.2/forge-1.15.2/templates/json/block_states.json.ftl
+++ b/plugins/generator-1.15.2/forge-1.15.2/templates/json/block_states.json.ftl
@@ -49,29 +49,17 @@
 <#elseif data.rotationMode?? && data.rotationMode == 5>
 {
   "variants": {
-    "facing=south": {
-      "model": "${modid}:block/${registryname}"
-    },
-    "facing=north": {
-      "model": "${modid}:block/${registryname}"
-    },
-    "facing=east": {
-      "model": "${modid}:block/${registryname}",
-      "x": 90
-    },
-    "facing=west": {
-      "model": "${modid}:block/${registryname}",
-      "x": 90
-    },
-    "facing=up": {
+    "axis=x": {
       "model": "${modid}:block/${registryname}",
       "x": 90,
       "y": 90
     },
-    "facing=down": {
+    "axis=y": {
+      "model": "${modid}:block/${registryname}"
+    },
+    "axis=z": {
       "model": "${modid}:block/${registryname}",
-      "x": 90,
-      "y": 90
+      "x": 90
     }
   }
 }

--- a/plugins/generator-1.15.2/forge-1.15.2/utils/boundingboxes.java.ftl
+++ b/plugins/generator-1.15.2/forge-1.15.2/utils/boundingboxes.java.ftl
@@ -33,17 +33,14 @@
             </#if>
         }
     <#else>
-        switch ((Direction) state.get(FACING)) {
-            case SOUTH:
-            case NORTH:
+        switch ((Direction.Axis) state.get(AXIS)) {
+            case X:
+                <@makeBoundingBox positiveBoxes negativeBoxes noOffset "x"/>
+            case Y:
             default:
-                <@makeBoundingBox positiveBoxes negativeBoxes noOffset "north"/>
-            case EAST:
-            case WEST:
-                <@makeBoundingBox positiveBoxes negativeBoxes noOffset "up"/>
-            case UP:
-            case DOWN:
-                <@makeBoundingBox positiveBoxes negativeBoxes noOffset "log_up"/>
+                <@makeBoundingBox positiveBoxes negativeBoxes noOffset "y"/>
+            case Z:
+                <@makeBoundingBox positiveBoxes negativeBoxes noOffset "z"/>
         }
     </#if>
 </#macro>
@@ -57,10 +54,10 @@
         makeCuboidShape(${box.mz}, ${box.my}, ${16 - box.mx}, ${box.Mz}, ${box.My}, ${16 - box.Mx})
     <#elseif facing == "up">
         makeCuboidShape(${box.mx}, ${16 - box.mz}, ${box.my}, ${box.Mx}, ${16 - box.Mz}, ${box.My})
-    <#elseif facing == "down">
+    <#elseif facing == "down" || facing == "z">
         makeCuboidShape(${box.mx}, ${box.mz}, ${16 - box.my}, ${box.Mx}, ${box.Mz}, ${16 - box.My})
-    <#elseif facing == "log_up">
-        makeCuboidShape(${box.my}, ${16 - box.mx}, ${16 - box.mz}, ${box.My}, ${16 - box.Mx}, ${16 - box.Mz})
+    <#elseif facing == "x">
+        makeCuboidShape(${box.my}, ${box.mz}, ${box.mx}, ${box.My}, ${box.Mz}, ${box.Mx})
     <#else>
         makeCuboidShape(${box.mx}, ${box.my}, ${box.mz}, ${box.Mx}, ${box.My}, ${box.Mz})
     </#if>

--- a/plugins/generator-1.16.5/forge-1.16.5/templates/block.java.ftl
+++ b/plugins/generator-1.16.5/forge-1.16.5/templates/block.java.ftl
@@ -161,8 +161,10 @@ public class ${name}Block extends ${JavaModName}Elements.ModElement {
 
 		<#if data.rotationMode == 1 || data.rotationMode == 3>
 		public static final DirectionProperty FACING = HorizontalBlock.HORIZONTAL_FACING;
-		<#elseif data.rotationMode == 2 || data.rotationMode == 4 || data.rotationMode == 5>
+		<#elseif data.rotationMode == 2 || data.rotationMode == 4>
 		public static final DirectionProperty FACING = DirectionalBlock.FACING;
+		<#elseif data.rotationMode == 5>
+		public static final EnumProperty<Direction.Axis> AXIS = BlockStateProperties.AXIS;
         </#if>
         <#if data.isWaterloggable>
         public static final BooleanProperty WATERLOGGED = BlockStateProperties.WATERLOGGED;
@@ -238,7 +240,7 @@ public class ${name}Block extends ${JavaModName}Elements.ModElement {
                                      <#elseif data.rotationMode == 2 || data.rotationMode == 4>
                                      .with(FACING, Direction.NORTH)
                                      <#elseif data.rotationMode == 5>
-                                     .with(FACING, Direction.SOUTH)
+                                     .with(AXIS, Direction.Axis.Y)
                                      </#if>
                                      <#if data.isWaterloggable>
                                      .with(WATERLOGGED, false)
@@ -336,11 +338,17 @@ public class ${name}Block extends ${JavaModName}Elements.ModElement {
 
 		<#if data.rotationMode != 0>
 		@Override protected void fillStateContainer(StateContainer.Builder<Block, BlockState> builder) {
-		    <#if data.isWaterloggable>
-      		    builder.add(FACING, WATERLOGGED);
-      		<#else>
-      		    builder.add(FACING);
-      		</#if>
+			<#if data.isWaterloggable>
+				<#if data.rotationMode == 5>
+	  			builder.add(AXIS, WATERLOGGED);
+	  			<#else>
+	  			builder.add(FACING, WATERLOGGED);
+	  			</#if>
+	  		<#elseif data.rotationMode == 5>
+	  			builder.add(AXIS);
+	  		<#else>
+	  			builder.add(FACING);
+	  		</#if>
    		}
 
 			<#if data.rotationMode != 5>
@@ -354,10 +362,10 @@ public class ${name}Block extends ${JavaModName}Elements.ModElement {
    			<#else>
 			@Override public BlockState rotate(BlockState state, Rotation rot) {
 				if(rot == Rotation.CLOCKWISE_90 || rot == Rotation.COUNTERCLOCKWISE_90) {
-					if((Direction) state.get(FACING) == Direction.WEST || (Direction) state.get(FACING) == Direction.EAST) {
-						return state.with(FACING, Direction.UP);
-					} else if((Direction) state.get(FACING) == Direction.UP || (Direction) state.get(FACING) == Direction.DOWN) {
-						return state.with(FACING, Direction.WEST);
+					if ((Direction.Axis) state.get(AXIS) == Direction.Axis.X) {
+						return state.with(AXIS, Direction.Axis.Z);
+					} else if ((Direction.Axis) state.get(AXIS) == Direction.Axis.Z) {
+						return state.with(AXIS, Direction.Axis.X);
 					}
 				}
 				return state;
@@ -370,13 +378,7 @@ public class ${name}Block extends ${JavaModName}Elements.ModElement {
 		    Direction facing = context.getFace();
 		    </#if>
 		    <#if data.rotationMode == 5>
-            Direction facing = context.getFace();
-            if (facing == Direction.WEST || facing == Direction.EAST)
-                facing = Direction.UP;
-            else if (facing == Direction.NORTH || facing == Direction.SOUTH)
-                facing = Direction.EAST;
-            else
-                facing = Direction.SOUTH;
+		    Direction.Axis axis = context.getFace().getAxis();
             </#if>
             <#if data.isWaterloggable>
             boolean flag = context.getWorld().getFluidState(context.getPos()).getFluid() == Fluids.WATER;
@@ -387,8 +389,10 @@ public class ${name}Block extends ${JavaModName}Elements.ModElement {
 			        .with(FACING, context.getPlacementHorizontalFacing().getOpposite())
 			        <#elseif data.rotationMode == 2>
 			        .with(FACING, context.getNearestLookingDirection().getOpposite())
-                    <#elseif data.rotationMode == 4 || data.rotationMode == 5>
+                    <#elseif data.rotationMode == 4>
 			        .with(FACING, facing)
+                    <#elseif data.rotationMode == 5>
+                    .with(AXIS, axis)
 			        </#if>
 			        <#if data.isWaterloggable>
 			        .with(WATERLOGGED, flag)

--- a/plugins/generator-1.16.5/forge-1.16.5/templates/json/block_states.json.ftl
+++ b/plugins/generator-1.16.5/forge-1.16.5/templates/json/block_states.json.ftl
@@ -49,29 +49,17 @@
 <#elseif data.rotationMode?? && data.rotationMode == 5>
 {
   "variants": {
-    "facing=south": {
-      "model": "${modid}:block/${registryname}"
-    },
-    "facing=north": {
-      "model": "${modid}:block/${registryname}"
-    },
-    "facing=east": {
-      "model": "${modid}:block/${registryname}",
-      "x": 90
-    },
-    "facing=west": {
-      "model": "${modid}:block/${registryname}",
-      "x": 90
-    },
-    "facing=up": {
+    "axis=x": {
       "model": "${modid}:block/${registryname}",
       "x": 90,
       "y": 90
     },
-    "facing=down": {
+    "axis=y": {
+      "model": "${modid}:block/${registryname}"
+    },
+    "axis=z": {
       "model": "${modid}:block/${registryname}",
-      "x": 90,
-      "y": 90
+      "x": 90
     }
   }
 }

--- a/plugins/generator-1.16.5/forge-1.16.5/utils/boundingboxes.java.ftl
+++ b/plugins/generator-1.16.5/forge-1.16.5/utils/boundingboxes.java.ftl
@@ -33,17 +33,14 @@
             </#if>
         }
     <#else>
-        switch ((Direction) state.get(FACING)) {
-            case SOUTH:
-            case NORTH:
+        switch ((Direction.Axis) state.get(AXIS)) {
+            case X:
+                <@makeBoundingBox positiveBoxes negativeBoxes noOffset "x"/>
+            case Y:
             default:
-                <@makeBoundingBox positiveBoxes negativeBoxes noOffset "north"/>
-            case EAST:
-            case WEST:
-                <@makeBoundingBox positiveBoxes negativeBoxes noOffset "up"/>
-            case UP:
-            case DOWN:
-                <@makeBoundingBox positiveBoxes negativeBoxes noOffset "log_up"/>
+                <@makeBoundingBox positiveBoxes negativeBoxes noOffset "y"/>
+            case Z:
+                <@makeBoundingBox positiveBoxes negativeBoxes noOffset "z"/>
         }
     </#if>
 </#macro>
@@ -57,10 +54,10 @@
         makeCuboidShape(${box.mz}, ${box.my}, ${16 - box.mx}, ${box.Mz}, ${box.My}, ${16 - box.Mx})
     <#elseif facing == "up">
         makeCuboidShape(${box.mx}, ${16 - box.mz}, ${box.my}, ${box.Mx}, ${16 - box.Mz}, ${box.My})
-    <#elseif facing == "down">
+    <#elseif facing == "down" || facing == "z">
         makeCuboidShape(${box.mx}, ${box.mz}, ${16 - box.my}, ${box.Mx}, ${box.Mz}, ${16 - box.My})
-    <#elseif facing == "log_up">
-        makeCuboidShape(${box.my}, ${16 - box.mx}, ${16 - box.mz}, ${box.My}, ${16 - box.Mx}, ${16 - box.Mz})
+    <#elseif facing == "x">
+        makeCuboidShape(${box.my}, ${box.mz}, ${box.mx}, ${box.My}, ${box.Mz}, ${box.Mx})
     <#else>
         makeCuboidShape(${box.mx}, ${box.my}, ${box.mz}, ${box.Mx}, ${box.My}, ${box.Mz})
     </#if>

--- a/plugins/generator-1.16.5/forge-1.16.5/utils/mcitems.ftl
+++ b/plugins/generator-1.16.5/forge-1.16.5/utils/mcitems.ftl
@@ -203,7 +203,7 @@
                     <#if ge.rotationMode != 0 && ge.rotationMode != 5>
                         <#assign properties += [{"name": "facing", "value": "north"}] />
                     <#elseif ge.rotationMode == 5>
-                        <#assign properties += [{"name": "facing", "value": "south"}] />
+                        <#assign properties += [{"name": "axis", "value": "y"}] />
                     </#if>
                 </#if>
             </#if>


### PR DESCRIPTION
This PR fixes #1484 by changing how log rotation is defined in the templates, although this will affect existing worlds with blocks that use this kind of rotation