### PR TITLE
Fixed some issues with join text block and parentheses removal

### DIFF
--- a/src/main/java/net/mcreator/blockly/java/ProcedureCodeOptimizer.java
+++ b/src/main/java/net/mcreator/blockly/java/ProcedureCodeOptimizer.java
@@ -78,11 +78,13 @@ public class ProcedureCodeOptimizer {
 				case OUTSIDE:
 					if (c == '/' && prevChar == '/') {
 						state = ParseState.INSIDE_INLINE_COMMENT;
-						topLevelChars.deleteCharAt(topLevelChars.length() - 1); // The previous character was part of the comment
+						if (blacklist != null && parentheses == 1)
+							topLevelChars.deleteCharAt(topLevelChars.length() - 1); // The previous character was part of the comment
 					}
 					else if (c == '*' && prevChar == '/') {
 						state = ParseState.INSIDE_COMMENT_BLOCK;
-						topLevelChars.deleteCharAt(topLevelChars.length() - 1);
+						if (blacklist != null && parentheses == 1)
+							topLevelChars.deleteCharAt(topLevelChars.length() - 1);
 					}
 					else if (c == '"')
 						state = ParseState.INSIDE_STRING;

--- a/src/main/java/net/mcreator/blockly/java/blocks/TextJoinBlock.java
+++ b/src/main/java/net/mcreator/blockly/java/blocks/TextJoinBlock.java
@@ -66,10 +66,10 @@ public class TextJoinBlock implements IBlockGenerator {
 			if (sumnum == 1) {
 				if (inputCodes.get(0).matches("\"[^\"]*\"")) { // The only element is a string, we return it as is
 					master.append(inputCodes.get(0));
-					return;
 				} else {
-					master.append("(\"\" + ");
+					master.append("(\"\" + " + inputCodes.get(0) + ")");
 				}
+				return;
 			} else {
 				master.append("(");
 			}


### PR DESCRIPTION
This PR fixes the text join block not working with a single non-string input, and the code optimizer throwing `IndexOutOfBoundsException` in some situations