### PR TITLE
Fixed some issues with 1.17 templates

### DIFF
--- a/plugins/generator-1.17.1/forge-1.17.1/templates/elementinits/items.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/templates/elementinits/items.java.ftl
@@ -10,11 +10,11 @@ package ${package}.init;
 
 @Mod.EventBusSubscriber(bus = Mod.EventBusSubscriber.Bus.MOD) public class ${JavaModName}Items {
 
+    private static final List<Item> REGISTRY = new ArrayList();
+
     <#list items as item>
     public static Item ${item.getModElement().geRegistryNameUpper()} = register(new ${item.getModElement().getName()}Item());
     </#list>
-
-    private static final List<Item> REGISTRY = new ArrayList();
 
     private static Item register(Item item) {
 		REGISTRY.add(item);

--- a/plugins/generator-1.17.1/forge-1.17.1/utils/mcitems.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/utils/mcitems.ftl
@@ -2,7 +2,7 @@
     <#if mappedBlock?starts_with("/*@BlockState*/")>
         <#return mappedBlock?replace("/*@BlockState*/","")>
     <#else>
-        <#return mappedBlockToBlock(mappedBlock) + ".getDefaultState()">
+        <#return mappedBlockToBlock(mappedBlock) + ".defaultBlockState()">
     </#if>
 </#function>
 


### PR DESCRIPTION
- Fixed null pointer exception when registering items
- Updated `mappedBlockToBlockStateCode` to 1.17