### PR TITLE
Ported some entity data procedures to 1.17

### DIFF
--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_canusecommand.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_canusecommand.java.ftl
@@ -1,0 +1,1 @@
+(${input$entity}.hasPermissions((int) ${input$permissionlevel}))

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_direction.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_direction.java.ftl
@@ -1,0 +1,1 @@
+(${input$entity}.getYRot())

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_getowner.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_getowner.java.ftl
@@ -1,0 +1,1 @@
+(entity instanceof TamableAnimal _tam_getOwn ? _tam_getOwn.getOwner() : null)

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_getridingentity.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_getridingentity.java.ftl
@@ -1,0 +1,1 @@
+(${input$entity}.getVehicle())

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_gettargetentity.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_gettargetentity.java.ftl
@@ -1,0 +1,1 @@
+(${input$entity} instanceof Mob _mob_target ? _mob_target.getTarget() : null)

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_haspotioneffect.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_haspotioneffect.java.ftl
@@ -1,0 +1,1 @@
+(${input$entity} instanceof LivingEntity _ent_hasEff ? _ent_hasEff.hasEffect(${generator.map(field$potion, "effects")}) : false)

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_health.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_health.java.ftl
@@ -1,0 +1,1 @@
+(${input$entity} instanceof LivingEntity _ent_health ? _ent_health.getHealth():-1)

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_name.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_name.java.ftl
@@ -1,0 +1,1 @@
+(${input$entity}.getDisplayName().getString())

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_pitch.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_pitch.java.ftl
@@ -1,0 +1,1 @@
+(${input$entity}.getXRot())

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_potioneffectlevel.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_potioneffectlevel.java.ftl
@@ -1,0 +1,2 @@
+(${input$entity} instanceof LivingEntity _ent_effLvl && _ent_effLvl.hasEffect(${generator.map(field$potion, "effects")}) ?
+    _ent_effLvl.getEffect(${generator.map(field$potion, "effects")}).getAmplifier() : 0)

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_potioneffectremaining.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_potioneffectremaining.java.ftl
@@ -1,0 +1,2 @@
+(${input$entity} instanceof LivingEntity _ent_effRem && _ent_effRem.hasEffect(${generator.map(field$potion, "effects")}) ?
+    _ent_effRem.getEffect(${generator.map(field$potion, "effects")}).getDuration() : 0)


### PR DESCRIPTION
This PR ports the following procedures to 1.17:
- Check permission level
- Get owner/vehicle/target of entity
- Get health
- Pitch/Yaw of entity
- Display name
- Has effect/Effect duration/Effect level