### PR TITLE
Add Java doc a few classes

### DIFF
--- a/src/main/java/net/mcreator/plugin/Plugin.java
+++ b/src/main/java/net/mcreator/plugin/Plugin.java
@@ -23,6 +23,9 @@ import net.mcreator.Launcher;
 import javax.annotation.Nonnull;
 import java.io.File;
 
+/**
+ * <p>A Plugin is a mod for MCreator allowing to alter, improve or extend features. Most of elements inside MCreator are plugin driven.</p>
+ */
 public class Plugin implements Comparable<Plugin> {
 
 	transient File file;
@@ -41,26 +44,62 @@ public class Plugin implements Comparable<Plugin> {
 		return file;
 	}
 
+	/**
+	 * MCreator detects if a plugin is included or not. This method is mainly used with plugins in preferences.
+	 *
+	 * @return <p>The plugin is builtin, so included with MCreator.</p>
+	 */
 	public boolean isBuiltin() {
 		return builtin;
 	}
 
+	/**
+	 * A plugin is loaded when all plugin dependencies are present.
+	 *
+	 * @return <p>The plugin is loaded.</p>
+	 */
 	public boolean isLoaded() {
 		return loaded;
 	}
 
+	/**
+	 * The ID is the plugin's registry name. It is used to differentiate each plugin in the code.
+	 * A plugin defines its own ID.
+	 *
+	 * @return <p>The plugin's ID</p>
+	 */
 	public String getID() {
 		return id;
 	}
 
+	/**
+	 * It returns a {@link PluginInfo} object containing additional and optional info about the plugin.
+	 * This object is only used inside the plugin panel.
+	 *
+	 * @return <p> Other info about the plugin</p>
+	 */
 	public PluginInfo getInfo() {
 		return info;
 	}
 
+	/**
+	 * <p>The weight of a plugin is its priority to be loaded. Higher this value is, higher its priority is.
+	 * This also determines how MCreator loads plugins. After MCreator has detected all plugins, it will check
+	 * for their weight and then, load plugins with the highest value first. It can be used to override another plugin,
+	 * but the value should never be higher than 10 as this is the value or core plugins.</p>
+	 *
+	 * @return <p>The weight of the plugin</p>
+	 */
 	public int getWeight() {
 		return weight;
 	}
 
+	/**
+	 * <p>The plugin is compatible when the minimal version is lower or equal to the current MCreator's version and
+	 * the maximal version is higher or equal to the current version. When a field is not defined, the field is considered as compatible.</p>
+	 *
+	 * @return <p>If the plugin is compatible with the version used.</p>
+	 */
 	public boolean isCompatible() {
 		if (minversion != -1) {
 			if (Launcher.version.versionlong < minversion)
@@ -74,10 +113,18 @@ public class Plugin implements Comparable<Plugin> {
 		return true;
 	}
 
+	/**
+	 *
+	 * @return <p>The minimal version of MCreator needed to use the plugin.</p>
+	 */
 	public long getMinVersion() {
 		return minversion;
 	}
 
+	/**
+	 *
+	 * @return <p>The MCreator's version when builtin and the plugin's version in the other case</p>
+	 */
 	public String getPluginVersion() {
 		if (isBuiltin()) {
 			return Launcher.version.getFullString();

--- a/src/main/java/net/mcreator/plugin/PluginInfo.java
+++ b/src/main/java/net/mcreator/plugin/PluginInfo.java
@@ -20,7 +20,10 @@ package net.mcreator.plugin;
 
 import java.util.List;
 
-public class PluginInfo {
+/**
+ * <p>PluginInfo contains all info about the plugin such as its name, its author or a description of it. Most of them are optional.</p>
+ */
+@SuppressWarnings("unused") public class PluginInfo {
 
 	public static final String VERSION_NOT_SPECIFIED = "not specified";
 
@@ -36,28 +39,55 @@ public class PluginInfo {
 	private String updateJSONURL;
 	private int pluginPageID;
 
+	/**
+	 *
+	 * @return <p>The displayed name of the plugin</p>
+	 */
 	public String getName() {
 		return name;
 	}
 
+	/**
+	 *
+	 * @return <p>A description displayed in the plugins panel.</p>
+	 */
 	public String getDescription() {
 		return description;
 	}
 
+	/**
+	 *
+	 * @return <p>The author(s) of the plugin to be displayed in the plugins panel.</p>
+	 */
 	public String getAuthor() {
 		return author;
 	}
 
+	/**
+	 * This method is used inside the {@link net.mcreator.ui.dialogs.UpdatePluginDialog} to check if the user has the latest update of the plugin.
+	 * See {@link Plugin} to read more about this.
+	 *
+	 * @return <p>The plugin's version if provided</p>
+	 */
 	public String getVersion() {
 		if (version == null)
 			return VERSION_NOT_SPECIFIED;
 		return version;
 	}
 
+	/**
+	 * See isLoaded in {@link Plugin} to get more info about its usage.
+	 *
+	 * @return <p>A list of plugin's IDs needed to use the plugin</p>
+	 */
 	public List<String> getDependencies() {
 		return dependencies;
 	}
 
+	/**
+	 *
+	 * @return <p>A String with optional credits to give to someone.</p>
+	 */
 	public String getCredits() {
 		if (credits == null) {
 			return "None";
@@ -65,10 +95,22 @@ public class PluginInfo {
 		return credits;
 	}
 
+	/**
+	 * <p>{@link net.mcreator.ui.dialogs.UpdatePluginDialog} uses this method to take an online JSON file containing info about new updates of the plugin.
+	 * When it detects the version is not equal to the version inside the provided file, MCreator will notify the user.</p>
+	 *
+	 * @return <p>A link to an online JSON file</p>
+	 */
 	public String getUpdateJSONURL() {
 		return updateJSONURL;
 	}
 
+	/**
+	 * <p>When a new update is detected, MCreator will use this number to provide a link to the plugin page of the MCreator website.
+	 * This number comes after https://mcreator.net/plugin/xxxxx/... The link used will follow this format: https://mcreator.net/node/xxxxx</p>
+	 *
+	 * @return <p>The URL number of the plugin page on the MCreator website.</p>
+	 */
 	public int getPluginPageID() {
 		return pluginPageID;
 	}

--- a/src/main/java/net/mcreator/plugin/PluginLoader.java
+++ b/src/main/java/net/mcreator/plugin/PluginLoader.java
@@ -40,12 +40,18 @@ import java.util.*;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+/**
+ * <p>This class detects and then try to load all builtin or custom {@link Plugin}s. </p>
+ */
 public class PluginLoader extends URLClassLoader {
 
 	private static final Logger LOG = LogManager.getLogger("Plugin Loader");
 
 	public static PluginLoader INSTANCE;
 
+	/**
+	 * <p>Set the value to the INSTANCE variable, so we can access values everywhere in the code.</p>
+	 */
 	public static void initInstance() {
 		INSTANCE = new PluginLoader();
 	}
@@ -55,6 +61,9 @@ public class PluginLoader extends URLClassLoader {
 
 	private final Reflections reflections;
 
+	/**
+	 * <p>The core of the detection and loading</p>
+	 */
 	public PluginLoader() {
 		super(new URL[] {}, null);
 
@@ -103,14 +112,30 @@ public class PluginLoader extends URLClassLoader {
 		checkForPluginUpdates();
 	}
 
+	/**
+	 *
+	 * @param pattern <p>Returned file names will need to follow this {@link Pattern}.</p>
+	 * @return <p>The path into a {@link Plugin} of all files following the provided {@link Pattern}.</p>
+	 */
 	public Set<String> getResources(Pattern pattern) {
 		return this.getResources(null, pattern);
 	}
 
+	/**
+	 *
+	 * @param pkg <p>The path of directories the method will use to access wanted files. Sub folders need to be split with a dot.</p>
+	 * @return <p>The path into a {@link Plugin} of all files inside the provided folder.</p>
+	 */
 	public Set<String> getResourcesInPackage(String pkg) {
 		return this.getResources(pkg, null);
 	}
 
+	/**
+	 *
+	 * @param pkg <p>The path of directories the method will use to access wanted files. Sub folders need to be split with a dot.</p>
+	 * @param pattern <p>Returned file names will need to follow this {@link Pattern}.</p>
+	 * @return <p>The path into a {@link Plugin} of all files inside the provided folder following the provided {@link Pattern} .</p>
+	 */
 	public Set<String> getResources(@Nullable String pkg, @Nullable Pattern pattern) {
 		Set<String> reflectionsRetval =
 				pattern != null ? this.reflections.getResources(pattern) : this.reflections.getResources(".*");
@@ -119,10 +144,18 @@ public class PluginLoader extends URLClassLoader {
 		return reflectionsRetval.stream().filter(e -> e.replace("/", ".").startsWith(pkg)).collect(Collectors.toSet());
 	}
 
+	/**
+	 *
+	 * @return <p> A {@link List} of all loaded plugins.</p>
+	 */
 	public List<Plugin> getPlugins() {
 		return plugins;
 	}
 
+	/**
+	 *
+	 * @return <p>A list of all plugin updates detected.</p>
+	 */
 	public List<PluginUpdateInfo> getPluginUpdates() {
 		return pluginUpdates;
 	}

--- a/src/main/java/net/mcreator/plugin/PluginUpdateInfo.java
+++ b/src/main/java/net/mcreator/plugin/PluginUpdateInfo.java
@@ -19,4 +19,7 @@
 
 package net.mcreator.plugin;
 
+/**
+ * <p>This record is used to save the plugin and the new version of the detected update.</p>
+ */
 public record PluginUpdateInfo(Plugin plugin, String newVersion) {}

--- a/src/main/java/net/mcreator/themes/Theme.java
+++ b/src/main/java/net/mcreator/themes/Theme.java
@@ -19,7 +19,6 @@
 
 package net.mcreator.themes;
 
-import net.mcreator.ui.dialogs.preferences.ThemesPanel;
 import net.mcreator.ui.init.L10N;
 
 import javax.annotation.Nullable;
@@ -74,7 +73,7 @@ import javax.swing.*;
 
 	/**
 	 *
-	 * @return <p>A description displayed in the {@link ThemesPanel} if provided.</p>
+	 * @return <p>A description displayed in the {@link net.mcreator.ui.dialogs.preferences.ThemesPanel} if provided.</p>
 	 */
 	public String getDescription() {
 		// Description inside the JSON file
@@ -157,7 +156,7 @@ import javax.swing.*;
 	/**
 	 * <p>To be detected, the name of the image file needs to be "icon.png" located into the main folder.</p>
 	 *
-	 * @param icon <p>An {@link ImageIcon} to display in {@link ThemesPanel}</p>
+	 * @param icon <p>An {@link ImageIcon} to display in {@link net.mcreator.ui.dialogs.preferences.ThemesPanel}</p>
 	 */
 	public void setIcon(ImageIcon icon) {
 		this.icon = icon;

--- a/src/main/java/net/mcreator/themes/Theme.java
+++ b/src/main/java/net/mcreator/themes/Theme.java
@@ -19,6 +19,7 @@
 
 package net.mcreator.themes;
 
+import net.mcreator.ui.dialogs.preferences.ThemesPanel;
 import net.mcreator.ui.init.L10N;
 
 import javax.annotation.Nullable;
@@ -44,18 +45,37 @@ import javax.swing.*;
 
 	private ImageIcon icon;
 
+	/**
+	 * The ID is the theme's registry name. It is used to differentiate each theme in the code.
+	 * This ID is also the main folder's name of the theme.
+	 *
+	 * @return <p>The theme's ID</p>
+	 */
 	public String getID() {
 		return id;
 	}
 
+	/**
+	 * This method sets the id of this theme using the name of its main folder.
+	 *
+	 * @param id <p>The theme's ID</p>
+	 */
 	public void setID(String id) {
 		this.id = id;
 	}
 
+	/**
+	 *
+	 * @return <p>Its displayed name</p>
+	 */
 	public String getName() {
 		return name;
 	}
 
+	/**
+	 *
+	 * @return <p>A description displayed in the {@link ThemesPanel} if provided.</p>
+	 */
 	public String getDescription() {
 		// Description inside the JSON file
 		if (description != null)
@@ -68,10 +88,18 @@ import javax.swing.*;
 			return "";
 	}
 
+	/**
+	 *
+	 * @return <p>A String with optional credits to give to someone.</p>
+	 */
 	@Nullable public String getCredits() {
 		return credits;
 	}
 
+	/**
+	 *
+	 * @return <p>The theme's version if provided</p>
+	 */
 	@Nullable public String getVersion() {
 		return version;
 	}
@@ -117,10 +145,20 @@ import javax.swing.*;
 			return ThemeLoader.getTheme("default_dark").getColorScheme();
 	}
 
+	/**
+	 * This icon is only with {@link net.mcreator.ui.dialogs.preferences.ThemesPanel}.
+	 *
+	 * @return <p>An {@link ImageIcon} representing the plugin.</p>
+	 */
 	public ImageIcon getIcon() {
 		return icon;
 	}
 
+	/**
+	 * <p>To be detected, the name of the image file needs to be "icon.png" located into the main folder.</p>
+	 *
+	 * @param icon <p>An {@link ImageIcon} to display in {@link ThemesPanel}</p>
+	 */
 	public void setIcon(ImageIcon icon) {
 		this.icon = icon;
 	}

--- a/src/main/java/net/mcreator/themes/ThemeLoader.java
+++ b/src/main/java/net/mcreator/themes/ThemeLoader.java
@@ -21,6 +21,7 @@ package net.mcreator.themes;
 
 import com.google.gson.Gson;
 import net.mcreator.io.FileIO;
+import net.mcreator.plugin.Plugin;
 import net.mcreator.plugin.PluginLoader;
 import net.mcreator.preferences.PreferencesManager;
 import net.mcreator.ui.init.UIRES;
@@ -37,7 +38,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
- * <p>ThemeLoader defines to load and use available Themes.</p>
+ * <p>This class detects and then try to load all {@link Theme}s.</p>
  */
 public class ThemeLoader {
 

--- a/src/main/java/net/mcreator/themes/ThemeLoader.java
+++ b/src/main/java/net/mcreator/themes/ThemeLoader.java
@@ -37,7 +37,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
- * ThemeLoader defines to load and use available Themes.
+ * <p>ThemeLoader defines to load and use available Themes.</p>
  */
 public class ThemeLoader {
 

--- a/src/main/java/net/mcreator/themes/ThemeLoader.java
+++ b/src/main/java/net/mcreator/themes/ThemeLoader.java
@@ -38,7 +38,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
- * <p>This class detects and then try to load all {@link Theme}s.</p>
+ * <p>This class detects and then tries to load all {@link Theme}s.</p>
  */
 public class ThemeLoader {
 


### PR DESCRIPTION
The code has a ton of classes without documentation, so it can be quite complex for new contributors to understand something. It will also be needed for Java plugins when it will be added.

This PR adds Java doc to every class inside the `plugins` and `themes` packages. `themes` already had some java doc, but I added missing methods.