### PR TITLE
Ported remaining entity management procedures to 1.17

### DIFF
--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_set_armor_slot_item.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_set_armor_slot_item.java.ftl
@@ -1,0 +1,8 @@
+<#include "mcitems.ftl">
+if (${input$entity} instanceof LivingEntity _entity) {
+	if (_entity instanceof Player _playerEntity)
+		_playerEntity.getInventory().armor.set((int) ${input$slotid}, ${mappedMCItemToItemStackCode(input$item, 1)});
+	else
+		_entity.setItemSlot(EquipmentSlot.byTypeAndIndex(EquipmentSlot.Type.ARMOR, (int) ${input$slotid}), ${mappedMCItemToItemStackCode(input$item, 1)});
+	if (_entity instanceof ServerPlayer _serverPlayer) _serverPlayer.getInventory().setChanged();
+}

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_set_display_name.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_set_display_name.java.ftl
@@ -1,0 +1,1 @@
+${input$entity}.setCustomName(new TextComponent(${input$displayname}));

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_set_fire.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_set_fire.java.ftl
@@ -1,0 +1,1 @@
+${input$entity}.setSecondsOnFire((int)${input$seconds});

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_set_health.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_set_health.java.ftl
@@ -1,0 +1,1 @@
+if(${input$entity} instanceof LivingEntity _entity) _entity.setHealth((float)${input$health});

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_set_mainhand_item.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_set_mainhand_item.java.ftl
@@ -1,0 +1,7 @@
+<#include "mcitems.ftl">
+if(${input$entity} instanceof LivingEntity _entity) {
+	ItemStack _setstack = ${mappedMCItemToItemStackCode(input$item, 1)};
+	_setstack.setCount((int) ${input$amount});
+	_entity.setItemInHand(InteractionHand.MAIN_HAND, _setstack);
+	if (_entity instanceof ServerPlayer _serverPlayer) _serverPlayer.getInventory().setChanged();
+}

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_set_movement.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_set_movement.java.ftl
@@ -1,0 +1,1 @@
+${input$entity}.setDeltaMovement(${input$vx},${input$vy},${input$vz});

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_set_nogravity.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_set_nogravity.java.ftl
@@ -1,0 +1,1 @@
+${input$entity}.setNoGravity(${input$gravityValue});

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_set_offhand_item.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_set_offhand_item.java.ftl
@@ -1,0 +1,7 @@
+<#include "mcitems.ftl">
+if(${input$entity} instanceof LivingEntity _entity) {
+	ItemStack _setstack = ${mappedMCItemToItemStackCode(input$item, 1)};
+	_setstack.setCount((int) ${input$amount});
+	_entity.setItemInHand(InteractionHand.OFF_HAND, _setstack);
+	if (_entity instanceof ServerPlayer _serverPlayer) _serverPlayer.getInventory().setChanged();
+}

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_set_oxygen.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_set_oxygen.java.ftl
@@ -1,0 +1,1 @@
+${input$entity}.setAirSupply((int)${input$air});

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_set_rotation.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_set_rotation.java.ftl
@@ -1,0 +1,13 @@
+{
+    Entity _ent = ${input$entity};
+    _ent.setYRot((float) (${input$yaw}));
+    _ent.setXRot((float) (${input$pitch}));
+    _ent.setYBodyRot(_ent.getYRot());
+    _ent.setYHeadRot(_ent.getYRot());
+    _ent.yRotO = _ent.getYRot();
+    _ent.xRotO = _ent.getXRot();
+    if(_ent instanceof LivingEntity _entity) {
+        _entity.yBodyRotO = _entity.getYRot();
+        _entity.yHeadRotO = _entity.getYRot();
+    }
+}

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_set_slot.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_set_slot.java.ftl
@@ -1,0 +1,10 @@
+<#include "mcitems.ftl">
+{
+	final ItemStack _setstack = ${mappedMCItemToItemStackCode(input$slotitem, 1)};
+	final int _sltid = (int)(${input$slotid});
+	_setstack.setCount((int) ${input$amount});
+	${input$entity}.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null).ifPresent(capability -> {
+		if (capability instanceof IItemHandlerModifiable _modHandler)
+            _modHandler.setStackInSlot(_sltid, _setstack);
+	});
+}

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_set_sneaking.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_set_sneaking.java.ftl
@@ -1,0 +1,1 @@
+${input$entity}.setShiftKeyDown(${input$boolean});

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_set_sprinting.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_set_sprinting.java.ftl
@@ -1,0 +1,1 @@
+${input$entity}.setSprinting(${input$boolean});

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_swing_mainhand.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_swing_mainhand.java.ftl
@@ -1,0 +1,1 @@
+if(${input$entity} instanceof LivingEntity _entity)	_entity.swing(InteractionHand.MAIN_HAND, true);

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_swing_offhand.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_swing_offhand.java.ftl
@@ -1,0 +1,1 @@
+if(${input$entity} instanceof LivingEntity _entity)	_entity.swing(InteractionHand.OFF_HAND, true);

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/move_entity.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/move_entity.java.ftl
@@ -1,0 +1,7 @@
+{
+	Entity _ent = ${input$entity};
+    _ent.teleportTo(${input$x},${input$y},${input$z});
+    if (_ent instanceof ServerPlayer _serverPlayer) {
+    	_serverPlayer.connection.teleport(${input$x}, ${input$y}, ${input$z}, _ent.getYRot(), _ent.getXRot(), Collections.emptySet());
+    }
+}


### PR DESCRIPTION
This PR ports the remaining entity management procedures to 1.17, except for "Shoot arrow" since ranged items aren't supported yet