### PR TITLE
Minor fixes, math blocks improvements

### DIFF
--- a/plugins/generator-1.17.1/forge-1.17.1/variables/actionresulttype.yaml
+++ b/plugins/generator-1.17.1/forge-1.17.1/variables/actionresulttype.yaml
@@ -1,1 +1,1 @@
-defaultvalue: ActionResultType.PASS
+defaultvalue: InteractionResult.PASS

--- a/src/main/java/net/mcreator/blockly/java/JavaKeywordsMap.java
+++ b/src/main/java/net/mcreator/blockly/java/JavaKeywordsMap.java
@@ -72,6 +72,7 @@ public final class JavaKeywordsMap {
 		put("MIN", "min");
 		put("MAX", "max");
 		put("ATAN2", "atan2");
+		put("HYPOT", "hypot");
 	}};
 
 	public static final HashMap<String, String> MATH_CONSTANTS = new HashMap<>() {{

--- a/src/main/java/net/mcreator/blockly/java/JavaKeywordsMap.java
+++ b/src/main/java/net/mcreator/blockly/java/JavaKeywordsMap.java
@@ -71,6 +71,7 @@ public final class JavaKeywordsMap {
 		put("POWER", "pow");
 		put("MIN", "min");
 		put("MAX", "max");
+		put("ATAN2", "atan2");
 	}};
 
 	public static final HashMap<String, String> MATH_CONSTANTS = new HashMap<>() {{

--- a/src/main/java/net/mcreator/blockly/java/JavaKeywordsMap.java
+++ b/src/main/java/net/mcreator/blockly/java/JavaKeywordsMap.java
@@ -22,7 +22,7 @@ import java.util.HashMap;
 
 public final class JavaKeywordsMap {
 
-	public static final HashMap<String, String> BINARY_OPERATORS = new HashMap<String, String>() {{
+	public static final HashMap<String, String> BINARY_OPERATORS = new HashMap<>() {{
 		// logic binary operations
 		put("EQ", "==");
 		put("NEQ", "!=");
@@ -47,9 +47,10 @@ public final class JavaKeywordsMap {
 		put("BXOR", "^");
 	}};
 
-	public static final HashMap<String, String> MATH_OPERATORS = new HashMap<String, String>() {{
+	public static final HashMap<String, String> MATH_OPERATORS = new HashMap<>() {{
 		// single input math operations
 		put("ROOT", "sqrt");
+		put("CUBEROOT", "cbrt");
 		put("ABS", "abs");
 		put("LN", "log");
 		put("LOG10", "log10");
@@ -64,6 +65,7 @@ public final class JavaKeywordsMap {
 		put("ROUNDDOWN", "floor");
 		put("RAD2DEG", "toDegrees");
 		put("DEG2RAD", "toRadians");
+		put("SIGNUM", "signum");
 
 		// dual input math operations
 		put("POWER", "pow");
@@ -71,7 +73,7 @@ public final class JavaKeywordsMap {
 		put("MAX", "max");
 	}};
 
-	public static final HashMap<String, String> MATH_CONSTANTS = new HashMap<String, String>() {{
+	public static final HashMap<String, String> MATH_CONSTANTS = new HashMap<>() {{
 		put("PI", "Math.PI");
 		put("E", "Math.E");
 		put("RANDOM", "Math.random()");

--- a/src/main/resources/blockly/js/mcreator_blocks.js
+++ b/src/main/resources/blockly/js/mcreator_blocks.js
@@ -279,6 +279,7 @@ Blockly.defineBlocksWithJsonArray([
                     ["Bitwise XOR", "BXOR"],
                     ["Min", "MIN"],
                     ["Max", "MAX"],
+                    ["hypot", "HYPOT"],
                     ["atan2", "ATAN2"]
                 ]
             },

--- a/src/main/resources/blockly/js/mcreator_blocks.js
+++ b/src/main/resources/blockly/js/mcreator_blocks.js
@@ -278,7 +278,8 @@ Blockly.defineBlocksWithJsonArray([
                     ["Bitwise OR", "BOR"],
                     ["Bitwise XOR", "BXOR"],
                     ["Min", "MIN"],
-                    ["Max", "MAX"]
+                    ["Max", "MAX"],
+                    ["atan2", "ATAN2"]
                 ]
             },
             {

--- a/src/main/resources/blockly/js/mcreator_blocks.js
+++ b/src/main/resources/blockly/js/mcreator_blocks.js
@@ -303,7 +303,9 @@ Blockly.defineBlocksWithJsonArray([
                     ["%{BKY_MATH_ROUND_OPERATOR_ROUNDUP}", "ROUNDUP"],
                     ["%{BKY_MATH_ROUND_OPERATOR_ROUNDDOWN}", "ROUNDDOWN"],
                     ["%{BKY_MATH_SINGLE_OP_ROOT}", 'ROOT'],
+                    ['cube root', 'CUBEROOT'],
                     ["%{BKY_MATH_SINGLE_OP_ABSOLUTE}", 'ABS'],
+                    ['signum', 'SIGNUM'],
                     ['ln', 'LN'],
                     ['log10', 'LOG10'],
                     ["%{BKY_MATH_TRIG_SIN}", "SIN"],
@@ -322,7 +324,6 @@ Blockly.defineBlocksWithJsonArray([
                 "check": "Number"
             }
         ],
-        "inputsInline": true,
         "output": "Number",
         "colour": "%{BKY_MATH_HUE}"
     },


### PR DESCRIPTION
- Fixed action result type variable having the wrong default value in 1.17
- Removed unnecessary inline from single math op block, added cube root and signum functions
- Added atan2 and hypot functions to dual math ops block