### PR TITLE
[1.18] Ported item related procedure blocks 1/2

### DIFF
--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/item_add_enhancement.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/item_add_enhancement.java.ftl
@@ -1,0 +1,2 @@
+<#include "mcitems.ftl">
+(${mappedMCItemToItemStackCode(input$item, 1)}).enchant(${generator.map(field$enhancement, "enchantments")},${opt.toInt(input$level)});

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/item_bucket_to_fluid.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/item_bucket_to_fluid.java.ftl
@@ -1,0 +1,2 @@
+<#include "mcitems.ftl">
+/*@BlockState*/(${mappedMCItemToItem(input$source)} instanceof BucketItem _bucket ? _bucket.getFluid().defaultFluidState().createLegacyBlock() : Blocks.AIR.defaultBlockState())

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/item_can_harvest.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/item_can_harvest.java.ftl
@@ -1,0 +1,2 @@
+<#include "mcitems.ftl">
+(${mappedMCItemToItem(input$item)}.isCorrectToolForDrops(${mappedBlockToBlockStateCode(input$block)}))

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/item_can_smelt.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/item_can_smelt.java.ftl
@@ -1,0 +1,2 @@
+<#include "mcitems.ftl">
+(world instanceof Level _lvlCanSmelt ? _lvlCanSmelt.getRecipeManager().getRecipeFor(RecipeType.SMELTING, new SimpleContainer(${mappedMCItemToItemStackCode(input$item, 1)}), _lvlCanSmelt).isPresent():false)

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/item_check_rarity.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/item_check_rarity.java.ftl
@@ -1,0 +1,2 @@
+<#include "mcitems.ftl">
+(${mappedMCItemToItemStackCode(input$item, 1)}.getRarity() == Rarity.${field$rarity})

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/item_cooldown_for.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/item_cooldown_for.java.ftl
@@ -1,0 +1,3 @@
+<#include "mcitems.ftl">
+if(${input$entity} instanceof Player _player)
+	_player.getCooldowns().addCooldown(${mappedMCItemToItem(input$item)}, ${opt.toInt(input$ticks)});

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/item_damage.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/item_damage.java.ftl
@@ -1,0 +1,8 @@
+<#include "mcitems.ftl">
+{
+	ItemStack _ist = ${mappedMCItemToItemStackCode(input$item, 1)};
+	if(_ist.hurt(${opt.toInt(input$amount)},new Random(),null)) {
+        _ist.shrink(1);
+        _ist.setDamageValue(0);
+    }
+}

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/item_enchanted_with_xp.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/item_enchanted_with_xp.java.ftl
@@ -1,0 +1,2 @@
+<#include "mcitems.ftl">
+/*@ItemStack*/(EnchantmentHelper.enchantItem(new Random(), ${mappedMCItemToItemStackCode(input$item, 1)}, ${opt.toInt(input$levels)}, ${input$treasure}))

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/item_fuel_power.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/item_fuel_power.java.ftl
@@ -1,0 +1,2 @@
+<#include "mcitems.ftl">
+/*@int*/(ForgeHooks.getBurnTime(${mappedMCItemToItemStackCode(input$item, 1)}, null))

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/item_get_damage.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/item_get_damage.java.ftl
@@ -1,0 +1,2 @@
+<#include "mcitems.ftl">
+/*@int*/((${mappedMCItemToItemStackCode(input$item, 1)}).getDamageValue())

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/item_get_enhancement.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/item_get_enhancement.java.ftl
@@ -1,0 +1,2 @@
+<#include "mcitems.ftl">
+/*@int*/(EnchantmentHelper.getItemEnchantmentLevel(${generator.map(field$enhancement, "enchantments")}, ${mappedMCItemToItemStackCode(input$item, 1)}))

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/item_get_food_value.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/item_get_food_value.java.ftl
@@ -1,0 +1,2 @@
+<#include "mcitems.ftl">
+/*@int*/(${mappedMCItemToItem(input$item)}.isEdible() ? ${mappedMCItemToItem(input$item)}.getFoodProperties().getNutrition() : 0)

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/item_get_max_damage.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/item_get_max_damage.java.ftl
@@ -1,0 +1,2 @@
+<#include "mcitems.ftl">
+/*@int*/((${mappedMCItemToItemStackCode(input$item, 1)}).getMaxDamage())

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/item_get_saturation_value.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/item_get_saturation_value.java.ftl
@@ -1,0 +1,2 @@
+<#include "mcitems.ftl">
+/*@float*/(${mappedMCItemToItem(input$item)}.isEdible() ? ${mappedMCItemToItem(input$item)}.getFoodProperties().getSaturationModifier() : 0)

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/item_is_enchantable.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/item_is_enchantable.java.ftl
@@ -1,0 +1,2 @@
+<#include "mcitems.ftl">
+((${mappedMCItemToItemStackCode(input$item, 1)}).isEnchantable())

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/item_is_enchanted.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/item_is_enchanted.java.ftl
@@ -1,0 +1,2 @@
+<#include "mcitems.ftl">
+((${mappedMCItemToItemStackCode(input$item, 1)}).isEnchanted())

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/item_is_food.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/item_is_food.java.ftl
@@ -1,0 +1,2 @@
+<#include "mcitems.ftl">
+(${mappedMCItemToItem(input$item)}.isEdible())

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/item_istool.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/item_istool.java.ftl
@@ -1,0 +1,2 @@
+<#include "mcitems.ftl">
+(${mappedMCItemToItem(input$item)} instanceof ${field$tool_type}Item)

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/item_name.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/item_name.java.ftl
@@ -1,0 +1,2 @@
+<#include "mcitems.ftl">
+(${mappedMCItemToItemStackCode(input$item, 1)}.getDisplayName().getString())

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/itemstack_to_mcitem.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/itemstack_to_mcitem.java.ftl
@@ -1,0 +1,1 @@
+/*@ItemStack*/itemstack


### PR DESCRIPTION
This PR ports the half (21/40) procedure blocks related to items/item stacks.

Based on my tests, nothing changed since Forge 1.17.1.