### PR TITLE
Implemented Workspace and Global MCreatorPreferences

### DIFF
--- a/src/main/java/net/mcreator/Launcher.java
+++ b/src/main/java/net/mcreator/Launcher.java
@@ -79,12 +79,12 @@ public class Launcher {
 		LOG.info("Current JAVA_HOME for running instance: " + System.getProperty("java.home"));
 
 		// after we have libraries loaded, we load preferences
-		PreferencesManager.loadPreferences();
+		PreferencesManager.loadGlobalPreferences();
 
 		// set system properties from preferences
-		System.setProperty("awt.useSystemAAFontSettings", PreferencesManager.PREFERENCES.ui.textAntialiasingType);
-		System.setProperty("swing.aatext", Boolean.toString(PreferencesManager.PREFERENCES.ui.aatext));
-		System.setProperty("sun.java2d.opengl", Boolean.toString(PreferencesManager.PREFERENCES.ui.use2DAcceleration));
+		System.setProperty("awt.useSystemAAFontSettings", PreferencesManager.GlobalPREFERENCES.ui.textAntialiasingType);
+		System.setProperty("swing.aatext", Boolean.toString(PreferencesManager.GlobalPREFERENCES.ui.aatext));
+		System.setProperty("sun.java2d.opengl", Boolean.toString(PreferencesManager.GlobalPREFERENCES.ui.use2DAcceleration));
 		System.setProperty("sun.java2d.d3d", "false");
 		System.setProperty("prism.lcdtext", "false");
 

--- a/src/main/java/net/mcreator/gradle/GradleErrorDecoder.java
+++ b/src/main/java/net/mcreator/gradle/GradleErrorDecoder.java
@@ -65,7 +65,7 @@ public class GradleErrorDecoder {
 		if ((err.contains("No cached version of ") && err.contains(" available for offline mode.")) || (
 				err.contains(" not found! Maybe you are running in offline mode?") && err
 						.contains("java.io.FileNotFoundException"))) {
-			if (PreferencesManager.PREFERENCES.gradle.offline)
+			if (PreferencesManager.GlobalPREFERENCES.gradle.offline)
 				return GradleErrorDialogs.showErrorDialog(GradleErrorCodes.GRADLE_CACHEDATA_OUTDATED, whereToShow);
 			else
 				return GradleErrorDialogs.showErrorDialog(GradleErrorCodes.GRADLE_CACHEDATA_ERROR, whereToShow);

--- a/src/main/java/net/mcreator/gradle/GradleUtils.java
+++ b/src/main/java/net/mcreator/gradle/GradleUtils.java
@@ -45,8 +45,8 @@ public class GradleUtils {
 
 	public static BuildLauncher getGradleTaskLauncher(Workspace workspace, String... tasks) {
 		BuildLauncher retval = getGradleProjectConnection(workspace).newBuild().forTasks(tasks)
-				.setJvmArguments("-Xms" + PreferencesManager.PREFERENCES.gradle.xms + "m",
-						"-Xmx" + PreferencesManager.PREFERENCES.gradle.xmx + "m");
+				.setJvmArguments("-Xms" + PreferencesManager.GlobalPREFERENCES.gradle.xms + "m",
+						"-Xmx" + PreferencesManager.GlobalPREFERENCES.gradle.xmx + "m");
 
 		String java_home = getJavaHome();
 		if (java_home != null) // make sure detected JAVA_HOME is not null

--- a/src/main/java/net/mcreator/minecraft/BedrockUtils.java
+++ b/src/main/java/net/mcreator/minecraft/BedrockUtils.java
@@ -85,7 +85,7 @@ public class BedrockUtils {
 								if (option != 2) {
 									if (option == 1) {
 										PreferencesManager.PREFERENCES.bedrock.silentReload = true;
-										PreferencesManager.storePreferences(PreferencesManager.PREFERENCES);
+										PreferencesManager.storeWorkspacePreferences(PreferencesManager.PREFERENCES);
 									}
 
 									WindowsProcessUtil.killProcess(MC_PROCESS);

--- a/src/main/java/net/mcreator/preferences/GlobalPreferencesData.java
+++ b/src/main/java/net/mcreator/preferences/GlobalPreferencesData.java
@@ -1,0 +1,87 @@
+/*
+ * MCreator (https://mcreator.net/)
+ * Copyright (C) 2012-2020, Pylo
+ * Copyright (C) 2020-2021, Pylo, opensource contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package net.mcreator.preferences;
+
+import net.mcreator.io.OS;
+import net.mcreator.ui.init.L10N;
+import net.mcreator.ui.laf.MCreatorTheme;
+
+import java.awt.*;
+import java.util.Locale;
+
+public class GlobalPreferencesData {
+
+	@GlobalPreferencesSection public BackupsSettings backups = new BackupsSettings();
+	@GlobalPreferencesSection public UISettings ui = new UISettings();
+	@GlobalPreferencesSection public NotificationSettings notifications = new NotificationSettings();
+	@GlobalPreferencesSection public GradleSettings gradle = new GradleSettings();
+
+
+	public static class UISettings {
+
+		@GlobalPreferencesEntry public Color interfaceAccentColor = MCreatorTheme.MAIN_TINT_DEFAULT;
+
+		@GlobalPreferencesEntry public Locale language = L10N.DEFAULT_LOCALE;
+
+		@GlobalPreferencesEntry public boolean aatext = true;
+
+		@GlobalPreferencesEntry(arrayData = { "on", "off", "gasp", "lcd", "lcd_hbgr", "lcd_vrgb", "lcd_vbgr" })
+		public String textAntialiasingType = "on";
+
+		@GlobalPreferencesEntry public boolean expandSectionsByDefault = false;
+		@GlobalPreferencesEntry public boolean use2DAcceleration = false;
+		@GlobalPreferencesEntry public boolean autoreloadTabs = true;
+		@GlobalPreferencesEntry public boolean discordRichPresenceEnable = true;
+
+	}
+
+	public static class NotificationSettings {
+
+		@GlobalPreferencesEntry public boolean openWhatsNextPage = true;
+		@GlobalPreferencesEntry public boolean checkAndNotifyForUpdates = true;
+		@GlobalPreferencesEntry public boolean checkAndNotifyForPatches = true;
+		@GlobalPreferencesEntry public boolean checkAndNotifyForPluginUpdates = false;
+
+	}
+
+	public static class BackupsSettings {
+
+		@GlobalPreferencesEntry(min = 10, max = 1800) public int workspaceAutosaveInterval = 30;
+		@GlobalPreferencesEntry(min = 3, max = 120) public int automatedBackupInterval = 5;
+		@GlobalPreferencesEntry(min = 2, max = 20) public int numberOfBackupsToStore = 10;
+		@GlobalPreferencesEntry public boolean backupOnVersionSwitch = true;
+
+	}
+
+	public static class GradleSettings {
+
+		@GlobalPreferencesEntry public boolean compileOnSave = true;
+		@GlobalPreferencesEntry public boolean passLangToMinecraft = true;
+
+		@GlobalPreferencesEntry(min = 128, meta = "max:maxram") public int xms =
+				OS.getBundledJVMBits() == OS.BIT64 ? 625 : 512;
+
+		@GlobalPreferencesEntry(min = 128, meta = "max:maxram") public int xmx =
+				OS.getBundledJVMBits() == OS.BIT64 ? 2048 : 1500;
+
+		@GlobalPreferencesEntry public boolean offline = false;
+	}
+
+}

--- a/src/main/java/net/mcreator/preferences/GlobalPreferencesEntry.java
+++ b/src/main/java/net/mcreator/preferences/GlobalPreferencesEntry.java
@@ -1,0 +1,39 @@
+/*
+ * MCreator (https://mcreator.net/)
+ * Copyright (C) 2012-2020, Pylo
+ * Copyright (C) 2020-2021, Pylo, opensource contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package net.mcreator.preferences;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME) public @interface GlobalPreferencesEntry {
+
+	double min() default Double.NaN;
+
+	double max() default Double.NaN;
+
+	String meta() default "";
+
+	String[] arrayData() default {};
+
+	boolean arrayDataEditable() default false;
+
+	int visualWidth() default -1;
+
+}

--- a/src/main/java/net/mcreator/preferences/GlobalPreferencesSection.java
+++ b/src/main/java/net/mcreator/preferences/GlobalPreferencesSection.java
@@ -1,0 +1,26 @@
+/*
+ * MCreator (https://mcreator.net/)
+ * Copyright (C) 2012-2020, Pylo
+ * Copyright (C) 2020-2021, Pylo, opensource contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package net.mcreator.preferences;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME) public @interface GlobalPreferencesSection {}
+

--- a/src/main/java/net/mcreator/preferences/PreferencesData.java
+++ b/src/main/java/net/mcreator/preferences/PreferencesData.java
@@ -18,61 +18,15 @@
 
 package net.mcreator.preferences;
 
-import net.mcreator.io.OS;
-import net.mcreator.ui.init.L10N;
-import net.mcreator.ui.laf.MCreatorTheme;
-
-import java.awt.*;
 import java.io.File;
-import java.util.Locale;
 
 public class PreferencesData {
 
-	@PreferencesSection public UISettings ui = new UISettings();
-	@PreferencesSection public BackupsSettings backups = new BackupsSettings();
 	@PreferencesSection public BlocklySettings blockly = new BlocklySettings();
 	@PreferencesSection public IDESettings ide = new IDESettings();
-	@PreferencesSection public GradleSettings gradle = new GradleSettings();
 	@PreferencesSection public BedrockSettings bedrock = new BedrockSettings();
-	@PreferencesSection public NotificationSettings notifications = new NotificationSettings();
 
 	public HiddenPreferences hidden = new HiddenPreferences();
-
-	public static class UISettings {
-
-		@PreferencesEntry public Color interfaceAccentColor = MCreatorTheme.MAIN_TINT_DEFAULT;
-
-		@PreferencesEntry public Locale language = L10N.DEFAULT_LOCALE;
-
-		@PreferencesEntry public boolean aatext = true;
-
-		@PreferencesEntry(arrayData = { "on", "off", "gasp", "lcd", "lcd_hbgr", "lcd_vrgb", "lcd_vbgr" })
-		public String textAntialiasingType = "on";
-
-		@PreferencesEntry public boolean expandSectionsByDefault = false;
-		@PreferencesEntry public boolean use2DAcceleration = false;
-		@PreferencesEntry public boolean autoreloadTabs = true;
-		@PreferencesEntry public boolean discordRichPresenceEnable = true;
-
-	}
-
-	public static class NotificationSettings {
-
-		@PreferencesEntry public boolean openWhatsNextPage = true;
-		@PreferencesEntry public boolean checkAndNotifyForUpdates = true;
-		@PreferencesEntry public boolean checkAndNotifyForPatches = true;
-		@PreferencesEntry public boolean checkAndNotifyForPluginUpdates = false;
-
-	}
-
-	public static class BackupsSettings {
-
-		@PreferencesEntry(min = 10, max = 1800) public int workspaceAutosaveInterval = 30;
-		@PreferencesEntry(min = 3, max = 120) public int automatedBackupInterval = 5;
-		@PreferencesEntry(min = 2, max = 20) public int numberOfBackupsToStore = 10;
-		@PreferencesEntry public boolean backupOnVersionSwitch = true;
-
-	}
 
 	public static class BlocklySettings {
 
@@ -100,20 +54,6 @@ public class PreferencesData {
 		@PreferencesEntry public boolean lineNumbers = true;
 		@PreferencesEntry public boolean errorInfoEnable = true;
 
-	}
-
-	public static class GradleSettings {
-
-		@PreferencesEntry public boolean compileOnSave = true;
-		@PreferencesEntry public boolean passLangToMinecraft = true;
-
-		@PreferencesEntry(min = 128, meta = "max:maxram") public int xms =
-				OS.getBundledJVMBits() == OS.BIT64 ? 625 : 512;
-
-		@PreferencesEntry(min = 128, meta = "max:maxram") public int xmx =
-				OS.getBundledJVMBits() == OS.BIT64 ? 2048 : 1500;
-
-		@PreferencesEntry public boolean offline = false;
 	}
 
 	public static class BedrockSettings {

--- a/src/main/java/net/mcreator/ui/MCreator.java
+++ b/src/main/java/net/mcreator/ui/MCreator.java
@@ -96,7 +96,7 @@ public final class MCreator extends JFrame implements IWorkspaceProvider, IGener
 		if (vcs != null) {
 			this.workspace.setVCS(vcs);
 		}
-		
+
 		PreferencesManager.loadWorkspacePreferences(workspaceFile.getParentFile(), workspace);
 		LOG.info("Loaded preferences for current workspace");
 

--- a/src/main/java/net/mcreator/ui/MCreator.java
+++ b/src/main/java/net/mcreator/ui/MCreator.java
@@ -85,7 +85,7 @@ public final class MCreator extends JFrame implements IWorkspaceProvider, IGener
 
 	private final long windowUID;
 
-	public MCreator(@Nullable MCreatorApplication application, @Nonnull Workspace workspace) {
+	public MCreator(@Nullable MCreatorApplication application, @Nonnull Workspace workspace, @Nonnull File workspaceFile) {
 		LOG.info("Opening MCreator workspace: " + workspace.getWorkspaceSettings().getModID());
 
 		this.windowUID = System.currentTimeMillis();
@@ -95,8 +95,11 @@ public final class MCreator extends JFrame implements IWorkspaceProvider, IGener
 		WorkspaceVCS vcs = WorkspaceVCS.loadVCSWorkspace(this.workspace);
 		if (vcs != null) {
 			this.workspace.setVCS(vcs);
-			LOG.info("Loaded VCS for current workspace");
 		}
+
+		PreferencesManager pm = new PreferencesManager();
+		pm.loadWorkspacePreferences(workspaceFile.getParentFile(), workspace);
+		LOG.info("Loaded preferences for current workspace");
 
 		this.gradleConsole = new GradleConsole(this);
 		this.gradleConsole.addGradleStateListener(new GradleStateListener() {
@@ -274,7 +277,7 @@ public final class MCreator extends JFrame implements IWorkspaceProvider, IGener
 
 			// backup if new version and backups are enabled
 			if (workspace.getMCreatorVersion() < Launcher.version.versionlong
-					&& PreferencesManager.PREFERENCES.backups.backupOnVersionSwitch) {
+					&& PreferencesManager.GlobalPREFERENCES.backups.backupOnVersionSwitch) {
 				ShareableZIPManager.exportZIP("Workspace backup",
 						new File(workspace.getFolderManager().getWorkspaceCacheDir(),
 								"FullBackup" + workspace.getMCreatorVersion() + ".zip"), this, true);
@@ -283,7 +286,7 @@ public final class MCreator extends JFrame implements IWorkspaceProvider, IGener
 			// if we need to setup MCreator, we do so
 			if (WorkspaceGeneratorSetup.shouldSetupBeRan(workspace.getGenerator())) {
 				WorkspaceGeneratorSetupDialog
-						.runSetup(this, PreferencesManager.PREFERENCES.notifications.openWhatsNextPage);
+						.runSetup(this, PreferencesManager.GlobalPREFERENCES.notifications.openWhatsNextPage);
 			}
 
 			if (workspace.getMCreatorVersion()

--- a/src/main/java/net/mcreator/ui/MCreator.java
+++ b/src/main/java/net/mcreator/ui/MCreator.java
@@ -96,9 +96,8 @@ public final class MCreator extends JFrame implements IWorkspaceProvider, IGener
 		if (vcs != null) {
 			this.workspace.setVCS(vcs);
 		}
-
-		PreferencesManager pm = new PreferencesManager();
-		pm.loadWorkspacePreferences(workspaceFile.getParentFile(), workspace);
+		
+		PreferencesManager.loadWorkspacePreferences(workspaceFile.getParentFile(), workspace);
 		LOG.info("Loaded preferences for current workspace");
 
 		this.gradleConsole = new GradleConsole(this);

--- a/src/main/java/net/mcreator/ui/MCreatorApplication.java
+++ b/src/main/java/net/mcreator/ui/MCreatorApplication.java
@@ -182,7 +182,7 @@ public final class MCreatorApplication {
 				Desktop.getDesktop().setAboutHandler(aboutEvent -> AboutAction.showDialog(null));
 
 			if (Desktop.getDesktop().isSupported(Desktop.Action.APP_PREFERENCES))
-				Desktop.getDesktop().setPreferencesHandler(preferencesEvent -> new PreferencesDialog(null, null));
+				Desktop.getDesktop().setPreferencesHandler(preferencesEvent -> new PreferencesDialog(null, null, null));
 
 			if (Desktop.getDesktop().isSupported(Desktop.Action.APP_QUIT_HANDLER))
 				Desktop.getDesktop().setQuitHandler((e, response) -> MCreatorApplication.this.closeApplication());
@@ -252,7 +252,7 @@ public final class MCreatorApplication {
 				JOptionPane.showMessageDialog(workspaceSelector, L10N.t("dialog.workspace.open_failed_message"),
 						L10N.t("dialog.workspace.open_failed_title"), JOptionPane.ERROR_MESSAGE);
 			} else {
-				MCreator mcreator = new MCreator(this, workspace);
+				MCreator mcreator = new MCreator(this, workspace, workspaceFile);
 				if (!this.openMCreators.contains(mcreator)) {
 					this.workspaceSelector.setVisible(false);
 					this.openMCreators.add(mcreator);
@@ -320,7 +320,7 @@ public final class MCreatorApplication {
 		}
 
 		LOG.debug("Performing exit tasks");
-		PreferencesManager.storePreferences(PreferencesManager.PREFERENCES); // store any potential preferences changes
+		PreferencesManager.storeGlobalPreferences(PreferencesManager.GlobalPREFERENCES); // store any potential preferences changes
 		analytics.trackMCreatorClose(); // track app close in sync mode
 
 		discordClient.close(); // close discord client

--- a/src/main/java/net/mcreator/ui/StatusBar.java
+++ b/src/main/java/net/mcreator/ui/StatusBar.java
@@ -96,7 +96,7 @@ public class StatusBar extends JPanel {
 		JLabel preferences = new JLabel(UIRES.get("settings"));
 		preferences.addMouseListener(new MouseAdapter() {
 			@Override public void mouseClicked(MouseEvent e) {
-				new PreferencesDialog(mcreator, null);
+				new PreferencesDialog(mcreator, null, true);
 			}
 		});
 		preferences.setCursor(new Cursor(Cursor.HAND_CURSOR));

--- a/src/main/java/net/mcreator/ui/action/ActionRegistry.java
+++ b/src/main/java/net/mcreator/ui/action/ActionRegistry.java
@@ -204,7 +204,7 @@ public class ActionRegistry {
 		this.mcreatorPublish = new VisitURIAction(this, L10N.t("action.publish_modification"),
 				MCreatorApplication.SERVER_DOMAIN + "/node/add/modification/");
 		this.preferences = new BasicAction(this, L10N.t("action.preferences"),
-				e -> new PreferencesDialog(mcreator, null)).setIcon(UIRES.get("settings"));
+				e -> new PreferencesDialog(mcreator, null, false)).setIcon(UIRES.get("settings"));
 		this.exitMCreator = new BasicAction(this, L10N.t("action.exit"),
 				e -> mcreator.getApplication().closeApplication());
 		this.aboutMCreator = new AboutAction(this);

--- a/src/main/java/net/mcreator/ui/action/impl/gradle/RunClientAction.java
+++ b/src/main/java/net/mcreator/ui/action/impl/gradle/RunClientAction.java
@@ -40,7 +40,7 @@ public class RunClientAction extends GradleAction {
 				actionRegistry.getMCreator().getGenerator().runResourceSetupTasks();
 				actionRegistry.getMCreator().getGenerator().generateBase();
 
-				if (PreferencesManager.PREFERENCES.gradle.passLangToMinecraft)
+				if (PreferencesManager.GlobalPREFERENCES.gradle.passLangToMinecraft)
 					MinecraftOptionsUtils
 							.setLangTo(actionRegistry.getMCreator().getWorkspace(), L10N.getLocaleString());
 

--- a/src/main/java/net/mcreator/ui/action/impl/gradle/RunServerAction.java
+++ b/src/main/java/net/mcreator/ui/action/impl/gradle/RunServerAction.java
@@ -104,7 +104,7 @@ public class RunServerAction extends GradleAction {
 					actionRegistry.getMCreator().getGenerator().runResourceSetupTasks();
 					actionRegistry.getMCreator().getGenerator().generateBase();
 
-					if (PreferencesManager.PREFERENCES.gradle.passLangToMinecraft)
+					if (PreferencesManager.GlobalPREFERENCES.gradle.passLangToMinecraft)
 						MinecraftOptionsUtils
 								.setLangTo(actionRegistry.getMCreator().getWorkspace(), L10N.getLocaleString());
 

--- a/src/main/java/net/mcreator/ui/component/util/DiscordClient.java
+++ b/src/main/java/net/mcreator/ui/component/util/DiscordClient.java
@@ -39,7 +39,7 @@ public class DiscordClient implements Closeable {
 	private final Timer timer = new Timer();
 
 	public DiscordClient() {
-		if (!PreferencesManager.PREFERENCES.ui.discordRichPresenceEnable)
+		if (!PreferencesManager.GlobalPREFERENCES.ui.discordRichPresenceEnable)
 			return;
 
 		try {
@@ -66,7 +66,7 @@ public class DiscordClient implements Closeable {
 	}
 
 	public void updatePresence(String state, String details, String smallImage) {
-		if (!PreferencesManager.PREFERENCES.ui.discordRichPresenceEnable)
+		if (!PreferencesManager.GlobalPREFERENCES.ui.discordRichPresenceEnable)
 			return;
 
 		new Thread(() -> {
@@ -85,7 +85,7 @@ public class DiscordClient implements Closeable {
 	}
 
 	@Override public void close() {
-		if (!PreferencesManager.PREFERENCES.ui.discordRichPresenceEnable)
+		if (!PreferencesManager.GlobalPREFERENCES.ui.discordRichPresenceEnable)
 			return;
 
 		try {

--- a/src/main/java/net/mcreator/ui/dialogs/UpdateNotifyDialog.java
+++ b/src/main/java/net/mcreator/ui/dialogs/UpdateNotifyDialog.java
@@ -45,7 +45,7 @@ public class UpdateNotifyDialog {
 			UpdateInfo updateInfo = MCreatorApplication.WEB_API.getUpdateInfo();
 			if (updateInfo != null) {
 				long newMajor = MCreatorVersionNumber.majorStringToLong(updateInfo.getLatestMajor());
-				if (newMajor > oldMajor && (PreferencesManager.PREFERENCES.notifications.checkAndNotifyForUpdates
+				if (newMajor > oldMajor && (PreferencesManager.GlobalPREFERENCES.notifications.checkAndNotifyForUpdates
 						|| Launcher.version.isSnapshot())) {
 					JPanel pan = new JPanel(new BorderLayout());
 					JLabel upde = L10N
@@ -79,7 +79,7 @@ public class UpdateNotifyDialog {
 					Release thisRelease = updateInfo.getReleases().get(Launcher.version.major);
 					if (thisRelease != null) {
 						if (Launcher.version.buildlong < Long.parseLong(thisRelease.getLatestBuild()) && (
-								PreferencesManager.PREFERENCES.notifications.checkAndNotifyForPatches
+								PreferencesManager.GlobalPREFERENCES.notifications.checkAndNotifyForPatches
 										|| Launcher.version.isSnapshot())) {
 							JPanel pan = new JPanel(new BorderLayout());
 							JLabel upde = L10N.label("dialog.update_notify.more_recent_build", Launcher.version.major,

--- a/src/main/java/net/mcreator/ui/dialogs/UpdatePluginDialog.java
+++ b/src/main/java/net/mcreator/ui/dialogs/UpdatePluginDialog.java
@@ -33,7 +33,7 @@ import java.awt.*;
 public class UpdatePluginDialog {
 
 	public static void showPluginUpdateDialogIfUpdatesExist(Window parent) {
-		if (PreferencesManager.PREFERENCES.notifications.checkAndNotifyForPluginUpdates && !PluginLoader.INSTANCE
+		if (PreferencesManager.GlobalPREFERENCES.notifications.checkAndNotifyForPluginUpdates && !PluginLoader.INSTANCE
 				.getPluginUpdates().isEmpty()) {
 			JPanel pan = new JPanel(new BorderLayout(10, 15));
 

--- a/src/main/java/net/mcreator/ui/dialogs/workspace/WorkspaceGeneratorSetupDialog.java
+++ b/src/main/java/net/mcreator/ui/dialogs/workspace/WorkspaceGeneratorSetupDialog.java
@@ -148,7 +148,7 @@ public class WorkspaceGeneratorSetupDialog {
 		if (action == 0) {
 			runSetup(m, false);
 		} else if (action == 1) {
-			new PreferencesDialog(m, null);
+			new PreferencesDialog(m, null, true);
 			runSetup(m, false);
 		} else if (action == 2) {
 			StringSelection stringSelection = new StringSelection(m.getGradleConsole().getConsoleText());

--- a/src/main/java/net/mcreator/ui/gradle/GradleConsole.java
+++ b/src/main/java/net/mcreator/ui/gradle/GradleConsole.java
@@ -307,10 +307,10 @@ public class GradleConsole extends JPanel {
 
 		long millis = System.currentTimeMillis();
 
-		if (PreferencesManager.PREFERENCES.gradle.offline && gradleSetupTaskRunning) {
+		if (PreferencesManager.GlobalPREFERENCES.gradle.offline && gradleSetupTaskRunning) {
 			JOptionPane.showMessageDialog(ref, L10N.t("dialog.gradle_console.offline_mode_message"),
 					L10N.t("dialog.gradle_console.offline_mode_title"), JOptionPane.WARNING_MESSAGE);
-			PreferencesManager.PREFERENCES.gradle.offline = false;
+			PreferencesManager.GlobalPREFERENCES.gradle.offline = false;
 		}
 
 		String[] commandTokens = command.split(" ");
@@ -320,7 +320,7 @@ public class GradleConsole extends JPanel {
 
 		BuildLauncher task = GradleUtils.getGradleTaskLauncher(ref.getWorkspace(), commands);
 
-		if (PreferencesManager.PREFERENCES.gradle.offline)
+		if (PreferencesManager.GlobalPREFERENCES.gradle.offline)
 			arguments.add("--offline");
 
 		task.addArguments(arguments);

--- a/src/main/java/net/mcreator/ui/gradle/GradleErrorDialogs.java
+++ b/src/main/java/net/mcreator/ui/gradle/GradleErrorDialogs.java
@@ -70,7 +70,7 @@ public class GradleErrorDialogs {
 	}
 
 	private static void showGradleCacheDataErrorDialog(MCreator whereToShow, int errorCode) {
-		if (PreferencesManager.PREFERENCES.gradle.offline) {
+		if (PreferencesManager.GlobalPREFERENCES.gradle.offline) {
 			showGradleCacheOutdatedDialogOfflineMode(whereToShow, errorCode);
 		} else {
 			String msg = L10N.t("gradle.errors.cache_corrupted");
@@ -93,7 +93,7 @@ public class GradleErrorDialogs {
 				.showOptionDialog(whereToShow, applyAppendx(msg, errorCode), L10N.t("gradle.errors.title"),
 						JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE, null, options, options[0]);
 		if (option == 0) {
-			new PreferencesDialog(whereToShow, "Gradle settings");
+			new PreferencesDialog(whereToShow, "Gradle settings", true);
 		}
 	}
 
@@ -118,7 +118,7 @@ public class GradleErrorDialogs {
 				.showOptionDialog(whereToShow, applyAppendx(msg, errorCode), L10N.t("gradle.errors.title"),
 						JOptionPane.YES_NO_OPTION, JOptionPane.ERROR_MESSAGE, null, options, options[0]);
 		if (option == 0) {
-			new PreferencesDialog(whereToShow, "Gradle settings");
+			new PreferencesDialog(whereToShow, "Gradle settings", true);
 		}
 	}
 

--- a/src/main/java/net/mcreator/ui/init/L10N.java
+++ b/src/main/java/net/mcreator/ui/init/L10N.java
@@ -99,7 +99,7 @@ public class L10N {
 
 	public static Locale getLocale() {
 		if (selectedLocale == null)
-			selectedLocale = PreferencesManager.PREFERENCES.ui.language;
+			selectedLocale = PreferencesManager.GlobalPREFERENCES.ui.language;
 
 		return selectedLocale;
 	}

--- a/src/main/java/net/mcreator/ui/laf/MCreatorTheme.java
+++ b/src/main/java/net/mcreator/ui/laf/MCreatorTheme.java
@@ -65,10 +65,10 @@ public class MCreatorTheme extends OceanTheme {
 				LOG.warn(colorScheme.getInterfaceAccentColor()
 								+ " in the current theme is not a valid hexadecimal number. The color defined by the user will be used.",
 						exception.getMessage());
-				MAIN_TINT = PreferencesManager.PREFERENCES.ui.interfaceAccentColor;
+				MAIN_TINT = PreferencesManager.GlobalPREFERENCES.ui.interfaceAccentColor;
 			}
 		} else {
-			MAIN_TINT = PreferencesManager.PREFERENCES.ui.interfaceAccentColor;
+			MAIN_TINT = PreferencesManager.GlobalPREFERENCES.ui.interfaceAccentColor;
 		}
 
 		try {

--- a/src/main/java/net/mcreator/ui/modgui/ArmorGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/ArmorGUI.java
@@ -306,7 +306,7 @@ public class ArmorGUI extends ModElementGUI<Armor> {
 								new JLabel(":"), helmetModelPart, L10N.label("elementgui.armor.texture"),
 								helmetModelTexture), PanelUtils
 						.join(FlowLayout.LEFT, L10N.label("elementgui.armor.special_information"), helmetSpecialInfo)));
-		helmetModelPanel.toggleVisibility(PreferencesManager.PREFERENCES.ui.expandSectionsByDefault);
+		helmetModelPanel.toggleVisibility(PreferencesManager.GlobalPREFERENCES.ui.expandSectionsByDefault);
 
 		JComponent helText = PanelUtils
 				.centerAndSouthElement(PanelUtils.centerInPanelPadding(textureHelmet, 0, 0), enableHelmet);
@@ -333,7 +333,7 @@ public class ArmorGUI extends ModElementGUI<Armor> {
 								armsModelPartL, L10N.label("elementgui.armor.part_arm_right"), armsModelPartR,
 								L10N.label("elementgui.armor.texture"), bodyModelTexture), PanelUtils
 						.join(FlowLayout.LEFT, L10N.label("elementgui.armor.special_information"), bodySpecialInfo)));
-		bodyModelPanel.toggleVisibility(PreferencesManager.PREFERENCES.ui.expandSectionsByDefault);
+		bodyModelPanel.toggleVisibility(PreferencesManager.GlobalPREFERENCES.ui.expandSectionsByDefault);
 
 		destal.add(PanelUtils.westAndCenterElement(bodText, PanelUtils.centerAndSouthElement(
 				PanelUtils.join(FlowLayout.LEFT, L10N.label("elementgui.armor.body_name"), bodyName), bodyModelPanel),
@@ -354,7 +354,7 @@ public class ArmorGUI extends ModElementGUI<Armor> {
 								L10N.label("elementgui.armor.texture"), leggingsModelTexture), PanelUtils
 						.join(FlowLayout.LEFT, L10N.label("elementgui.armor.special_information"),
 								leggingsSpecialInfo)));
-		leggingsModelPanel.toggleVisibility(PreferencesManager.PREFERENCES.ui.expandSectionsByDefault);
+		leggingsModelPanel.toggleVisibility(PreferencesManager.GlobalPREFERENCES.ui.expandSectionsByDefault);
 
 		destal.add(PanelUtils.westAndCenterElement(legText, PanelUtils.centerAndSouthElement(
 				PanelUtils.join(FlowLayout.LEFT, L10N.label("elementgui.armor.leggings_name"), leggingsName),
@@ -374,7 +374,7 @@ public class ArmorGUI extends ModElementGUI<Armor> {
 								new JLabel(": L"), bootsModelPartL, new JLabel("R"), bootsModelPartR,
 								L10N.label("elementgui.armor.texture"), bootsModelTexture), PanelUtils
 						.join(FlowLayout.LEFT, L10N.label("elementgui.armor.special_information"), bootsSpecialInfo)));
-		bootsModelPanel.toggleVisibility(PreferencesManager.PREFERENCES.ui.expandSectionsByDefault);
+		bootsModelPanel.toggleVisibility(PreferencesManager.GlobalPREFERENCES.ui.expandSectionsByDefault);
 
 		destal.add(PanelUtils.westAndCenterElement(bootText, PanelUtils.centerAndSouthElement(
 				PanelUtils.join(FlowLayout.LEFT, L10N.label("elementgui.armor.boots_name"), bootsName),

--- a/src/main/java/net/mcreator/ui/modgui/CustomGUIGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/CustomGUIGUI.java
@@ -62,7 +62,7 @@ public class CustomGUIGUI extends ModElementGUI<GUI> {
 		CollapsiblePanel events = new CollapsiblePanel(L10N.t("elementgui.gui.gui_triggers"),
 				PanelUtils.join(FlowLayout.LEFT, 1, 1, PanelUtils.gridElements(1, 3, 5, 0, onOpen, onTick, onClosed)));
 		events.setOpaque(false);
-		events.toggleVisibility(PreferencesManager.PREFERENCES.ui.expandSectionsByDefault);
+		events.toggleVisibility(PreferencesManager.GlobalPREFERENCES.ui.expandSectionsByDefault);
 
 		JPanel main = new JPanel(new BorderLayout(0, 5));
 		main.setOpaque(false);

--- a/src/main/java/net/mcreator/ui/modgui/ModElementGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/ModElementGUI.java
@@ -95,7 +95,7 @@ public abstract class ModElementGUI<GE extends GeneratableElement> extends ViewB
 
 		// reload data lists in a background thread
 		this.tabIn.setTabShownListener(tab -> {
-			if (PreferencesManager.PREFERENCES.ui.autoreloadTabs)
+			if (PreferencesManager.GlobalPREFERENCES.ui.autoreloadTabs)
 				reloadDataLists();
 		});
 
@@ -431,7 +431,7 @@ public abstract class ModElementGUI<GE extends GeneratableElement> extends ViewB
 		afterGeneratableElementStored();
 
 		// build if selected and needed
-		if (PreferencesManager.PREFERENCES.gradle.compileOnSave && mcreator.getModElementManager()
+		if (PreferencesManager.GlobalPREFERENCES.gradle.compileOnSave && mcreator.getModElementManager()
 				.usesGeneratableElementJava(element))
 			mcreator.actionRegistry.buildWorkspace.doAction();
 

--- a/src/main/java/net/mcreator/ui/workspace/selector/RecentWorkspacesRenderer.java
+++ b/src/main/java/net/mcreator/ui/workspace/selector/RecentWorkspacesRenderer.java
@@ -48,8 +48,10 @@ class RecentWorkspacesRenderer extends JLabel implements ListCellRenderer<Recent
 
 			if (isSelected) {
 				setIcon(ImageUtils.colorize(icon, (Color) UIManager.get("MCreatorLAF.MAIN_TINT"), false));
+				setBorder(BorderFactory.createCompoundBorder(BorderFactory.createLineBorder(Color.gray), BorderFactory.createEmptyBorder(2, 0, 3, 2)));
 			} else {
 				setIcon(icon);
+				setBorder(BorderFactory.createEmptyBorder(2, 0, 3, 0));
 			}
 
 			setIconTextGap(10);

--- a/src/main/java/net/mcreator/ui/workspace/selector/WorkspaceSelector.java
+++ b/src/main/java/net/mcreator/ui/workspace/selector/WorkspaceSelector.java
@@ -229,7 +229,7 @@ public final class WorkspaceSelector extends JFrame implements DropTargetListene
 		prefs.setHorizontalTextPosition(JLabel.LEFT);
 		prefs.addMouseListener(new MouseAdapter() {
 			@Override public void mouseClicked(MouseEvent mouseEvent) {
-				new PreferencesDialog(WorkspaceSelector.this, null);
+				new PreferencesDialog(WorkspaceSelector.this, null, false);
 			}
 		});
 		southcenter.add(prefs);

--- a/src/main/java/net/mcreator/workspace/WorkspaceFileManager.java
+++ b/src/main/java/net/mcreator/workspace/WorkspaceFileManager.java
@@ -68,7 +68,7 @@ public class WorkspaceFileManager implements Closeable {
 
 		// start autosave scheduler
 		lastSchedule = dataSaveExecutor
-				.schedule(new SaveTask(this), PreferencesManager.PREFERENCES.backups.workspaceAutosaveInterval,
+				.schedule(new SaveTask(this), PreferencesManager.GlobalPREFERENCES.backups.workspaceAutosaveInterval,
 						TimeUnit.SECONDS);
 	}
 
@@ -143,7 +143,7 @@ public class WorkspaceFileManager implements Closeable {
 	}
 
 	private void rotateWorkspaceFileBackup() {
-		int numberOfBackupsExcludingCurrent = PreferencesManager.PREFERENCES.backups.numberOfBackupsToStore - 1;
+		int numberOfBackupsExcludingCurrent = PreferencesManager.GlobalPREFERENCES.backups.numberOfBackupsToStore - 1;
 		File[] existingBackupsArray = folderManager.getWorkspaceBackupsCacheDir().listFiles();
 
 		if (existingBackupsArray != null && existingBackupsArray.length > 0) { // we already have some backups
@@ -152,7 +152,7 @@ public class WorkspaceFileManager implements Closeable {
 			Collections.reverse(existingBackups);
 			long lastBackupTime = existingBackups.get(0).lastModified();
 			if ((System.currentTimeMillis() - lastBackupTime) / (1000 * 60)
-					> PreferencesManager.PREFERENCES.backups.automatedBackupInterval) {  // check if we have surpassed backup interval
+					> PreferencesManager.GlobalPREFERENCES.backups.automatedBackupInterval) {  // check if we have surpassed backup interval
 				if (existingBackupsArray.length
 						> numberOfBackupsExcludingCurrent) // only delete old ones if we have more than threshold of backups
 					existingBackups.stream().skip(numberOfBackupsExcludingCurrent).forEach(File::delete);
@@ -193,7 +193,7 @@ public class WorkspaceFileManager implements Closeable {
 
 			// after we call save, we schedule a new call
 			fileManager.lastSchedule = fileManager.dataSaveExecutor.schedule(new SaveTask(fileManager),
-					PreferencesManager.PREFERENCES.backups.workspaceAutosaveInterval, TimeUnit.SECONDS);
+					PreferencesManager.GlobalPREFERENCES.backups.workspaceAutosaveInterval, TimeUnit.SECONDS);
 		}
 	}
 

--- a/src/test/java/net/mcreator/integration/generator/GeneratorsTest.java
+++ b/src/test/java/net/mcreator/integration/generator/GeneratorsTest.java
@@ -62,7 +62,7 @@ public class GeneratorsTest {
 		ConsolePane.DEBUG_CONTENTS_TO_LOG = true;
 
 		// reduce autosave interval for tests
-		PreferencesManager.PREFERENCES.backups.workspaceAutosaveInterval = 2000;
+		PreferencesManager.GlobalPREFERENCES.backups.workspaceAutosaveInterval = 2000;
 	}
 
 	public @TestFactory Stream<DynamicTest> testGenerators() {
@@ -109,7 +109,7 @@ public class GeneratorsTest {
 
 					GradleDaemonUtils.stopAllDaemons(workspace);
 
-					new MCreator(null, workspace).getGradleConsole()
+					new MCreator(null, workspace, null).getGradleConsole()
 							.exec(workspace.getGeneratorConfiguration().getGradleTaskFor("setup_task"), taskResult -> {
 								if (taskResult.getStatusByMCreator() == GradleErrorCodes.STATUS_OK) {
 									workspace.getGenerator().reloadGradleCaches();

--- a/src/test/java/net/mcreator/integration/ui/DialogsTest.java
+++ b/src/test/java/net/mcreator/integration/ui/DialogsTest.java
@@ -83,7 +83,7 @@ public class DialogsTest {
 		Workspace workspace = Workspace
 				.createWorkspace(new File(tempDirWithPrefix.toFile(), "test_mod.mcreator"), workspaceSettings);
 
-		mcreator = new MCreator(null, workspace);
+		mcreator = new MCreator(null, workspace, null);
 	}
 
 	@BeforeEach void printName(TestInfo testInfo) {
@@ -108,7 +108,7 @@ public class DialogsTest {
 	}
 
 	@Test public void testPreferencesDialog() throws Throwable {
-		UITestUtil.waitUntilWindowIsOpen(mcreator, () -> new PreferencesDialog(mcreator, null));
+		UITestUtil.waitUntilWindowIsOpen(mcreator, () -> new PreferencesDialog(mcreator, null, null));
 	}
 
 	@Test public void testMCItemSelector() throws Throwable {

--- a/src/test/java/net/mcreator/integration/ui/DialogsTest.java
+++ b/src/test/java/net/mcreator/integration/ui/DialogsTest.java
@@ -58,6 +58,8 @@ public class DialogsTest {
 
 	private static MCreator mcreator;
 
+	private static File workspaceFile;
+
 	@BeforeAll public static void initTest() throws IOException {
 		System.setProperty("log_directory", System.getProperty("java.io.tmpdir"));
 		LOG = LogManager.getLogger("Dialogs Test");
@@ -83,7 +85,7 @@ public class DialogsTest {
 		Workspace workspace = Workspace
 				.createWorkspace(new File(tempDirWithPrefix.toFile(), "test_mod.mcreator"), workspaceSettings);
 
-		mcreator = new MCreator(null, workspace, null);
+		mcreator = new MCreator(null, workspace, workspaceFile);
 	}
 
 	@BeforeEach void printName(TestInfo testInfo) {

--- a/src/test/java/net/mcreator/integration/ui/ImageMakerTest.java
+++ b/src/test/java/net/mcreator/integration/ui/ImageMakerTest.java
@@ -52,6 +52,8 @@ public class ImageMakerTest {
 
 	private static MCreator mcreator;
 
+	private static File workspaceFile;
+
 	@BeforeAll public static void initTest() throws IOException {
 		System.setProperty("log_directory", System.getProperty("java.io.tmpdir"));
 		LOG = LogManager.getLogger("Image Maker Test");
@@ -76,7 +78,7 @@ public class ImageMakerTest {
 		Workspace workspace = Workspace
 				.createWorkspace(new File(tempDirWithPrefix.toFile(), "test_mod.mcreator"), workspaceSettings);
 
-		mcreator = new MCreator(null, workspace, null);
+		mcreator = new MCreator(null, workspace, workspaceFile);
 	}
 
 	@BeforeEach void printName(TestInfo testInfo) {

--- a/src/test/java/net/mcreator/integration/ui/ImageMakerTest.java
+++ b/src/test/java/net/mcreator/integration/ui/ImageMakerTest.java
@@ -76,7 +76,7 @@ public class ImageMakerTest {
 		Workspace workspace = Workspace
 				.createWorkspace(new File(tempDirWithPrefix.toFile(), "test_mod.mcreator"), workspaceSettings);
 
-		mcreator = new MCreator(null, workspace);
+		mcreator = new MCreator(null, workspace, null);
 	}
 
 	@BeforeEach void printName(TestInfo testInfo) {

--- a/src/test/java/net/mcreator/integration/ui/ModElementUITest.java
+++ b/src/test/java/net/mcreator/integration/ui/ModElementUITest.java
@@ -76,6 +76,7 @@ public class ModElementUITest {
 
 	private static Workspace workspace;
 	private static MCreator mcreator;
+	private static File workspaceFile;
 
 	@BeforeAll public static void initTest() throws IOException {
 		System.setProperty("log_directory", System.getProperty("java.io.tmpdir"));
@@ -102,7 +103,7 @@ public class ModElementUITest {
 		workspace = Workspace
 				.createWorkspace(new File(tempDirWithPrefix.toFile(), "test_mod.mcreator"), workspaceSettings);
 
-		mcreator = new MCreator(null, workspace);
+		mcreator = new MCreator(null, workspace, workspaceFile);
 
 		TestWorkspaceDataProvider.fillWorkspaceWithTestData(workspace);
 
@@ -128,7 +129,7 @@ public class ModElementUITest {
 		}
 
 		// reduce autosave interval for tests
-		PreferencesManager.PREFERENCES.backups.workspaceAutosaveInterval = 2000;
+		PreferencesManager.GlobalPREFERENCES.backups.workspaceAutosaveInterval = 2000;
 
 		LOG.info("Test workspace folder: " + workspace.getWorkspaceFolder());
 	}
@@ -138,7 +139,7 @@ public class ModElementUITest {
 		Random random = new Random(rgenseed);
 		LOG.info("Random number generator seed: " + rgenseed);
 
-		PreferencesManager.PREFERENCES.ui.language = L10N.DEFAULT_LOCALE;
+		PreferencesManager.GlobalPREFERENCES.ui.language = L10N.DEFAULT_LOCALE;
 		L10N.initTranslations();
 
 		// test mod elements using default (en) translations
@@ -151,12 +152,12 @@ public class ModElementUITest {
 		Random random = new Random(rgenseed);
 		LOG.info("Random number generator seed: " + rgenseed);
 
-		PreferencesManager.PREFERENCES.ui.language = L10N.getSupportedLocales().stream()
+		PreferencesManager.GlobalPREFERENCES.ui.language = L10N.getSupportedLocales().stream()
 				.filter(locale -> locale != L10N.DEFAULT_LOCALE).max(Comparator.comparingInt(L10N::getLocaleSupport))
 				.orElse(null);
 		L10N.initTranslations();
 
-		LOG.info("Testing mod element GUI for locale " + PreferencesManager.PREFERENCES.ui.language);
+		LOG.info("Testing mod element GUI for locale " + PreferencesManager.GlobalPREFERENCES.ui.language);
 
 		testModElementLoading(random);
 	}


### PR DESCRIPTION
This PR does multiple things, It implements Preferences for the Workspace only and some global preferences (eg language) for whole MCreator, individual preferences for workspace is something i always wished to have XD

- [x] Added 2 types of classes for preferences, Kept normal name for workspace (subject to review) and other one GlobalPreferences Data
- [x] Made a different dialog for Global Preferences (might merge both into 1 later)
- [x] Added the Global preferences to be loaded when launching MCreator
- [x] Added the Workspace preferences to be loaded when opening a workspace
- [x] Changed Files which used normal preferences to global preferences (bunch of small changes in different classes)
- [ ] Make Themes specific to workspace (if wanted)
- [ ] Make loaded Plugins specific to workspace (if wanted)


If you open preferences in Workspace Selector, it will only show Global Preferences
And if you open it in a Workspace, it will show both

This PR is still a work in progress

Might aswell make the 2 last steps in another PRs, the preferences still usable right now