### PR TITLE
Support for break/continue block inside custom blocks

### DIFF
--- a/plugins/mcreator-core/procedures/entity_inventory_foreach.json
+++ b/plugins/mcreator-core/procedures/entity_inventory_foreach.json
@@ -15,6 +15,9 @@
       "name": "foreach"
     }
   ],
+  "extensions": [
+    "is_custom_loop"
+  ],
   "inputsInline": true,
   "previousStatement": null,
   "nextStatement": null,

--- a/plugins/mcreator-core/procedures/world_entity_inrange_foreach.json
+++ b/plugins/mcreator-core/procedures/world_entity_inrange_foreach.json
@@ -30,6 +30,9 @@
       "name": "foreach"
     }
   ],
+  "extensions": [
+    "is_custom_loop"
+  ],
   "inputsInline": true,
   "previousStatement": null,
   "nextStatement": null,

--- a/plugins/mcreator-core/procedures/world_entity_player_foreach.json
+++ b/plugins/mcreator-core/procedures/world_entity_player_foreach.json
@@ -10,6 +10,9 @@
       "name": "foreach"
     }
   ],
+  "extensions": [
+    "is_custom_loop"
+  ],
   "inputsInline": true,
   "previousStatement": null,
   "nextStatement": null,

--- a/src/main/resources/blockly/js/mcreator_blocks.js
+++ b/src/main/resources/blockly/js/mcreator_blocks.js
@@ -361,6 +361,9 @@ Blockly.defineBlocksWithJsonArray([
             "type": "input_statement",
             "name": "DO"
         }],
+        "extensions": [
+            "is_custom_loop"
+        ],
         "previousStatement": null,
         "nextStatement": null,
         "colour": "%{BKY_LOOPS_HUE}"
@@ -444,8 +447,11 @@ Blockly.defineBlocksWithJsonArray([
     },
 ]);
 
-// add custom loop to loop types
-Blockly.Constants.Loops.CONTROL_FLOW_IN_LOOP_CHECK_MIXIN.LOOP_TYPES.push('controls_while');
+// Extension to mark a procedure block as a custom loop
+Blockly.Extensions.register('is_custom_loop',
+    function () {
+        Blockly.Constants.Loops.CONTROL_FLOW_IN_LOOP_CHECK_MIXIN.LOOP_TYPES.push(this.type);
+    });
 
 Blockly.Extensions.register('biome_list_provider',
     function () {


### PR DESCRIPTION
This PR adds an extension (`is_custom_loop`) to mark procedure blocks as loops, so that the "break/continue" block can be used with them