### PR TITLE
Added support requests forum link to issues config

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
   - name: "Feature request"
-    url: https://mcreator.net/forum/68
+    url: https://mcreator.net/forum/81
     about: Suggest an idea for this project
   - name: "[Read before opening a new issue] Issue tracker rules and tips"
     url: https://mcreator.net/wiki/tips-reporting-bugs-and-issues
@@ -9,6 +9,3 @@ contact_links:
   - name: "Knowledge base"
     url: https://mcreator.net/support/knowledgebase
     about: Collection of commonly asked questions and problems
-  - name: "MCreator's forum"
-    url: https://mcreator.net/forum
-    about: Alternative place to report bugs or feature requests, also place for support questions

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
+  - name: "Feature request"
+    url: https://mcreator.net/forum/68
+    about: Suggest an idea for this project
   - name: "[Read before opening a new issue] Issue tracker rules and tips"
     url: https://mcreator.net/wiki/tips-reporting-bugs-and-issues
     about: Some issue tracker rules and general tips


### PR DESCRIPTION
It was noted that support requests were moved to MCreator forum. However, users seem to keep posting such requests at the issue tracker. So...
This PR readds _Feature request_ option to the tracker, but **in form of link that leads to the website forum** so users are no longer confused.

**Preview:**
![image](https://user-images.githubusercontent.com/71347607/124638061-3115c080-de93-11eb-94fe-4277d587e04b.png)