### PR TITLE
Ported more block data procedures to 1.17

### DIFF
--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/block_fluid_to_bucket.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/block_fluid_to_bucket.java.ftl
@@ -1,0 +1,3 @@
+<#include "mcitems.ftl">
+/*@ItemStack*/(${mappedBlockToBlock(input$block)} instanceof LiquidBlock _liquid ?
+        new ItemStack(_liquid.getFluid().getBucket()) : ItemStack.EMPTY)

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/block_is_fluid.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/block_is_fluid.java.ftl
@@ -1,0 +1,2 @@
+<#include "mcitems.ftl">
+(${mappedBlockToBlock(input$block)} instanceof LiquidBlock)

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/block_is_fluid_source.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/block_is_fluid_source.java.ftl
@@ -1,0 +1,2 @@
+<#include "mcitems.ftl">
+(${mappedBlockToBlockStateCode(input$block)}.getFluidState().isSource())

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/block_is_tagged_in.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/block_is_tagged_in.java.ftl
@@ -1,0 +1,2 @@
+<#include "mcitems.ftl">
+(BlockTags.getAllTags().getTagOrEmpty(new ResourceLocation((${input$b}).toLowerCase(java.util.Locale.ENGLISH))).contains(${mappedBlockToBlock(input$a)}))

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/block_is_waterloggable.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/block_is_waterloggable.java.ftl
@@ -1,0 +1,2 @@
+<#include "mcitems.ftl">
+(${mappedBlockToBlock(input$block)} instanceof SimpleWaterloggedBlock)

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/blockitem_to_mcitem.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/blockitem_to_mcitem.java.ftl
@@ -1,0 +1,2 @@
+<#include "mcitems.ftl">
+/*@ItemStack*/(new ItemStack(${mappedBlockToBlock(input$source)}))

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/blockstate_from_deps.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/blockstate_from_deps.java.ftl
@@ -1,0 +1,1 @@
+/*@BlockState*/blockstate

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/item_bucket_to_fluid.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/item_bucket_to_fluid.java.ftl
@@ -1,0 +1,2 @@
+<#include "mcitems.ftl">
+/*@BlockState*/(${mappedMCItemToItem(input$source)} instanceof BucketItem _bucket ? _bucket.getFluid().defaultFluidState().createLegacyBlock() : Blocks.AIR.defaultBlockState())

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/mcitem_to_block.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/mcitem_to_block.java.ftl
@@ -1,0 +1,2 @@
+<#include "mcitems.ftl">
+/*@BlockState*/(${mappedMCItemToItem(input$source)} instanceof BlockItem _bi ? _bi.getBlock().defaultBlockState() : Blocks.AIR.defaultBlockState())


### PR DESCRIPTION
This PR ports the following procedure blocks:
- Provided blockstate
- Block to item / item to block
- Bucket to fluid / fluid to block
- Is block waterloggable
- Is block fluid
- Is block fluid source
- Is block tagged in