### PR TITLE
Update Log4j to 2.15

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ dependencies {
     implementation group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
     implementation group: 'de.javagl', name: 'obj', version: '0.3.0'
     implementation group: 'com.univocity', name: 'univocity-parsers', version: '2.9.1'
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.14.1'
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.15.0'
     implementation group: 'org.apache.commons', name: 'commons-text', version: '1.9'
     implementation group: 'org.eclipse.jgit', name: 'org.eclipse.jgit', version: '5.13.0.202109080827-r'
     implementation group: 'org.slf4j', name: 'slf4j-nop', version: '1.7.32'


### PR DESCRIPTION
It updates the version of Log4j used by MCreator 2.15, so we can be sure this issue https://github.com/advisories/GHSA-jfh8-c2jp-5v3q can not happen with MCreator.