### PR TITLE
Ported some player procedure blocks to 1.17

### DIFF
--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_add_exhaustion.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_add_exhaustion.java.ftl
@@ -1,0 +1,1 @@
+if (${input$entity} instanceof Player _player) _player.causeFoodExhaustion((float)${input$amount});

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_add_recipe.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_add_recipe.java.ftl
@@ -1,0 +1,2 @@
+<#include "mcelements.ftl">
+if(${input$entity} instanceof ServerPlayer _serverPlayer) _serverPlayer.awardRecipesByKey(new ResourceLocation[]{${toResourceLocation(input$recipe)}});

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_add_xp.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_add_xp.java.ftl
@@ -1,0 +1,1 @@
+if (${input$entity} instanceof Player _player) _player.giveExperiencePoints((int)${input$xpamount});

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_add_xp_level.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_add_xp_level.java.ftl
@@ -1,0 +1,1 @@
+if (${input$entity} instanceof Player _player) _player.giveExperienceLevels((int)${input$xpamount});

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_checkgamemode.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_checkgamemode.java.ftl
@@ -1,0 +1,11 @@
+(new Object(){
+	public boolean checkGamemode(Entity _ent){
+		if(_ent instanceof ServerPlayer _serverPlayer) {
+			return _serverPlayer.gameMode.getGameModeForPlayer() == GameType.${generator.map(field$gamemode, "gamemodes")};
+		} else if(_ent.level.isClientSide() && _ent instanceof AbstractClientPlayer _clientPlayer) {
+			PlayerInfo _pi = Minecraft.getInstance().getConnection().getPlayerInfo(_clientPlayer.getGameProfile().getId());
+			return _pi != null && _pi.getGameMode() == GameType.${generator.map(field$gamemode, "gamemodes")};
+		}
+		return false;
+	}
+}.checkGamemode(${input$entity}))

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_foodlevel.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_foodlevel.java.ftl
@@ -1,0 +1,1 @@
+(${input$entity} instanceof Player _playerFoodLvl ? _playerFoodLvl.getFoodData().getFoodLevel():0)

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_get_saturation.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_get_saturation.java.ftl
@@ -1,0 +1,1 @@
+((${input$entity} instanceof Player _playerSaturation)? _playerSaturation.getFoodData().getSaturationLevel():0)

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_get_saturation.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_get_saturation.java.ftl
@@ -1,1 +1,1 @@
-((${input$entity} instanceof Player _playerSaturation)? _playerSaturation.getFoodData().getSaturationLevel():0)
+(${input$entity} instanceof Player _playerSaturation? _playerSaturation.getFoodData().getSaturationLevel():0)

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_get_scoreboard_score.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_get_scoreboard_score.java.ftl
@@ -1,0 +1,13 @@
+(new Object(){
+	public int getScore(String score, Entity _ent){
+		if(_ent instanceof Player _player) {
+			Scoreboard _sc = _player.getScoreboard();
+			Objective _so = _sc.getObjective(score);
+			if (_so != null) {
+				Score _scr = _sc.getOrCreatePlayerScore(_player.getScoreboardName(), _so);
+				return _scr.getScore();
+			}
+		}
+		return 0;
+	}
+}.getScore(${input$score}, ${input$entity}))

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_has_recipe.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_has_recipe.java.ftl
@@ -1,0 +1,10 @@
+<#include "mcelements.ftl">
+(new Object() {
+    public boolean hasRecipe(Entity _ent, ResourceLocation recipe) {
+        if (_ent instanceof ServerPlayer _player)
+            return _player.getRecipeBook().contains(recipe);
+        else if (_ent.level.isClientSide() && _ent instanceof LocalPlayer _player)
+            return _player.getRecipeBook().contains(recipe);
+        return false;
+    }
+}.hasRecipe(${input$entity}, ${toResourceLocation(input$recipe)}))

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_iscreative.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_iscreative.java.ftl
@@ -1,0 +1,1 @@
+(${input$entity} instanceof Player _player_isCreative ? _player_isCreative.getAbilities().instabuild:false)

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_iscreative.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_iscreative.java.ftl
@@ -1,1 +1,1 @@
-(${input$entity} instanceof Player _player_isCreative ? _player_isCreative.getAbilities().instabuild:false)
+(${input$entity} instanceof Player _playerIsCreative ? _playerIsCreative.getAbilities().instabuild:false)

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_remove_recipe.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_remove_recipe.java.ftl
@@ -1,0 +1,3 @@
+<#include "mcelements.ftl">
+if (${input$entity} instanceof ServerPlayer _serverPlayer)
+    _serverPlayer.server.getRecipeManager().byKey(${toResourceLocation(input$recipe)}).ifPresent(_rec -> _serverPlayer.resetRecipes(Collections.singleton(_rec)));

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_remove_xp.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_remove_xp.java.ftl
@@ -1,0 +1,1 @@
+if (${input$entity} instanceof Player _player) _player.giveExperiencePoints(-((int)${input$amount}));

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_remove_xp_level.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_remove_xp_level.java.ftl
@@ -1,0 +1,1 @@
+if (${input$entity} instanceof Player _player) _player.giveExperienceLevels(-((int)${input$xpamount}));

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_set_foodlevel.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_set_foodlevel.java.ftl
@@ -1,0 +1,1 @@
+if (${input$entity} instanceof Player _player) _player.getFoodData().setFoodLevel((int)${input$foodlevel});

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_set_gamemode.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_set_gamemode.java.ftl
@@ -1,0 +1,1 @@
+if (${input$entity} instanceof ServerPlayer _player) _player.setGameMode(GameType.${generator.map(field$gamemode, "gamemodes")});

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_set_saturation.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_set_saturation.java.ftl
@@ -1,0 +1,1 @@
+if (${input$entity} instanceof Player _player) _player.getFoodData().setSaturation((float)(${input$amount}));

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_set_scoreboard_score.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_set_scoreboard_score.java.ftl
@@ -1,0 +1,12 @@
+{
+	Entity _ent = ${input$entity};
+	if(_ent instanceof Player _player) {
+		Scoreboard _sc = _player.getScoreboard();
+		Objective _so = _sc.getObjective(${input$score});
+		if (_so == null) {
+			_so = _sc.addObjective(${input$score}, ObjectiveCriteria.DUMMY, new TextComponent(${input$score}), ObjectiveCriteria.RenderType.INTEGER);
+		}
+		Score _scr = _sc.getOrCreatePlayerScore(_player.getScoreboardName(), _so);
+		_scr.setScore((int)${input$value});
+	}
+}

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_xplevel.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_xplevel.java.ftl
@@ -1,0 +1,1 @@
+(${input$entity} instanceof Player _playerXpLvl ? _playerXpLvl.experienceLevel:0)


### PR DESCRIPTION
This PR ports the following player procedure blocks to 1.17:
- Food procedures
- XP procedures
- Gamemode procedures
- Scoreboard procedures
- Recipe procedures