### PR TITLE
Added optional "group" field for procedure blocks, grouped some itemstack procedures

### DIFF
--- a/plugins/mcreator-core/procedures/item_add_enhancement.json
+++ b/plugins/mcreator-core/procedures/item_add_enhancement.json
@@ -19,6 +19,7 @@
   "nextStatement": null,
   "colour": 350,
   "mcreator": {
+    "group": "enchanting",
     "toolbox_id": "itemmanagement",
     "toolbox_init": [
       "<value name=\"level\"><block type=\"math_number\"><field name=\"NUM\">10</field></block></value>",

--- a/plugins/mcreator-core/procedures/item_can_smelt.json
+++ b/plugins/mcreator-core/procedures/item_can_smelt.json
@@ -10,6 +10,7 @@
   "output": "Boolean",
   "colour": "%{BKY_LOGIC_HUE}",
   "mcreator": {
+    "group": "smelting",
     "toolbox_id": "itemmanagement",
     "toolbox_init": [
       "<value name=\"item\"><block type=\"itemstack_to_mcitem\"></block></value>"

--- a/plugins/mcreator-core/procedures/item_damage.json
+++ b/plugins/mcreator-core/procedures/item_damage.json
@@ -16,6 +16,7 @@
   "nextStatement": null,
   "colour": 350,
   "mcreator": {
+    "group": "damage",
     "toolbox_id": "itemmanagement",
     "toolbox_init": [
       "<value name=\"amount\"><block type=\"math_number\"><field name=\"NUM\">1</field></block></value>",

--- a/plugins/mcreator-core/procedures/item_enchanted_with_xp.json
+++ b/plugins/mcreator-core/procedures/item_enchanted_with_xp.json
@@ -20,6 +20,7 @@
   "output": "MCItem",
   "colour": 350,
   "mcreator": {
+    "group": "enchanting",
     "toolbox_id": "itemmanagement",
     "toolbox_init": [
       "<value name=\"item\"><block type=\"mcitem_all\"><field name=\"value\"></field></block></value>",

--- a/plugins/mcreator-core/procedures/item_fuel_power.json
+++ b/plugins/mcreator-core/procedures/item_fuel_power.json
@@ -10,6 +10,7 @@
   "output": "Number",
   "colour": "%{BKY_MATH_HUE}",
   "mcreator": {
+    "group": "smelting",
     "toolbox_id": "itemmanagement",
     "toolbox_init": [
       "<value name=\"item\"><block type=\"itemstack_to_mcitem\"></block></value>"

--- a/plugins/mcreator-core/procedures/item_get_damage.json
+++ b/plugins/mcreator-core/procedures/item_get_damage.json
@@ -9,6 +9,7 @@
   "output": "Number",
   "colour": "%{BKY_MATH_HUE}",
   "mcreator": {
+    "group": "damage",
     "toolbox_id": "itemmanagement",
     "toolbox_init": [
       "<value name=\"item\"><block type=\"itemstack_to_mcitem\"></block></value>"

--- a/plugins/mcreator-core/procedures/item_get_enhancement.json
+++ b/plugins/mcreator-core/procedures/item_get_enhancement.json
@@ -13,6 +13,7 @@
   "output": "Number",
   "colour": "%{BKY_MATH_HUE}",
   "mcreator": {
+    "group": "enchanting",
     "toolbox_id": "itemmanagement",
     "toolbox_init": [
       "<value name=\"item\"><block type=\"itemstack_to_mcitem\"></block></value>"

--- a/plugins/mcreator-core/procedures/item_get_food_value.json
+++ b/plugins/mcreator-core/procedures/item_get_food_value.json
@@ -9,6 +9,7 @@
   "output": "Number",
   "colour": "%{BKY_MATH_HUE}",
   "mcreator": {
+    "group": "food",
     "toolbox_id": "itemmanagement",
     "toolbox_init": [
       "<value name=\"item\"><block type=\"itemstack_to_mcitem\"></block></value>"

--- a/plugins/mcreator-core/procedures/item_get_max_damage.json
+++ b/plugins/mcreator-core/procedures/item_get_max_damage.json
@@ -9,6 +9,7 @@
   "output": "Number",
   "colour": "%{BKY_MATH_HUE}",
   "mcreator": {
+    "group": "damage",
     "toolbox_id": "itemmanagement",
     "toolbox_init": [
       "<value name=\"item\"><block type=\"itemstack_to_mcitem\"></block></value>"

--- a/plugins/mcreator-core/procedures/item_get_saturation_value.json
+++ b/plugins/mcreator-core/procedures/item_get_saturation_value.json
@@ -9,6 +9,7 @@
   "output": "Number",
   "colour": "%{BKY_MATH_HUE}",
   "mcreator": {
+    "group": "food",
     "toolbox_id": "itemmanagement",
     "toolbox_init": [
       "<value name=\"item\"><block type=\"itemstack_to_mcitem\"></block></value>"

--- a/plugins/mcreator-core/procedures/item_is_enchantable.json
+++ b/plugins/mcreator-core/procedures/item_is_enchantable.json
@@ -10,6 +10,7 @@
   "output": "Boolean",
   "colour": "%{BKY_LOGIC_HUE}",
   "mcreator": {
+    "group": "enchanting",
     "toolbox_id": "itemmanagement",
     "toolbox_init": [
       "<value name=\"item\"><block type=\"itemstack_to_mcitem\"></block></value>"

--- a/plugins/mcreator-core/procedures/item_is_enchanted.json
+++ b/plugins/mcreator-core/procedures/item_is_enchanted.json
@@ -10,6 +10,7 @@
   "output": "Boolean",
   "colour": "%{BKY_LOGIC_HUE}",
   "mcreator": {
+    "group": "enchanting",
     "toolbox_id": "itemmanagement",
     "toolbox_init": [
       "<value name=\"item\"><block type=\"itemstack_to_mcitem\"></block></value>"

--- a/plugins/mcreator-core/procedures/item_is_food.json
+++ b/plugins/mcreator-core/procedures/item_is_food.json
@@ -10,6 +10,7 @@
   "output": "Boolean",
   "colour": "%{BKY_LOGIC_HUE}",
   "mcreator": {
+    "group": "food",
     "toolbox_id": "itemmanagement",
     "toolbox_init": [
       "<value name=\"item\"><block type=\"itemstack_to_mcitem\"></block></value>"

--- a/plugins/mcreator-core/procedures/item_name.json
+++ b/plugins/mcreator-core/procedures/item_name.json
@@ -10,6 +10,7 @@
   "output": "String",
   "colour": "%{BKY_TEXTS_HUE}",
   "mcreator": {
+    "group": "name",
     "toolbox_id": "itemmanagement",
     "toolbox_init": [
       "<value name=\"item\"><block type=\"mcitem_all\"><field name=\"value\"></field></block></value>"

--- a/plugins/mcreator-core/procedures/item_set_damage.json
+++ b/plugins/mcreator-core/procedures/item_set_damage.json
@@ -16,6 +16,7 @@
   "nextStatement": null,
   "colour": 350,
   "mcreator": {
+    "group": "damage",
     "toolbox_id": "itemmanagement",
     "toolbox_init": [
       "<value name=\"amount\"><block type=\"math_number\"><field name=\"NUM\">0</field></block></value>",

--- a/plugins/mcreator-core/procedures/item_set_display_name.json
+++ b/plugins/mcreator-core/procedures/item_set_display_name.json
@@ -16,6 +16,7 @@
   "nextStatement": null,
   "colour": 350,
   "mcreator": {
+    "group": "name",
     "toolbox_id": "itemmanagement",
     "toolbox_init": [
       "<value name=\"displayname\"><block type=\"text\"><field name=\"TEXT\">Display name</field></block></value>",

--- a/plugins/mcreator-core/procedures/item_smelting_result.json
+++ b/plugins/mcreator-core/procedures/item_smelting_result.json
@@ -10,6 +10,7 @@
   "output": "MCItem",
   "colour": 350,
   "mcreator": {
+    "group": "smelting",
     "toolbox_id": "itemmanagement",
     "toolbox_init": [
       "<value name=\"item\"><block type=\"itemstack_to_mcitem\"></block></value>"

--- a/plugins/mcreator-core/procedures/itemstack_get_count.json
+++ b/plugins/mcreator-core/procedures/itemstack_get_count.json
@@ -9,6 +9,7 @@
   "output": "Number",
   "colour": "%{BKY_MATH_HUE}",
   "mcreator": {
+    "group": "count",
     "toolbox_id": "itemmanagement",
     "toolbox_init": [
       "<value name=\"item\"><block type=\"itemstack_to_mcitem\"></block></value>"

--- a/plugins/mcreator-core/procedures/itemstack_grow.json
+++ b/plugins/mcreator-core/procedures/itemstack_grow.json
@@ -16,6 +16,7 @@
   "nextStatement": null,
   "colour": 350,
   "mcreator": {
+    "group": "count",
     "toolbox_id": "itemmanagement",
     "toolbox_init": [
       "<value name=\"amount\"><block type=\"math_number\"><field name=\"NUM\">1</field></block></value>",

--- a/plugins/mcreator-core/procedures/itemstack_has_enchantment.json
+++ b/plugins/mcreator-core/procedures/itemstack_has_enchantment.json
@@ -13,6 +13,7 @@
     "enhancement_list_provider"
   ],
   "mcreator": {
+    "group": "enchanting",
     "toolbox_id": "itemmanagement",
     "toolbox_init": [
       "<value name=\"item\"><block type=\"itemstack_to_mcitem\"></block></value>"

--- a/plugins/mcreator-core/procedures/itemstack_remove_specific_enchantment.json
+++ b/plugins/mcreator-core/procedures/itemstack_remove_specific_enchantment.json
@@ -14,6 +14,7 @@
     "enhancement_list_provider"
   ],
   "mcreator": {
+    "group": "enchanting",
     "toolbox_id": "itemmanagement",
     "toolbox_init": [
       "<value name=\"item\"><block type=\"itemstack_to_mcitem\"></block></value>"

--- a/plugins/mcreator-core/procedures/itemstack_set_count.json
+++ b/plugins/mcreator-core/procedures/itemstack_set_count.json
@@ -16,6 +16,7 @@
   "nextStatement": null,
   "colour": 350,
   "mcreator": {
+    "group": "count",
     "toolbox_id": "itemmanagement",
     "toolbox_init": [
       "<value name=\"amount\"><block type=\"math_number\"><field name=\"NUM\">64</field></block></value>",

--- a/plugins/mcreator-core/procedures/itemstack_shrink.json
+++ b/plugins/mcreator-core/procedures/itemstack_shrink.json
@@ -16,6 +16,7 @@
   "nextStatement": null,
   "colour": 350,
   "mcreator": {
+    "group": "count",
     "toolbox_id": "itemmanagement",
     "toolbox_init": [
       "<value name=\"amount\"><block type=\"math_number\"><field name=\"NUM\">1</field></block></value>",

--- a/src/main/java/net/mcreator/blockly/data/ToolboxBlock.java
+++ b/src/main/java/net/mcreator/blockly/data/ToolboxBlock.java
@@ -38,6 +38,7 @@ import java.util.stream.Collectors;
 	@Nullable private List<Dependency> dependencies;
 	@Nullable private List<String> warnings;
 	@Nullable private List<String> required_apis;
+	@Nullable private String group;
 	@Nullable public List<String> toolbox_init;
 
 	public boolean error_in_statement_blocks = false;
@@ -93,6 +94,8 @@ import java.util.stream.Collectors;
 	}
 
 	String getGroupEstimate() {
+		if (this.group != null)
+			return this.group;
 		int a = StringUtils.ordinalIndexOf(this.machine_name, "_", 2);
 		if (a > 0)
 			return this.machine_name.substring(0, a);


### PR DESCRIPTION
This PR adds an optional `group` field for procedure blocks, which can be used to group similar procedures together correctly (for example, item enchanting procedures, item damage procedures etc.). If no group is specified, the old system for grouping is used