### PR TITLE
1.17 Global triggers Part 3

### DIFF
--- a/plugins/generator-1.17.1/forge-1.17.1/triggers/entity_item_pickup.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/triggers/entity_item_pickup.java.ftl
@@ -1,0 +1,13 @@
+@Mod.EventBusSubscriber public class ${name}Procedure {
+	@SubscribeEvent public static void onPickup(EntityItemPickupEvent event) {
+	    Player entity = event.getPlayer();
+		Map<String, Object> dependencies = new HashMap<>();
+		dependencies.put("x", entity.getX());
+		dependencies.put("y", entity.getY());
+		dependencies.put("z", entity.getZ());
+		dependencies.put("world",entity.level);
+		dependencies.put("entity",entity);
+		dependencies.put("itemstack",event.getItem().getItem());
+		dependencies.put("event",event);
+		execute(dependencies);
+	}

--- a/plugins/generator-1.17.1/forge-1.17.1/triggers/entity_joins_world.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/triggers/entity_joins_world.java.ftl
@@ -5,7 +5,7 @@
 		dependencies.put("x", entity.getX());
 		dependencies.put("y", entity.getY());
 		dependencies.put("z", entity.getZ());
-		dependencies.put("world",entity.level);
+		dependencies.put("world", event.getWorld());
 		dependencies.put("entity",entity);
 		dependencies.put("event",event);
 		execute(dependencies);

--- a/plugins/generator-1.17.1/forge-1.17.1/triggers/entity_joins_world.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/triggers/entity_joins_world.java.ftl
@@ -1,0 +1,12 @@
+@Mod.EventBusSubscriber public class ${name}Procedure {
+	@SubscribeEvent public static void onEntityJoin(EntityJoinWorldEvent event) {
+		Entity entity=event.getEntity();
+		Map<String, Object> dependencies = new HashMap<>();
+		dependencies.put("x", entity.getX());
+		dependencies.put("y", entity.getY());
+		dependencies.put("z", entity.getZ());
+		dependencies.put("world",entity.level);
+		dependencies.put("entity",entity);
+		dependencies.put("event",event);
+		execute(dependencies);
+	}

--- a/plugins/generator-1.17.1/forge-1.17.1/triggers/entity_jumps.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/triggers/entity_jumps.java.ftl
@@ -1,0 +1,12 @@
+@Mod.EventBusSubscriber public class ${name}Procedure {
+	@SubscribeEvent public static void onEntityJump(LivingEvent.LivingJumpEvent event) {
+		LivingEntity entity=event.getEntityLiving();
+		Map<String, Object> dependencies = new HashMap<>();
+		dependencies.put("x", entity.getX());
+		dependencies.put("y", entity.getY());
+		dependencies.put("z", entity.getZ());
+		dependencies.put("world",entity.level);
+		dependencies.put("entity",entity);
+		dependencies.put("event",event);
+		execute(dependencies);
+	}

--- a/plugins/generator-1.17.1/forge-1.17.1/triggers/entity_pickupxp.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/triggers/entity_pickupxp.java.ftl
@@ -1,0 +1,14 @@
+@Mod.EventBusSubscriber public class ${name}Procedure {
+	@SubscribeEvent public static void onPickupXP(PlayerXpEvent.PickupXp event) {
+		if (event != null && event.getEntity() != null) {
+			Entity entity = event.getEntity();
+			Map<String, Object> dependencies = new HashMap<>();
+            dependencies.put("x", entity.getX());
+		    dependencies.put("y", entity.getY());
+		    dependencies.put("z", entity.getZ());
+		    dependencies.put("world",entity.level);
+			dependencies.put("entity", entity);
+			dependencies.put("event", event);
+			execute(dependencies);
+		}
+	}

--- a/plugins/generator-1.17.1/forge-1.17.1/triggers/entity_pre_hurt.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/triggers/entity_pre_hurt.java.ftl
@@ -1,0 +1,16 @@
+@Mod.EventBusSubscriber public class ${name}Procedure {
+	@SubscribeEvent public static void onEntityAttacked(LivingHurtEvent event) {
+		if (event != null && event.getEntity() != null) {
+			Entity entity = event.getEntity();
+			Map<String, Object> dependencies = new HashMap<>();
+		    dependencies.put("x", entity.getX());
+		    dependencies.put("y", entity.getY());
+		    dependencies.put("z", entity.getZ());
+		    dependencies.put("world",entity.level);
+			dependencies.put("amount", event.getAmount());
+			dependencies.put("entity", entity);
+			dependencies.put("sourceentity", event.getSource().getEntity());
+			dependencies.put("event", event);
+			execute(dependencies);
+		}
+	}

--- a/plugins/generator-1.17.1/forge-1.17.1/triggers/entity_sets_attack_target.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/triggers/entity_sets_attack_target.java.ftl
@@ -1,0 +1,13 @@
+@Mod.EventBusSubscriber public class ${name}Procedure {
+	@SubscribeEvent public static void onEntitySetsAttackTarget(LivingSetAttackTargetEvent event) {
+		LivingEntity sourceentity=event.getEntityLiving();
+		Map<String, Object> dependencies = new HashMap<>();
+		dependencies.put("x", sourceentity.getX());
+		dependencies.put("y", sourceentity.getY());
+		dependencies.put("z", sourceentity.getZ());
+		dependencies.put("world",sourceentity.level);
+		dependencies.put("entity", event.getTarget());
+		dependencies.put("sourceentity", sourceentity);
+		dependencies.put("event", event);
+		execute(dependencies);
+	}

--- a/plugins/generator-1.17.1/forge-1.17.1/triggers/entity_spawns.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/triggers/entity_spawns.java.ftl
@@ -1,0 +1,12 @@
+@Mod.EventBusSubscriber public class ${name}Procedure {
+	@SubscribeEvent public static void onEntitySpawned(EntityJoinWorldEvent event) {
+		Entity entity=event.getEntity();
+		Map<String, Object> dependencies = new HashMap<>();
+		dependencies.put("x", entity.getX());
+		dependencies.put("y", entity.getY());
+		dependencies.put("z", entity.getZ());
+		dependencies.put("world",entity.level);
+		dependencies.put("entity",entity);
+		dependencies.put("event",event);
+		execute(dependencies);
+	}

--- a/plugins/generator-1.17.1/forge-1.17.1/triggers/entity_spawns.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/triggers/entity_spawns.java.ftl
@@ -5,7 +5,7 @@
 		dependencies.put("x", entity.getX());
 		dependencies.put("y", entity.getY());
 		dependencies.put("z", entity.getZ());
-		dependencies.put("world",entity.level);
+		dependencies.put("world", event.getWorld());
 		dependencies.put("entity",entity);
 		dependencies.put("event",event);
 		execute(dependencies);


### PR DESCRIPTION
This PR ports the next 7 global triggers to 1.17.
- Entity item pickup
- Entity joins world
- Entity jumps
- Entity pickups xp
- Entity pre hurt
- Entity sets attack target
- Entity spawns