### PR TITLE
Ported more world data procedures to 1.17

### DIFF
--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/world_data_checkdifficulty.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/world_data_checkdifficulty.java.ftl
@@ -1,0 +1,1 @@
+(world.getDifficulty()==Difficulty.${field$difficulty})

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/world_data_isair.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/world_data_isair.java.ftl
@@ -1,0 +1,1 @@
+(world.isEmptyBlock(new BlockPos((int)${input$x},(int)${input$y},(int)${input$z})))

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/world_data_isday.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/world_data_isday.java.ftl
@@ -1,0 +1,1 @@
+(world instanceof Level _lvl_isDay? _lvl_isDay.isDay():false)

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/world_data_israining.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/world_data_israining.java.ftl
@@ -1,0 +1,1 @@
+(world.getLevelData().isRaining())

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/world_data_isremote.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/world_data_isremote.java.ftl
@@ -1,0 +1,1 @@
+(world.isClientSide())

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/world_data_isthundering.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/world_data_isthundering.java.ftl
@@ -1,0 +1,1 @@
+(world.getLevelData().isThundering())

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/world_data_number_players_server.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/world_data_number_players_server.java.ftl
@@ -1,0 +1,1 @@
+(world.isClientSide() ? Minecraft.getInstance().getConnection().getOnlinePlayers().size() : ServerLifecycleHooks.getCurrentServer().getPlayerCount())

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/world_data_number_players_world.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/world_data_number_players_world.java.ftl
@@ -1,0 +1,1 @@
+(world.players().size())

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/world_entity_inrange.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/world_entity_inrange.java.ftl
@@ -1,0 +1,11 @@
+((Entity) world.getEntitiesOfClass(${generator.map(field$entity, "entities", 0)}.class, new AABB(
+            ${input$x} - (${input$range} / 2d), ${input$y} - (${input$range} / 2d), ${input$z} - (${input$range} / 2d),
+            ${input$x} + (${input$range} / 2d), ${input$y} + (${input$range} / 2d), ${input$z} + (${input$range} / 2d)), e -> true)
+    .stream()
+	.sorted(new Object() {
+		Comparator<Entity> compareDistOf(double _x, double _y, double _z) {
+		    return Comparator.comparing((Function<Entity, Double>) (_entcnd -> _entcnd.distanceToSqr(_x, _y, _z)));
+		}
+	}.compareDistOf(${input$x}, ${input$y}, ${input$z}))
+    .findFirst().orElse(null)
+)

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/world_entity_inrange_exists.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/world_entity_inrange_exists.java.ftl
@@ -1,0 +1,4 @@
+(!world.getEntitiesOfClass(${generator.map(field$entity, "entities", 0)}.class, new AABB(
+            ${input$x} - (${input$range} / 2d), ${input$y} - (${input$range} / 2d), ${input$z} - (${input$range} / 2d),
+            ${input$x} + (${input$range} / 2d), ${input$y} + (${input$range} / 2d), ${input$z} + (${input$range} / 2d)), e -> true)
+    .isEmpty())


### PR DESCRIPTION
This PR ports the following procedure blocks to 1.17:
- Check difficulty
- Is air at
- Is day
- Is raining/thundering
- Is client side
- Number of players in world/server
- Closest entity/Does entity exist