### PR TITLE
Fix entity dependency block class names

### DIFF
--- a/src/main/java/net/mcreator/blockly/java/BlocklyToJava.java
+++ b/src/main/java/net/mcreator/blockly/java/BlocklyToJava.java
@@ -60,11 +60,11 @@ public abstract class BlocklyToJava extends BlocklyToCode {
 
 		// add Minecraft related blocks
 		blockGenerators.add(new CoordinateBlock());
-		blockGenerators.add(new EventOrTargetEntityDependenyBlock());
-		blockGenerators.add(new SourceEntityDependenyBlock());
+		blockGenerators.add(new EventOrTargetEntityDependencyBlock());
+		blockGenerators.add(new SourceEntityDependencyBlock());
 		blockGenerators.add(new EntityIteratorDependencyBlock());
 		blockGenerators.add(new ImediateSourceEntityDependencyBlock());
-		blockGenerators.add(new DirectionDependenyBlock());
+		blockGenerators.add(new DirectionDependencyBlock());
 		blockGenerators.add(new DirectionConstantBlock());
 		blockGenerators.add(new NullBlock());
 		blockGenerators.add(new MCItemBlock());

--- a/src/main/java/net/mcreator/blockly/java/blocks/DirectionDependencyBlock.java
+++ b/src/main/java/net/mcreator/blockly/java/blocks/DirectionDependencyBlock.java
@@ -23,15 +23,15 @@ import net.mcreator.blockly.IBlockGenerator;
 import net.mcreator.blockly.data.Dependency;
 import org.w3c.dom.Element;
 
-public class SourceEntityDependenyBlock implements IBlockGenerator {
+public class DirectionDependencyBlock implements IBlockGenerator {
 
 	@Override public void generateBlock(BlocklyToCode master, Element block) {
-		master.append("sourceentity");
-		master.addDependency(new Dependency("sourceentity", "entity"));
+		master.append("direction");
+		master.addDependency(new Dependency("direction", "direction"));
 	}
 
 	@Override public String[] getSupportedBlocks() {
-		return new String[] { "source_entity_from_deps" };
+		return new String[] { "direction_from_deps" };
 	}
 
 	@Override public BlockType getBlockType() {

--- a/src/main/java/net/mcreator/blockly/java/blocks/EventOrTargetEntityDependencyBlock.java
+++ b/src/main/java/net/mcreator/blockly/java/blocks/EventOrTargetEntityDependencyBlock.java
@@ -23,15 +23,15 @@ import net.mcreator.blockly.IBlockGenerator;
 import net.mcreator.blockly.data.Dependency;
 import org.w3c.dom.Element;
 
-public class DirectionDependenyBlock implements IBlockGenerator {
+public class EventOrTargetEntityDependencyBlock implements IBlockGenerator {
 
 	@Override public void generateBlock(BlocklyToCode master, Element block) {
-		master.append("direction");
-		master.addDependency(new Dependency("direction", "direction"));
+		master.append("entity");
+		master.addDependency(new Dependency("entity", "entity"));
 	}
 
 	@Override public String[] getSupportedBlocks() {
-		return new String[] { "direction_from_deps" };
+		return new String[] { "entity_from_deps" };
 	}
 
 	@Override public BlockType getBlockType() {

--- a/src/main/java/net/mcreator/blockly/java/blocks/SourceEntityDependencyBlock.java
+++ b/src/main/java/net/mcreator/blockly/java/blocks/SourceEntityDependencyBlock.java
@@ -23,15 +23,15 @@ import net.mcreator.blockly.IBlockGenerator;
 import net.mcreator.blockly.data.Dependency;
 import org.w3c.dom.Element;
 
-public class EventOrTargetEntityDependenyBlock implements IBlockGenerator {
+public class SourceEntityDependencyBlock implements IBlockGenerator {
 
 	@Override public void generateBlock(BlocklyToCode master, Element block) {
-		master.append("entity");
-		master.addDependency(new Dependency("entity", "entity"));
+		master.append("sourceentity");
+		master.addDependency(new Dependency("sourceentity", "entity"));
 	}
 
 	@Override public String[] getSupportedBlocks() {
-		return new String[] { "entity_from_deps" };
+		return new String[] { "source_entity_from_deps" };
 	}
 
 	@Override public BlockType getBlockType() {


### PR DESCRIPTION
This PR fixes the `Dependeny` word to `Dependency` of some class names.