### PR TITLE
[1.18] Ported living entities

### DIFF
--- a/plugins/generator-1.18.1/forge-1.18.1/livingentity.definition.yaml
+++ b/plugins/generator-1.18.1/forge-1.18.1/livingentity.definition.yaml
@@ -1,0 +1,21 @@
+templates:
+  - template: livingentity/livingentity.java.ftl
+    name: "@SRCROOT/@BASEPACKAGEPATH/entity/@NAMEEntity.java"
+  - template: livingentity/livingentity_renderer.java.ftl
+    name: "@SRCROOT/@BASEPACKAGEPATH/client/renderer/@NAMERenderer.java"
+  - template: livingentity/livingentity_projectile.java.ftl
+    name: "@SRCROOT/@BASEPACKAGEPATH/entity/@NAMEEntityProjectile.java"
+    condition: hasCustomProjectile()
+    deleteWhenConditionFalse: true
+  - template: json/spawn_egg.json.ftl
+    writer: json
+    name: "@MODASSETSROOT/models/item/@registryname_spawn_egg.json"
+    condition: hasSpawnEgg
+    deleteWhenConditionFalse: true
+
+localizationkeys:
+  - key: item.@modid.@registryname_spawn_egg
+    mapto: mobName
+    suffix: " Spawn Egg"
+  - key: entity.@modid.@registryname
+    mapto: mobName

--- a/plugins/generator-1.18.1/forge-1.18.1/templates/elementinits/entities.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/templates/elementinits/entities.java.ftl
@@ -73,5 +73,23 @@ package ${package}.init;
 		event.getRegistry().registerAll(REGISTRY.toArray(new EntityType[0]));
 	}
 
+	@SubscribeEvent public static void init(FMLCommonSetupEvent event) {
+		event.enqueueWork(() -> {
+		<#list entities as entity>
+			<#if entity.getModElement().getTypeString() == "livingentity">
+				${entity.getModElement().getName()}Entity.init();
+			</#if>
+		</#list>
+		});
+	}
+
+	@SubscribeEvent public static void registerAttributes(EntityAttributeCreationEvent event) {
+		<#list entities as entity>
+			<#if entity.getModElement().getTypeString() == "livingentity">
+				event.put(${entity.getModElement().getRegistryNameUpper()}, ${entity.getModElement().getName()}Entity.createAttributes().build());
+			</#if>
+		</#list>
+	}
+
 }
 <#-- @formatter:on -->

--- a/plugins/generator-1.18.1/forge-1.18.1/templates/elementinits/entities.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/templates/elementinits/entities.java.ftl
@@ -46,6 +46,20 @@ package ${package}.init;
 						register("entitybullet${entity.getModElement().getRegistryName()}", EntityType.Builder.<${entity.getModElement().getName()}Entity>
 							of(${entity.getModElement().getName()}Entity::new, MobCategory.MISC).setCustomClientFactory(${entity.getModElement().getName()}Entity::new)
 							.setShouldReceiveVelocityUpdates(true).setTrackingRange(64).setUpdateInterval(1).sized(0.5f, 0.5f));
+		<#else>
+			public static final EntityType<${entity.getModElement().getName()}Entity> ${entity.getModElement().getRegistryNameUpper()} =
+						register("${entity.getModElement().getRegistryName()}",
+								EntityType.Builder.<${entity.getModElement().getName()}Entity>
+								of(${entity.getModElement().getName()}Entity::new, ${generator.map(entity.mobSpawningType, "mobspawntypes")})
+								.setShouldReceiveVelocityUpdates(true).setTrackingRange(${entity.trackingRange}).setUpdateInterval(3)
+								.setCustomClientFactory(${entity.getModElement().getName()}Entity::new)
+							<#if entity.immuneToFire>.fireImmune()</#if>.sized(${entity.modelWidth}f, ${entity.modelHeight}f));
+			<#if entity.hasCustomProjectile()>
+			public static final EntityType<${entity.getModElement().getName()}EntityProjectile> ${entity.getModElement().getRegistryNameUpper()}_PROJECTILE =
+					register("entitybullet${entity.getModElement().getRegistryName()}", EntityType.Builder.<${entity.getModElement().getName()}EntityProjectile>
+							of(${entity.getModElement().getName()}EntityProjectile::new, MobCategory.MISC).setShouldReceiveVelocityUpdates(true).setTrackingRange(64)
+							.setUpdateInterval(1).setCustomClientFactory(${entity.getModElement().getName()}EntityProjectile::new).sized(0.5f, 0.5f));
+			</#if>
 		</#if>
     </#list>
 

--- a/plugins/generator-1.18.1/forge-1.18.1/templates/elementinits/entityrenderers.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/templates/elementinits/entityrenderers.java.ftl
@@ -46,6 +46,11 @@ package ${package}.init;
 				<#else>
 				event.registerEntityRenderer(${JavaModName}Entities.${entity.getModElement().getRegistryNameUpper()}, ThrownItemRenderer::new);
 				</#if>
+			<#else>
+				event.registerEntityRenderer(${JavaModName}Entities.${entity.getModElement().getRegistryNameUpper()}, ${entity.getModElement().getName()}Renderer::new);
+				<#if entity.hasCustomProjectile()>
+				event.registerEntityRenderer(${JavaModName}Entities.${entity.getModElement().getRegistryNameUpper()}_PROJECTILE, ThrownItemRenderer::new);
+				</#if>
 			</#if>
 		</#list>
 	}

--- a/plugins/generator-1.18.1/forge-1.18.1/templates/elementinits/items.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/templates/elementinits/items.java.ftl
@@ -56,6 +56,10 @@ package ${package}.init;
             <#if item.enableBoots>
             public static final Item ${item.getModElement().getRegistryNameUpper()}_BOOTS = register(new ${item.getModElement().getName()}Item.Boots());
             </#if>
+        <#elseif item.getModElement().getTypeString() == "livingentity">
+            public static final Item ${item.getModElement().getRegistryNameUpper()} = register(new SpawnEggItem(${JavaModName}Entities.${item.getModElement().getRegistryNameUpper()},
+                    ${item.spawnEggBaseColor.getRGB()}, ${item.spawnEggDotColor.getRGB()}, new Item.Properties() <#if item.creativeTab??>.tab(${item.creativeTab})<#else>
+                    .tab(CreativeModeTab.TAB_MISC)</#if>).setRegistryName("${item.getModElement().getRegistryName()}_spawn_egg"));
         <#else>
             public static final Item ${item.getModElement().getRegistryNameUpper()} = register(new ${item.getModElement().getName()}Item());
         </#if>

--- a/plugins/generator-1.18.1/forge-1.18.1/templates/json/spawn_egg.json.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/templates/json/spawn_egg.json.ftl
@@ -1,0 +1,3 @@
+{
+    "parent": "item/template_spawn_egg"
+}

--- a/plugins/generator-1.18.1/forge-1.18.1/templates/livingentity/livingentity.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/templates/livingentity/livingentity.java.ftl
@@ -1,0 +1,819 @@
+<#--
+ # MCreator (https://mcreator.net/)
+ # Copyright (C) 2012-2020, Pylo
+ # Copyright (C) 2020-2022, Pylo, opensource contributors
+ # 
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ # 
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ # 
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ # 
+ # Additional permission for code generator templates (*.ftl files)
+ # 
+ # As a special exception, you may create a larger work that contains part or 
+ # all of the MCreator code generator templates (*.ftl files) and distribute 
+ # that work under terms of your choice, so long as that work isn't itself a 
+ # template for code generation. Alternatively, if you modify or redistribute 
+ # the template itself, you may (at your option) remove this special exception, 
+ # which will cause the template and the resulting code generator output files 
+ # to be licensed under the GNU General Public License without this special 
+ # exception.
+-->
+
+<#-- @formatter:off -->
+<#include "../mcitems.ftl">
+<#include "../procedures.java.ftl">
+<#include "../particles.java.ftl">
+
+package ${package}.entity;
+
+import net.minecraft.world.entity.ai.attributes.Attribute;
+import net.minecraft.world.entity.ai.attributes.Attributes;
+import net.minecraft.world.level.material.Material;
+import net.minecraft.nbt.Tag;
+import net.minecraft.sounds.SoundEvent;
+
+import javax.annotation.Nullable;
+
+<#assign extendsClass = "PathfinderMob">
+
+<#if data.aiBase != "(none)" >
+	<#assign extendsClass = data.aiBase?replace("Enderman", "EnderMan")>
+<#else>
+	<#assign extendsClass = data.mobBehaviourType?replace("Mob", "Monster")?replace("Creature", "PathfinderMob")>
+</#if>
+
+<#if data.breedable>
+	<#assign extendsClass = "Animal">
+</#if>
+
+<#if (data.tameable && data.breedable)>
+	<#assign extendsClass = "TamableAnimal">
+</#if>
+
+<#if data.spawnThisMob>@Mod.EventBusSubscriber</#if>
+public class ${name}Entity extends ${extendsClass} <#if data.ranged>implements RangedAttackMob</#if> {
+
+	<#if data.spawnThisMob>
+		<#assign spawnBiomes = w.filterBrokenReferences(data.restrictionBiomes)>
+
+		<#if spawnBiomes?has_content>
+		private static final Set<ResourceLocation> SPAWN_BIOMES = Set.of(
+			<#list spawnBiomes as restrictionBiome>
+				new ResourceLocation("${restrictionBiome}")<#if restrictionBiome?has_next>,</#if>
+			</#list>
+		);
+		</#if>
+
+		@SubscribeEvent public static void addLivingEntityToBiomes(BiomeLoadingEvent event) {
+			<#if spawnBiomes?has_content>
+			if (SPAWN_BIOMES.contains(event.getName()))
+			</#if>
+				event.getSpawns().getSpawner(${generator.map(data.mobSpawningType, "mobspawntypes")})
+						.add(new MobSpawnSettings.SpawnerData(${JavaModName}Entities.${data.getModElement().getRegistryNameUpper()},
+							${data.spawningProbability}, ${data.minNumberOfMobsPerGroup}, ${data.maxNumberOfMobsPerGroup}));
+		}
+	</#if>
+
+	<#if data.isBoss>
+	private final ServerBossEvent bossInfo = new ServerBossEvent(this.getDisplayName(),
+			ServerBossEvent.BossBarColor.${data.bossBarColor}, ServerBossEvent.BossBarOverlay.${data.bossBarType});
+	</#if>
+
+	public ${name}Entity(PlayMessages.SpawnEntity packet, Level world) {
+    	this(${JavaModName}Entities.${data.getModElement().getRegistryNameUpper()}, world);
+    }
+
+	public ${name}Entity(EntityType<${name}Entity> type, Level world) {
+    	super(type, world);
+		xpReward = ${data.xpAmount};
+		setNoAi(${(!data.hasAI)});
+
+		<#if data.mobLabel?has_content >
+        	setCustomName(new TextComponent("${data.mobLabel}"));
+        	setCustomNameVisible(true);
+        </#if>
+
+		<#if !data.doesDespawnWhenIdle>
+			setPersistenceRequired();
+        </#if>
+
+		<#if !data.equipmentMainHand.isEmpty()>
+        this.setItemSlot(EquipmentSlot.MAINHAND, ${mappedMCItemToItemStackCode(data.equipmentMainHand, 1)});
+        </#if>
+        <#if !data.equipmentOffHand.isEmpty()>
+        this.setItemSlot(EquipmentSlot.OFFHAND, ${mappedMCItemToItemStackCode(data.equipmentOffHand, 1)});
+        </#if>
+        <#if !data.equipmentHelmet.isEmpty()>
+        this.setItemSlot(EquipmentSlot.HEAD, ${mappedMCItemToItemStackCode(data.equipmentHelmet, 1)});
+        </#if>
+        <#if !data.equipmentBody.isEmpty()>
+        this.setItemSlot(EquipmentSlot.CHEST, ${mappedMCItemToItemStackCode(data.equipmentBody, 1)});
+        </#if>
+        <#if !data.equipmentLeggings.isEmpty()>
+        this.setItemSlot(EquipmentSlot.LEGS, ${mappedMCItemToItemStackCode(data.equipmentLeggings, 1)});
+        </#if>
+        <#if !data.equipmentBoots.isEmpty()>
+        this.setItemSlot(EquipmentSlot.FEET, ${mappedMCItemToItemStackCode(data.equipmentBoots, 1)});
+        </#if>
+
+		<#if data.flyingMob>
+		this.moveControl = new FlyingMoveControl(this, 10, true);
+		<#elseif data.waterMob>
+		this.setPathfindingMalus(BlockPathTypes.WATER, 0);
+		this.moveControl = new MoveControl(this) {
+			@Override public void tick() {
+			    if (${name}Entity.this.isInWater())
+                    ${name}Entity.this.setDeltaMovement(${name}Entity.this.getDeltaMovement().add(0, 0.005, 0));
+
+				if (this.operation == MoveControl.Operation.MOVE_TO && !${name}Entity.this.getNavigation().isDone()) {
+					double dx = this.wantedX - ${name}Entity.this.getX();
+					double dy = this.wantedY - ${name}Entity.this.getY();
+					double dz = this.wantedZ - ${name}Entity.this.getZ();
+
+					float f = (float) (Mth.atan2(dz, dx) * (double) (180 / Math.PI)) - 90;
+					float f1 = (float) (this.speedModifier * ${name}Entity.this.getAttribute(Attributes.MOVEMENT_SPEED).getValue());
+
+					${name}Entity.this.setYRot(this.rotlerp(${name}Entity.this.getYRot(), f, 10));
+					${name}Entity.this.yBodyRot = ${name}Entity.this.getYRot();
+					${name}Entity.this.yHeadRot = ${name}Entity.this.getYRot();
+
+					if (${name}Entity.this.isInWater()) {
+						${name}Entity.this.setSpeed((float) ${name}Entity.this.getAttribute(Attributes.MOVEMENT_SPEED).getValue());
+
+						float f2 = - (float) (Mth.atan2(dy, (float) Math.sqrt(dx * dx + dz * dz)) * (180 / Math.PI));
+						f2 = Mth.clamp(Mth.wrapDegrees(f2), -85, 85);
+						${name}Entity.this.setXRot(this.rotlerp(${name}Entity.this.getXRot(), f2, 5));
+						float f3 = Mth.cos(${name}Entity.this.getXRot() * (float) (Math.PI / 180.0));
+
+						${name}Entity.this.setZza(f3 * f1);
+						${name}Entity.this.setYya((float) (f1 * dy));
+					} else {
+						${name}Entity.this.setSpeed(f1 * 0.05F);
+					}
+				} else {
+					${name}Entity.this.setSpeed(0);
+					${name}Entity.this.setYya(0);
+					${name}Entity.this.setZza(0);
+				}
+			}
+		};
+		</#if>
+	}
+
+	@Override public Packet<?> getAddEntityPacket() {
+		return NetworkHooks.getEntitySpawningPacket(this);
+	}
+
+	<#if data.flyingMob>
+	@Override protected PathNavigation createNavigation(Level world) {
+		return new FlyingPathNavigation(this, world);
+	}
+	<#elseif data.waterMob>
+	@Override protected PathNavigation createNavigation(Level world) {
+		return new WaterBoundPathNavigation(this, world);
+	}
+	</#if>
+
+	<#if data.hasAI>
+	@Override protected void registerGoals() {
+		super.registerGoals();
+
+		<#if aicode??>
+            ${aicode}
+        </#if>
+
+        <#if data.ranged>
+            this.goalSelector.addGoal(1, new RangedAttackGoal(this, 1.25, 20, 10) {
+				@Override public boolean canContinueToUse() {
+					return this.canUse();
+				}
+			});
+        </#if>
+	}
+	</#if>
+
+	@Override public MobType getMobType() {
+		return MobType.${data.mobCreatureType};
+	}
+
+	<#if !data.doesDespawnWhenIdle>
+	@Override public boolean removeWhenFarAway(double distanceToClosestPlayer) {
+		return false;
+	}
+    </#if>
+
+	<#if data.mountedYOffset != 0>
+	@Override public double getPassengersRidingOffset() {
+		return super.getPassengersRidingOffset() + ${data.mountedYOffset};
+	}
+	</#if>
+
+	<#if !data.mobDrop.isEmpty()>
+    protected void dropCustomDeathLoot(DamageSource source, int looting, boolean recentlyHitIn) {
+        super.dropCustomDeathLoot(source, looting, recentlyHitIn);
+        this.spawnAtLocation(${mappedMCItemToItemStackCode(data.mobDrop, 1)});
+   	}
+	</#if>
+
+   	<#if data.livingSound.getMappedValue()?has_content>
+	@Override public SoundEvent getAmbientSound() {
+		return ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("${data.livingSound}"));
+	}
+	</#if>
+
+   	<#if data.stepSound?has_content && data.stepSound.getMappedValue()?has_content>
+	@Override public void playStepSound(BlockPos pos, BlockState blockIn) {
+		this.playSound(ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("${data.stepSound}")), 0.15f, 1);
+	}
+	</#if>
+
+	@Override public SoundEvent getHurtSound(DamageSource ds) {
+		return ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("${data.hurtSound}"));
+	}
+
+	@Override public SoundEvent getDeathSound() {
+		return ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("${data.deathSound}"));
+	}
+
+	<#if hasProcedure(data.onStruckByLightning)>
+	@Override public void thunderHit(ServerLevel serverWorld, LightningBolt lightningBolt) {
+		super.thunderHit(serverWorld, lightningBolt);
+		double x = this.getX();
+		double y = this.getY();
+		double z = this.getZ();
+		Entity entity = this;
+		Level world = this.level;
+		<@procedureOBJToCode data.onStruckByLightning/>
+	}
+    </#if>
+
+	<#if hasProcedure(data.whenMobFalls) || data.flyingMob>
+	@Override public boolean causeFallDamage(float l, float d, DamageSource source) {
+		<#if hasProcedure(data.whenMobFalls) >
+			double x = this.getX();
+			double y = this.getY();
+			double z = this.getZ();
+			Entity entity = this;
+			Level world = this.level;
+			<@procedureOBJToCode data.whenMobFalls/>
+		</#if>
+
+		<#if data.flyingMob >
+			return false;
+		<#else>
+			return super.causeFallDamage(l, d, source);
+		</#if>
+	}
+    </#if>
+
+	<#if hasProcedure(data.whenMobIsHurt) || data.immuneToArrows || data.immuneToFallDamage
+		|| data.immuneToCactus || data.immuneToDrowning || data.immuneToLightning || data.immuneToPotions
+		|| data.immuneToPlayer || data.immuneToExplosion || data.immuneToTrident || data.immuneToAnvil
+		|| data.immuneToDragonBreath || data.immuneToWither>
+	@Override public boolean hurt(DamageSource source, float amount) {
+		<#if hasProcedure(data.whenMobIsHurt)>
+			double x = this.getX();
+			double y = this.getY();
+			double z = this.getZ();
+			Entity entity = this;
+			Level world = this.level;
+			Entity sourceentity = source.getEntity();
+			<@procedureOBJToCode data.whenMobIsHurt/>
+		</#if>
+		<#if data.immuneToArrows>
+			if (source.getDirectEntity() instanceof AbstractArrow)
+				return false;
+		</#if>
+		<#if data.immuneToPlayer>
+			if (source.getDirectEntity() instanceof Player)
+				return false;
+		</#if>
+		<#if data.immuneToPotions>
+			if (source.getDirectEntity() instanceof ThrownPotion)
+				return false;
+		</#if>
+		<#if data.immuneToFallDamage>
+			if (source == DamageSource.FALL)
+				return false;
+		</#if>
+		<#if data.immuneToCactus>
+			if (source == DamageSource.CACTUS)
+				return false;
+		</#if>
+		<#if data.immuneToDrowning>
+			if (source == DamageSource.DROWN)
+				return false;
+		</#if>
+		<#if data.immuneToLightning>
+			if (source == DamageSource.LIGHTNING_BOLT)
+				return false;
+		</#if>
+		<#if data.immuneToExplosion>
+			if (source.isExplosion())
+				return false;
+		</#if>
+		<#if data.immuneToTrident>
+			if (source.getMsgId().equals("trident"))
+				return false;
+		</#if>
+		<#if data.immuneToAnvil>
+			if (source == DamageSource.ANVIL)
+				return false;
+		</#if>
+		<#if data.immuneToDragonBreath>
+			if (source == DamageSource.DRAGON_BREATH)
+				return false;
+		</#if>
+		<#if data.immuneToWither>
+			if (source == DamageSource.WITHER)
+				return false;
+			if (source.getMsgId().equals("witherSkull"))
+				return false;
+		</#if>
+		return super.hurt(source, amount);
+	}
+    </#if>
+
+	<#if hasProcedure(data.whenMobDies)>
+	@Override public void die(DamageSource source) {
+		super.die(source);
+		double x = this.getX();
+		double y = this.getY();
+		double z = this.getZ();
+		Entity sourceentity = source.getEntity();
+		Entity entity = this;
+		Level world = this.level;
+		<@procedureOBJToCode data.whenMobDies/>
+	}
+    </#if>
+
+	<#if hasProcedure(data.onInitialSpawn)>
+	@Override public SpawnGroupData finalizeSpawn(ServerLevelAccessor world, DifficultyInstance difficulty,
+			MobSpawnType reason, @Nullable SpawnGroupData livingdata, @Nullable CompoundTag tag) {
+		SpawnGroupData retval = super.finalizeSpawn(world, difficulty, reason, livingdata, tag);
+		double x = this.getX();
+		double y = this.getY();
+		double z = this.getZ();
+		Entity entity = this;
+		<@procedureOBJToCode data.onInitialSpawn/>
+		return retval;
+	}
+    </#if>
+
+	<#if data.guiBoundTo?has_content && data.guiBoundTo != "<NONE>">
+	private final ItemStackHandler inventory = new ItemStackHandler(${data.inventorySize}) {
+		@Override public int getSlotLimit(int slot) {
+			return ${data.inventoryStackSize};
+		}
+	};
+
+	private final CombinedInvWrapper combined = new CombinedInvWrapper(inventory, new EntityHandsInvWrapper(this), new EntityArmorInvWrapper(this));
+
+	@Override public <T> LazyOptional<T> getCapability(@Nonnull Capability<T> capability, @Nullable Direction side) {
+		if (this.isAlive() && capability == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY && side == null)
+			return LazyOptional.of(() -> combined).cast();
+
+		return super.getCapability(capability, side);
+	}
+
+   	@Override protected void dropEquipment() {
+		super.dropEquipment();
+		for(int i = 0; i < inventory.getSlots(); ++i) {
+			ItemStack itemstack = inventory.getStackInSlot(i);
+			if (!itemstack.isEmpty() && !EnchantmentHelper.hasVanishingCurse(itemstack)) {
+				this.spawnAtLocation(itemstack);
+			}
+		}
+	}
+
+	@Override public void addAdditionalSaveData(CompoundTag compound) {
+    	super.addAdditionalSaveData(compound);
+		compound.put("InventoryCustom", inventory.serializeNBT());
+	}
+
+	@Override public void readAdditionalSaveData(CompoundTag compound) {
+    	super.readAdditionalSaveData(compound);
+		Tag inventoryCustom = compound.get("InventoryCustom");
+		if(inventoryCustom instanceof CompoundTag inventoryTag)
+			inventory.deserializeNBT(inventoryTag);
+    }
+    </#if>
+
+	<#if hasProcedure(data.onRightClickedOn) || data.ridable || (data.tameable && data.breedable) || (data.guiBoundTo?has_content && data.guiBoundTo != "<NONE>")>
+	@Override public InteractionResult mobInteract(Player sourceentity, InteractionHand hand) {
+		ItemStack itemstack = sourceentity.getItemInHand(hand);
+		InteractionResult retval = InteractionResult.sidedSuccess(this.level.isClientSide());
+
+		<#if data.guiBoundTo?has_content && data.guiBoundTo != "<NONE>">
+			<#if data.ridable>
+				if (sourceentity.isSecondaryUseActive()) {
+			</#if>
+				if(sourceentity instanceof ServerPlayer serverPlayer) {
+					NetworkHooks.openGui(serverPlayer, new MenuProvider() {
+
+						@Override public Component getDisplayName() {
+							return new TextComponent("${data.mobName}");
+						}
+
+						@Override public AbstractContainerMenu createMenu(int id, Inventory inventory, Player player) {
+							FriendlyByteBuf packetBuffer = new FriendlyByteBuf(Unpooled.buffer());
+							packetBuffer.writeBlockPos(sourceentity.blockPosition());
+							packetBuffer.writeByte(0);
+							packetBuffer.writeVarInt(${name}Entity.this.getId());
+							return new ${data.guiBoundTo}Menu(id, inventory, packetBuffer);
+						}
+
+					}, buf -> {
+						buf.writeBlockPos(sourceentity.blockPosition());
+						buf.writeByte(0);
+						buf.writeVarInt(this.getId());
+					});
+				}
+			<#if data.ridable>
+					return InteractionResult.sidedSuccess(this.level.isClientSide());
+				}
+			</#if>
+		</#if>
+
+		<#if (data.tameable && data.breedable)>
+			Item item = itemstack.getItem();
+			if (itemstack.getItem() instanceof SpawnEggItem) {
+				retval = super.mobInteract(sourceentity, hand);
+			} else if (this.level.isClientSide()) {
+				retval = (this.isTame() && this.isOwnedBy(sourceentity) || this.isFood(itemstack))
+						? InteractionResult.sidedSuccess(this.level.isClientSide()) : InteractionResult.PASS;
+			} else {
+				if (this.isTame()) {
+					if (this.isOwnedBy(sourceentity)) {
+						if (item.isEdible() && this.isFood(itemstack) && this.getHealth() < this.getMaxHealth()) {
+							this.usePlayerItem(sourceentity, hand, itemstack);
+							this.heal((float)item.getFoodProperties().getNutrition());
+							retval = InteractionResult.sidedSuccess(this.level.isClientSide());
+						} else if (this.isFood(itemstack) && this.getHealth() < this.getMaxHealth()) {
+							this.usePlayerItem(sourceentity, hand, itemstack);
+							this.heal(4);
+							retval = InteractionResult.sidedSuccess(this.level.isClientSide());
+						} else {
+							retval = super.mobInteract(sourceentity, hand);
+						}
+					}
+				} else if (this.isFood(itemstack)) {
+					this.usePlayerItem(sourceentity, hand, itemstack);
+					if (this.random.nextInt(3) == 0 && !net.minecraftforge.event.ForgeEventFactory.onAnimalTame(this, sourceentity)) {
+						this.tame(sourceentity);
+						this.level.broadcastEntityEvent(this, (byte) 7);
+					} else {
+						this.level.broadcastEntityEvent(this, (byte) 6);
+					}
+
+					this.setPersistenceRequired();
+					retval = InteractionResult.sidedSuccess(this.level.isClientSide());
+				} else {
+					retval = super.mobInteract(sourceentity, hand);
+					if (retval == InteractionResult.SUCCESS || retval == InteractionResult.CONSUME)
+						this.setPersistenceRequired();
+				}
+			}
+		<#else>
+			super.mobInteract(sourceentity, hand);
+		</#if>
+
+		<#if data.ridable>
+		sourceentity.startRiding(this);
+	    </#if>
+
+		<#if hasProcedure(data.onRightClickedOn)>
+			double x = this.getX();
+			double y = this.getY();
+			double z = this.getZ();
+			Entity entity = this;
+			Level world = this.level;
+			<#if hasReturnValueOf(data.onRightClickedOn, "actionresulttype")>
+				return <@procedureOBJToInteractionResultCode data.onRightClickedOn/>;
+			<#else>
+				<@procedureOBJToCode data.onRightClickedOn/>
+				return retval;
+			</#if>
+		<#else>
+			return retval;
+		</#if>
+	}
+    </#if>
+
+	<#if hasProcedure(data.whenThisMobKillsAnother)>
+	@Override public void awardKillScore(Entity entity, int score, DamageSource damageSource) {
+		super.awardKillScore(entity, score, damageSource);
+		double x = this.getX();
+		double y = this.getY();
+		double z = this.getZ();
+		Entity sourceentity = this;
+		Level world = this.level;
+		<@procedureOBJToCode data.whenThisMobKillsAnother/>
+	}
+    </#if>
+
+	<#if hasProcedure(data.onMobTickUpdate)>
+	@Override public void baseTick() {
+		super.baseTick();
+		double x = this.getX();
+		double y = this.getY();
+		double z = this.getZ();
+		Entity entity = this;
+		Level world = this.level;
+		<@procedureOBJToCode data.onMobTickUpdate/>
+	}
+    </#if>
+
+	<#if hasProcedure(data.onPlayerCollidesWith)>
+	@Override public void playerTouch(Player sourceentity) {
+		super.playerTouch(sourceentity);
+		Entity entity = this;
+		Level world = this.level;
+		double x = this.getX();
+		double y = this.getY();
+		double z = this.getZ();
+		<@procedureOBJToCode data.onPlayerCollidesWith/>
+	}
+    </#if>
+
+    <#if data.ranged>
+	    @Override public void performRangedAttack(LivingEntity target, float flval) {
+			<#if data.rangedItemType == "Default item">
+				${name}EntityProjectile entityarrow = new ${name}EntityProjectile(${JavaModName}Entities.${data.getModElement().getRegistryNameUpper()}_PROJECTILE, this, this.level);
+				double d0 = target.getY() + target.getEyeHeight() - 1.1;
+				double d1 = target.getX() - this.getX();
+				double d3 = target.getZ() - this.getZ();
+				entityarrow.shoot(d1, d0 - entityarrow.getY() + Math.sqrt(d1 * d1 + d3 * d3) * 0.2F, d3, 1.6F, 12.0F);
+				level.addFreshEntity(entityarrow);
+			<#else>
+				${data.rangedItemType}Entity.shoot(this, target);
+			</#if>
+		}
+    </#if>
+
+	<#if data.breedable>
+        @Override public AgeableMob getBreedOffspring(ServerLevel serverWorld, AgeableMob ageable) {
+			${name}Entity retval = ${JavaModName}Entities.${data.getModElement().getRegistryNameUpper()}.create(serverWorld);
+			retval.finalizeSpawn(serverWorld, serverWorld.getCurrentDifficultyAt(retval.blockPosition()), MobSpawnType.BREEDING, null, null);
+			return retval;
+		}
+
+		@Override public boolean isFood(ItemStack stack) {
+			return List.of(<#list data.breedTriggerItems as breedTriggerItem>${mappedMCItemToItem(breedTriggerItem)}<#if breedTriggerItem?has_next>,</#if></#list>).contains(stack);
+		}
+    </#if>
+
+	<#if data.waterMob>
+	@Override public boolean canBreatheUnderwater() {
+    	return true;
+    }
+
+    @Override public boolean checkSpawnObstruction(LevelReader world) {
+		return world.isUnobstructed(this);
+	}
+
+    @Override public boolean isPushedByFluid() {
+		return false;
+    }
+	</#if>
+
+	<#if data.disableCollisions>
+	@Override public boolean isPushable() {
+		return false;
+	}
+
+   	@Override protected void doPush(Entity entityIn) {
+   	}
+
+   	@Override protected void pushEntities() {
+   	}
+	</#if>
+
+	<#if data.isBoss>
+	@Override public boolean canChangeDimensions() {
+		return false;
+	}
+
+	@Override public void startSeenByPlayer(ServerPlayer player) {
+		super.startSeenByPlayer(player);
+		this.bossInfo.addPlayer(player);
+	}
+
+	@Override public void stopSeenByPlayer(ServerPlayer player) {
+		super.stopSeenByPlayer(player);
+		this.bossInfo.removePlayer(player);
+	}
+
+	@Override public void customServerAiStep() {
+		super.customServerAiStep();
+		this.bossInfo.setProgress(this.getHealth() / this.getMaxHealth());
+	}
+	</#if>
+
+    <#if data.ridable && (data.canControlForward || data.canControlStrafe)>
+        @Override public void travel(Vec3 dir) {
+        	<#if data.canControlForward || data.canControlStrafe>
+			Entity entity = this.getPassengers().isEmpty() ? null : (Entity) this.getPassengers().get(0);
+			if (this.isVehicle()) {
+				this.setYRot(entity.getYRot());
+				this.yRotO = this.getYRot();
+				this.setXRot(entity.getXRot() * 0.5F);
+				this.setRot(this.getYRot(), this.getXRot());
+				this.flyingSpeed = this.getSpeed() * 0.15F;
+				this.yBodyRot = entity.getYRot();
+				this.yHeadRot = entity.getYRot();
+				this.maxUpStep = 1.0F;
+
+				if (entity instanceof LivingEntity passenger) {
+					this.setSpeed((float) this.getAttributeValue(Attributes.MOVEMENT_SPEED));
+
+					<#if data.canControlForward>
+						float forward = passenger.zza;
+					<#else>
+						float forward = 0;
+					</#if>
+
+					<#if data.canControlStrafe>
+						float strafe = passenger.xxa;
+					<#else>
+						float strafe = 0;
+					</#if>
+
+					super.travel(new Vec3(strafe, 0, forward));
+				}
+
+				this.animationSpeedOld = this.animationSpeed;
+				double d1 = this.getX() - this.xo;
+				double d0 = this.getZ() - this.zo;
+				float f1 = (float) Math.sqrt(d1 * d1 + d0 * d0) * 4;
+				if (f1 > 1.0F) f1 = 1.0F;
+				this.animationSpeed += (f1 - this.animationSpeed) * 0.4F;
+				this.animationPosition += this.animationSpeed;
+				return;
+			}
+			this.maxUpStep = 0.5F;
+			this.flyingSpeed = 0.02F;
+			</#if>
+
+			super.travel(dir);
+		}
+    </#if>
+
+	<#if data.flyingMob>
+	@Override protected void checkFallDamage(double y, boolean onGroundIn, BlockState state, BlockPos pos) {
+   	}
+
+   	@Override public void setNoGravity(boolean ignored) {
+		super.setNoGravity(true);
+	}
+    </#if>
+
+    <#if data.spawnParticles || data.flyingMob>
+    public void aiStep() {
+		super.aiStep();
+
+		<#if data.flyingMob>
+		this.setNoGravity(true);
+		</#if>
+
+		<#if data.spawnParticles>
+		double x = this.getX();
+		double y = this.getY();
+		double z = this.getZ();
+		Entity entity = this;
+		Level world = this.level;
+		<#if hasProcedure(data.particleCondition)>
+			if(<@procedureOBJToConditionCode data.particleCondition/>)
+		</#if>
+        <@particles data.particleSpawningShape data.particleToSpawn data.particleSpawningRadious data.particleAmount/>
+		</#if>
+	}
+    </#if>
+
+	public static void init() {
+		<#if data.spawnThisMob>
+			<#if data.mobSpawningType == "creature">
+			SpawnPlacements.register(${JavaModName}Entities.${data.getModElement().getRegistryNameUpper()},
+					SpawnPlacements.Type.ON_GROUND, Heightmap.Types.MOTION_BLOCKING_NO_LEAVES,
+				<#if hasProcedure(data.spawningCondition)>
+					(entityType, world, reason, pos, random) -> {
+						int x = pos.getX();
+						int y = pos.getY();
+						int z = pos.getZ();
+						return <@procedureOBJToConditionCode data.spawningCondition/>;
+					}
+				<#else>
+					(entityType, world, reason, pos, random) ->
+							(world.getBlockState(pos.below()).getMaterial() == Material.GRASS && world.getRawBrightness(pos, 0) > 8)
+				</#if>
+			);
+			<#elseif data.mobSpawningType == "ambient" || data.mobSpawningType == "misc">
+			SpawnPlacements.register(${JavaModName}Entities.${data.getModElement().getRegistryNameUpper()},
+					SpawnPlacements.Type.NO_RESTRICTIONS, Heightmap.Types.MOTION_BLOCKING_NO_LEAVES,
+					<#if hasProcedure(data.spawningCondition)>
+					(entityType, world, reason, pos, random) -> {
+						int x = pos.getX();
+						int y = pos.getY();
+						int z = pos.getZ();
+						return <@procedureOBJToConditionCode data.spawningCondition/>;
+					}
+					<#else>
+					Mob::checkMobSpawnRules
+					</#if>
+			);
+			<#elseif data.mobSpawningType == "waterCreature" || data.mobSpawningType == "waterAmbient">
+			SpawnPlacements.register(${JavaModName}Entities.${data.getModElement().getRegistryNameUpper()},
+					SpawnPlacements.Type.IN_WATER, Heightmap.Types.MOTION_BLOCKING_NO_LEAVES,
+					<#if hasProcedure(data.spawningCondition)>
+					(entityType, world, reason, pos, random) -> {
+						int x = pos.getX();
+						int y = pos.getY();
+						int z = pos.getZ();
+						return <@procedureOBJToConditionCode data.spawningCondition/>;
+					}
+					<#else>
+					(entityType, world, reason, pos, random) ->
+							(world.getBlockState(pos).is(Blocks.WATER) && world.getBlockState(pos.above()).is(Blocks.WATER))
+					</#if>
+			);
+			<#elseif data.mobSpawningType == "undergroundWaterCreature">
+			SpawnPlacements.register(${JavaModName}Entities.${data.getModElement().getRegistryNameUpper()},
+					SpawnPlacements.Type.IN_WATER, Heightmap.Types.MOTION_BLOCKING_NO_LEAVES,
+					<#if hasProcedure(data.spawningCondition)>
+					(entityType, world, reason, pos, random) -> {
+						int x = pos.getX();
+						int y = pos.getY();
+						int z = pos.getZ();
+						return <@procedureOBJToConditionCode data.spawningCondition/>;
+					}
+					<#else>
+					(entityType, world, reason, pos, random) -> {
+					    return world.getFluidState(pos.below()).is(FluidTags.WATER) && world.getBlockState(pos.above()).is(Blocks.WATER) && pos.getY() >= (world.getSeaLevel() - 13) && pos.getY() <= world.getSeaLevel();
+                    }
+					</#if>
+			);
+			<#else>
+			SpawnPlacements.register(${JavaModName}Entities.${data.getModElement().getRegistryNameUpper()},
+					SpawnPlacements.Type.ON_GROUND, Heightmap.Types.MOTION_BLOCKING_NO_LEAVES,
+					<#if hasProcedure(data.spawningCondition)>
+					(entityType, world, reason, pos, random) -> {
+						int x = pos.getX();
+						int y = pos.getY();
+						int z = pos.getZ();
+						return <@procedureOBJToConditionCode data.spawningCondition/>;
+					}
+					<#else>
+						(entityType, world, reason, pos, random) ->
+								(world.getDifficulty() != Difficulty.PEACEFUL && Monster.isDarkEnoughToSpawn(world, pos, random)
+										&& Mob.checkMobSpawnRules(entityType, world, reason, pos, random))
+					</#if>
+			);
+			</#if>
+		</#if>
+
+		<#if data.spawnInDungeons>
+			DungeonHooks.addDungeonMob(${JavaModName}Entities.${data.getModElement().getRegistryNameUpper()}, 180);
+		</#if>
+	}
+
+	public static AttributeSupplier.Builder createAttributes() {
+		AttributeSupplier.Builder builder = Mob.createMobAttributes();
+		builder = builder.add(Attributes.MOVEMENT_SPEED, ${data.movementSpeed});
+		builder = builder.add(Attributes.MAX_HEALTH, ${data.health});
+		builder = builder.add(Attributes.ARMOR, ${data.armorBaseValue});
+		builder = builder.add(Attributes.ATTACK_DAMAGE, ${data.attackStrength});
+
+		<#if (data.knockbackResistance > 0)>
+		builder = builder.add(Attributes.KNOCKBACK_RESISTANCE, ${data.knockbackResistance});
+		</#if>
+
+		<#if (data.attackKnockback > 0)>
+		builder = builder.add(Attributes.ATTACK_KNOCKBACK, ${data.attackKnockback});
+		</#if>
+
+		<#if data.flyingMob>
+		builder = builder.add(Attributes.FLYING_SPEED, ${data.movementSpeed});
+		</#if>
+
+		<#if data.waterMob>
+		builder = builder.add(ForgeMod.SWIM_SPEED.get(), ${data.movementSpeed});
+		</#if>
+
+		<#if data.aiBase == "Zombie">
+		builder = builder.add(Attributes.SPAWN_REINFORCEMENTS_CHANCE);
+		</#if>
+
+		return builder;
+	}
+
+}
+<#-- @formatter:on -->

--- a/plugins/generator-1.18.1/forge-1.18.1/templates/livingentity/livingentity_projectile.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/templates/livingentity/livingentity_projectile.java.ftl
@@ -35,7 +35,7 @@ package ${package}.entity;
 
 @OnlyIn(value = Dist.CLIENT, _interface = ItemSupplier.class) public class ${name}EntityProjectile extends AbstractArrow implements ItemSupplier {
 
-	public ${name}EntityProjectile(FMLPlayMessages.SpawnEntity packet, Level world) {
+	public ${name}EntityProjectile(PlayMessages.SpawnEntity packet, Level world) {
 		super(${JavaModName}Entities.${data.getModElement().getRegistryNameUpper()}_PROJECTILE, world);
 	}
 

--- a/plugins/generator-1.18.1/forge-1.18.1/templates/livingentity/livingentity_projectile.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/templates/livingentity/livingentity_projectile.java.ftl
@@ -1,0 +1,71 @@
+<#--
+ # MCreator (https://mcreator.net/)
+ # Copyright (C) 2012-2020, Pylo
+ # Copyright (C) 2020-2022, Pylo, opensource contributors
+ # 
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ # 
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ # 
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ # 
+ # Additional permission for code generator templates (*.ftl files)
+ # 
+ # As a special exception, you may create a larger work that contains part or 
+ # all of the MCreator code generator templates (*.ftl files) and distribute 
+ # that work under terms of your choice, so long as that work isn't itself a 
+ # template for code generation. Alternatively, if you modify or redistribute 
+ # the template itself, you may (at your option) remove this special exception, 
+ # which will cause the template and the resulting code generator output files 
+ # to be licensed under the GNU General Public License without this special 
+ # exception.
+-->
+
+<#-- @formatter:off -->
+<#include "../mcitems.ftl">
+
+package ${package}.entity;
+
+@OnlyIn(value = Dist.CLIENT, _interface = ItemSupplier.class) public class ${name}EntityProjectile extends AbstractArrow implements ItemSupplier {
+
+	public ${name}EntityProjectile(FMLPlayMessages.SpawnEntity packet, Level world) {
+		super(${JavaModName}Entities.${data.getModElement().getRegistryNameUpper()}_PROJECTILE, world);
+	}
+
+	public ${name}EntityProjectile(EntityType<? extends ${name}EntityProjectile> type, Level world) {
+		super(type, world);
+	}
+
+	public ${name}EntityProjectile(EntityType<? extends ${name}EntityProjectile> type, double x, double y, double z, Level world) {
+		super(type, x, y, z, world);
+	}
+
+	public ${name}EntityProjectile(EntityType<? extends ${name}EntityProjectile> type, LivingEntity entity, Level world) {
+		super(type, entity, world);
+	}
+
+	@Override public Packet<?> getAddEntityPacket() {
+		return NetworkHooks.getEntitySpawningPacket(this);
+	}
+
+	@Override protected void doPostHurtEffects(LivingEntity livingEntity) {
+		super.doPostHurtEffects(livingEntity);
+		livingEntity.setArrowCount(livingEntity.getArrowCount() - 1);
+	}
+
+	@Override @OnlyIn(Dist.CLIENT) public ItemStack getItem() {
+		return ${mappedMCItemToItemStackCode(data.rangedAttackItem, 1)};
+	}
+
+	@Override protected ItemStack getPickupItem() {
+		return ${mappedMCItemToItemStackCode(data.rangedAttackItem, 1)};
+	}
+}
+<#-- @formatter:on -->

--- a/plugins/generator-1.18.1/forge-1.18.1/templates/livingentity/livingentity_renderer.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/templates/livingentity/livingentity_renderer.java.ftl
@@ -83,7 +83,7 @@ public class ${name}Renderer extends <#if humanoid>Humanoid</#if>MobRenderer<${n
 		</#if>
 
 		<#if data.mobModelGlowTexture?has_content>
-		this.addLayer(new EyesLayer(this) {
+		this.addLayer(new EyesLayer<${name}Entity, ${model}>(this) {
 			@Override public RenderType renderType() {
 				return RenderType.eyes(new ResourceLocation("${modid}:textures/${data.mobModelGlowTexture}"));
 			}

--- a/plugins/generator-1.18.1/forge-1.18.1/templates/livingentity/livingentity_renderer.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/templates/livingentity/livingentity_renderer.java.ftl
@@ -1,0 +1,98 @@
+<#--
+ # MCreator (https://mcreator.net/)
+ # Copyright (C) 2012-2020, Pylo
+ # Copyright (C) 2020-2022, Pylo, opensource contributors
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # Additional permission for code generator templates (*.ftl files)
+ #
+ # As a special exception, you may create a larger work that contains part or
+ # all of the MCreator code generator templates (*.ftl files) and distribute
+ # that work under terms of your choice, so long as that work isn't itself a
+ # template for code generation. Alternatively, if you modify or redistribute
+ # the template itself, you may (at your option) remove this special exception,
+ # which will cause the template and the resulting code generator output files
+ # to be licensed under the GNU General Public License without this special
+ # exception.
+-->
+
+<#-- @formatter:off -->
+package ${package}.client.renderer;
+
+<#assign humanoid = false>
+<#assign model = "HumanoidModel">
+
+<#if data.mobModelName == "Chicken">
+	<#assign super = "super(context, new ChickenModel(context.bakeLayer(ModelLayers.CHICKEN)), " + data.modelShadowSize + "f);">
+	<#assign model = "ChickenModel">
+<#elseif data.mobModelName == "Cow">
+	<#assign super = "super(context, new CowModel(context.bakeLayer(ModelLayers.COW)), " + data.modelShadowSize + "f);">
+	<#assign model = "CowModel">
+<#elseif data.mobModelName == "Creeper">
+	<#assign super = "super(context, new CreeperModel(context.bakeLayer(ModelLayers.CREEPER)), " + data.modelShadowSize + "f);">
+	<#assign model = "CreeperModel">
+<#elseif data.mobModelName == "Ghast">
+	<#assign super = "super(context, new GhastModel(context.bakeLayer(ModelLayers.GHAST)), " + data.modelShadowSize + "f);">
+	<#assign model = "GhastModel">
+<#elseif data.mobModelName == "Pig">
+	<#assign super = "super(context, new PigModel(context.bakeLayer(ModelLayers.PIG)), " + data.modelShadowSize + "f);">
+	<#assign model = "PigModel">
+<#elseif data.mobModelName == "Slime">
+	<#assign super = "super(context, new SlimeModel(context.bakeLayer(ModelLayers.SLIME)), " + data.modelShadowSize + "f);">
+	<#assign model = "SlimeModel">
+<#elseif data.mobModelName == "Spider">
+	<#assign super = "super(context, new SpiderModel(context.bakeLayer(ModelLayers.SPIDER)), " + data.modelShadowSize + "f);">
+	<#assign model = "SpiderModel">
+<#elseif data.mobModelName == "Villager">
+	<#assign super = "super(context, new VillagerModel(context.bakeLayer(ModelLayers.VILLAGER)), " + data.modelShadowSize + "f);">
+	<#assign model = "VillagerModel">
+<#elseif data.mobModelName == "Silverfish">
+	<#assign super = "super(context, new SilverfishModel(context.bakeLayer(ModelLayers.SILVERFISH)), " + data.modelShadowSize + "f);">
+	<#assign model = "SilverfishModel">
+<#elseif !data.isBuiltInModel()>
+	<#assign super = "super(context, new ${data.mobModelName}(context.bakeLayer(${data.mobModelName}.LAYER_LOCATION)), " + data.modelShadowSize + "f);">
+	<#assign model = data.mobModelName>
+<#else>
+	<#assign super = "super(context, new HumanoidModel(context.bakeLayer(ModelLayers.PLAYER)), " + data.modelShadowSize + "f);">
+	<#assign model = "HumanoidModel">
+	<#assign humanoid = true>
+</#if>
+
+<#assign model = model + "<" + name + "Entity>">
+
+public class ${name}Renderer extends <#if humanoid>Humanoid</#if>MobRenderer<${name}Entity, ${model}> {
+
+	public ${name}Renderer(EntityRendererProvider.Context context) {
+		${super}
+
+		<#if humanoid>
+		this.addLayer(new HumanoidArmorLayer(this, new HumanoidModel(context.bakeLayer(ModelLayers.PLAYER_INNER_ARMOR)),
+				new HumanoidModel(context.bakeLayer(ModelLayers.PLAYER_OUTER_ARMOR))));
+		</#if>
+
+		<#if data.mobModelGlowTexture?has_content>
+		this.addLayer(new EyesLayer(this) {
+			@Override public RenderType renderType() {
+				return RenderType.eyes(new ResourceLocation("${modid}:textures/${data.mobModelGlowTexture}"));
+			}
+		});
+		</#if>
+	}
+
+	@Override public ResourceLocation getTextureLocation(${name}Entity entity) {
+		return new ResourceLocation("${modid}:textures/${data.mobModelTexture}"); 
+	}
+
+}

--- a/plugins/generator-1.18.1/forge-1.18.1/utils/particles.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/utils/particles.java.ftl
@@ -1,0 +1,52 @@
+<#include "tokens.ftl">
+
+<#macro particles type particleObj radius amount>
+    <#if type=="Spread">
+        <@particlesSpread particleObj radius amount/>
+    <#elseif type=="Top">
+        <@particlesTop particleObj radius amount/>
+    <#elseif type=="Tube">
+        <@particlesTube particleObj radius amount/>
+    <#elseif type=="Plane">
+        <@particlesPlane particleObj radius amount/>
+    </#if>
+</#macro>
+
+<#macro particlesPlane particleObj radius amount>
+for(int l=0;l< ${amount}; ++l) {
+	double x0 = x + 0.5 + (random.nextFloat() - 0.5) * ${radius}D * 20;
+	double y0 = y + 1.2 + (random.nextFloat() - 0.5) * ${radius}D;
+	double z0 = z + 0.5 + (random.nextFloat() - 0.5) * ${radius}D * 20;
+	world.addParticle(${particleObj.toString()}, x0, y0, z0, 0, 0, 0);
+}
+</#macro>
+
+<#macro particlesSpread particleObj radius amount>
+for (int l = 0; l < ${amount}; ++l) {
+	double x0 = x + random.nextFloat();
+	double y0 = y + random.nextFloat();
+	double z0 = z + random.nextFloat();
+	double dx = (random.nextFloat() - 0.5D) * ${radius}D;
+	double dy = (random.nextFloat() - 0.5D) * ${radius}D;
+	double dz = (random.nextFloat() - 0.5D) * ${radius}D;
+	world.addParticle(${particleObj.toString()}, x0, y0, z0, dx, dy, dz);
+}
+</#macro>
+
+<#macro particlesTop particleObj radius amount>
+for (int l = 0; l < ${amount}; ++l) {
+	double x0 = x + 0.5 + (random.nextFloat() - 0.5) * ${radius}D;
+	double y0 = y + 1.2 + (random.nextFloat() - 0.5) * ${radius}D;
+	double z0 = z + 0.5 + (random.nextFloat() - 0.5) * ${radius}D;
+	world.addParticle(${particleObj.toString()}, x0, y0, z0, 0, 0, 0);
+}
+</#macro>
+
+<#macro particlesTube particleObj radius amount>
+for (int l = 0; l < ${amount}; ++l){
+	double x0 = x + 0.5 + (random.nextFloat()-0.5)* ${radius}D;
+	double y0 = y + 1.2 + (random.nextFloat()-0.5)* ${radius}D*100;
+	double z0 = z + 0.5 +(random.nextFloat()-0.5)* ${radius}D;
+	world.addParticle(${particleObj.toString()},x0,y0,z0,0,0,0);
+}
+</#macro>


### PR DESCRIPTION
It ports living entities to Forge 1.18.1. No AI task blocks are ported in this PR.

`undergroundWaterCreature` (mobSpawningType) now uses the code used by `checkSurfaceWaterAnimalSpawnRules` (the new `checkUndergroundWaterCreatureSpawnRules`), because the provided entity type in the method now requires to extends `WaterAnimal` for some reasons. The code is not 100% the same as I changed variable names and put the 2 int vars directly into the real code line, but simply be aware of this.

Except for the previous element, nothing else has to be changed into the code since Forge 1.17.1.
The following model uses Forge 1.17.1 (Mojmaps) on BlockBench.
[TestCube.java.txt](https://github.com/MCreator/MCreator/files/7805860/TestCube.java.txt)
![test_cube](https://user-images.githubusercontent.com/38427877/148021375-ae436176-b719-4a6e-a097-cc83c2fff416.png)
 

Note: Everything compiles fine, but I only tested a bit in game. More testing should be done to be sure of everything.