### PR TITLE
Fixed compilation error if no dispense procedure is selected

### DIFF
--- a/plugins/generator-1.15.2/forge-1.15.2/templates/item.java.ftl
+++ b/plugins/generator-1.15.2/forge-1.15.2/templates/item.java.ftl
@@ -84,7 +84,7 @@ package ${package}.item;
 							return itemstack;
 						</#if>
 					<#else>
-						if(success) itemstack.shrink(1);
+						if(this.successful) itemstack.shrink(1);
 						return itemstack;
 					</#if>
 				}

--- a/plugins/generator-1.16.5/forge-1.16.5/templates/item.java.ftl
+++ b/plugins/generator-1.16.5/forge-1.16.5/templates/item.java.ftl
@@ -73,9 +73,9 @@ package ${package}.item;
 					int z = blockSource.getBlockPos().getZ();
 
 					this.setSuccessful(<@procedureOBJToConditionCode data.dispenseSuccessCondition/>);
+					boolean success = this.isSuccessful();
 
 					<#if hasProcedure(data.dispenseResultItemstack)>
-						boolean success = this.isSuccessful();
 						<#if hasReturnValue(data.dispenseResultItemstack)>
 							return <@procedureOBJToItemstackCode data.dispenseResultItemstack/>;
 						<#else>

--- a/plugins/generator-1.16.5/forge-1.16.5/templates/item.java.ftl
+++ b/plugins/generator-1.16.5/forge-1.16.5/templates/item.java.ftl
@@ -73,9 +73,9 @@ package ${package}.item;
 					int z = blockSource.getBlockPos().getZ();
 
 					this.setSuccessful(<@procedureOBJToConditionCode data.dispenseSuccessCondition/>);
-					boolean success = this.isSuccessful();
 
 					<#if hasProcedure(data.dispenseResultItemstack)>
+						boolean success = this.isSuccessful();
 						<#if hasReturnValue(data.dispenseResultItemstack)>
 							return <@procedureOBJToItemstackCode data.dispenseResultItemstack/>;
 						<#else>
@@ -84,7 +84,7 @@ package ${package}.item;
 							return itemstack;
 						</#if>
 					<#else>
-						if(success) itemstack.shrink(1);
+						if(this.isSuccessful()) itemstack.shrink(1);
 						return itemstack;
 					</#if>
 				}


### PR DESCRIPTION
This PR fixes a compilation error that happens if custom dispense behavior is enabled, but no procedure is selected