### PR TITLE
Custom tool types

### DIFF
--- a/plugins/mcreator-core/modbases/tooltypes/axe.json
+++ b/plugins/mcreator-core/modbases/tooltypes/axe.json
@@ -1,4 +1,7 @@
 {
   "name": "Axe",
-  "itemIcon": "IRON_AXE"
+  "itemIcon": "IRON_AXE",
+  "exclusionFields": [
+    "blocksAffected"
+  ]
 }

--- a/plugins/mcreator-core/modbases/tooltypes/axe.json
+++ b/plugins/mcreator-core/modbases/tooltypes/axe.json
@@ -1,0 +1,4 @@
+{
+  "name": "Axe",
+  "itemIcon": "IRON_AXE"
+}

--- a/plugins/mcreator-core/modbases/tooltypes/fishing_rod.json
+++ b/plugins/mcreator-core/modbases/tooltypes/fishing_rod.json
@@ -1,4 +1,11 @@
 {
   "name": "Fishing rod",
-  "itemIcon": "FISHING_ROD"
+  "itemIcon": "FISHING_ROD",
+  "exclusionFields": [
+    "harvestLevel",
+    "efficiency",
+    "damageVsEntity",
+    "attackSpeed",
+    "blocksAffected"
+  ]
 }

--- a/plugins/mcreator-core/modbases/tooltypes/fishing_rod.json
+++ b/plugins/mcreator-core/modbases/tooltypes/fishing_rod.json
@@ -1,0 +1,4 @@
+{
+  "name": "Fishing rod",
+  "itemIcon": "FISHING_ROD"
+}

--- a/plugins/mcreator-core/modbases/tooltypes/hoe.json
+++ b/plugins/mcreator-core/modbases/tooltypes/hoe.json
@@ -1,4 +1,7 @@
 {
   "name": "Hoe",
-  "itemIcon": "IRON_HOE"
+  "itemIcon": "IRON_HOE",
+  "exclusionFields": [
+    "blocksAffected"
+  ]
 }

--- a/plugins/mcreator-core/modbases/tooltypes/hoe.json
+++ b/plugins/mcreator-core/modbases/tooltypes/hoe.json
@@ -1,0 +1,4 @@
+{
+  "name": "Hoe",
+  "itemIcon": "IRON_HOE"
+}

--- a/plugins/mcreator-core/modbases/tooltypes/multi_tool.json
+++ b/plugins/mcreator-core/modbases/tooltypes/multi_tool.json
@@ -1,4 +1,7 @@
 {
   "name": "MultiTool",
-  "itemIcon": "mod"
+  "itemIcon": "mod",
+  "exclusionFields": [
+    "blocksAffected"
+  ]
 }

--- a/plugins/mcreator-core/modbases/tooltypes/multi_tool.json
+++ b/plugins/mcreator-core/modbases/tooltypes/multi_tool.json
@@ -1,0 +1,4 @@
+{
+  "name": "MultiTool",
+  "itemIcon": "mod"
+}

--- a/plugins/mcreator-core/modbases/tooltypes/pickaxe.json
+++ b/plugins/mcreator-core/modbases/tooltypes/pickaxe.json
@@ -1,0 +1,4 @@
+{
+  "name": "Pickaxe",
+  "itemIcon": "IRON_PICKAXE"
+}

--- a/plugins/mcreator-core/modbases/tooltypes/pickaxe.json
+++ b/plugins/mcreator-core/modbases/tooltypes/pickaxe.json
@@ -1,4 +1,7 @@
 {
   "name": "Pickaxe",
-  "itemIcon": "IRON_PICKAXE"
+  "itemIcon": "IRON_PICKAXE",
+  "exclusionFields": [
+    "blocksAffected"
+  ]
 }

--- a/plugins/mcreator-core/modbases/tooltypes/shears.json
+++ b/plugins/mcreator-core/modbases/tooltypes/shears.json
@@ -1,4 +1,11 @@
 {
   "name": "Shears",
-  "itemIcon": "SHEARS"
+  "itemIcon": "SHEARS",
+  "exclusionFields": [
+    "harvestLevel",
+    "damageVsEntity",
+    "attackSpeed",
+    "blocksAffected",
+    "repairItems"
+  ]
 }

--- a/plugins/mcreator-core/modbases/tooltypes/shears.json
+++ b/plugins/mcreator-core/modbases/tooltypes/shears.json
@@ -1,0 +1,4 @@
+{
+  "name": "Shears",
+  "itemIcon": "SHEARS"
+}

--- a/plugins/mcreator-core/modbases/tooltypes/spade.json
+++ b/plugins/mcreator-core/modbases/tooltypes/spade.json
@@ -1,4 +1,7 @@
 {
   "name": "Spade",
-  "itemIcon": "IRON_SHOVEL"
+  "itemIcon": "IRON_SHOVEL",
+  "exclusionFields": [
+    "blocksAffected"
+  ]
 }

--- a/plugins/mcreator-core/modbases/tooltypes/spade.json
+++ b/plugins/mcreator-core/modbases/tooltypes/spade.json
@@ -1,0 +1,4 @@
+{
+  "name": "Spade",
+  "itemIcon": "IRON_SHOVEL"
+}

--- a/plugins/mcreator-core/modbases/tooltypes/special.json
+++ b/plugins/mcreator-core/modbases/tooltypes/special.json
@@ -1,4 +1,8 @@
 {
   "name": "Special",
-  "itemIcon": "mod"
+  "itemIcon": "mod",
+  "exclusionFields": [
+    "harvestLevel",
+    "repairItems"
+  ]
 }

--- a/plugins/mcreator-core/modbases/tooltypes/special.json
+++ b/plugins/mcreator-core/modbases/tooltypes/special.json
@@ -1,0 +1,4 @@
+{
+  "name": "Special",
+  "itemIcon": "mod"
+}

--- a/plugins/mcreator-core/modbases/tooltypes/sword.json
+++ b/plugins/mcreator-core/modbases/tooltypes/sword.json
@@ -1,4 +1,7 @@
 {
   "name": "Sword",
-  "itemIcon": "IRON_SWORD"
+  "itemIcon": "IRON_SWORD",
+  "exclusionFields": [
+    "blocksAffected"
+  ]
 }

--- a/plugins/mcreator-core/modbases/tooltypes/sword.json
+++ b/plugins/mcreator-core/modbases/tooltypes/sword.json
@@ -1,0 +1,4 @@
+{
+  "name": "Sword",
+  "itemIcon": "IRON_SWORD"
+}

--- a/src/main/java/net/mcreator/minecraft/modbases/ToolType.java
+++ b/src/main/java/net/mcreator/minecraft/modbases/ToolType.java
@@ -28,7 +28,7 @@ public class ToolType {
 	private String itemIcon;
 	private List<String> exclusionFields;
 
-	private final transient List<String> supportedGenerators = new ArrayList<>();
+	private final List<String> supportedGenerators = new ArrayList<>();
 
 	public String getName() {
 		return name;

--- a/src/main/java/net/mcreator/minecraft/modbases/ToolType.java
+++ b/src/main/java/net/mcreator/minecraft/modbases/ToolType.java
@@ -1,0 +1,47 @@
+/*
+ * MCreator (https://mcreator.net/)
+ * Copyright (C) 2012-2020, Pylo
+ * Copyright (C) 2020-2021, Pylo, opensource contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package net.mcreator.minecraft.modbases;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ToolType {
+
+	private String name;
+	private String itemIcon;
+
+	private final transient List<String> supportedGenerators = new ArrayList<>();
+
+	public String getName() {
+		return name;
+	}
+
+	public String getItemIcon() {
+		return itemIcon;
+	}
+
+	public List<String> getSupportedGenerators() {
+		return supportedGenerators;
+	}
+
+	public void addSupportedGenerator(String generatorName) {
+		supportedGenerators.add(generatorName);
+	}
+}

--- a/src/main/java/net/mcreator/minecraft/modbases/ToolType.java
+++ b/src/main/java/net/mcreator/minecraft/modbases/ToolType.java
@@ -26,6 +26,7 @@ public class ToolType {
 
 	private String name;
 	private String itemIcon;
+	private List<String> exclusionFields;
 
 	private final transient List<String> supportedGenerators = new ArrayList<>();
 
@@ -35,6 +36,10 @@ public class ToolType {
 
 	public String getItemIcon() {
 		return itemIcon;
+	}
+
+	public List<String> getExclusionFields() {
+		return exclusionFields;
 	}
 
 	public List<String> getSupportedGenerators() {

--- a/src/main/java/net/mcreator/minecraft/modbases/ToolTypesLoader.java
+++ b/src/main/java/net/mcreator/minecraft/modbases/ToolTypesLoader.java
@@ -36,7 +36,9 @@ public class ToolTypesLoader {
 
 	private static final List<ToolType> toolTypes = new ArrayList<>();
 
-	public static void init() {
+	public static ToolTypesLoader INSTANCE;
+
+	public ToolTypesLoader() {
 		LOG.debug("Loading tool types");
 
 		Set<String> fileNames = PluginLoader.INSTANCE.getResources("modbases.tooltypes",
@@ -50,15 +52,19 @@ public class ToolTypesLoader {
 		}
 	}
 
-	public static List<ToolType> getToolTypes() {
+	public static void init() {
+		INSTANCE = new ToolTypesLoader();
+	}
+
+	public List<ToolType> getToolTypes() {
 		return toolTypes;
 	}
 
-	public static boolean contains(String toolType) {
+	public boolean contains(String toolType) {
 		return toolTypes.stream().anyMatch(tool -> tool.getName().equals(toolType));
 	}
 
-	public static ToolType getToolType(String name) {
+	public ToolType getToolType(String name) {
 		return toolTypes.stream().filter(toolType -> toolType.getName().equals(name)).findFirst().orElse(null);
 
 	}

--- a/src/main/java/net/mcreator/minecraft/modbases/ToolTypesLoader.java
+++ b/src/main/java/net/mcreator/minecraft/modbases/ToolTypesLoader.java
@@ -1,0 +1,66 @@
+/*
+ * MCreator (https://mcreator.net/)
+ * Copyright (C) 2012-2020, Pylo
+ * Copyright (C) 2020-2021, Pylo, opensource contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package net.mcreator.minecraft.modbases;
+
+import com.google.gson.Gson;
+import net.mcreator.io.FileIO;
+import net.mcreator.plugin.PluginLoader;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+public class ToolTypesLoader {
+
+	private static final Logger LOG = LogManager.getLogger("Tool Type Loader");
+
+	private static final List<ToolType> toolTypes = new ArrayList<>();
+
+	public static void init() {
+		LOG.debug("Loading tool types");
+
+		Set<String> fileNames = PluginLoader.INSTANCE.getResources("modbases.tooltypes",
+				Pattern.compile("^[^$].*\\.json"));
+
+		final Gson gson = new Gson();
+
+		for (String file : fileNames) {
+			ToolType tooltype = gson.fromJson(FileIO.readResourceToString(PluginLoader.INSTANCE, file), ToolType.class);
+			toolTypes.add(tooltype);
+		}
+	}
+
+	public static List<ToolType> getToolTypes() {
+		return toolTypes;
+	}
+
+	public static boolean contains(String toolType) {
+		return toolTypes.stream().anyMatch(tool -> tool.getName().equals(toolType));
+	}
+
+	public static ToolType getToolType(String name) {
+		return toolTypes.stream().filter(toolType -> toolType.getName().equals(name)).findFirst().orElse(null);
+
+	}
+
+}

--- a/src/main/java/net/mcreator/ui/MCreatorApplication.java
+++ b/src/main/java/net/mcreator/ui/MCreatorApplication.java
@@ -31,6 +31,7 @@ import net.mcreator.io.net.api.D8WebAPI;
 import net.mcreator.io.net.api.IWebAPI;
 import net.mcreator.minecraft.DataListLoader;
 import net.mcreator.minecraft.api.ModAPIManager;
+import net.mcreator.minecraft.modbases.ToolTypesLoader;
 import net.mcreator.plugin.PluginLoader;
 import net.mcreator.preferences.PreferencesManager;
 import net.mcreator.themes.ThemeLoader;
@@ -145,6 +146,9 @@ public final class MCreatorApplication {
 
 		// register mod element types
 		ModElementTypeLoader.loadModElements();
+
+		// load tool types
+		ToolTypesLoader.init();
 
 		splashScreen.setProgress(60, "Preloading resources");
 		TiledImageCache.loadAndTileImages();

--- a/src/main/java/net/mcreator/ui/init/BlockItemIcons.java
+++ b/src/main/java/net/mcreator/ui/init/BlockItemIcons.java
@@ -65,15 +65,6 @@ public class BlockItemIcons {
 
 	//@formatter:off
 	private static final HashMap<String, String> TEXTURE_MAPPINGS = new HashMap<String, String>() {{
-		//NewToolGUI
-		put("Pickaxe", 				"IRON_PICKAXE");
-		put("Axe", 					"IRON_AXE");
-		put("Sword", 				"IRON_SWORD");
-		put("Spade", 				"IRON_SHOVEL");
-		put("Hoe", 					"IRON_HOE");
-		put("Shears", 				"SHEARS");
-		put("Fishing rod",			"FISHING_ROD");
-
 		//NewBlockGUI
 		put("pickaxe", 				"IRON_PICKAXE");
 		put("axe", 					"IRON_AXE");

--- a/src/main/java/net/mcreator/ui/laf/renderer/ItemTexturesComboBoxRenderer.java
+++ b/src/main/java/net/mcreator/ui/laf/renderer/ItemTexturesComboBoxRenderer.java
@@ -18,6 +18,8 @@
 
 package net.mcreator.ui.laf.renderer;
 
+import net.mcreator.minecraft.modbases.ToolType;
+import net.mcreator.minecraft.modbases.ToolTypesLoader;
 import net.mcreator.ui.init.BlockItemIcons;
 import net.mcreator.ui.init.UIRES;
 import net.mcreator.util.image.ImageUtils;
@@ -47,11 +49,14 @@ public class ItemTexturesComboBoxRenderer extends JLabel implements ListCellRend
 
 		setText(value);
 
-		if (value.equals("Special") || value.equals("MultiTool")) {
-			setIcon(new ImageIcon(ImageUtils.resize(UIRES.get("mod").getImage(), 30)));
-		} else {
+		if(ToolTypesLoader.contains(value)) {
+			ToolType toolType = ToolTypesLoader.getToolType(value);
+			if (toolType.getItemIcon().equals("mod"))
+				setIcon(new ImageIcon(ImageUtils.resize(UIRES.get("mod").getImage(), 30)));
+			else
+				setIcon(new ImageIcon(ImageUtils.resize(BlockItemIcons.getIconForItem(toolType.getItemIcon()).getImage(), 30)));
+		} else
 			setIcon(new ImageIcon(ImageUtils.resize(BlockItemIcons.getIconFor(value).getImage(), 30)));
-		}
 
 		setHorizontalTextPosition(SwingConstants.RIGHT);
 		setHorizontalAlignment(SwingConstants.LEFT);

--- a/src/main/java/net/mcreator/ui/laf/renderer/ItemTexturesComboBoxRenderer.java
+++ b/src/main/java/net/mcreator/ui/laf/renderer/ItemTexturesComboBoxRenderer.java
@@ -49,8 +49,8 @@ public class ItemTexturesComboBoxRenderer extends JLabel implements ListCellRend
 
 		setText(value);
 
-		if(ToolTypesLoader.contains(value)) {
-			ToolType toolType = ToolTypesLoader.getToolType(value);
+		if(ToolTypesLoader.INSTANCE.contains(value)) {
+			ToolType toolType = ToolTypesLoader.INSTANCE.getToolType(value);
 			if (toolType.getItemIcon().equals("mod"))
 				setIcon(new ImageIcon(ImageUtils.resize(UIRES.get("mod").getImage(), 30)));
 			else

--- a/src/main/java/net/mcreator/ui/modgui/ToolGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/ToolGUI.java
@@ -23,6 +23,8 @@ import net.mcreator.element.parts.TabEntry;
 import net.mcreator.element.types.Tool;
 import net.mcreator.minecraft.DataListEntry;
 import net.mcreator.minecraft.ElementUtil;
+import net.mcreator.minecraft.modbases.ToolType;
+import net.mcreator.minecraft.modbases.ToolTypesLoader;
 import net.mcreator.ui.MCreator;
 import net.mcreator.ui.MCreatorApplication;
 import net.mcreator.ui.component.SearchableComboBox;
@@ -54,7 +56,9 @@ import javax.swing.*;
 import java.awt.*;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
@@ -71,9 +75,7 @@ public class ToolGUI extends ModElementGUI<Tool> {
 
 	private final VTextField name = new VTextField(28);
 
-	private final JComboBox<String> toolType = new JComboBox<>(
-			new String[] { "Pickaxe", "Axe", "Sword", "Spade", "Hoe", "Shears", "Fishing rod", "Special",
-					"MultiTool" });
+	private JComboBox<String> toolType;
 
 	private final JCheckBox immuneToFire = L10N.checkbox("elementgui.common.enable");
 	private final JCheckBox stayInGridWhenCrafting = L10N.checkbox("elementgui.common.enable");
@@ -148,6 +150,8 @@ public class ToolGUI extends ModElementGUI<Tool> {
 
 		repairItems = new MCItemListField(mcreator, ElementUtil::loadBlocksAndItems);
 
+		toolType = new JComboBox<>(
+				ToolTypesLoader.getToolTypes().stream().map(ToolType::getName).sorted().toArray(String[]::new));
 		toolType.setRenderer(new ItemTexturesComboBoxRenderer());
 
 		JPanel pane2 = new JPanel(new BorderLayout(10, 10));

--- a/src/main/java/net/mcreator/ui/modgui/ToolGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/ToolGUI.java
@@ -151,7 +151,7 @@ public class ToolGUI extends ModElementGUI<Tool> {
 		repairItems = new MCItemListField(mcreator, ElementUtil::loadBlocksAndItems);
 
 		toolType = new JComboBox<>(
-				ToolTypesLoader.getToolTypes().stream().map(ToolType::getName).sorted().toArray(String[]::new));
+				ToolTypesLoader.INSTANCE.getToolTypes().stream().map(ToolType::getName).sorted().toArray(String[]::new));
 		toolType.setRenderer(new ItemTexturesComboBoxRenderer());
 
 		JPanel pane2 = new JPanel(new BorderLayout(10, 10));

--- a/src/test/java/net/mcreator/integration/TestSetup.java
+++ b/src/test/java/net/mcreator/integration/TestSetup.java
@@ -25,6 +25,7 @@ import net.mcreator.generator.Generator;
 import net.mcreator.generator.GeneratorConfiguration;
 import net.mcreator.minecraft.DataListLoader;
 import net.mcreator.minecraft.api.ModAPIManager;
+import net.mcreator.minecraft.modbases.ToolTypesLoader;
 import net.mcreator.plugin.PluginLoader;
 import net.mcreator.themes.ThemeLoader;
 import net.mcreator.ui.MCreatorApplication;
@@ -108,6 +109,9 @@ public class TestSetup {
 
 		// register mod element types
 		ModElementTypeLoader.loadModElements();
+
+		// load tool types
+		ToolTypesLoader.init();
 
 		// load generator configurations
 		Set<String> fileNames = PluginLoader.INSTANCE.getResources(Pattern.compile("generator\\.yaml"));


### PR DESCRIPTION
This PR moves tool types to plugins, so plugins can add custom tool types.

- [x] Load custom tool types
- [x] Option to disable fields
- [ ] Move tool templates to individual templates (similar to procedure blocks)* **

*To be honest, I didn't understand the code of custom generators before, but with changes, I'm even more lost. So maybe this part won't be as good as others. Sorry.

**Even if this part is not implemented, custom tool types are possible as plugins can simply overwrite the code template. However, this part allows having multiple plugins adding new tool types at the same time.