### PR TITLE
Fixes to couple of procedure blocks

### DIFF
--- a/plugins/mcreator-core/blockly/mcreator_extensions.js
+++ b/plugins/mcreator-core/blockly/mcreator_extensions.js
@@ -32,7 +32,7 @@ Blockly.Extensions.register('material_list_provider',
 Blockly.Extensions.register('plant_type_list_provider',
     function () {
         this.appendDummyInput().appendField(new Blockly.FieldDropdown(
-            arrayToBlocklyDropDownArray(javabridge.getListOf("planttype"))), 'planttype');
+            arrayToBlocklyDropDownArray(javabridge.getListOf("planttypes"))), 'planttype');
     });
 
 // Extension to mark a procedure block as a custom loop

--- a/plugins/mcreator-core/procedures/compare_mcblock_material.json
+++ b/plugins/mcreator-core/procedures/compare_mcblock_material.json
@@ -20,6 +20,9 @@
   "colour": "%{BKY_LOGIC_HUE}",
   "mcreator": {
     "toolbox_id": "blockdata",
+    "toolbox_init": [
+      "<value name=\"a\"><block type=\"blockstate_from_deps\"></block></value>"
+    ],
     "fields": [
       "material"
     ],


### PR DESCRIPTION
- Fixed "Check plant type" procedure block not loading the plant type list correctly
- The "Compare block material" procedure now has "Provided blockstate" as its default input