### PR TITLE
Improvements to code optimizer and code of some procedure blocks

### DIFF
--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/_print.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/_print.java.ftl
@@ -1,1 +1,1 @@
-${JavaModName}.LOGGER.info(${opt.removeParenthesesIgnoreComment(value)});
+${JavaModName}.LOGGER.info(${opt.removeParentheses(value)});

--- a/src/main/java/net/mcreator/blockly/java/ProcedureCodeOptimizer.java
+++ b/src/main/java/net/mcreator/blockly/java/ProcedureCodeOptimizer.java
@@ -21,7 +21,7 @@ package net.mcreator.blockly.java;
 
 import org.apache.commons.lang3.StringUtils;
 
-@SuppressWarnings("unused") public class ProcedureCodeOptimizer {
+public class ProcedureCodeOptimizer {
 	enum ParseState {
 		INSIDE_INLINE_COMMENT, INSIDE_COMMENT_BLOCK, INSIDE_STRING, INSIDE_STRING_ESCAPE_SEQUENCE, OUTSIDE
 	}
@@ -49,11 +49,11 @@ import org.apache.commons.lang3.StringUtils;
 		String prefix;
 		if (toClean.startsWith("/*@BlockState*/")) {
 			prefix = "/*@BlockState*/";
-			toClean = toClean.replaceFirst("/\\*@BlockState\\*/", "");
+			toClean = toClean.substring(15);
 		}
 		else if (code.startsWith("/*@ItemStack*/")) {
 			prefix = "/*@ItemStack*/";
-			toClean = toClean.replaceFirst("/\\*@ItemStack\\*/", "");
+			toClean = toClean.substring(14);
 		} else {
 			prefix = "";
 		}

--- a/src/main/java/net/mcreator/blockly/java/ProcedureCodeOptimizer.java
+++ b/src/main/java/net/mcreator/blockly/java/ProcedureCodeOptimizer.java
@@ -19,6 +19,8 @@
 
 package net.mcreator.blockly.java;
 
+import org.jboss.forge.roaster._shade.org.apache.commons.lang3.StringUtils;
+
 @SuppressWarnings("unused") public class ProcedureCodeOptimizer {
 	enum ParseState {
 		INSIDE_INLINE_COMMENT, INSIDE_COMMENT_BLOCK, INSIDE_STRING, INSIDE_STRING_ESCAPE_SEQUENCE, OUTSIDE
@@ -26,30 +28,73 @@ package net.mcreator.blockly.java;
 
 	/**
 	 * This method attempts to remove the parentheses surrounding the given code, if they are paired.
+	 * Eventual marker comments at the beginning of the input are ignored.
 	 * @param code The code to optimize
 	 * @return If possible, the code without surrounding parentheses
 	 */
 	public static String removeParentheses(String code) {
+		return removeParentheses(code, null);
+	}
+
+	/**
+	 * This method attempts to remove the parentheses surrounding the given code, if they are paired.
+	 * The optimization will fail if any of the blacklisted characters appears at the top nesting level.
+	 * Eventual marker comments at the beginning of the input are ignored.
+	 * @param code The code to optimize
+	 * @param blacklist The characters that can't be contained at the top nesting level
+	 * @return If possible, the code without surrounding parentheses
+	 */
+	public static String removeParentheses(String code, String blacklist) {
 		String toClean = code.strip();
-		if (toClean.startsWith("(") && toClean.endsWith(")")) {
+		String prefix;
+		if (toClean.startsWith("/*@BlockState*/")) {
+			prefix = "/*@BlockState*/";
+			toClean = toClean.replaceFirst("/\\*@BlockState\\*/", "");
+		}
+		else if (code.startsWith("/*@ItemStack*/")) {
+			prefix = "/*@ItemStack*/";
+			toClean = toClean.replaceFirst("/\\*@ItemStack\\*/", "");
+		} else {
+			prefix = "";
+		}
+		return canRemoveParentheses(toClean, blacklist) ? prefix + toClean.substring(1, toClean.length() - 1) : code;
+	}
+
+	/**
+	 * This method checks if the given code has surrounding parentheses that can be removed (starts and ends with
+	 * parentheses, they are paired, and there's no blacklisted character at the top nesting level)
+	 * @param toCheck The code to perform the check on
+	 * @param blacklist The characters that can't be contained at the top nesting level
+	 * @return true if the parentheses can be removed
+	 */
+	private static boolean canRemoveParentheses(String toCheck, String blacklist) {
+		if (toCheck.startsWith("(") && toCheck.endsWith(")")) {
 			var state = ParseState.OUTSIDE;
 			int parentheses = 1;
 			char prevChar = '(';
 			int backSlashCounter = 0;
-			for (int i = 1; i < toClean.length() - 1; i++) {
-				char c = toClean.charAt(i);
+			var topLevelChars = new StringBuilder();
+			for (int i = 1; i < toCheck.length() - 1; i++) {
+				char c = toCheck.charAt(i);
 				switch (state) {
 				case OUTSIDE:
-					if (c == '/' && prevChar == '/')
+					if (c == '/' && prevChar == '/') {
 						state = ParseState.INSIDE_INLINE_COMMENT;
-					else if (c == '*' && prevChar == '/')
+						topLevelChars.deleteCharAt(topLevelChars.length() - 1); // The previous character was part of the comment
+					}
+					else if (c == '*' && prevChar == '/') {
 						state = ParseState.INSIDE_COMMENT_BLOCK;
+						topLevelChars.deleteCharAt(topLevelChars.length() - 1);
+					}
 					else if (c == '"')
 						state = ParseState.INSIDE_STRING;
 					else if (c == '(')
 						parentheses++;
 					else if (c == ')' && --parentheses == 0) // The first ( isn't paired with the last ), we can't remove them
-						return code;
+						return false;
+					else if (blacklist != null && parentheses == 1) {
+						topLevelChars.append(c);
+					}
 					break;
 				case INSIDE_INLINE_COMMENT:
 					if (c == '\n' || c == '\r')
@@ -76,31 +121,9 @@ package net.mcreator.blockly.java;
 				}
 				prevChar = c;
 			}
-			return toClean.substring(1, toClean.length() - 1);
+			return StringUtils.containsNone(topLevelChars, blacklist);
 		}
-		return code;
-	}
-
-	/**
-	 * This method removes the parentheses surrounding the input code, while ignoring the blockstate/itemstack markers.
-	 * @param code The code to optimize
-	 * @return The code without the initial comment and, if possible, without surrounding parentheses
-	 */
-	public static String removeParenthesesIgnoreComment(String code) {
-		String prefix;
-		String withoutComment;
-		if (code.startsWith("/*@BlockState*/")) {
-			prefix = "/*@BlockState*/";
-			withoutComment = code.replaceFirst("/\\*@BlockState\\*/", "");
-		}
-		else if (code.startsWith("/*@ItemStack*/")) {
-			prefix = "/*@ItemStack*/";
-			withoutComment = code.replaceFirst("/\\*@ItemStack\\*/", "");
-		} else {
-			prefix = "";
-			withoutComment = code;
-		}
-		return prefix + removeParentheses(withoutComment);
+		return false;
 	}
 
 	/**

--- a/src/main/java/net/mcreator/blockly/java/ProcedureCodeOptimizer.java
+++ b/src/main/java/net/mcreator/blockly/java/ProcedureCodeOptimizer.java
@@ -19,7 +19,7 @@
 
 package net.mcreator.blockly.java;
 
-import org.jboss.forge.roaster._shade.org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 @SuppressWarnings("unused") public class ProcedureCodeOptimizer {
 	enum ParseState {

--- a/src/main/java/net/mcreator/blockly/java/ProcedureCodeOptimizer.java
+++ b/src/main/java/net/mcreator/blockly/java/ProcedureCodeOptimizer.java
@@ -46,7 +46,7 @@ public class ProcedureCodeOptimizer {
 	 */
 	public static String removeParentheses(String code, String blacklist) {
 		String toClean = code.strip();
-		String prefix;
+		String prefix = "";
 		if (toClean.startsWith("/*@BlockState*/")) {
 			prefix = "/*@BlockState*/";
 			toClean = toClean.substring(15);
@@ -54,8 +54,6 @@ public class ProcedureCodeOptimizer {
 		else if (code.startsWith("/*@ItemStack*/")) {
 			prefix = "/*@ItemStack*/";
 			toClean = toClean.substring(14);
-		} else {
-			prefix = "";
 		}
 		return canRemoveParentheses(toClean, blacklist) ? prefix + toClean.substring(1, toClean.length() - 1) : code;
 	}

--- a/src/main/java/net/mcreator/blockly/java/blocks/BinaryOperationsBlock.java
+++ b/src/main/java/net/mcreator/blockly/java/blocks/BinaryOperationsBlock.java
@@ -26,7 +26,6 @@ import net.mcreator.blockly.java.ProcedureCodeOptimizer;
 import net.mcreator.generator.template.TemplateGeneratorException;
 import net.mcreator.ui.init.L10N;
 import net.mcreator.util.XMLUtil;
-import org.apache.commons.lang3.StringUtils;
 import org.w3c.dom.Element;
 
 import java.util.List;
@@ -104,8 +103,6 @@ public class BinaryOperationsBlock implements IBlockGenerator {
 		} else {
 			return code;
 		}
-		if (StringUtils.containsNone(code, lowerPriority))
-			return ProcedureCodeOptimizer.removeParentheses(code);
-		return code;
+		return ProcedureCodeOptimizer.removeParentheses(code, lowerPriority);
 	}
 }

--- a/src/main/java/net/mcreator/blockly/java/blocks/LogicNegateBlock.java
+++ b/src/main/java/net/mcreator/blockly/java/blocks/LogicNegateBlock.java
@@ -24,7 +24,6 @@ import net.mcreator.blockly.IBlockGenerator;
 import net.mcreator.blockly.java.ProcedureCodeOptimizer;
 import net.mcreator.generator.template.TemplateGeneratorException;
 import net.mcreator.util.XMLUtil;
-import org.apache.commons.lang3.StringUtils;
 import org.w3c.dom.Element;
 
 public class LogicNegateBlock implements IBlockGenerator {
@@ -58,8 +57,8 @@ public class LogicNegateBlock implements IBlockGenerator {
 	}
 
 	private static String withoutParentheses(String code) {
-		if (code.contains("instanceof") || StringUtils.containsAny(code, "=><&|^!?"))
+		if (code.contains("instanceof"))
 			return code;
-		return ProcedureCodeOptimizer.removeParentheses(code);
+		return ProcedureCodeOptimizer.removeParentheses(code, "=><&|^!?");
 	}
 }

--- a/src/main/java/net/mcreator/blockly/java/blocks/PrintTextBlock.java
+++ b/src/main/java/net/mcreator/blockly/java/blocks/PrintTextBlock.java
@@ -42,7 +42,7 @@ public class PrintTextBlock implements IBlockGenerator {
 					master.append(master.getTemplateGenerator().generateFromTemplate("_print.java.ftl", dataModel));
 				} else {
 					master.append("System.out.println(");
-					master.append(ProcedureCodeOptimizer.removeParenthesesIgnoreComment(elementcode));
+					master.append(ProcedureCodeOptimizer.removeParentheses(elementcode));
 					master.append(");");
 				}
 			}


### PR DESCRIPTION
- The "remove parentheses" method now ignores initial markers by default
- Added an optional blacklist input: if one of the characters in the blacklist appears in the top nesting level (as in `(here (not here))`), the parentheses won't be removed
- The binary/negate operation blocks will ignore lower priority operations (except `instanceof`) if they're nested inside more parentheses
- The join text block now removes parentheses from the inputs if possible, and will add `""` at most once