### PR TITLE
Fishing rod tool type

### DIFF
--- a/plugins/generator-1.15.2/forge-1.15.2/templates/tool.java.ftl
+++ b/plugins/generator-1.15.2/forge-1.15.2/templates/tool.java.ftl
@@ -343,6 +343,23 @@ public class ${name}Item extends ${JavaModName}Elements.ModElement{
 		}
 
 	}
+<#elseif data.toolType == "Fishing rod">
+    private static class ItemToolCustom extends FishingRodItem {
+
+		protected ItemToolCustom() {
+			super(new Item.Properties().group(${data.creativeTab}).maxDamage(${data.usageCount}));
+		}
+
+		@Override public boolean hitEntity(ItemStack stack, LivingEntity target, LivingEntity attacker) {
+			stack.damageItem(2, attacker, i -> i.sendBreakAnimation(EquipmentSlotType.MAINHAND));
+			return true;
+		}
+
+		@Override public int getItemEnchantability() {
+			return ${data.enchantability};
+		}
+
+	}
 </#if>
 
 }

--- a/plugins/generator-1.15.2/forge-1.15.2/templates/tool.java.ftl
+++ b/plugins/generator-1.15.2/forge-1.15.2/templates/tool.java.ftl
@@ -359,6 +359,17 @@ public class ${name}Item extends ${JavaModName}Elements.ModElement{
 			return ${data.enchantability};
 		}
 
+		<#if data.repairItems?has_content>
+		    @Override
+            public boolean getIsRepairable(ItemStack toRepair, ItemStack repair) {
+                <#list data.repairItems as repairItem>
+                    if (repair.equals(${mappedMCItemToItemStackCode(repairItem,1)?replace(", 1", "")}))
+                        return true;
+                </#list>
+                return false;
+            }
+        </#if>
+
 	}
 </#if>
 

--- a/plugins/generator-1.15.2/forge-1.15.2/templates/tool.java.ftl
+++ b/plugins/generator-1.15.2/forge-1.15.2/templates/tool.java.ftl
@@ -350,11 +350,6 @@ public class ${name}Item extends ${JavaModName}Elements.ModElement{
 			super(new Item.Properties().group(${data.creativeTab}).maxDamage(${data.usageCount}));
 		}
 
-		@Override public boolean hitEntity(ItemStack stack, LivingEntity target, LivingEntity attacker) {
-			stack.damageItem(2, attacker, i -> i.sendBreakAnimation(EquipmentSlotType.MAINHAND));
-			return true;
-		}
-
 		@Override public int getItemEnchantability() {
 			return ${data.enchantability};
 		}

--- a/plugins/generator-1.15.2/forge-1.15.2/templates/tool.java.ftl
+++ b/plugins/generator-1.15.2/forge-1.15.2/templates/tool.java.ftl
@@ -362,11 +362,12 @@ public class ${name}Item extends ${JavaModName}Elements.ModElement{
 		<#if data.repairItems?has_content>
 		    @Override
             public boolean getIsRepairable(ItemStack toRepair, ItemStack repair) {
+                Item repairItem = repair.getItem();
+                return
                 <#list data.repairItems as repairItem>
-                    if (repair.equals(${mappedMCItemToItemStackCode(repairItem,1)?replace(", 1", "")}))
-                        return true;
-                </#list>
-                return false;
+                	repairItem == ${mappedMCItemToItem(repairItem)}
+                	<#if repairItem?has_next>||</#if>
+                </#list>;
             }
         </#if>
 

--- a/plugins/generator-1.16.5/forge-1.16.5/templates/tool.java.ftl
+++ b/plugins/generator-1.16.5/forge-1.16.5/templates/tool.java.ftl
@@ -376,12 +376,6 @@ public class ${name}Item extends ${JavaModName}Elements.ModElement{
 			);
 		}
 
-		@Override
-		public boolean onBlockDestroyed(ItemStack stack, World worldIn, BlockState state, BlockPos pos, LivingEntity entityLiving) {
-			stack.damageItem(1, entityLiving, i -> i.sendBreakAnimation(EquipmentSlotType.MAINHAND));
-			return true;
-		}
-
 		@Override public boolean hitEntity(ItemStack stack, LivingEntity target, LivingEntity attacker) {
 			stack.damageItem(2, attacker, i -> i.sendBreakAnimation(EquipmentSlotType.MAINHAND));
 			return true;
@@ -390,6 +384,17 @@ public class ${name}Item extends ${JavaModName}Elements.ModElement{
 		@Override public int getItemEnchantability() {
 			return ${data.enchantability};
 		}
+
+		<#if data.repairItems?has_content>
+		    @Override
+            public boolean getIsRepairable(ItemStack toRepair, ItemStack repair) {
+                <#list data.repairItems as repairItem>
+                    if (repair.equals(${mappedMCItemToItemStackCode(repairItem,1)?replace(", 1", "")}))
+                        return true;
+                </#list>
+                return false;
+            }
+        </#if>
 
 	}
 </#if>

--- a/plugins/generator-1.16.5/forge-1.16.5/templates/tool.java.ftl
+++ b/plugins/generator-1.16.5/forge-1.16.5/templates/tool.java.ftl
@@ -357,6 +357,35 @@ public class ${name}Item extends ${JavaModName}Elements.ModElement{
 		}
 
 	}
+<#elseif data.toolType == "Fishing rod">
+    private static class ItemToolCustom extends FishingRodItem {
+
+		protected ItemToolCustom() {
+			super(new Item.Properties()
+				.group(${data.creativeTab})
+				.maxDamage(${data.usageCount})
+				<#if data.immuneToFire>
+				.isImmuneToFire()
+				</#if>
+			);
+		}
+
+		@Override
+		public boolean onBlockDestroyed(ItemStack stack, World worldIn, BlockState state, BlockPos pos, LivingEntity entityLiving) {
+			stack.damageItem(1, entityLiving, i -> i.sendBreakAnimation(EquipmentSlotType.MAINHAND));
+			return true;
+		}
+
+		@Override public boolean hitEntity(ItemStack stack, LivingEntity target, LivingEntity attacker) {
+			stack.damageItem(2, attacker, i -> i.sendBreakAnimation(EquipmentSlotType.MAINHAND));
+			return true;
+		}
+
+		@Override public int getItemEnchantability() {
+			return ${data.enchantability};
+		}
+
+	}
 </#if>
 
 }

--- a/plugins/generator-1.16.5/forge-1.16.5/templates/tool.java.ftl
+++ b/plugins/generator-1.16.5/forge-1.16.5/templates/tool.java.ftl
@@ -388,14 +388,14 @@ public class ${name}Item extends ${JavaModName}Elements.ModElement{
 		<#if data.repairItems?has_content>
 		    @Override
             public boolean getIsRepairable(ItemStack toRepair, ItemStack repair) {
+                Item repairItem = repair.getItem();
+                return
                 <#list data.repairItems as repairItem>
-                    if (repair.equals(${mappedMCItemToItemStackCode(repairItem,1)?replace(", 1", "")}))
-                        return true;
-                </#list>
-                return false;
+                	repairItem == ${mappedMCItemToItem(repairItem)}
+                	<#if repairItem?has_next>||</#if>
+                </#list>;
             }
         </#if>
-
 	}
 </#if>
 

--- a/plugins/generator-1.16.5/forge-1.16.5/templates/tool.java.ftl
+++ b/plugins/generator-1.16.5/forge-1.16.5/templates/tool.java.ftl
@@ -376,11 +376,6 @@ public class ${name}Item extends ${JavaModName}Elements.ModElement{
 			);
 		}
 
-		@Override public boolean hitEntity(ItemStack stack, LivingEntity target, LivingEntity attacker) {
-			stack.damageItem(2, attacker, i -> i.sendBreakAnimation(EquipmentSlotType.MAINHAND));
-			return true;
-		}
-
 		@Override public int getItemEnchantability() {
 			return ${data.enchantability};
 		}

--- a/plugins/generator-1.16.5/forge-1.16.5/templates/tool.java.ftl
+++ b/plugins/generator-1.16.5/forge-1.16.5/templates/tool.java.ftl
@@ -318,7 +318,13 @@ public class ${name}Item extends ${JavaModName}Elements.ModElement{
     private static class ItemToolCustom extends Item {
 
 		protected ItemToolCustom() {
-			super(new Item.Properties().group(${data.creativeTab}).maxDamage(${data.usageCount}));
+			super(new Item.Properties()
+				.group(${data.creativeTab})
+				.maxDamage(${data.usageCount})
+				<#if data.immuneToFire>
+				.isImmuneToFire()
+				</#if>
+			);
 		}
 
 		@Override

--- a/src/main/java/net/mcreator/ui/init/BlockItemIcons.java
+++ b/src/main/java/net/mcreator/ui/init/BlockItemIcons.java
@@ -72,6 +72,7 @@ public class BlockItemIcons {
 		put("Spade", 				"IRON_SHOVEL");
 		put("Hoe", 					"IRON_HOE");
 		put("Shears", 				"SHEARS");
+		put("Fishing rod",			"FISHING_ROD");
 
 		//NewBlockGUI
 		put("pickaxe", 				"IRON_PICKAXE");

--- a/src/main/java/net/mcreator/ui/modgui/ToolGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/ToolGUI.java
@@ -72,7 +72,7 @@ public class ToolGUI extends ModElementGUI<Tool> {
 	private final VTextField name = new VTextField(28);
 
 	private final JComboBox<String> toolType = new JComboBox<>(
-			new String[] { "Pickaxe", "Axe", "Sword", "Spade", "Hoe", "Shears", "Special", "MultiTool" });
+			new String[] { "Pickaxe", "Axe", "Sword", "Spade", "Hoe", "Shears", "Fishing rod", "Special", "MultiTool" });
 
 	private final JCheckBox immuneToFire = L10N.checkbox("elementgui.common.enable");
 	private final JCheckBox stayInGridWhenCrafting = L10N.checkbox("elementgui.common.enable");
@@ -274,8 +274,27 @@ public class ToolGUI extends ModElementGUI<Tool> {
 		blocksAffected.setEnabled(false);
 
 		toolType.addActionListener(event -> {
-			if (toolType.getSelectedItem() != null)
-				blocksAffected.setEnabled(toolType.getSelectedItem().equals("Special"));
+			if (toolType.getSelectedItem() != null) {
+				if (toolType.getSelectedItem().equals("Special")) {
+					blocksAffected.setEnabled(true);
+					repairItems.setEnabled(false);
+				} else if (toolType.getSelectedItem().equals("Fishing rod")) {
+					harvestLevel.setEnabled(false);
+					efficiency.setEnabled(false);
+					blocksAffected.setEnabled(false);
+					repairItems.setEnabled(false);
+					damageVsEntity.setEnabled(false);
+					attackSpeed.setEnabled(false);
+				} else {
+					harvestLevel.setEnabled(true);
+					efficiency.setEnabled(true);
+					blocksAffected.setEnabled(false);
+					repairItems.setEnabled(true);
+					damageVsEntity.setEnabled(true);
+					attackSpeed.setEnabled(true);
+				}
+			}
+
 		});
 
 		pane4.setOpaque(false);

--- a/src/main/java/net/mcreator/ui/modgui/ToolGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/ToolGUI.java
@@ -273,29 +273,7 @@ public class ToolGUI extends ModElementGUI<Tool> {
 
 		blocksAffected.setEnabled(false);
 
-		toolType.addActionListener(event -> {
-			if (toolType.getSelectedItem() != null) {
-				if (toolType.getSelectedItem().equals("Special")) {
-					blocksAffected.setEnabled(true);
-					repairItems.setEnabled(false);
-				} else if (toolType.getSelectedItem().equals("Fishing rod")) {
-					harvestLevel.setEnabled(false);
-					efficiency.setEnabled(false);
-					blocksAffected.setEnabled(false);
-					repairItems.setEnabled(false);
-					damageVsEntity.setEnabled(false);
-					attackSpeed.setEnabled(false);
-				} else {
-					harvestLevel.setEnabled(true);
-					efficiency.setEnabled(true);
-					blocksAffected.setEnabled(false);
-					repairItems.setEnabled(true);
-					damageVsEntity.setEnabled(true);
-					attackSpeed.setEnabled(true);
-				}
-			}
-
-		});
+		toolType.addActionListener(event -> updateFields());
 
 		pane4.setOpaque(false);
 
@@ -330,6 +308,37 @@ public class ToolGUI extends ModElementGUI<Tool> {
 		if (!isEditingMode()) {
 			String readableNameFromModElement = StringUtils.machineToReadableName(modElement.getName());
 			name.setText(readableNameFromModElement);
+		}
+	}
+
+	private void updateFields() {
+		if (toolType.getSelectedItem() != null) {
+			if (toolType.getSelectedItem().equals("Special")) {
+				harvestLevel.setEnabled(false);
+				blocksAffected.setEnabled(true);
+				repairItems.setEnabled(false);
+			} else if (toolType.getSelectedItem().equals("Fishing rod")) {
+				harvestLevel.setEnabled(false);
+				efficiency.setEnabled(false);
+				blocksAffected.setEnabled(false);
+				damageVsEntity.setEnabled(false);
+				attackSpeed.setEnabled(false);
+			} else if (toolType.getSelectedItem().equals("MultiTool")) {
+				blocksAffected.setEnabled(false);
+			} else if (toolType.getSelectedItem().equals("Shears")) {
+				harvestLevel.setEnabled(false);
+				blocksAffected.setEnabled(false);
+				repairItems.setEnabled(false);
+				damageVsEntity.setEnabled(false);
+				attackSpeed.setEnabled(false);
+			} else {
+				harvestLevel.setEnabled(true);
+				efficiency.setEnabled(true);
+				blocksAffected.setEnabled(false);
+				repairItems.setEnabled(true);
+				damageVsEntity.setEnabled(true);
+				attackSpeed.setEnabled(true);
+			}
 		}
 	}
 
@@ -399,6 +408,7 @@ public class ToolGUI extends ModElementGUI<Tool> {
 		blocksAffected.setListElements(tool.blocksAffected);
 
 		updateGlowElements();
+		updateFields();
 
 		if (toolType.getSelectedItem() != null)
 			blocksAffected.setEnabled(toolType.getSelectedItem().equals("Special"));

--- a/src/main/java/net/mcreator/ui/modgui/ToolGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/ToolGUI.java
@@ -313,12 +313,12 @@ public class ToolGUI extends ModElementGUI<Tool> {
 
 	private void updateFields() {
 		if (toolType.getSelectedItem() != null) {
-			blocksAffected.setEnabled(true);
 			harvestLevel.setEnabled(true);
 			efficiency.setEnabled(true);
-			repairItems.setEnabled(true);
 			damageVsEntity.setEnabled(true);
 			attackSpeed.setEnabled(true);
+			blocksAffected.setEnabled(true);
+			repairItems.setEnabled(true);
 
 			if (toolType.getSelectedItem().equals("Special")) {
 				harvestLevel.setEnabled(false);
@@ -326,15 +326,15 @@ public class ToolGUI extends ModElementGUI<Tool> {
 			} else if (toolType.getSelectedItem().equals("Fishing rod")) {
 				harvestLevel.setEnabled(false);
 				efficiency.setEnabled(false);
-				blocksAffected.setEnabled(false);
 				damageVsEntity.setEnabled(false);
 				attackSpeed.setEnabled(false);
+				blocksAffected.setEnabled(false);
 			} else if (toolType.getSelectedItem().equals("Shears")) {
 				harvestLevel.setEnabled(false);
-				blocksAffected.setEnabled(false);
-				repairItems.setEnabled(false);
 				damageVsEntity.setEnabled(false);
 				attackSpeed.setEnabled(false);
+				blocksAffected.setEnabled(false);
+				repairItems.setEnabled(false);
 			} else {
 				blocksAffected.setEnabled(false);
 			}

--- a/src/main/java/net/mcreator/ui/modgui/ToolGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/ToolGUI.java
@@ -214,18 +214,18 @@ public class ToolGUI extends ModElementGUI<Tool> {
 		harvestLevel.setOpaque(false);
 		efficiency.setOpaque(false);
 
+		hasGlow.addActionListener(e -> updateGlowElements());
+
 		selp.add(HelpUtils
 				.wrapWithHelpButton(this.withEntry("common/gui_name"), L10N.label("elementgui.common.name_in_gui")));
 		selp.add(name);
 
+		selp.add(HelpUtils.wrapWithHelpButton(this.withEntry("tool/type"), L10N.label("elementgui.tool.type")));
+		selp.add(toolType);
+
 		selp.add(HelpUtils.wrapWithHelpButton(this.withEntry("common/creative_tab"),
 				L10N.label("elementgui.common.creative_tab")));
 		selp.add(creativeTab);
-
-		hasGlow.addActionListener(e -> updateGlowElements());
-
-		selp.add(HelpUtils.wrapWithHelpButton(this.withEntry("tool/type"), L10N.label("elementgui.tool.type")));
-		selp.add(toolType);
 
 		selp.add(HelpUtils
 				.wrapWithHelpButton(this.withEntry("tool/harvest_level"), L10N.label("elementgui.tool.harvest_level")));
@@ -313,9 +313,15 @@ public class ToolGUI extends ModElementGUI<Tool> {
 
 	private void updateFields() {
 		if (toolType.getSelectedItem() != null) {
+			blocksAffected.setEnabled(true);
+			harvestLevel.setEnabled(true);
+			efficiency.setEnabled(true);
+			repairItems.setEnabled(true);
+			damageVsEntity.setEnabled(true);
+			attackSpeed.setEnabled(true);
+
 			if (toolType.getSelectedItem().equals("Special")) {
 				harvestLevel.setEnabled(false);
-				blocksAffected.setEnabled(true);
 				repairItems.setEnabled(false);
 			} else if (toolType.getSelectedItem().equals("Fishing rod")) {
 				harvestLevel.setEnabled(false);
@@ -323,8 +329,6 @@ public class ToolGUI extends ModElementGUI<Tool> {
 				blocksAffected.setEnabled(false);
 				damageVsEntity.setEnabled(false);
 				attackSpeed.setEnabled(false);
-			} else if (toolType.getSelectedItem().equals("MultiTool")) {
-				blocksAffected.setEnabled(false);
 			} else if (toolType.getSelectedItem().equals("Shears")) {
 				harvestLevel.setEnabled(false);
 				blocksAffected.setEnabled(false);
@@ -332,12 +336,7 @@ public class ToolGUI extends ModElementGUI<Tool> {
 				damageVsEntity.setEnabled(false);
 				attackSpeed.setEnabled(false);
 			} else {
-				harvestLevel.setEnabled(true);
-				efficiency.setEnabled(true);
 				blocksAffected.setEnabled(false);
-				repairItems.setEnabled(true);
-				damageVsEntity.setEnabled(true);
-				attackSpeed.setEnabled(true);
 			}
 		}
 	}

--- a/src/main/java/net/mcreator/ui/validation/validators/JavaMemeberNameValidator.java
+++ b/src/main/java/net/mcreator/ui/validation/validators/JavaMemeberNameValidator.java
@@ -76,9 +76,9 @@ public class JavaMemeberNameValidator implements Validator {
 	}
 
 	private static final Set<String> common_names = new HashSet<>(
-			Arrays.asList("Axe", "Pickaxe", "Spade", "Hoe", "Shovel", "Sword", "Shears", "Overworld", "Nether", "World",
-					"Living", "Mob", "Monster", "Animal", "End", "Stairs", "Slab", "Fence", "Wall", "Leaves",
-					"TrapDoor", "Pane", "Door", "FenceGate", "Creature", "Item", "Block", "BoneMeal", "Diamond", "Ore",
-					"Gem", "Gold", "Iron", "Stack", "Emerald", "Entity", "Surface"));
+			Arrays.asList("Axe", "Pickaxe", "Spade", "Hoe", "Shovel", "Sword", "Shears", "FishingRod", "Compass", "Clock",
+					"Shield", "Overworld", "Nether", "World", "Living", "Mob", "Monster", "Animal", "End", "Stairs",
+					"Slab", "Fence", "Wall", "Leaves", "TrapDoor", "Pane", "Door", "FenceGate", "Creature", "Item",
+					"Block", "BoneMeal", "Diamond", "Ore", "Gem", "Gold", "Iron", "Stack", "Emerald", "Entity", "Surface"));
 
 }


### PR DESCRIPTION
This PR adds a new Fishing rod tool type. Custom fishing rods can't use all settings of the tool mod element, so some of them are disabled when the user selects the fishing rod.


![custom fishing rod](https://user-images.githubusercontent.com/38427877/124958124-ce820900-dfe7-11eb-9153-901714145c25.gif)
