### PR TITLE
Fized sorting of copper blocks (1.17)

### DIFF
--- a/plugins/generator-1.17.1/forge-1.17.1/mappings/blocksitems.yaml
+++ b/plugins/generator-1.17.1/forge-1.17.1/mappings/blocksitems.yaml
@@ -2627,102 +2627,102 @@ Blocks.POWDER_SNOW:
 Blocks.SCULK_SENSOR:
   - Blocks.SCULK_SENSOR
   - "sculk_sensor"
-Blocks.OXIDIZED_COPPER:
-  - Blocks.OXIDIZED_COPPER
-  - "oxidized_copper"
-Blocks.WEATHERED_COPPER:
-  - Blocks.WEATHERED_COPPER
-  - "weathered_copper"
-Blocks.EXPOSED_COPPER:
-  - Blocks.EXPOSED_COPPER
-  - "exposed_copper"
 Blocks.COPPER_BLOCK:
   - Blocks.COPPER_BLOCK
   - "copper_block"
-Blocks.OXIDIZED_CUT_COPPER:
-  - Blocks.OXIDIZED_CUT_COPPER
-  - "oxidized_cut_copper"
-Blocks.WEATHERED_CUT_COPPER:
-  - Blocks.WEATHERED_CUT_COPPER
-  - "weathered_cut_copper"
-Blocks.EXPOSED_CUT_COPPER:
-  - Blocks.EXPOSED_CUT_COPPER
-  - "exposed_cut_copper"
+Blocks.EXPOSED_COPPER:
+  - Blocks.EXPOSED_COPPER
+  - "exposed_copper"
+Blocks.WEATHERED_COPPER:
+  - Blocks.WEATHERED_COPPER
+  - "weathered_copper"
+Blocks.OXIDIZED_COPPER:
+  - Blocks.OXIDIZED_COPPER
+  - "oxidized_copper"
 Blocks.CUT_COPPER:
   - Blocks.CUT_COPPER
   - "cut_copper"
-Blocks.OXIDIZED_CUT_COPPER_STAIRS:
-  - Blocks.OXIDIZED_CUT_COPPER_STAIRS
-  - "oxidized_cut_copper_stairs"
-Blocks.WEATHERED_CUT_COPPER_STAIRS:
-  - Blocks.WEATHERED_CUT_COPPER_STAIRS
-  - "weathered_cut_copper_stairs"
-Blocks.EXPOSED_CUT_COPPER_STAIRS:
-  - Blocks.EXPOSED_CUT_COPPER_STAIRS
-  - "exposed_cut_copper_stairs"
+Blocks.EXPOSED_CUT_COPPER:
+  - Blocks.EXPOSED_CUT_COPPER
+  - "exposed_cut_copper"
+Blocks.WEATHERED_CUT_COPPER:
+  - Blocks.WEATHERED_CUT_COPPER
+  - "weathered_cut_copper"
+Blocks.OXIDIZED_CUT_COPPER:
+  - Blocks.OXIDIZED_CUT_COPPER
+  - "oxidized_cut_copper"
 Blocks.CUT_COPPER_STAIRS:
   - Blocks.CUT_COPPER_STAIRS
   - "cut_copper_stairs"
-Blocks.OXIDIZED_CUT_COPPER_SLAB:
-  - Blocks.OXIDIZED_CUT_COPPER_SLAB
-  - "oxidized_cut_copper_slab"
-Blocks.WEATHERED_CUT_COPPER_SLAB:
-  - Blocks.WEATHERED_CUT_COPPER_SLAB
-  - "weathered_cut_copper_slab"
-Blocks.EXPOSED_CUT_COPPER_SLAB:
-  - Blocks.EXPOSED_CUT_COPPER_SLAB
-  - "exposed_cut_copper_slab"
+Blocks.EXPOSED_CUT_COPPER_STAIRS:
+  - Blocks.EXPOSED_CUT_COPPER_STAIRS
+  - "exposed_cut_copper_stairs"
+Blocks.WEATHERED_CUT_COPPER_STAIRS:
+  - Blocks.WEATHERED_CUT_COPPER_STAIRS
+  - "weathered_cut_copper_stairs"
+Blocks.OXIDIZED_CUT_COPPER_STAIRS:
+  - Blocks.OXIDIZED_CUT_COPPER_STAIRS
+  - "oxidized_cut_copper_stairs"
 Blocks.CUT_COPPER_SLAB:
   - Blocks.CUT_COPPER_SLAB
   - "cut_copper_slab"
+Blocks.EXPOSED_CUT_COPPER_SLAB:
+  - Blocks.EXPOSED_CUT_COPPER_SLAB
+  - "exposed_cut_copper_slab"
+Blocks.WEATHERED_CUT_COPPER_SLAB:
+  - Blocks.WEATHERED_CUT_COPPER_SLAB
+  - "weathered_cut_copper_slab"
+Blocks.OXIDIZED_CUT_COPPER_SLAB:
+  - Blocks.OXIDIZED_CUT_COPPER_SLAB
+  - "oxidized_cut_copper_slab"
 Blocks.WAXED_COPPER_BLOCK:
   - Blocks.WAXED_COPPER_BLOCK
   - "waxed_copper_block"
-Blocks.WAXED_WEATHERED_COPPER:
-  - Blocks.WAXED_WEATHERED_COPPER
-  - "waxed_weathered_copper"
 Blocks.WAXED_EXPOSED_COPPER:
   - Blocks.WAXED_EXPOSED_COPPER
   - "waxed_exposed_copper"
+Blocks.WAXED_WEATHERED_COPPER:
+  - Blocks.WAXED_WEATHERED_COPPER
+  - "waxed_weathered_copper"
 Blocks.WAXED_OXIDIZED_COPPER:
   - Blocks.WAXED_OXIDIZED_COPPER
   - "waxed_oxidized_copper"
-Blocks.WAXED_OXIDIZED_CUT_COPPER:
-  - Blocks.WAXED_OXIDIZED_CUT_COPPER
-  - "waxed_oxidized_cut_copper"
-Blocks.WAXED_WEATHERED_CUT_COPPER:
-  - Blocks.WAXED_WEATHERED_CUT_COPPER
-  - "waxed_weathered_cut_copper"
-Blocks.WAXED_EXPOSED_CUT_COPPER:
-  - Blocks.WAXED_EXPOSED_CUT_COPPER
-  - "waxed_exposed_cut_copper"
 Blocks.WAXED_CUT_COPPER:
   - Blocks.WAXED_CUT_COPPER
   - "waxed_cut_copper"
-Blocks.WAXED_OXIDIZED_CUT_COPPER_STAIRS:
-  - Blocks.WAXED_OXIDIZED_CUT_COPPER_STAIRS
-  - "waxed_oxidized_cut_copper_stairs"
-Blocks.WAXED_WEATHERED_CUT_COPPER_STAIRS:
-  - Blocks.WAXED_WEATHERED_CUT_COPPER_STAIRS
-  - "waxed_weathered_cut_copper_stairs"
-Blocks.WAXED_EXPOSED_CUT_COPPER_STAIRS:
-  - Blocks.WAXED_EXPOSED_CUT_COPPER_STAIRS
-  - "waxed_exposed_cut_copper_stairs"
+Blocks.WAXED_EXPOSED_CUT_COPPER:
+  - Blocks.WAXED_EXPOSED_CUT_COPPER
+  - "waxed_exposed_cut_copper"
+Blocks.WAXED_WEATHERED_CUT_COPPER:
+  - Blocks.WAXED_WEATHERED_CUT_COPPER
+  - "waxed_weathered_cut_copper"
+Blocks.WAXED_OXIDIZED_CUT_COPPER:
+  - Blocks.WAXED_OXIDIZED_CUT_COPPER
+  - "waxed_oxidized_cut_copper"
 Blocks.WAXED_CUT_COPPER_STAIRS:
   - Blocks.WAXED_CUT_COPPER_STAIRS
   - "waxed_cut_copper_stairs"
-Blocks.WAXED_OXIDIZED_CUT_COPPER_SLAB:
-  - Blocks.WAXED_OXIDIZED_CUT_COPPER_SLAB
-  - "waxed_oxidized_cut_copper_slab"
-Blocks.WAXED_WEATHERED_CUT_COPPER_SLAB:
-  - Blocks.WAXED_WEATHERED_CUT_COPPER_SLAB
-  - "waxed_weathered_cut_copper_slab"
-Blocks.WAXED_EXPOSED_CUT_COPPER_SLAB:
-  - Blocks.WAXED_EXPOSED_CUT_COPPER_SLAB
-  - "waxed_exposed_cut_copper_slab"
+Blocks.WAXED_EXPOSED_CUT_COPPER_STAIRS:
+  - Blocks.WAXED_EXPOSED_CUT_COPPER_STAIRS
+  - "waxed_exposed_cut_copper_stairs"
+Blocks.WAXED_WEATHERED_CUT_COPPER_STAIRS:
+  - Blocks.WAXED_WEATHERED_CUT_COPPER_STAIRS
+  - "waxed_weathered_cut_copper_stairs"
+Blocks.WAXED_OXIDIZED_CUT_COPPER_STAIRS:
+  - Blocks.WAXED_OXIDIZED_CUT_COPPER_STAIRS
+  - "waxed_oxidized_cut_copper_stairs"
 Blocks.WAXED_CUT_COPPER_SLAB:
   - Blocks.WAXED_CUT_COPPER_SLAB
   - "waxed_cut_copper_slab"
+Blocks.WAXED_EXPOSED_CUT_COPPER_SLAB:
+  - Blocks.WAXED_EXPOSED_CUT_COPPER_SLAB
+  - "waxed_exposed_cut_copper_slab"
+Blocks.WAXED_WEATHERED_CUT_COPPER_SLAB:
+  - Blocks.WAXED_WEATHERED_CUT_COPPER_SLAB
+  - "waxed_weathered_cut_copper_slab"
+Blocks.WAXED_OXIDIZED_CUT_COPPER_SLAB:
+  - Blocks.WAXED_OXIDIZED_CUT_COPPER_SLAB
+  - "waxed_oxidized_cut_copper_slab"
 Blocks.LIGHTNING_ROD:
   - Blocks.LIGHTNING_ROD
   - "lightning_rod"

--- a/plugins/mcreator-core/datalists/blocksitems.yaml
+++ b/plugins/mcreator-core/datalists/blocksitems.yaml
@@ -683,165 +683,165 @@
   type: block
   texture: IRON_BLOCK
 
-- Blocks.OXIDIZED_COPPER:
-  readable_name: "Oxidized Copper"
+- Blocks.COPPER_BLOCK:
+  readable_name: "Copper Block"
   type: block
-  texture: OXIDIZED_COPPER
-
-- Blocks.WEATHERED_COPPER:
-  readable_name: "Weathered Copper"
-  type: block
-  texture: WEATHERED_COPPER
+  texture: COPPER_BLOCK
 
 - Blocks.EXPOSED_COPPER:
   readable_name: "Exposed Copper"
   type: block
   texture: EXPOSED_COPPER
 
-- Blocks.COPPER_BLOCK:
-  readable_name: "Copper Block"
+- Blocks.WEATHERED_COPPER:
+  readable_name: "Weathered Copper"
   type: block
-  texture: COPPER_BLOCK
+  texture: WEATHERED_COPPER
 
-- Blocks.OXIDIZED_CUT_COPPER:
-  readable_name: "Oxidized Cut Copper"
+- Blocks.OXIDIZED_COPPER:
+  readable_name: "Oxidized Copper"
   type: block
-  texture: OXIDIZED_CUT_COPPER
-
-- Blocks.WEATHERED_CUT_COPPER:
-  readable_name: "Weathered Cut Copper"
-  type: block
-  texture: WEATHERED_CUT_COPPER
-
-- Blocks.EXPOSED_CUT_COPPER:
-  readable_name: "Exposed Cut Copper"
-  type: block
-  texture: EXPOSED_CUT_COPPER
+  texture: OXIDIZED_COPPER
 
 - Blocks.CUT_COPPER:
   readable_name: "Cut Copper"
   type: block
   texture: CUT_COPPER
 
-- Blocks.OXIDIZED_CUT_COPPER_STAIRS:
-  readable_name: "Oxidized Cut Copper Stairs"
+- Blocks.EXPOSED_CUT_COPPER:
+  readable_name: "Exposed Cut Copper"
   type: block
-  texture: OXIDIZED_CUT_COPPER_STAIRS
+  texture: EXPOSED_CUT_COPPER
 
-- Blocks.WEATHERED_CUT_COPPER_STAIRS:
-  readable_name: "Weathered Cut Copper Stairs"
+- Blocks.WEATHERED_CUT_COPPER:
+  readable_name: "Weathered Cut Copper"
   type: block
-  texture: WEATHERED_CUT_COPPER_STAIRS
+  texture: WEATHERED_CUT_COPPER
 
-- Blocks.EXPOSED_CUT_COPPER_STAIRS:
-  readable_name: "Exposed Cut Copper Stairs"
+- Blocks.OXIDIZED_CUT_COPPER:
+  readable_name: "Oxidized Cut Copper"
   type: block
-  texture: EXPOSED_CUT_COPPER_STAIRS
+  texture: OXIDIZED_CUT_COPPER
 
 - Blocks.CUT_COPPER_STAIRS:
   readable_name: "Cut Copper Stairs"
   type: block
   texture: CUT_COPPER_STAIRS
 
-- Blocks.OXIDIZED_CUT_COPPER_SLAB:
-  readable_name: "Oxidized Cut Copper Slab"
+- Blocks.EXPOSED_CUT_COPPER_STAIRS:
+  readable_name: "Exposed Cut Copper Stairs"
   type: block
-  texture: OXIDIZED_CUT_COPPER_SLAB
+  texture: EXPOSED_CUT_COPPER_STAIRS
 
-- Blocks.WEATHERED_CUT_COPPER_SLAB:
-  readable_name: "Weathered Cut Copper Slab"
+- Blocks.WEATHERED_CUT_COPPER_STAIRS:
+  readable_name: "Weathered Cut Copper Stairs"
   type: block
-  texture: WEATHERED_CUT_COPPER_SLAB
+  texture: WEATHERED_CUT_COPPER_STAIRS
 
-- Blocks.EXPOSED_CUT_COPPER_SLAB:
-  readable_name: "Exposed Cut Copper Slab"
+- Blocks.OXIDIZED_CUT_COPPER_STAIRS:
+  readable_name: "Oxidized Cut Copper Stairs"
   type: block
-  texture: EXPOSED_CUT_COPPER_SLAB
+  texture: OXIDIZED_CUT_COPPER_STAIRS
 
 - Blocks.CUT_COPPER_SLAB:
   readable_name: "Cut Copper Slab"
   type: block
   texture: CUT_COPPER_SLAB
 
-- Blocks.WAXED_OXIDIZED_COPPER:
-  readable_name: "Waxed Oxidized Copper"
+- Blocks.EXPOSED_CUT_COPPER_SLAB:
+  readable_name: "Exposed Cut Copper Slab"
   type: block
-  texture: WAXED_OXIDIZED_COPPER
+  texture: EXPOSED_CUT_COPPER_SLAB
 
-- Blocks.WAXED_WEATHERED_COPPER:
-  readable_name: "Waxed Weathered Copper"
+- Blocks.WEATHERED_CUT_COPPER_SLAB:
+  readable_name: "Weathered Cut Copper Slab"
   type: block
-  texture: WAXED_WEATHERED_COPPER
+  texture: WEATHERED_CUT_COPPER_SLAB
 
-- Blocks.WAXED_EXPOSED_COPPER:
-  readable_name: "Waxed Exposed Copper"
+- Blocks.OXIDIZED_CUT_COPPER_SLAB:
+  readable_name: "Oxidized Cut Copper Slab"
   type: block
-  texture: WAXED_EXPOSED_COPPER
+  texture: OXIDIZED_CUT_COPPER_SLAB
 
 - Blocks.WAXED_COPPER_BLOCK:
   readable_name: "Waxed Copper Block"
   type: block
   texture: WAXED_COPPER_BLOCK
 
-- Blocks.WAXED_OXIDIZED_CUT_COPPER:
-  readable_name: "Waxed Oxidized Cut Copper"
+- Blocks.WAXED_EXPOSED_COPPER:
+  readable_name: "Waxed Exposed Copper"
   type: block
-  texture: WAXED_OXIDIZED_CUT_COPPER
+  texture: WAXED_EXPOSED_COPPER
 
-- Blocks.WAXED_WEATHERED_CUT_COPPER:
-  readable_name: "Waxed Weathered Cut Copper"
+- Blocks.WAXED_WEATHERED_COPPER:
+  readable_name: "Waxed Weathered Copper"
   type: block
-  texture: WAXED_WEATHERED_CUT_COPPER
+  texture: WAXED_WEATHERED_COPPER
 
-- Blocks.WAXED_EXPOSED_CUT_COPPER:
-  readable_name: "Waxed Exposed Cut Copper"
+- Blocks.WAXED_OXIDIZED_COPPER:
+  readable_name: "Waxed Oxidized Copper"
   type: block
-  texture: WAXED_EXPOSED_CUT_COPPER
+  texture: WAXED_OXIDIZED_COPPER
 
 - Blocks.WAXED_CUT_COPPER:
   readable_name: "Waxed Cut Copper"
   type: block
   texture: WAXED_CUT_COPPER
 
-- Blocks.WAXED_OXIDIZED_CUT_COPPER_STAIRS:
-  readable_name: "Waxed Oxidized Cut Copper Stairs"
+- Blocks.WAXED_EXPOSED_CUT_COPPER:
+  readable_name: "Waxed Exposed Cut Copper"
   type: block
-  texture: WAXED_OXIDIZED_CUT_COPPER_STAIRS
+  texture: WAXED_EXPOSED_CUT_COPPER
 
-- Blocks.WAXED_WEATHERED_CUT_COPPER_STAIRS:
-  readable_name: "Waxed Weathered Cut Copper Stairs"
+- Blocks.WAXED_WEATHERED_CUT_COPPER:
+  readable_name: "Waxed Weathered Cut Copper"
   type: block
-  texture: WAXED_WEATHERED_CUT_COPPER_STAIRS
+  texture: WAXED_WEATHERED_CUT_COPPER
 
-- Blocks.WAXED_EXPOSED_CUT_COPPER_STAIRS:
-  readable_name: "Waxed Exposed Cut Copper Stairs"
+- Blocks.WAXED_OXIDIZED_CUT_COPPER:
+  readable_name: "Waxed Oxidized Cut Copper"
   type: block
-  texture: WAXED_EXPOSED_CUT_COPPER_STAIRS
+  texture: WAXED_OXIDIZED_CUT_COPPER
 
 - Blocks.WAXED_CUT_COPPER_STAIRS:
   readable_name: "Waxed Cut Copper Stairs"
   type: block
   texture: WAXED_CUT_COPPER_STAIRS
 
-- Blocks.WAXED_OXIDIZED_CUT_COPPER_SLAB:
-  readable_name: "Waxed Oxidized Cut Copper Slab"
+- Blocks.WAXED_EXPOSED_CUT_COPPER_STAIRS:
+  readable_name: "Waxed Exposed Cut Copper Stairs"
   type: block
-  texture: WAXED_OXIDIZED_CUT_COPPER_SLAB
+  texture: WAXED_EXPOSED_CUT_COPPER_STAIRS
 
-- Blocks.WAXED_WEATHERED_CUT_COPPER_SLAB:
-  readable_name: "Waxed Weathered Cut Copper Slab"
+- Blocks.WAXED_WEATHERED_CUT_COPPER_STAIRS:
+  readable_name: "Waxed Weathered Cut Copper Stairs"
   type: block
-  texture: WAXED_WEATHERED_CUT_COPPER_SLAB
+  texture: WAXED_WEATHERED_CUT_COPPER_STAIRS
+
+- Blocks.WAXED_OXIDIZED_CUT_COPPER_STAIRS:
+  readable_name: "Waxed Oxidized Cut Copper Stairs"
+  type: block
+  texture: WAXED_OXIDIZED_CUT_COPPER_STAIRS
+
+- Blocks.WAXED_CUT_COPPER_SLAB:
+  readable_name: "Waxed Cut Copper Slab"
+  type: block
+  texture: WAXED_CUT_COPPER_SLAB
 
 - Blocks.WAXED_EXPOSED_CUT_COPPER_SLAB:
   readable_name: "Waxed Exposed Cut Copper Slab"
   type: block
   texture: WAXED_EXPOSED_CUT_COPPER_SLAB
 
-- Blocks.WAXED_CUT_COPPER_SLAB:
-  readable_name: "Waxed Cut Copper Slab"
+- Blocks.WAXED_WEATHERED_CUT_COPPER_SLAB:
+  readable_name: "Waxed Weathered Cut Copper Slab"
   type: block
-  texture: WAXED_CUT_COPPER_SLAB
+  texture: WAXED_WEATHERED_CUT_COPPER_SLAB
+
+- Blocks.WAXED_OXIDIZED_CUT_COPPER_SLAB:
+  readable_name: "Waxed Oxidized Cut Copper Slab"
+  type: block
+  texture: WAXED_OXIDIZED_CUT_COPPER_SLAB
 
 - Blocks.REDSTONE_BLOCK:
   readable_name: "Redstone Block"


### PR DESCRIPTION
In this PR, copper blocks get sorted from _Normal_ to _Oxidized_ (it was reversed before):
![image](https://user-images.githubusercontent.com/71347607/145242227-9ca3faf0-ea00-46b0-b563-0ba544ad39f7.png)