### PR TITLE
Move 1.16.5 paintings to a global template file

### DIFF
--- a/plugins/generator-1.16.5/forge-1.16.5/painting.definition.yaml
+++ b/plugins/generator-1.16.5/forge-1.16.5/painting.definition.yaml
@@ -1,3 +1,3 @@
-templates:
-  - template: painting.java.ftl
-    name: "@SRCROOT/@BASEPACKAGEPATH/painting/@NAMEPainting.java"
+global_templates:
+  - template: elementinits/paintings.java.ftl
+    name: "@SRCROOT/@BASEPACKAGEPATH/init/@JavaModNamePaintings.java"

--- a/plugins/generator-1.16.5/forge-1.16.5/templates/elementinits/paintings.java.ftl
+++ b/plugins/generator-1.16.5/forge-1.16.5/templates/elementinits/paintings.java.ftl
@@ -1,6 +1,7 @@
 <#--
  # MCreator (https://mcreator.net/)
- # Copyright (C) 2020 Pylo and contributors
+ # Copyright (C) 2012-2020, Pylo
+ # Copyright (C) 2020-2021, Pylo, opensource contributors
  #
  # This program is free software: you can redistribute it and/or modify
  # it under the terms of the GNU General Public License as published by
@@ -28,15 +29,21 @@
 -->
 
 <#-- @formatter:off -->
-<#include "procedures.java.ftl">
 
-package ${package}.painting;
+/*
+ *    MCreator note: This file will be REGENERATED on each build.
+ */
 
-@Mod.EventBusSubscriber(bus = Mod.EventBusSubscriber.Bus.MOD) public class ${name}Painting {
-	
-	@SubscribeEvent public static void registerPaintingType(RegistryEvent.Register<PaintingType> event) {
-		event.getRegistry().register(new PaintingType(${data.width}, ${data.height}).setRegistryName("${registryname}"));
+package ${package}.init;
+
+@Mod.EventBusSubscriber(bus = Mod.EventBusSubscriber.Bus.MOD) public class ${JavaModName}Paintings {
+
+	@SubscribeEvent public static void registerPaintingTypes(RegistryEvent.Register<PaintingType> event) {
+		<#list paintings as painting>
+		    event.getRegistry().register(new PaintingType(${painting.width}, ${painting.height}).setRegistryName("${painting.getModElement().getRegistryName()}"));
+        </#list>
 	}
 
 }
+
 <#-- @formatter:on -->


### PR DESCRIPTION
The Forge 1.17.1 generator will have a good code, but the Forge 1.16.5 will still have the old ugly code. This PR moves paintings to a global template file, the same way we did with 