### PR TITLE
Ported direction procedures to 1.18.1

### DIFF
--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/direction_compare_axes.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/direction_compare_axes.java.ftl
@@ -1,0 +1,2 @@
+<#include "mcelements.ftl">
+(${toAxis(input$a)} == ${toAxis(input$b)})

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/direction_foreach.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/direction_foreach.java.ftl
@@ -1,0 +1,3 @@
+for (Direction directioniterator : Direction.values()) {
+    ${statement$foreach}
+}

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/direction_foreach_horizontal.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/direction_foreach_horizontal.java.ftl
@@ -1,0 +1,3 @@
+for (Direction directioniterator : Direction.Plane.HORIZONTAL) {
+    ${statement$foreach}
+}

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/direction_iterator.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/direction_iterator.java.ftl
@@ -1,0 +1,1 @@
+directioniterator

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/direction_offset_x.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/direction_offset_x.java.ftl
@@ -1,0 +1,1 @@
+/*@int*/(${input$direction}.getStepX())

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/direction_offset_y.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/direction_offset_y.java.ftl
@@ -1,0 +1,1 @@
+/*@int*/(${input$direction}.getStepY())

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/direction_offset_z.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/direction_offset_z.java.ftl
@@ -1,0 +1,1 @@
+/*@int*/(${input$direction}.getStepZ())

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/direction_opposite.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/direction_opposite.java.ftl
@@ -1,0 +1,1 @@
+(${input$direction}.getOpposite())

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/direction_random.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/direction_random.java.ftl
@@ -1,0 +1,1 @@
+Direction.getRandom(new Random())

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/direction_rotated_clockwise.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/direction_rotated_clockwise.java.ftl
@@ -1,0 +1,1 @@
+(${input$direction}.getClockWise(Direction.Axis.Y))

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/direction_rotated_counterclockwise.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/direction_rotated_counterclockwise.java.ftl
@@ -1,0 +1,1 @@
+(${input$direction}.getCounterClockWise(Direction.Axis.Y))


### PR DESCRIPTION
This PR ports all the procedures in the direction tab to 1.18 (code is the same as 1.17)