### PR TITLE
Added dependencies to some block/plant triggers

### DIFF
--- a/plugins/generator-1.15.2/forge-1.15.2/templates/block.java.ftl
+++ b/plugins/generator-1.15.2/forge-1.15.2/templates/block.java.ftl
@@ -713,6 +713,9 @@ public class ${name}Block extends ${JavaModName}Elements.ModElement {
 			</#if>
 
 			<#if hasProcedure(data.onRightClicked)>
+				double hitX = hit.getHitVec().x;
+				double hitY = hit.getHitVec().y;
+				double hitZ = hit.getHitVec().z;
 				Direction direction = hit.getFace();
 				<#if hasReturnValue(data.onRightClicked)>
 				ActionResultType result = <@procedureOBJToActionResultTypeCode data.onRightClicked/>;

--- a/plugins/generator-1.15.2/forge-1.15.2/templates/plant.java.ftl
+++ b/plugins/generator-1.15.2/forge-1.15.2/templates/plant.java.ftl
@@ -601,6 +601,9 @@ import net.minecraft.util.SoundEvent;
 			int x = pos.getX();
 			int y = pos.getY();
 			int z = pos.getZ();
+			double hitX = hit.getHitVec().x;
+			double hitY = hit.getHitVec().y;
+			double hitZ = hit.getHitVec().z;
 			Direction direction = hit.getFace();
 			<#if hasReturnValue(data.onRightClicked)>
 			return <@procedureOBJToActionResultTypeCode data.onRightClicked/>;

--- a/plugins/generator-1.16.5/forge-1.16.5/templates/block.java.ftl
+++ b/plugins/generator-1.16.5/forge-1.16.5/templates/block.java.ftl
@@ -745,6 +745,9 @@ public class ${name}Block extends ${JavaModName}Elements.ModElement {
 			</#if>
 
 			<#if hasProcedure(data.onRightClicked)>
+				double hitX = hit.getHitVec().x;
+				double hitY = hit.getHitVec().y;
+				double hitZ = hit.getHitVec().z;
 				Direction direction = hit.getFace();
 				<#if hasReturnValue(data.onRightClicked)>
 				ActionResultType result = <@procedureOBJToActionResultTypeCode data.onRightClicked/>;

--- a/plugins/generator-1.16.5/forge-1.16.5/templates/plant.java.ftl
+++ b/plugins/generator-1.16.5/forge-1.16.5/templates/plant.java.ftl
@@ -639,6 +639,9 @@ import net.minecraft.util.SoundEvent;
 			int x = pos.getX();
 			int y = pos.getY();
 			int z = pos.getZ();
+			double hitX = hit.getHitVec().x;
+			double hitY = hit.getHitVec().y;
+			double hitZ = hit.getHitVec().z;
 			Direction direction = hit.getFace();
 			<#if hasReturnValue(data.onRightClicked)>
 				return <@procedureOBJToActionResultTypeCode data.onRightClicked/>;

--- a/src/main/java/net/mcreator/ui/modgui/BlockGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/BlockGUI.java
@@ -869,7 +869,7 @@ public class BlockGUI extends ModElementGUI<Block> {
 				PanelUtils.westAndEastElement(selp, PanelUtils.centerAndSouthElement(selp3, soundProperties))));
 		pane3.setOpaque(false);
 
-		JPanel events2 = new JPanel(new GridLayout(5, 3, 5, 5));
+		JPanel events2 = new JPanel(new GridLayout(4, 5, 5, 5));
 		events2.setOpaque(false);
 
 		events2.add(onRightClicked);

--- a/src/main/java/net/mcreator/ui/modgui/BlockGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/BlockGUI.java
@@ -268,7 +268,8 @@ public class BlockGUI extends ModElementGUI<Block> {
 
 		onBlockAdded = new ProcedureSelector(this.withEntry("block/when_added"), mcreator,
 				L10N.t("elementgui.block.event_on_block_added"),
-				Dependency.fromString("x:number/y:number/z:number/world:world/blockstate:blockstate"));
+				Dependency.fromString(
+						"x:number/y:number/z:number/world:world/blockstate:blockstate/oldState:blockstate/moving:logic"));
 		onNeighbourBlockChanges = new ProcedureSelector(this.withEntry("block/when_neighbour_changes"), mcreator,
 				L10N.t("elementgui.common.event_on_neighbour_block_changes"),
 				Dependency.fromString("x:number/y:number/z:number/world:world/blockstate:blockstate"));
@@ -299,7 +300,7 @@ public class BlockGUI extends ModElementGUI<Block> {
 		onRightClicked = new ProcedureSelector(this.withEntry("block/when_right_clicked"), mcreator,
 				L10N.t("elementgui.block.event_on_right_clicked"), VariableTypeLoader.BuiltInTypes.ACTIONRESULTTYPE,
 				Dependency.fromString(
-						"x:number/y:number/z:number/world:world/entity:entity/direction:direction/blockstate:blockstate")).makeReturnValueOptional();
+						"x:number/y:number/z:number/world:world/entity:entity/direction:direction/blockstate:blockstate/hitX:number/hitY:number/hitZ:number")).makeReturnValueOptional();
 		onRedstoneOn = new ProcedureSelector(this.withEntry("block/on_redstone_on"), mcreator,
 				L10N.t("elementgui.block.event_on_redstone_on"),
 				Dependency.fromString("x:number/y:number/z:number/world:world/blockstate:blockstate"));
@@ -868,7 +869,7 @@ public class BlockGUI extends ModElementGUI<Block> {
 				PanelUtils.westAndEastElement(selp, PanelUtils.centerAndSouthElement(selp3, soundProperties))));
 		pane3.setOpaque(false);
 
-		JPanel events2 = new JPanel(new GridLayout(4, 5, 5, 5));
+		JPanel events2 = new JPanel(new GridLayout(5, 3, 5, 5));
 		events2.setOpaque(false);
 
 		events2.add(onRightClicked);

--- a/src/main/java/net/mcreator/ui/modgui/PlantGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/PlantGUI.java
@@ -173,7 +173,8 @@ public class PlantGUI extends ModElementGUI<Plant> {
 
 		onBlockAdded = new ProcedureSelector(this.withEntry("block/when_added"), mcreator,
 				L10N.t("elementgui.plant.event_on_added"),
-				Dependency.fromString("x:number/y:number/z:number/world:world/blockstate:blockstate"));
+				Dependency.fromString(
+						"x:number/y:number/z:number/world:world/blockstate:blockstate/oldState:blockstate/moving:logic"));
 		onNeighbourBlockChanges = new ProcedureSelector(this.withEntry("block/when_neighbour_changes"), mcreator,
 				L10N.t("elementgui.common.event_on_neighbour_block_changes"),
 				Dependency.fromString("x:number/y:number/z:number/world:world/blockstate:blockstate"));
@@ -201,7 +202,7 @@ public class PlantGUI extends ModElementGUI<Plant> {
 		onRightClicked = new ProcedureSelector(this.withEntry("block/when_right_clicked"), mcreator,
 				L10N.t("elementgui.plant.event_on_right_clicked"), VariableTypeLoader.BuiltInTypes.ACTIONRESULTTYPE,
 				Dependency.fromString(
-						"x:number/y:number/z:number/world:world/entity:entity/direction:direction/blockstate:blockstate")).makeReturnValueOptional();
+						"x:number/y:number/z:number/world:world/entity:entity/direction:direction/blockstate:blockstate/hitX:number/hitY:number/hitZ:number")).makeReturnValueOptional();
 
 		placingCondition = new ProcedureSelector(this.withEntry("plant/placing_condition"), mcreator,
 				L10N.t("elementgui.plant.condition_additional_placing"), VariableTypeLoader.BuiltInTypes.LOGIC,
@@ -626,7 +627,7 @@ public class PlantGUI extends ModElementGUI<Plant> {
 		pane5.add("Center", PanelUtils.totalCenterInPanel(plocb));
 		pane5.setOpaque(false);
 
-		JPanel events2 = new JPanel(new GridLayout(3, 4, 5, 5));
+		JPanel events2 = new JPanel(new GridLayout(4, 3, 5, 5));
 		events2.setOpaque(false);
 		events2.add(onRightClicked);
 		events2.add(onBlockAdded);

--- a/src/main/java/net/mcreator/ui/modgui/PlantGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/PlantGUI.java
@@ -627,7 +627,7 @@ public class PlantGUI extends ModElementGUI<Plant> {
 		pane5.add("Center", PanelUtils.totalCenterInPanel(plocb));
 		pane5.setOpaque(false);
 
-		JPanel events2 = new JPanel(new GridLayout(4, 3, 5, 5));
+		JPanel events2 = new JPanel(new GridLayout(3, 4, 5, 5));
 		events2.setOpaque(false);
 		events2.add(onRightClicked);
 		events2.add(onBlockAdded);

--- a/src/main/java/net/mcreator/ui/procedure/AbstractProcedureSelector.java
+++ b/src/main/java/net/mcreator/ui/procedure/AbstractProcedureSelector.java
@@ -139,19 +139,33 @@ public abstract class AbstractProcedureSelector extends JPanel {
 		}
 
 		StringBuilder deps = new StringBuilder();
+
 		if (smallIcons)
-			deps.append("<html><div style='font-size: 8px; margin-top: 0; margin-bottom: 0; color: white;'>");
+			deps.append(
+					"<html><div style='font-size: 8px; margin-top: 0; margin-bottom: 0; color: white; line-height: 20px;'>");
 		else
-			deps.append("<html><div style='font-size: 9px; margin-top: 2px; margin-bottom: 1px; color: white;'>");
+			deps.append(
+					"<html><div style='font-size: 9px; margin-top: 2px; margin-bottom: 1px; color: white; line-height: 20px;'>");
+
+		int idx = 0;
 		for (Dependency dependency : providedDependencies) {
+			if (idx == 6 && providedDependencies.length > 6)
+				deps.append("<p style='margin-top: 3'>");
+
 			String bg = "999999";
-			String optcss = "color: #444444;";
+			String optcss;
+
 			if (dependencies != null && dependencies.contains(dependency)) {
 				optcss = "color: #ffffff;";
 				bg = Integer.toHexString(dependency.getColor().getRGB()).substring(2);
+			} else {
+				optcss = "color: #" + Integer.toHexString(dependency.getColor().darker().getRGB()).substring(2) + ";";
 			}
+
 			deps.append("<span style='background: #").append(bg).append("; ").append(optcss).append("'>&nbsp;")
 					.append(dependency.getName()).append("&nbsp;</span>&#32;");
+
+			idx++;
 		}
 
 		depslab.setText(deps.toString());


### PR DESCRIPTION
This PR adds some dependencies to the "On block right clicked" and "On block added" triggers:
- Added `oldState` and `moving` to "On block added"
- Added `hitX`, `hitY`, and `hitZ` to "On block right clicked"