### PR TITLE
Ported energy & fluid tanks procedures to 1.17

### DIFF
--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/block_energy_can_extract.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/block_energy_can_extract.java.ftl
@@ -1,0 +1,12 @@
+<#-- @formatter:off -->
+(new Object(){
+	public boolean canExtractEnergy(LevelAccessor level, BlockPos pos) {
+		AtomicBoolean _retval = new AtomicBoolean(false);
+		BlockEntity _ent = level.getBlockEntity(pos);
+		if (_ent != null)
+			_ent.getCapability(CapabilityEnergy.ENERGY, ${input$direction}).ifPresent(capability ->
+				_retval.set(capability.canExtract()));
+		return _retval.get();
+	}
+}.canExtractEnergy(world, new BlockPos((int)${input$x},(int)${input$y},(int)${input$z})))
+<#-- @formatter:on -->

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/block_energy_can_receive.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/block_energy_can_receive.java.ftl
@@ -1,0 +1,12 @@
+<#-- @formatter:off -->
+(new Object(){
+	public boolean canReceiveEnergy(LevelAccessor level, BlockPos pos) {
+		AtomicBoolean _retval = new AtomicBoolean(false);
+		BlockEntity _ent = level.getBlockEntity(pos);
+		if (_ent != null)
+			_ent.getCapability(CapabilityEnergy.ENERGY, ${input$direction}).ifPresent(capability ->
+				_retval.set(capability.canReceive()));
+		return _retval.get();
+	}
+}.canReceiveEnergy(world, new BlockPos((int)${input$x},(int)${input$y},(int)${input$z})))
+<#-- @formatter:on -->

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/block_energy_check_extract.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/block_energy_check_extract.java.ftl
@@ -1,0 +1,12 @@
+<#-- @formatter:off -->
+(new Object(){
+	public int extractEnergySimulate(LevelAccessor level, BlockPos pos, int _amount) {
+		AtomicInteger _retval = new AtomicInteger(0);
+		BlockEntity _ent = level.getBlockEntity(pos);
+		if (_ent != null)
+			_ent.getCapability(CapabilityEnergy.ENERGY, ${input$direction}).ifPresent(capability ->
+				_retval.set(capability.extractEnergy(_amount, true)));
+		return _retval.get();
+	}
+}.extractEnergySimulate(world, new BlockPos((int)${input$x},(int)${input$y},(int)${input$z}),(int)${input$amount}))
+<#-- @formatter:on -->

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/block_energy_check_receive.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/block_energy_check_receive.java.ftl
@@ -1,0 +1,12 @@
+<#-- @formatter:off -->
+(new Object(){
+	public int receiveEnergySimulate(LevelAccessor level, BlockPos pos, int _amount) {
+		AtomicInteger _retval = new AtomicInteger(0);
+		BlockEntity _ent = level.getBlockEntity(pos);
+		if (_ent != null)
+			_ent.getCapability(CapabilityEnergy.ENERGY, ${input$direction}).ifPresent(capability ->
+				_retval.set(capability.receiveEnergy(_amount, true)));
+		return _retval.get();
+	}
+}.receiveEnergySimulate(world, new BlockPos((int)${input$x},(int)${input$y},(int)${input$z}),(int)${input$amount}))
+<#-- @formatter:on -->

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/block_energy_extract.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/block_energy_extract.java.ftl
@@ -1,0 +1,9 @@
+<#-- @formatter:off -->
+{
+	BlockEntity _ent = world.getBlockEntity(new BlockPos((int)${input$x},(int)${input$y},(int)${input$z}));
+	int _amount = (int)${input$amount};
+	if (_ent != null)
+		_ent.getCapability(CapabilityEnergy.ENERGY, ${input$direction}).ifPresent(capability ->
+			capability.extractEnergy(_amount, false));
+}
+<#-- @formatter:on -->

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/block_energy_get.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/block_energy_get.java.ftl
@@ -1,0 +1,12 @@
+<#-- @formatter:off -->
+(new Object(){
+	public int getEnergyStored(LevelAccessor level, BlockPos pos) {
+		AtomicInteger _retval = new AtomicInteger(0);
+		BlockEntity _ent = level.getBlockEntity(pos);
+		if (_ent != null)
+			_ent.getCapability(CapabilityEnergy.ENERGY, ${input$direction}).ifPresent(capability ->
+				_retval.set(capability.getEnergyStored()));
+		return _retval.get();
+	}
+}.getEnergyStored(world, new BlockPos((int)${input$x},(int)${input$y},(int)${input$z})))
+<#-- @formatter:on -->

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/block_energy_get_max.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/block_energy_get_max.java.ftl
@@ -1,0 +1,12 @@
+<#-- @formatter:off -->
+(new Object(){
+	public int getMaxEnergyStored(LevelAccessor level, BlockPos pos) {
+		AtomicInteger _retval = new AtomicInteger(0);
+		BlockEntity _ent = level.getBlockEntity(pos);
+		if (_ent != null)
+			_ent.getCapability(CapabilityEnergy.ENERGY, ${input$direction}).ifPresent(capability ->
+				_retval.set(capability.getMaxEnergyStored()));
+		return _retval.get();
+	}
+}.getMaxEnergyStored(world, new BlockPos((int)${input$x},(int)${input$y},(int)${input$z})))
+<#-- @formatter:on -->

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/block_energy_receive.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/block_energy_receive.java.ftl
@@ -1,0 +1,9 @@
+<#-- @formatter:off -->
+{
+	BlockEntity _ent = world.getBlockEntity(new BlockPos((int)${input$x},(int)${input$y},(int)${input$z}));
+	int _amount = (int)${input$amount};
+	if (_ent != null)
+		_ent.getCapability(CapabilityEnergy.ENERGY, ${input$direction}).ifPresent(capability ->
+			capability.receiveEnergy(_amount, false));
+}
+<#-- @formatter:on -->

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/block_fluidtank_check_drain.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/block_fluidtank_check_drain.java.ftl
@@ -1,0 +1,12 @@
+<#-- @formatter:off -->
+(new Object(){
+	public int drainTankSimulate(LevelAccessor level, BlockPos pos, int amount) {
+		AtomicInteger _retval = new AtomicInteger(0);
+		BlockEntity _ent = level.getBlockEntity(pos);
+		if (_ent != null)
+			_ent.getCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, ${input$direction}).ifPresent(capability ->
+				_retval.set(capability.drain(amount, IFluidHandler.FluidAction.SIMULATE).getAmount()));
+		return _retval.get();
+	}
+}.drainTankSimulate(world, new BlockPos((int)${input$x},(int)${input$y},(int)${input$z}),(int)${input$amount}))
+<#-- @formatter:on -->

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/block_fluidtank_check_fill.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/block_fluidtank_check_fill.java.ftl
@@ -1,0 +1,18 @@
+<#-- @formatter:off -->
+(new Object(){
+	public int fillTankSimulate(LevelAccessor level, BlockPos pos, int amount) {
+		AtomicInteger _retval = new AtomicInteger(0);
+		BlockEntity _ent = level.getBlockEntity(pos);
+		if (_ent != null)
+			_ent.getCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, ${input$direction}).ifPresent(capability ->
+				<#if field$fluid.startsWith("CUSTOM:")>
+				<#assign fluid = field$fluid?replace("CUSTOM:", "")>
+				_retval.set(capability.fill(new FluidStack(${JavaModName}Fluids.${fluid?ends_with(":Flowing")?then("FLOWING_","")}${generator.getRegistryNameForModElement(fluid?remove_ending(":Flowing"))?upper_case}, amount), IFluidHandler.FluidAction.SIMULATE))
+				<#else>
+				_retval.set(capability.fill(new FluidStack(Fluids.${generator.map(field$fluid, "fluid")}, amount), IFluidHandler.FluidAction.SIMULATE))
+				</#if>
+		);
+		return _retval.get();
+	}
+}.fillTankSimulate(world, new BlockPos((int)${input$x},(int)${input$y},(int)${input$z}),(int)${input$amount}))
+<#-- @formatter:on -->

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/block_fluidtank_drain.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/block_fluidtank_drain.java.ftl
@@ -1,0 +1,10 @@
+<#include "mcitems.ftl">
+<#-- @formatter:off -->
+{
+	BlockEntity _ent = world.getBlockEntity(new BlockPos((int)${input$x},(int)${input$y},(int)${input$z}));
+	int _amount = (int)${input$amount};
+	if (_ent != null)
+		_ent.getCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, ${input$direction}).ifPresent(capability ->
+			capability.drain(_amount, IFluidHandler.FluidAction.EXECUTE));
+}
+<#-- @formatter:on -->

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/block_fluidtank_fill.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/block_fluidtank_fill.java.ftl
@@ -1,0 +1,16 @@
+<#include "mcitems.ftl">
+<#-- @formatter:off -->
+{
+	BlockEntity _ent = world.getBlockEntity(new BlockPos((int)${input$x},(int)${input$y},(int)${input$z}));
+	int _amount = (int)${input$amount};
+	if (_ent != null)
+		_ent.getCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, ${input$direction}).ifPresent(capability ->
+			<#if field$fluid.startsWith("CUSTOM:")>
+			<#assign fluid = field$fluid?replace("CUSTOM:", "")>
+			capability.fill(new FluidStack(${JavaModName}Fluids.${fluid?ends_with(":Flowing")?then("FLOWING_","")}${generator.getRegistryNameForModElement(fluid?remove_ending(":Flowing"))?upper_case}, _amount), IFluidHandler.FluidAction.EXECUTE)
+			<#else>
+			capability.fill(new FluidStack(Fluids.${generator.map(field$fluid, "fluid")}, _amount), IFluidHandler.FluidAction.EXECUTE)
+			</#if>
+		);
+}
+<#-- @formatter:on -->

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/block_fluidtank_get.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/block_fluidtank_get.java.ftl
@@ -1,0 +1,12 @@
+<#-- @formatter:off -->
+(new Object() {
+	public int getFluidTankLevel(LevelAccessor level, BlockPos pos, int tank) {
+		AtomicInteger _retval = new AtomicInteger(0);
+		BlockEntity _ent = level.getBlockEntity(pos);
+		if (_ent != null)
+			_ent.getCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, ${input$direction}).ifPresent(capability ->
+				_retval.set(capability.getFluidInTank(tank).getAmount()));
+		return _retval.get();
+	}
+}.getFluidTankLevel(world, new BlockPos((int)${input$x},(int)${input$y},(int)${input$z}), (int)${input$tank}))
+<#-- @formatter:on -->

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/block_fluidtank_get_max.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/block_fluidtank_get_max.java.ftl
@@ -1,0 +1,12 @@
+<#-- @formatter:off -->
+(new Object() {
+	public int getFluidTankCapacity(LevelAccessor level, BlockPos pos, int tank) {
+		AtomicInteger _retval = new AtomicInteger(0);
+		BlockEntity _ent = level.getBlockEntity(pos);
+		if (_ent != null)
+			_ent.getCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, ${input$direction}).ifPresent(capability ->
+				_retval.set(capability.getTankCapacity(tank)));
+		return _retval.get();
+	}
+}.getFluidTankCapacity(world, new BlockPos((int)${input$x},(int)${input$y},(int)${input$z}), (int)${input$tank}))
+<#-- @formatter:on -->

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/block_fluidtank_tanks.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/block_fluidtank_tanks.java.ftl
@@ -1,0 +1,12 @@
+<#-- @formatter:off -->
+(new Object() {
+	public int getBlockTanks(LevelAccessor level, BlockPos pos) {
+		AtomicInteger _retval = new AtomicInteger(0);
+		BlockEntity _ent = level.getBlockEntity(pos);
+		if (_ent != null)
+			_ent.getCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, ${input$direction}).ifPresent(capability ->
+				_retval.set(capability.getTanks()));
+		return _retval.get();
+	}
+}.getBlockTanks(world, new BlockPos((int)${input$x},(int)${input$y},(int)${input$z})))
+<#-- @formatter:on -->


### PR DESCRIPTION
This PR ports the energy & fluid tanks procedures to 1.17, assuming fluids will be registered as `ModFluids.FLUID` and `ModFluids.FLOWING_FLUID`