### PR TITLE
Help context classes structure overhaul

### DIFF
--- a/src/main/java/net/mcreator/ui/help/HelpContextWithEntry.java
+++ b/src/main/java/net/mcreator/ui/help/HelpContextWithEntry.java
@@ -21,18 +21,5 @@ package net.mcreator.ui.help;
 import javax.annotation.Nullable;
 import java.net.URI;
 
-public record HelpContextWithEntry(@Nullable String name, @Nullable URI contextURL, @Nullable String entry)
-		implements IHelpContext {
-
-	@Nullable @Override public String getContextName() {
-		return name;
-	}
-
-	@Nullable @Override public URI getContextURL() {
-		return contextURL;
-	}
-
-	@Nullable @Override public String getEntry() {
-		return entry;
-	}
-}
+public record HelpContextWithEntry(@Nullable String contextName, @Nullable URI contextURL, @Nullable String entry)
+		implements IHelpContext {}

--- a/src/main/java/net/mcreator/ui/help/HelpLoader.java
+++ b/src/main/java/net/mcreator/ui/help/HelpLoader.java
@@ -84,14 +84,14 @@ public class HelpLoader {
 	}
 
 	public static boolean hasFullHelp(IHelpContext helpContext) {
-		return helpContext != null && helpContext.getEntry() != null && getFromCache(helpContext.getEntry()) != null;
+		return helpContext != null && helpContext.entry() != null && getFromCache(helpContext.entry()) != null;
 	}
 
 	public static String loadHelpFor(IHelpContext helpContext) {
 		if (helpContext != null) {
 			URI uri = null;
 			try {
-				uri = helpContext.getContextURL();
+				uri = helpContext.contextURL();
 			} catch (URISyntaxException ignored) {
 			}
 
@@ -99,27 +99,29 @@ public class HelpLoader {
 					"<html><head><style>table{ border-collapse: collapse; border-spacing: 0; } "
 							+ "th { border: 1px solid #a0a0a0; } td { border: 1px solid #a0a0a0; } </style></head><body>");
 
-			if (helpContext.getEntry() != null) {
-				String helpText = getFromCache(helpContext.getEntry());
+			if (helpContext.entry() != null) {
+				String helpText = getFromCache(helpContext.entry());
 				if (helpText != null) {
-					if ((helpText.contains("${") || helpText.contains("<#"))
-							&& helpContext instanceof ModElementHelpContext meHelpContext) {
+					if (helpText.contains("${") || helpText.contains("<#")) {
 						try {
 							Map<String, Object> dataModel = new HashMap<>();
-							dataModel.put("data", meHelpContext.getModElementFromGUI());
-							dataModel.put("registryname",
-									meHelpContext.getModElementFromGUI().getModElement().getRegistryName());
-							dataModel.put("name", meHelpContext.getModElementFromGUI().getModElement().getName());
-							dataModel.put("elementtype",
-									meHelpContext.getModElementFromGUI().getModElement().getType().getReadableName());
 							dataModel.put("l10n", new L10N());
 
-							if (meHelpContext.getModElementFromGUI().getModElement().getGenerator() != null)
-								dataModel.putAll(meHelpContext.getModElementFromGUI().getModElement().getGenerator()
-										.getBaseDataModelProvider().provide());
+							if (helpContext instanceof ModElementHelpContext meHelpContext) {
+								dataModel.put("data", meHelpContext.getModElementFromGUI());
+								dataModel.put("registryname",
+										meHelpContext.getModElementFromGUI().getModElement().getRegistryName());
+								dataModel.put("name", meHelpContext.getModElementFromGUI().getModElement().getName());
+								dataModel.put("elementtype",
+										meHelpContext.getModElementFromGUI().getModElement().getType()
+												.getReadableName());
+								if (meHelpContext.getModElementFromGUI().getModElement().getGenerator() != null)
+									dataModel.putAll(meHelpContext.getModElementFromGUI().getModElement().getGenerator()
+											.getBaseDataModelProvider().provide());
+							}
 
-							Template freemarkerTemplate = new Template(helpContext.getEntry(),
-									new StringReader(helpText), configuration);
+							Template freemarkerTemplate = new Template(helpContext.entry(), new StringReader(helpText),
+									configuration);
 							StringWriter stringWriter = new StringWriter();
 							freemarkerTemplate.process(dataModel, stringWriter, configuration.getBeansWrapper());
 
@@ -131,16 +133,16 @@ public class HelpLoader {
 						helpString.append(renderer.render(parser.parse(helpText)));
 					}
 				} else {
-					helpString.append(L10N.t("help_loader.no_help_entry", helpContext.getEntry()));
+					helpString.append(L10N.t("help_loader.no_help_entry", helpContext.entry()));
 				}
 
-				if (uri != null && helpContext.getContextName() != null) {
-					helpString.append(L10N.t("help_loader.learn_about", uri.toString(), helpContext.getContextName()));
+				if (uri != null && helpContext.contextName() != null) {
+					helpString.append(L10N.t("help_loader.learn_about", uri.toString(), helpContext.contextName()));
 				}
 
 				return helpString.toString();
-			} else if (uri != null && helpContext.getContextName() != null) {
-				return L10N.t("help_loader.no_entry_learn_more", uri.toString(), helpContext.getContextName());
+			} else if (uri != null && helpContext.contextName() != null) {
+				return L10N.t("help_loader.no_entry_learn_more", uri.toString(), helpContext.contextName());
 			}
 		}
 

--- a/src/main/java/net/mcreator/ui/help/IHelpContext.java
+++ b/src/main/java/net/mcreator/ui/help/IHelpContext.java
@@ -25,30 +25,30 @@ import java.net.URISyntaxException;
 public interface IHelpContext {
 
 	IHelpContext NONE = new IHelpContext() {
-		@Override public @Nullable String getContextName() {
+		@Override public @Nullable String contextName() {
 			return null;
 		}
 
-		@Override public @Nullable URI getContextURL() {
+		@Override public @Nullable URI contextURL() {
 			return null;
 		}
 	};
 
 	default IHelpContext withEntry(String entry) {
 		try {
-			return new HelpContextWithEntry(this.getContextName(), this.getContextURL(), entry);
+			return new HelpContextWithEntry(this.contextName(), this.contextURL(), entry);
 		} catch (URISyntaxException e) {
-			return new HelpContextWithEntry(this.getContextName(), null, entry);
+			return new HelpContextWithEntry(this.contextName(), null, entry);
 		}
 	}
 
-	default String getEntry() {
+	default String entry() {
 		return null;
 	}
 
-	@Nullable String getContextName();
+	@Nullable String contextName();
 
-	@Nullable default URI getContextURL() throws URISyntaxException {
+	@Nullable default URI contextURL() throws URISyntaxException {
 		return null;
 	}
 

--- a/src/main/java/net/mcreator/ui/help/ModElementHelpContext.java
+++ b/src/main/java/net/mcreator/ui/help/ModElementHelpContext.java
@@ -25,20 +25,8 @@ import javax.annotation.Nullable;
 import java.net.URI;
 import java.util.function.Supplier;
 
-public record ModElementHelpContext(@Nullable String name, @Nullable URI contextURL, @Nullable String entry,
+public record ModElementHelpContext(@Nullable String contextName, @Nullable URI contextURL, @Nullable String entry,
 									Supplier<GeneratableElement> generatableElement) implements IHelpContext {
-
-	@Nullable @Override public String getContextName() {
-		return name;
-	}
-
-	@Nullable @Override public URI getContextURL() {
-		return contextURL;
-	}
-
-	@Nullable @Override public String getEntry() {
-		return entry;
-	}
 
 	public GeneratableElement getModElementFromGUI() {
 		return generatableElement.get();

--- a/src/main/java/net/mcreator/ui/modgui/AchievementGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/AchievementGUI.java
@@ -345,7 +345,7 @@ public class AchievementGUI extends ModElementGUI<Achievement> {
 		return achievement;
 	}
 
-	@Override public @Nullable URI getContextURL() throws URISyntaxException {
+	@Override public @Nullable URI contextURL() throws URISyntaxException {
 		return new URI(MCreatorApplication.SERVER_DOMAIN + "/wiki/how-make-achievement");
 	}
 

--- a/src/main/java/net/mcreator/ui/modgui/ArmorGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/ArmorGUI.java
@@ -935,7 +935,7 @@ public class ArmorGUI extends ModElementGUI<Armor> {
 		modElement.reinit();
 	}
 
-	@Override public @Nullable URI getContextURL() throws URISyntaxException {
+	@Override public @Nullable URI contextURL() throws URISyntaxException {
 		return new URI(MCreatorApplication.SERVER_DOMAIN + "/wiki/how-make-armor");
 	}
 

--- a/src/main/java/net/mcreator/ui/modgui/BiomeGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/BiomeGUI.java
@@ -799,7 +799,7 @@ public class BiomeGUI extends ModElementGUI<Biome> {
 		return biome;
 	}
 
-	@Override public @Nullable URI getContextURL() throws URISyntaxException {
+	@Override public @Nullable URI contextURL() throws URISyntaxException {
 		return new URI(MCreatorApplication.SERVER_DOMAIN + "/wiki/how-make-biome");
 	}
 

--- a/src/main/java/net/mcreator/ui/modgui/BlockGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/BlockGUI.java
@@ -1634,7 +1634,7 @@ public class BlockGUI extends ModElementGUI<Block> {
 		return block;
 	}
 
-	@Override public @Nullable URI getContextURL() throws URISyntaxException {
+	@Override public @Nullable URI contextURL() throws URISyntaxException {
 		return new URI(MCreatorApplication.SERVER_DOMAIN + "/wiki/how-make-block");
 	}
 

--- a/src/main/java/net/mcreator/ui/modgui/CommandGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/CommandGUI.java
@@ -131,7 +131,7 @@ public class CommandGUI extends ModElementGUI<Command> {
 		return command;
 	}
 
-	@Override public @Nullable URI getContextURL() throws URISyntaxException {
+	@Override public @Nullable URI contextURL() throws URISyntaxException {
 		return new URI(MCreatorApplication.SERVER_DOMAIN + "/wiki/making-command");
 	}
 

--- a/src/main/java/net/mcreator/ui/modgui/DimensionGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/DimensionGUI.java
@@ -428,7 +428,7 @@ public class DimensionGUI extends ModElementGUI<Dimension> {
 		modElement.reinit();
 	}
 
-	@Override public @Nullable URI getContextURL() throws URISyntaxException {
+	@Override public @Nullable URI contextURL() throws URISyntaxException {
 		return new URI(MCreatorApplication.SERVER_DOMAIN + "/wiki/how-make-dimension");
 	}
 

--- a/src/main/java/net/mcreator/ui/modgui/EnchantmentGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/EnchantmentGUI.java
@@ -208,7 +208,7 @@ public class EnchantmentGUI extends ModElementGUI<Enchantment> {
 		return enchantment;
 	}
 
-	@Override public @Nullable URI getContextURL() throws URISyntaxException {
+	@Override public @Nullable URI contextURL() throws URISyntaxException {
 		return new URI(MCreatorApplication.SERVER_DOMAIN + "/wiki/how-make-enchantment");
 	}
 

--- a/src/main/java/net/mcreator/ui/modgui/FluidGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/FluidGUI.java
@@ -596,7 +596,7 @@ public class FluidGUI extends ModElementGUI<Fluid> {
 		modElement.reinit();
 	}
 
-	@Override public @Nullable URI getContextURL() throws URISyntaxException {
+	@Override public @Nullable URI contextURL() throws URISyntaxException {
 		return new URI(MCreatorApplication.SERVER_DOMAIN + "/wiki/how-make-fluid");
 	}
 

--- a/src/main/java/net/mcreator/ui/modgui/FoodGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/FoodGUI.java
@@ -380,7 +380,7 @@ public class FoodGUI extends ModElementGUI<Food> {
 		return food;
 	}
 
-	@Override public @Nullable URI getContextURL() throws URISyntaxException {
+	@Override public @Nullable URI contextURL() throws URISyntaxException {
 		return new URI(MCreatorApplication.SERVER_DOMAIN + "/wiki/how-make-food");
 	}
 

--- a/src/main/java/net/mcreator/ui/modgui/FuelGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/FuelGUI.java
@@ -90,7 +90,7 @@ public class FuelGUI extends ModElementGUI<Fuel> {
 		return fuel;
 	}
 
-	@Override public @Nullable URI getContextURL() throws URISyntaxException {
+	@Override public @Nullable URI contextURL() throws URISyntaxException {
 		return new URI(MCreatorApplication.SERVER_DOMAIN + "/wiki/how-make-fuel");
 	}
 

--- a/src/main/java/net/mcreator/ui/modgui/FunctionGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/FunctionGUI.java
@@ -138,12 +138,12 @@ public class FunctionGUI extends ModElementGUI<Function> {
 		return function;
 	}
 
-	@Override public @Nullable URI getContextURL() throws URISyntaxException {
-		return new URI(MCreatorApplication.SERVER_DOMAIN + "/wiki/how-make-function");
-	}
-
 	@Override protected boolean allowCodePreview() {
 		return false;
+	}
+
+	@Override public @Nullable URI contextURL() throws URISyntaxException {
+		return new URI(MCreatorApplication.SERVER_DOMAIN + "/wiki/how-make-function");
 	}
 
 }

--- a/src/main/java/net/mcreator/ui/modgui/GameRuleGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/GameRuleGUI.java
@@ -182,7 +182,8 @@ public class GameRuleGUI extends ModElementGUI<GameRule> {
 		modElement.reinit();
 	}
 
-	@Override public @Nullable URI getContextURL() throws URISyntaxException {
+	@Override public @Nullable URI contextURL() throws URISyntaxException {
 		return new URI(MCreatorApplication.SERVER_DOMAIN + "/wiki/how-make-game-rule");
 	}
+
 }

--- a/src/main/java/net/mcreator/ui/modgui/ItemGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/ItemGUI.java
@@ -535,7 +535,7 @@ public class ItemGUI extends ModElementGUI<Item> {
 		return item;
 	}
 
-	@Override public @Nullable URI getContextURL() throws URISyntaxException {
+	@Override public @Nullable URI contextURL() throws URISyntaxException {
 		return new URI(MCreatorApplication.SERVER_DOMAIN + "/wiki/how-make-item");
 	}
 

--- a/src/main/java/net/mcreator/ui/modgui/LivingEntityGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/LivingEntityGUI.java
@@ -1113,7 +1113,7 @@ public class LivingEntityGUI extends ModElementGUI<LivingEntity> {
 		return livingEntity;
 	}
 
-	@Override public @Nullable URI getContextURL() throws URISyntaxException {
+	@Override public @Nullable URI contextURL() throws URISyntaxException {
 		return new URI(MCreatorApplication.SERVER_DOMAIN + "/wiki/how-make-mob");
 	}
 

--- a/src/main/java/net/mcreator/ui/modgui/LootTableGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/LootTableGUI.java
@@ -157,7 +157,7 @@ public class LootTableGUI extends ModElementGUI<LootTable> {
 		return loottable;
 	}
 
-	@Override public @Nullable URI getContextURL() throws URISyntaxException {
+	@Override public @Nullable URI contextURL() throws URISyntaxException {
 		return new URI(MCreatorApplication.SERVER_DOMAIN + "/wiki/how-make-loot-table");
 	}
 

--- a/src/main/java/net/mcreator/ui/modgui/ModElementGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/ModElementGUI.java
@@ -564,16 +564,16 @@ public abstract class ModElementGUI<GE extends GeneratableElement> extends ViewB
 		void modElementCreated(GE generatableElement);
 	}
 
-	@Override @Nullable public String getContextName() {
+	@Override @Nullable public String contextName() {
 		return modElement.getType().getReadableName();
 	}
 
 	@Override @Nullable public IHelpContext withEntry(String entry) {
 		try {
-			return new ModElementHelpContext(this.getContextName(), this.getContextURL(), entry,
+			return new ModElementHelpContext(this.contextName(), this.contextURL(), entry,
 					this::getElementFromGUI);
 		} catch (URISyntaxException e) {
-			return new ModElementHelpContext(this.getContextName(), null, entry, this::getElementFromGUI);
+			return new ModElementHelpContext(this.contextName(), null, entry, this::getElementFromGUI);
 		}
 	}
 

--- a/src/main/java/net/mcreator/ui/modgui/MusicDiscGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/MusicDiscGUI.java
@@ -260,7 +260,7 @@ public class MusicDiscGUI extends ModElementGUI<MusicDisc> {
 		return musicDisc;
 	}
 
-	@Override public @Nullable URI getContextURL() throws URISyntaxException {
+	@Override public @Nullable URI contextURL() throws URISyntaxException {
 		return new URI(MCreatorApplication.SERVER_DOMAIN + "/wiki/how-make-music-disc");
 	}
 

--- a/src/main/java/net/mcreator/ui/modgui/PaintingGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/PaintingGUI.java
@@ -133,7 +133,7 @@ public class PaintingGUI extends ModElementGUI<Painting> {
 		return painting;
 	}
 
-	@Override public @Nullable URI getContextURL() throws URISyntaxException {
+	@Override public @Nullable URI contextURL() throws URISyntaxException {
 		return new URI(MCreatorApplication.SERVER_DOMAIN + "/wiki/how-make-painting");
 	}
 

--- a/src/main/java/net/mcreator/ui/modgui/ParticleGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/ParticleGUI.java
@@ -232,7 +232,7 @@ public class ParticleGUI extends ModElementGUI<Particle> {
 		return particle;
 	}
 
-	@Override public @Nullable URI getContextURL() throws URISyntaxException {
+	@Override public @Nullable URI contextURL() throws URISyntaxException {
 		return new URI(MCreatorApplication.SERVER_DOMAIN + "/wiki/how-make-particle");
 	}
 

--- a/src/main/java/net/mcreator/ui/modgui/PlantGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/PlantGUI.java
@@ -985,7 +985,7 @@ public class PlantGUI extends ModElementGUI<Plant> {
 		return plant;
 	}
 
-	@Override public @Nullable URI getContextURL() throws URISyntaxException {
+	@Override public @Nullable URI contextURL() throws URISyntaxException {
 		return new URI(MCreatorApplication.SERVER_DOMAIN + "/wiki/how-make-plant");
 	}
 

--- a/src/main/java/net/mcreator/ui/modgui/PotionEffectGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/PotionEffectGUI.java
@@ -244,7 +244,7 @@ public class PotionEffectGUI extends ModElementGUI<PotionEffect> {
 		return potion;
 	}
 
-	@Override public @Nullable URI getContextURL() throws URISyntaxException {
+	@Override public @Nullable URI contextURL() throws URISyntaxException {
 		return new URI(MCreatorApplication.SERVER_DOMAIN + "/wiki/how-make-potion");
 	}
 

--- a/src/main/java/net/mcreator/ui/modgui/PotionGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/PotionGUI.java
@@ -162,7 +162,8 @@ public class PotionGUI extends ModElementGUI<Potion> {
 		return potion;
 	}
 
-	@Override public @Nullable URI getContextURL() throws URISyntaxException {
+	@Override public @Nullable URI contextURL() throws URISyntaxException {
 		return new URI(MCreatorApplication.SERVER_DOMAIN + "/wiki/how-make-potion");
 	}
+
 }

--- a/src/main/java/net/mcreator/ui/modgui/RangedItemGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/RangedItemGUI.java
@@ -536,7 +536,7 @@ public class RangedItemGUI extends ModElementGUI<RangedItem> {
 		return rangedItem;
 	}
 
-	@Override public @Nullable URI getContextURL() throws URISyntaxException {
+	@Override public @Nullable URI contextURL() throws URISyntaxException {
 		return new URI(MCreatorApplication.SERVER_DOMAIN + "/wiki/how-make-gun");
 	}
 

--- a/src/main/java/net/mcreator/ui/modgui/RecipeGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/RecipeGUI.java
@@ -379,7 +379,7 @@ public class RecipeGUI extends ModElementGUI<Recipe> {
 		return recipe;
 	}
 
-	@Override public @Nullable URI getContextURL() throws URISyntaxException {
+	@Override public @Nullable URI contextURL() throws URISyntaxException {
 		return new URI(MCreatorApplication.SERVER_DOMAIN + "/wiki/how-make-recipe");
 	}
 

--- a/src/main/java/net/mcreator/ui/modgui/StructureGenGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/StructureGenGUI.java
@@ -249,7 +249,7 @@ public class StructureGenGUI extends ModElementGUI<Structure> {
 		return structure;
 	}
 
-	@Override public @Nullable URI getContextURL() throws URISyntaxException {
+	@Override public @Nullable URI contextURL() throws URISyntaxException {
 		return new URI(MCreatorApplication.SERVER_DOMAIN + "/wiki/how-make-structure");
 	}
 

--- a/src/main/java/net/mcreator/ui/modgui/TabGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/TabGUI.java
@@ -127,7 +127,7 @@ public class TabGUI extends ModElementGUI<Tab> {
 		return tab;
 	}
 
-	@Override public @Nullable URI getContextURL() throws URISyntaxException {
+	@Override public @Nullable URI contextURL() throws URISyntaxException {
 		return new URI(MCreatorApplication.SERVER_DOMAIN + "/wiki/how-make-creative-inventory-tab");
 	}
 

--- a/src/main/java/net/mcreator/ui/modgui/TagGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/TagGUI.java
@@ -163,7 +163,7 @@ public class TagGUI extends ModElementGUI<Tag> {
 		return tag;
 	}
 
-	@Override public @Nullable URI getContextURL() throws URISyntaxException {
+	@Override public @Nullable URI contextURL() throws URISyntaxException {
 		return new URI(MCreatorApplication.SERVER_DOMAIN + "/wiki/how-make-tag");
 	}
 

--- a/src/main/java/net/mcreator/ui/modgui/ToolGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/ToolGUI.java
@@ -459,7 +459,8 @@ public class ToolGUI extends ModElementGUI<Tool> {
 		return tool;
 	}
 
-	@Override public @Nullable URI getContextURL() throws URISyntaxException {
+	@Override public @Nullable URI contextURL() throws URISyntaxException {
 		return new URI(MCreatorApplication.SERVER_DOMAIN + "/wiki/how-make-tool");
 	}
+
 }


### PR DESCRIPTION
This PR renames `IHelpContext` methods (so that both of its implementing classes (that are both records) implement those methods with their record components) and enables basic help tips (not from mod elements) to use translated strings (i. e. `L10N`).
This was originally suggested on https://github.com/MCreator/MCreator/pull/1676#pullrequestreview-741135819.