### PR TITLE
[1.18] Ported more world data blocks

### DIFF
--- a/plugins/generator-1.18/forge-1.18/procedures/world_data_isremote.java.ftl
+++ b/plugins/generator-1.18/forge-1.18/procedures/world_data_isremote.java.ftl
@@ -1,0 +1,1 @@
+(world.isClientSide())

--- a/plugins/generator-1.18/forge-1.18/procedures/world_data_isthundering.java.ftl
+++ b/plugins/generator-1.18/forge-1.18/procedures/world_data_isthundering.java.ftl
@@ -1,0 +1,1 @@
+(world.getLevelData().isThundering())

--- a/plugins/generator-1.18/forge-1.18/procedures/world_data_light_level.java.ftl
+++ b/plugins/generator-1.18/forge-1.18/procedures/world_data_light_level.java.ftl
@@ -1,0 +1,1 @@
+/*@int*/(world.getMaxLocalRawBrightness(new BlockPos((int)${input$x},(int)${input$y},(int)${input$z})))

--- a/plugins/generator-1.18/forge-1.18/procedures/world_data_moon_phase.java.ftl
+++ b/plugins/generator-1.18/forge-1.18/procedures/world_data_moon_phase.java.ftl
@@ -1,0 +1,1 @@
+/*@int*/(world.dimensionType().moonPhase(world.dayTime()))

--- a/plugins/generator-1.18/forge-1.18/procedures/world_data_number_players_server.java.ftl
+++ b/plugins/generator-1.18/forge-1.18/procedures/world_data_number_players_server.java.ftl
@@ -1,0 +1,1 @@
+/*@int*/(world.isClientSide() ? Minecraft.getInstance().getConnection().getOnlinePlayers().size() : ServerLifecycleHooks.getCurrentServer().getPlayerCount())

--- a/plugins/generator-1.18/forge-1.18/procedures/world_data_number_players_world.java.ftl
+++ b/plugins/generator-1.18/forge-1.18/procedures/world_data_number_players_world.java.ftl
@@ -1,0 +1,1 @@
+/*@int*/(world.players().size())

--- a/plugins/generator-1.18/forge-1.18/procedures/world_data_spawn_x.java.ftl
+++ b/plugins/generator-1.18/forge-1.18/procedures/world_data_spawn_x.java.ftl
@@ -1,0 +1,1 @@
+/*@int*/(world.getLevelData().getXSpawn())

--- a/plugins/generator-1.18/forge-1.18/procedures/world_data_spawn_y.java.ftl
+++ b/plugins/generator-1.18/forge-1.18/procedures/world_data_spawn_y.java.ftl
@@ -1,0 +1,1 @@
+/*@int*/(world.getLevelData().getYSpawn())

--- a/plugins/generator-1.18/forge-1.18/procedures/world_data_spawn_z.java.ftl
+++ b/plugins/generator-1.18/forge-1.18/procedures/world_data_spawn_z.java.ftl
@@ -1,0 +1,1 @@
+/*@int*/(world.getLevelData().getZSpawn())


### PR DESCRIPTION
This PR ports the following world data blocks:

- Is remote
- Is thundering
- Get light level
- Get moon phase
- Get the number of players on the server
- Get the number of players in the world
- Get x/y/z spawn point