### PR TITLE
[1.18] Ported even more entity blocks

### DIFF
--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_isinvisible.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_isinvisible.java.ftl
@@ -1,0 +1,1 @@
+(${input$entity}.isInvisible())

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_isinvulnerable.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_isinvulnerable.java.ftl
@@ -1,0 +1,1 @@
+(${input$entity}.isInvulnerable())

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_isinwater.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_isinwater.java.ftl
@@ -1,0 +1,1 @@
+(${input$entity}.isInWater())

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_isinwater_orbubblecolumn.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_isinwater_orbubblecolumn.java.ftl
@@ -1,0 +1,1 @@
+(${input$entity}.isInWaterOrBubble())

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_isinwaterrain_orbubblecolumn.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_isinwaterrain_orbubblecolumn.java.ftl
@@ -1,0 +1,1 @@
+(${input$entity}.isInWaterRainOrBubble())

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_isleashed.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_isleashed.java.ftl
@@ -1,0 +1,1 @@
+(${input$entity} instanceof Mob _mobEnt ? _mobEnt.isLeashed():false)

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_isnonboss.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_isnonboss.java.ftl
@@ -1,0 +1,1 @@
+(${input$entity}.canChangeDimensions())

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_isonground.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_isonground.java.ftl
@@ -1,0 +1,1 @@
+(${input$entity}.isOnGround())

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_isriding.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_isriding.java.ftl
@@ -1,0 +1,1 @@
+(${input$entity}.isPassenger())

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_issneaking.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_issneaking.java.ftl
@@ -1,0 +1,1 @@
+(${input$entity}.isShiftKeyDown())

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_issprinting.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_issprinting.java.ftl
@@ -1,0 +1,1 @@
+(${input$entity}.isSprinting())

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_istamed.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_istamed.java.ftl
@@ -1,0 +1,1 @@
+(${input$entity} instanceof TamableAnimal _tamEnt ? _tamEnt.isTame():false)

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_istamed_by.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_istamed_by.java.ftl
@@ -1,0 +1,2 @@
+(${input$entity} instanceof TamableAnimal _tamIsTamedBy && ${input$tamedBy} instanceof LivingEntity _livEnt
+        ? _tamIsTamedBy.isOwnedBy(_livEnt):false)

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_look_face.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_look_face.java.ftl
@@ -1,0 +1,3 @@
+(${input$entity}.level.clip(new ClipContext(${input$entity}.getEyePosition(1f),${input$entity}.getEyePosition(1f)
+    .add(${input$entity}.getViewVector(1f).scale(${input$maxdistance})), ClipContext.Block.${field$block_mode},
+    ClipContext.Fluid.${field$fluid_mode}, ${input$entity})).getDirection())

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_looking_at_block.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_looking_at_block.java.ftl
@@ -1,0 +1,3 @@
+(${input$entity}.level.clip(new ClipContext(${input$entity}.getEyePosition(1f),${input$entity}.getEyePosition(1f)
+    .add(${input$entity}.getViewVector(1f).scale(${input$maxdistance})), ClipContext.Block.${field$block_mode},
+    ClipContext.Fluid.${field$fluid_mode}, ${input$entity})).getType() == HitResult.Type.BLOCK)

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_lookpos_x.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_lookpos_x.java.ftl
@@ -1,0 +1,3 @@
+/*@int*/(${input$entity}.level.clip(new ClipContext(${input$entity}.getEyePosition(1f),${input$entity}.getEyePosition(1f)
+    .add(${input$entity}.getViewVector(1f).scale(${input$maxdistance})), ClipContext.Block.${field$block_mode!"OUTLINE"},
+    ClipContext.Fluid.${field$fluid_mode!"NONE"}, ${input$entity})).getBlockPos().getX())

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_lookpos_y.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_lookpos_y.java.ftl
@@ -1,0 +1,3 @@
+/*@int*/(${input$entity}.level.clip(new ClipContext(${input$entity}.getEyePosition(1f),${input$entity}.getEyePosition(1f)
+    .add(${input$entity}.getViewVector(1f).scale(${input$maxdistance})), ClipContext.Block.${field$block_mode!"OUTLINE"},
+    ClipContext.Fluid.${field$fluid_mode!"NONE"}, ${input$entity})).getBlockPos().getY())

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_lookpos_z.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_lookpos_z.java.ftl
@@ -1,0 +1,3 @@
+/*@int*/(${input$entity}.level.clip(new ClipContext(${input$entity}.getEyePosition(1f),${input$entity}.getEyePosition(1f)
+    .add(${input$entity}.getViewVector(1f).scale(${input$maxdistance})), ClipContext.Block.${field$block_mode!"OUTLINE"},
+    ClipContext.Fluid.${field$fluid_mode!"NONE"}, ${input$entity})).getBlockPos().getZ())

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_makeride.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_makeride.java.ftl
@@ -1,0 +1,1 @@
+${input$sourceentity}.startRiding(${input$entity});

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_maketamed.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_maketamed.java.ftl
@@ -1,0 +1,1 @@
+if (${input$entity} instanceof TamableAnimal _toTame && ${input$sourceentity} instanceof Player _owner) _toTame.tame(_owner);

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_name.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_name.java.ftl
@@ -1,0 +1,1 @@
+(${input$entity}.getDisplayName().getString())

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_nbt_logic_get.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_nbt_logic_get.java.ftl
@@ -1,0 +1,1 @@
+(${input$entity}.getPersistentData().getBoolean(${input$tagName}))

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_nbt_logic_set.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_nbt_logic_set.java.ftl
@@ -1,0 +1,1 @@
+${input$entity}.getPersistentData().putBoolean(${input$tagName}, ${input$tagValue});

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_nbt_num_get.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_nbt_num_get.java.ftl
@@ -1,0 +1,1 @@
+(${input$entity}.getPersistentData().getDouble(${input$tagName}))

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_nbt_num_set.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_nbt_num_set.java.ftl
@@ -1,0 +1,1 @@
+${input$entity}.getPersistentData().putDouble(${input$tagName}, ${input$tagValue});

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_nbt_text_get.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_nbt_text_get.java.ftl
@@ -1,0 +1,1 @@
+(${input$entity}.getPersistentData().getString(${input$tagName}))

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_nbt_text_set.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_nbt_text_set.java.ftl
@@ -1,0 +1,1 @@
+${input$entity}.getPersistentData().putString(${input$tagName}, ${input$tagValue});


### PR DESCRIPTION
This PR ports more entity procedures to 1.18 (the code is the same as 1.17).
However, the NBT Tag blocks didn't seem to work with the trigger I used ("Before entity is hurt"), so I don't know if this is due to the trigger or if it's the code needing to be changed.