### PR TITLE
[1.18.1] Ported some world management procedure blocks

### DIFF
--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/place_schematic.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/place_schematic.java.ftl
@@ -1,0 +1,12 @@
+if(world instanceof ServerLevel _serverworld) {
+	StructureTemplate template = _serverworld.getStructureManager().getOrCreate(new ResourceLocation("${modid}" ,"${field$schematic}"));
+	if(template!=null){
+		template.placeInWorld(_serverworld,
+				new BlockPos((int) ${input$x},(int) ${input$y},(int) ${input$z}),
+				new BlockPos((int) ${input$x},(int) ${input$y},(int) ${input$z}),
+				new StructurePlaceSettings()
+						.setRotation(Rotation.${field$rotation!'NONE'})
+						.setMirror(Mirror.${field$mirror!'NONE'})
+						.setIgnoreEntities(false), _serverworld.random, 3);
+	}
+}

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/play_sound.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/play_sound.java.ftl
@@ -1,0 +1,11 @@
+if(world instanceof Level _level) {
+	if(!_level.isClientSide()) {
+		_level.playSound(null, new BlockPos((int) ${input$x}, (int) ${input$y}, (int) ${input$z}),
+	    	ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("${generator.map(field$sound, "sounds")?replace("CUSTOM:", "${modid}:")}")),
+			SoundSource.${generator.map(field$soundcategory!"neutral", "soundcategories")}, ${opt.toFloat(input$level)}, ${opt.toFloat(input$pitch)});
+	} else {
+		_level.playLocalSound(${input$x}, ${input$y}, ${input$z},
+	    	ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("${generator.map(field$sound, "sounds")?replace("CUSTOM:", "${modid}:")}")),
+			SoundSource.${generator.map(field$soundcategory!"neutral", "soundcategories")}, ${opt.toFloat(input$level)}, ${opt.toFloat(input$pitch)}, false);
+	}
+}

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/provided_dimensionid.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/provided_dimensionid.java.ftl
@@ -1,0 +1,1 @@
+(dimension)

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/run_function.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/run_function.java.ftl
@@ -1,7 +1,7 @@
 <#include "mcelements.ftl">
 if(world instanceof ServerLevel _level && _level.getServer() != null) {
 	Optional<CommandFunction> _fopt = _level.getServer().getFunctions().get(${toResourceLocation(input$function)});
-	_fopt.isPresent(_level.getServer().getFunctions().execute(_fopt.get(),
+	_fopt.isPresent(commandFunction -> _level.getServer().getFunctions().execute(_fopt.get(),
                     new CommandSourceStack(CommandSource.NULL, new Vec3(${input$x}, ${input$y}, ${input$z}), Vec2.ZERO,
                     _level, 4, "", new TextComponent(""), _level.getServer(), null)))
 }

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/run_function.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/run_function.java.ftl
@@ -1,7 +1,7 @@
 <#include "mcelements.ftl">
 if(world instanceof ServerLevel _level && _level.getServer() != null) {
 	Optional<CommandFunction> _fopt = _level.getServer().getFunctions().get(${toResourceLocation(input$function)});
-	_fopt.isPresent(commandFunction -> _level.getServer().getFunctions().execute(_fopt.get(),
+	_fopt.ifPresent(commandFunction -> _level.getServer().getFunctions().execute(_fopt.get(),
                     new CommandSourceStack(CommandSource.NULL, new Vec3(${input$x}, ${input$y}, ${input$z}), Vec2.ZERO,
-                    _level, 4, "", new TextComponent(""), _level.getServer(), null)))
+                    _level, 4, "", new TextComponent(""), _level.getServer(), null)));
 }

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/run_function.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/run_function.java.ftl
@@ -1,0 +1,7 @@
+<#include "mcelements.ftl">
+if(world instanceof ServerLevel _level && _level.getServer() != null) {
+	Optional<CommandFunction> _fopt = _level.getServer().getFunctions().get(${toResourceLocation(input$function)});
+	_fopt.isPresent(_level.getServer().getFunctions().execute(_fopt.get(),
+                    new CommandSourceStack(CommandSource.NULL, new Vec3(${input$x}, ${input$y}, ${input$z}), Vec2.ZERO,
+                    _level, 4, "", new TextComponent(""), _level.getServer(), null)))
+}

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/set_global_spawn.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/set_global_spawn.java.ftl
@@ -1,0 +1,2 @@
+if(world.getLevelData() instanceof WritableLevelData _levelData)
+    _levelData.setSpawn(new BlockPos((int)${input$x},(int)${input$y},(int)${input$z}), 0);

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/set_time.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/set_time.java.ftl
@@ -1,0 +1,1 @@
+if(world instanceof ServerLevel _level) _level.setDayTime(${opt.toInt(input$time)});

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/shoot_arrow.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/shoot_arrow.java.ftl
@@ -1,0 +1,11 @@
+if (${input$entity} instanceof LivingEntity _ent_sa && !_ent_sa.level.isClientSide()) {
+	<#if field$rangeditem?has_content && field$rangeditem != "Arrow">
+		${field$rangeditem}Entity.shoot(_ent_sa.level, _ent_sa, _ent_sa.level.getRandom(), ${opt.toFloat(input$speed)}, ${opt.toFloat(input$damage)}, ${opt.toInt(input$knockback)});
+	<#else>
+		Arrow entityToSpawn = new Arrow(_ent_sa.level, _ent_sa);
+		entityToSpawn.shoot(${input$entity}.getLookAngle().x, ${input$entity}.getLookAngle().y, ${input$entity}.getLookAngle().z, ${opt.toFloat(input$speed)}, 0);
+		entityToSpawn.setBaseDamage(${opt.toFloat(input$damage)});
+		entityToSpawn.setKnockback(${opt.toInt(input$knockback)});
+		_ent_sa.level.addFreshEntity(entityToSpawn);
+	</#if>
+}

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/spawn_entity.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/spawn_entity.java.ftl
@@ -1,0 +1,16 @@
+<#assign entity = generator.map(field$entity, "entities", 1)!"null">
+<#if entity != "null">
+if(world instanceof ServerLevel _level) {
+	<#if !field$entity?starts_with("CUSTOM:")>
+	Entity entityToSpawn = new ${generator.map(field$entity, "entities", 0)}(${entity}, _level);
+	<#else>
+	Entity entityToSpawn = new ${entity}(${JavaModName}Entities.${generator.getRegistryNameForModElement(field$entity?replace("CUSTOM:", ""))?upper_case}, _level);
+	</#if>
+	entityToSpawn.moveTo(${input$x}, ${input$y}, ${input$z}, world.getRandom().nextFloat() * 360F, 0);
+
+	if (entityToSpawn instanceof Mob _mobToSpawn)
+		_mobToSpawn.finalizeSpawn(_level, world.getCurrentDifficultyAt(entityToSpawn.blockPosition()), MobSpawnType.MOB_SUMMONED, null, null);
+
+	world.addFreshEntity(entityToSpawn);
+}
+</#if>

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/spawn_entity_with_rotation.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/spawn_entity_with_rotation.java.ftl
@@ -1,0 +1,18 @@
+<#assign entity = generator.map(field$entity, "entities", 1)!"null">
+<#if entity != "null">
+if(world instanceof ServerLevel _level) {
+	<#if !field$entity?starts_with("CUSTOM:")>
+	Entity entityToSpawn = new ${generator.map(field$entity, "entities", 0)}(${entity}, _level);
+   	<#else>
+	Entity entityToSpawn = new ${entity}(${JavaModName}Entities.${generator.getRegistryNameForModElement(field$entity?replace("CUSTOM:", ""))?upper_case}, _level);
+   	</#if>
+	entityToSpawn.moveTo(${input$x}, ${input$y}, ${input$z}, ${opt.toFloat(input$yaw)}, ${opt.toFloat(input$pitch)});
+	entityToSpawn.setYBodyRot(${opt.toFloat(input$yaw)});
+	entityToSpawn.setYHeadRot(${opt.toFloat(input$yaw)});
+
+	if (entityToSpawn instanceof Mob _mobToSpawn)
+		_mobToSpawn.finalizeSpawn(_level, world.getCurrentDifficultyAt(entityToSpawn.blockPosition()), MobSpawnType.MOB_SUMMONED, null, null);
+
+	world.addFreshEntity(entityToSpawn);
+}
+</#if>

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/spawn_entity_with_rotation_velocity.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/spawn_entity_with_rotation_velocity.java.ftl
@@ -1,0 +1,19 @@
+<#assign entity = generator.map(field$entity, "entities", 1)!"null">
+<#if entity != "null">
+if(world instanceof ServerLevel _level) {
+	<#if !field$entity?starts_with("CUSTOM:")>
+	Entity entityToSpawn = new ${generator.map(field$entity, "entities", 0)}(${entity}, _level);
+   	<#else>
+	Entity entityToSpawn = new ${entity}(${JavaModName}Entities.${generator.getRegistryNameForModElement(field$entity?replace("CUSTOM:", ""))?upper_case}, _level);
+   	</#if>
+	entityToSpawn.moveTo(${input$x}, ${input$y}, ${input$z}, ${opt.toFloat(input$yaw)}, ${opt.toFloat(input$pitch)});
+	entityToSpawn.setYBodyRot(${opt.toFloat(input$yaw)});
+	entityToSpawn.setYHeadRot(${opt.toFloat(input$yaw)});
+	entityToSpawn.setDeltaMovement(${input$vx},${input$vy},${input$vz});
+
+	if (entityToSpawn instanceof Mob _mobToSpawn)
+		_mobToSpawn.finalizeSpawn(_level, world.getCurrentDifficultyAt(entityToSpawn.blockPosition()), MobSpawnType.MOB_SUMMONED, null, null);
+
+	world.addFreshEntity(entityToSpawn);
+}
+</#if>

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/spawn_gem.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/spawn_gem.java.ftl
@@ -1,0 +1,9 @@
+<#include "mcitems.ftl">
+if(world instanceof Level _level && !_level.isClientSide()) {
+	ItemEntity entityToSpawn=new ItemEntity(_level, ${input$x}, ${input$y}, ${input$z}, ${mappedMCItemToItemStackCode(input$block, 1)});
+	entityToSpawn.setPickUpDelay(${opt.toInt(input$pickUpDelay!10)});
+    <#if (field$despawn!true)?lower_case == "false">
+    entityToSpawn.setUnlimitedLifetime();
+    </#if>
+	_level.addFreshEntity(entityToSpawn);
+}

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/spawn_particle.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/spawn_particle.java.ftl
@@ -1,0 +1,1 @@
+world.addParticle(${generator.map(field$particle, "particles")}, ${input$x}, ${input$y}, ${input$z}, ${input$xs}, ${input$ys}, ${input$zs});

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/spawn_particle_multi.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/spawn_particle_multi.java.ftl
@@ -1,0 +1,2 @@
+if(world instanceof ServerLevel _level)
+	_level.sendParticles(${generator.map(field$particle, "particles")}, ${input$x}, ${input$y}, ${input$z}, ${opt.toInt(input$count)}, ${input$dx}, ${input$dy}, ${input$dz}, ${input$speed});

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/spawn_xporb.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/spawn_xporb.java.ftl
@@ -1,0 +1,2 @@
+if (world instanceof Level _level && !_level.isClientSide())
+	_level.addFreshEntity(new ExperienceOrb(_level, ${input$x}, ${input$y}, ${input$z},${opt.toInt(input$xpamount)}));

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/strike_lightning.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/strike_lightning.java.ftl
@@ -1,0 +1,6 @@
+if(world instanceof ServerLevel _level) {
+	LightningBolt entityToSpawn = EntityType.LIGHTNING_BOLT.create(_level);
+	entityToSpawn.moveTo(Vec3.atBottomCenterOf(new BlockPos((int)${input$x},(int)${input$y},(int)${input$z})));
+	entityToSpawn.setVisualOnly(${(field$effectOnly!false)?lower_case});
+	_level.addFreshEntity(entityToSpawn);
+}


### PR DESCRIPTION
It ports 14 world management blocks + 1 entity management block.

Nothing in the code has changed since Forge 1.17.1.
I simply changed a bit the code of https://github.com/MCreator/MCreator/pull/2165/files#diff-81b25cb7b3acd24b9246b9d7b02f5b44159d07b60e70afd9eaa7183da276942cR4, so instead to be a condition, it uses the `ifPresent(lamba)` method of `Optional`.