### PR TITLE
[1.17 & 1.18] Refactored global triggers

### DIFF
--- a/plugins/generator-1.17.1/forge-1.17.1/triggers/block_multiplace.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/triggers/block_multiplace.java.ftl
@@ -1,17 +1,16 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onBlockMultiPlace(BlockEvent.EntityMultiPlaceEvent event) {
-		Entity entity = event.getEntity();
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
 			"x": "event.getPos().getX()",
 			"y": "event.getPos().getY()",
 			"z": "event.getPos().getZ()",
-			"px": "entity.getX()",
-			"py": "entity.getY()",
-			"pz": "entity.getZ()",
+			"px": "event.getEntity().getX()",
+			"py": "event.getEntity().getY()",
+			"pz": "event.getEntity().getZ()",
 			"world": "event.getWorld()",
-			"entity": "entity",
+			"entity": "event.getEntity()",
 			"blockstate": "event.getState()",
 			"placedagainst": "event.getPlacedAgainst()",
 			"event": "event"

--- a/plugins/generator-1.17.1/forge-1.17.1/triggers/block_place.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/triggers/block_place.java.ftl
@@ -1,17 +1,16 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onBlockPlace(BlockEvent.EntityPlaceEvent event) {
-		Entity entity = event.getEntity();
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
 			"x": "event.getPos().getX()",
 			"y": "event.getPos().getY()",
 			"z": "event.getPos().getZ()",
-			"px": "entity.getX()",
-			"py": "entity.getY()",
-			"pz": "entity.getZ()",
+			"px": "event.getEntity().getX()",
+			"py": "event.getEntity().getY()",
+			"pz": "event.getEntity().getZ()",
 			"world": "event.getWorld()",
-			"entity": "entity",
+			"entity": "event.getEntity()",
 			"blockstate": "event.getState()",
 			"placedagainst": "event.getPlacedAgainst()",
 			"event": "event"

--- a/plugins/generator-1.17.1/forge-1.17.1/triggers/bonemeal_used.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/triggers/bonemeal_used.java.ftl
@@ -1,7 +1,6 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
-	@SubscribeEvent public static void onBonemeal(BonemealEvent event){
-		Player entity=event.getPlayer();
+	@SubscribeEvent public static void onBonemeal(BonemealEvent event) {
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
 			"x": "event.getPos().getX()",
@@ -9,7 +8,7 @@
 			"z": "event.getPos().getZ()",
 			"world": "event.getWorld()",
 			"itemstack": "event.getStack()",
-			"entity": "entity",
+			"entity": "event.getPlayer()",
 			"blockstate": "event.getBlock()",
 			"event": "event"
 			}/>

--- a/plugins/generator-1.17.1/forge-1.17.1/triggers/bucket_filled.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/triggers/bucket_filled.java.ftl
@@ -1,16 +1,15 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onBucketFill(FillBucketEvent event) {
-		Player entity=event.getPlayer();
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-			"x": "entity.getX()",
-			"y": "entity.getY()",
-			"z": "entity.getZ()",
+			"x": "event.getPlayer().getX()",
+			"y": "event.getPlayer().getY()",
+			"z": "event.getPlayer().getZ()",
 			"world": "event.getWorld()",
 			"itemstack": "event.getFilledBucket()",
 			"originalitemstack": "event.getEmptyBucket()",
-			"entity": "entity",
+			"entity": "event.getPlayer()",
 			"event": "event"
 			}/>
 		</#compress></#assign>

--- a/plugins/generator-1.17.1/forge-1.17.1/triggers/chat_sent.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/triggers/chat_sent.java.ftl
@@ -1,14 +1,13 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
-	@SubscribeEvent public static void onChat(ServerChatEvent event){
-		ServerPlayer entity=event.getPlayer();
+	@SubscribeEvent public static void onChat(ServerChatEvent event) {
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-			"x": "entity.getX()",
-			"y": "entity.getY()",
-			"z": "entity.getZ()",
-			"world": "entity.level",
-			"entity": "entity",
+			"x": "event.getPlayer().getX()",
+			"y": "event.getPlayer().getY()",
+			"z": "event.getPlayer().getZ()",
+			"world": "event.getPlayer().level",
+			"entity": "event.getPlayer()",
 			"text": "event.getMessage()",
 			"event": "event"
 			}/>

--- a/plugins/generator-1.17.1/forge-1.17.1/triggers/command_executed.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/triggers/command_executed.java.ftl
@@ -5,9 +5,9 @@
 		if (entity != null) {
 			<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-		    	"x": "entity.getX()",
-		    	"y": "entity.getY()",
-		    	"z": "entity.getZ()",
+				"x": "entity.getX()",
+				"y": "entity.getY()",
+				"z": "entity.getZ()",
 				"world": "entity.level",
 				"entity": "entity",
 				"command": "event.getParseResults().getReader().getString()",

--- a/plugins/generator-1.17.1/forge-1.17.1/triggers/entity_attacked.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/triggers/entity_attacked.java.ftl
@@ -2,15 +2,14 @@
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onEntityAttacked(LivingAttackEvent event) {
 		if (event!=null && event.getEntity()!=null) {
-			Entity entity=event.getEntity();
 			<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-		    	"x": "entity.getX()",
-		    	"y": "entity.getY()",
-		    	"z": "entity.getZ()",
+				"x": "event.getEntity().getX()",
+				"y": "event.getEntity().getY()",
+				"z": "event.getEntity().getZ()",
 				"amount": "event.getAmount()",
-				"world": "entity.level",
-				"entity": "entity",
+				"world": "event.getEntity().level",
+				"entity": "event.getEntity()",
 				"sourceentity": "event.getSource().getEntity()",
 				"imediatesourceentity": "event.getSource().getDirectEntity()",
 				"event": "event"

--- a/plugins/generator-1.17.1/forge-1.17.1/triggers/entity_dies.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/triggers/entity_dies.java.ftl
@@ -2,14 +2,13 @@
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onEntityDeath(LivingDeathEvent event) {
 		if (event!=null && event.getEntity()!=null) {
-			Entity entity=event.getEntity();
 			<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-		    	"x": "entity.getX()",
-		    	"y": "entity.getY()",
-		    	"z": "entity.getZ()",
-				"world": "entity.level",
-				"entity": "entity",
+				"x": "event.getEntity().getX()",
+				"y": "event.getEntity().getY()",
+				"z": "event.getEntity().getZ()",
+				"world": "event.getEntity().level",
+				"entity": "event.getEntity()",
 				"sourceentity": "event.getSource().getEntity()",
 				"event": "event"
 				}/>

--- a/plugins/generator-1.17.1/forge-1.17.1/triggers/entity_dropxp.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/triggers/entity_dropxp.java.ftl
@@ -2,17 +2,16 @@
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onLivingDropXp(LivingExperienceDropEvent event) {
 		if (event != null && event.getEntity() != null) {
-			Entity entity = event.getEntity();
 			<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-		    	"x": "entity.getX()",
-		    	"y": "entity.getY()",
-		    	"z": "entity.getZ()",
+				"x": "event.getEntity().getX()",
+				"y": "event.getEntity().getY()",
+				"z": "event.getEntity().getZ()",
 				"droppedexperience": "event.getDroppedExperience()",
 				"originalexperience": "event.getOriginalExperience()",
 				"sourceentity": "event.getAttackingPlayer()",
-				"world": "entity.level",
-				"entity": "entity",
+				"world": "event.getEntity().level",
+				"entity": "event.getEntity()",
 				"event": "event"
 				}/>
 			</#compress></#assign>

--- a/plugins/generator-1.17.1/forge-1.17.1/triggers/entity_falls.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/triggers/entity_falls.java.ftl
@@ -2,16 +2,15 @@
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onEntityFall(LivingFallEvent event) {
 		if (event != null && event.getEntity() != null) {
-			Entity entity = event.getEntity();
 			<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-		    	"x": "entity.getX()",
-		    	"y": "entity.getY()",
-		    	"z": "entity.getZ()",
+				"x": "event.getEntity().getX()",
+				"y": "event.getEntity().getY()",
+				"z": "event.getEntity().getZ()",
 				"damagemultiplier": "event.getDamageMultiplier()",
 				"distance": "event.getDistance()",
-				"world": "entity.level",
-				"entity": "entity",
+				"world": "event.getEntity().level",
+				"entity": "event.getEntity()",
 				"event": "event"
 				}/>
 			</#compress></#assign>

--- a/plugins/generator-1.17.1/forge-1.17.1/triggers/entity_grief.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/triggers/entity_grief.java.ftl
@@ -1,14 +1,13 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onEntityGrief(EntityMobGriefingEvent event) {
-		Entity entity=event.getEntity();
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-			"x": "entity.getX()",
-			"y": "entity.getY()",
-			"z": "entity.getZ()",
-			"world": "entity.level",
-			"entity": "entity",
+			"x": "event.getEntity().getX()",
+			"y": "event.getEntity().getY()",
+			"z": "event.getEntity().getZ()",
+			"world": "event.getEntity().level",
+			"entity": "event.getEntity()",
 			"event": "event"
 			}/>
 		</#compress></#assign>

--- a/plugins/generator-1.17.1/forge-1.17.1/triggers/entity_healed.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/triggers/entity_healed.java.ftl
@@ -1,15 +1,14 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onEntityHealed(LivingHealEvent event) {
-		Entity entity = event.getEntity();
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-			"x": "entity.getX()",
-			"y": "entity.getY()",
-			"z": "entity.getZ()",
+			"x": "event.getEntity().getX()",
+			"y": "event.getEntity().getY()",
+			"z": "event.getEntity().getZ()",
 			"amount": "event.getAmount()",
-			"world": "entity.level",
-			"entity": "entity",
+			"world": "event.getEntity().level",
+			"entity": "event.getEntity()",
 			"event": "event"
 			}/>
 		</#compress></#assign>

--- a/plugins/generator-1.17.1/forge-1.17.1/triggers/entity_item_pickup.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/triggers/entity_item_pickup.java.ftl
@@ -1,14 +1,13 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onPickup(EntityItemPickupEvent event) {
-	    Player entity = event.getPlayer();
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-			"x": "entity.getX()",
-			"y": "entity.getY()",
-			"z": "entity.getZ()",
-			"world": "entity.level",
-			"entity": "entity",
+			"x": "event.getPlayer().getX()",
+			"y": "event.getPlayer().getY()",
+			"z": "event.getPlayer().getZ()",
+			"world": "event.getPlayer().level",
+			"entity": "event.getPlayer()",
 			"itemstack": "event.getItem().getItem()",
 			"event": "event"
 			}/>

--- a/plugins/generator-1.17.1/forge-1.17.1/triggers/entity_joins_world.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/triggers/entity_joins_world.java.ftl
@@ -1,14 +1,13 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onEntityJoin(EntityJoinWorldEvent event) {
-		Entity entity=event.getEntity();
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-			"x": "entity.getX()",
-			"y": "entity.getY()",
-			"z": "entity.getZ()",
+			"x": "event.getEntity().getX()",
+			"y": "event.getEntity().getY()",
+			"z": "event.getEntity().getZ()",
 			"world": "event.getWorld()",
-			"entity": "entity",
+			"entity": "event.getEntity()",
 			"event": "event"
 			}/>
 		</#compress></#assign>

--- a/plugins/generator-1.17.1/forge-1.17.1/triggers/entity_jumps.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/triggers/entity_jumps.java.ftl
@@ -1,14 +1,13 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onEntityJump(LivingEvent.LivingJumpEvent event) {
-		LivingEntity entity=event.getEntityLiving();
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-			"x": "entity.getX()",
-			"y": "entity.getY()",
-			"z": "entity.getZ()",
-			"world": "entity.level",
-			"entity": "entity",
+			"x": "event.getEntityLiving().getX()",
+			"y": "event.getEntityLiving().getY()",
+			"z": "event.getEntityLiving().getZ()",
+			"world": "event.getEntityLiving().level",
+			"entity": "event.getEntityLiving()",
 			"event": "event"
 			}/>
 		</#compress></#assign>

--- a/plugins/generator-1.17.1/forge-1.17.1/triggers/entity_pickupxp.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/triggers/entity_pickupxp.java.ftl
@@ -2,14 +2,13 @@
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onPickupXP(PlayerXpEvent.PickupXp event) {
 		if (event != null && event.getEntity() != null) {
-			Entity entity = event.getEntity();
 			<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-            	"x": "entity.getX()",
-		    	"y": "entity.getY()",
-		    	"z": "entity.getZ()",
-		    	"world": "entity.level",
-				"entity": "entity",
+				"x": "event.getEntity().getX()",
+				"y": "event.getEntity().getY()",
+				"z": "event.getEntity().getZ()",
+				"world": "event.getEntity().level",
+				"entity": "event.getEntity()",
 				"event": "event"
 				}/>
 			</#compress></#assign>

--- a/plugins/generator-1.17.1/forge-1.17.1/triggers/entity_pre_hurt.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/triggers/entity_pre_hurt.java.ftl
@@ -2,15 +2,14 @@
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onEntityAttacked(LivingHurtEvent event) {
 		if (event != null && event.getEntity() != null) {
-			Entity entity = event.getEntity();
 			<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-		    	"x": "entity.getX()",
-		    	"y": "entity.getY()",
-		    	"z": "entity.getZ()",
-		    	"world": "entity.level",
+				"x": "event.getEntity().getX()",
+				"y": "event.getEntity().getY()",
+				"z": "event.getEntity().getZ()",
+				"world": "event.getEntity().level",
 				"amount": "event.getAmount()",
-				"entity": "entity",
+				"entity": "event.getEntity()",
 				"sourceentity": "event.getSource().getEntity()",
 				"event": "event"
 				}/>

--- a/plugins/generator-1.17.1/forge-1.17.1/triggers/entity_sets_attack_target.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/triggers/entity_sets_attack_target.java.ftl
@@ -1,15 +1,14 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onEntitySetsAttackTarget(LivingSetAttackTargetEvent event) {
-		LivingEntity sourceentity=event.getEntityLiving();
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-			"x": " sourceentity.getX()",
-			"y": " sourceentity.getY()",
-			"z": " sourceentity.getZ()",
-			"world": "sourceentity.level",
+			"x": "event.getEntityLiving().getX()",
+			"y": "event.getEntityLiving().getY()",
+			"z": "event.getEntityLiving().getZ()",
+			"world": "event.getEntityLiving().level",
 			"entity": "event.getTarget()",
-			"sourceentity": " sourceentity",
+			"sourceentity": "event.getEntityLiving()",
 			"event": "event"
 			}/>
 		</#compress></#assign>

--- a/plugins/generator-1.17.1/forge-1.17.1/triggers/entity_spawns.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/triggers/entity_spawns.java.ftl
@@ -1,14 +1,13 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onEntitySpawned(EntityJoinWorldEvent event) {
-		Entity entity=event.getEntity();
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-			"x": "entity.getX()",
-			"y": "entity.getY()",
-			"z": "entity.getZ()",
+			"x": "event.getEntity().getX()",
+			"y": "event.getEntity().getY()",
+			"z": "event.getEntity().getZ()",
 			"world": "event.getWorld()",
-			"entity": "entity",
+			"entity": "event.getEntity()",
 			"event": "event"
 			}/>
 		</#compress></#assign>

--- a/plugins/generator-1.17.1/forge-1.17.1/triggers/entity_struck_by_lightning.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/triggers/entity_struck_by_lightning.java.ftl
@@ -1,14 +1,13 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onEntityStruckByLightning(EntityStruckByLightningEvent event) {
-		Entity entity=event.getEntity();
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-			"x": "entity.getX()",
-			"y": "entity.getY()",
-			"z": "entity.getZ()",
-			"world": "entity.level",
-			"entity": "entity",
+			"x": "event.getEntity().getX()",
+			"y": "event.getEntity().getY()",
+			"z": "event.getEntity().getZ()",
+			"world": "event.getEntity().level",
+			"entity": "event.getEntity()",
 			"event": "event"
 			}/>
 		</#compress></#assign>

--- a/plugins/generator-1.17.1/forge-1.17.1/triggers/entity_tamed.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/triggers/entity_tamed.java.ftl
@@ -1,14 +1,13 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onEntityTamed(AnimalTameEvent event) {
-		Entity entity = event.getAnimal();
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-			"x": "entity.getX()",
-			"y": "entity.getY()",
-			"z": "entity.getZ()",
-			"world": "entity.level",
-			"entity": "entity",
+			"x": "event.getAnimal().getX()",
+			"y": "event.getAnimal().getY()",
+			"z": "event.getAnimal().getZ()",
+			"world": "event.getAnimal().level",
+			"entity": "event.getAnimal()",
 			"sourceentity": "event.getTamer()",
 			"event": "event"
 			}/>

--- a/plugins/generator-1.17.1/forge-1.17.1/triggers/entity_ticks.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/triggers/entity_ticks.java.ftl
@@ -1,14 +1,13 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
-	@SubscribeEvent public static void onEntityTick(LivingEvent.LivingUpdateEvent event){
-		Entity entity = event.getEntityLiving();
+	@SubscribeEvent public static void onEntityTick(LivingEvent.LivingUpdateEvent event) {
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-			"x": "entity.getX()",
-			"y": "entity.getY()",
-			"z": "entity.getZ()",
-			"world": "entity.level",
-			"entity": "entity",
+			"x": "event.getEntityLiving().getX()",
+			"y": "event.getEntityLiving().getY()",
+			"z": "event.getEntityLiving().getZ()",
+			"world": "event.getEntityLiving().level",
+			"entity": "event.getEntityLiving()",
 			"event": "event"
 			}/>
 		</#compress></#assign>

--- a/plugins/generator-1.17.1/forge-1.17.1/triggers/entity_travels_to_dimension.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/triggers/entity_travels_to_dimension.java.ftl
@@ -1,15 +1,14 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
-	@SubscribeEvent public static void onEntityTravelToDimension(EntityTravelToDimensionEvent event){
-		Entity entity=event.getEntity();
+	@SubscribeEvent public static void onEntityTravelToDimension(EntityTravelToDimensionEvent event) {
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-			"x": "entity.getX()",
-			"y": "entity.getY()",
-			"z": "entity.getZ()",
-			"world": "entity.level",
+			"x": "event.getEntity().getX()",
+			"y": "event.getEntity().getY()",
+			"z": "event.getEntity().getZ()",
+			"world": "event.getEntity().level",
 			"dimension": "event.getDimension()",
-			"entity": "entity",
+			"entity": "event.getEntity()",
 			"event": "event"
 			}/>
 		</#compress></#assign>

--- a/plugins/generator-1.17.1/forge-1.17.1/triggers/explosion_occurs.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/triggers/explosion_occurs.java.ftl
@@ -1,12 +1,11 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onExplode(ExplosionEvent.Detonate event) {
-		Explosion explosion = event.getExplosion();
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-			"x": "explosion.getPosition().x",
-			"y": "explosion.getPosition().y",
-			"z": "explosion.getPosition().z",
+			"x": "event.getExplosion().getPosition().x",
+			"y": "event.getExplosion().getPosition().y",
+			"z": "event.getExplosion().getPosition().z",
 			"world": "event.getWorld()",
 			"event": "event"
 			}/>

--- a/plugins/generator-1.17.1/forge-1.17.1/triggers/gem_dropped.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/triggers/gem_dropped.java.ftl
@@ -1,15 +1,14 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onGemDropped(ItemTossEvent event) {
-		Player entity=event.getPlayer();
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-			"x": "entity.getX()",
-			"y": "entity.getY()",
-			"z": "entity.getZ()",
-			"entity": "entity",
+			"x": "event.getPlayer().getX()",
+			"y": "event.getPlayer().getY()",
+			"z": "event.getPlayer().getZ()",
+			"world": "event.getPlayer().level",
+			"entity": "event.getPlayer()",
 			"itemstack": "event.getEntityItem().getItem()",
-			"world": "entity.level",
 			"event": "event"
 			}/>
 		</#compress></#assign>

--- a/plugins/generator-1.17.1/forge-1.17.1/triggers/gem_expired.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/triggers/gem_expired.java.ftl
@@ -1,16 +1,15 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onItemExpire(ItemExpireEvent event) {
-		Entity entity=event.getEntity();
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-			"x": "entity.getX()",
-			"y": "entity.getY()",
-			"z": "entity.getZ()",
-			"entity": "entity",
-			"world": "entity.level",
-			"event": "event",
-			"itemstack": "event.getEntityItem().getItem()"
+			"x": "event.getEntity().getX()",
+			"y": "event.getEntity().getY()",
+			"z": "event.getEntity().getZ()",
+			"world": "event.getEntity().level",
+			"entity": "event.getEntity()",
+			"itemstack": "event.getEntityItem().getItem()",
+			"event": "event"
 			}/>
 		</#compress></#assign>
 		execute(event<#if dependenciesCode?has_content>,</#if>${dependenciesCode});

--- a/plugins/generator-1.17.1/forge-1.17.1/triggers/item_crafted.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/triggers/item_crafted.java.ftl
@@ -1,13 +1,12 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure  {
 	@SubscribeEvent public static void onItemCrafted(PlayerEvent.ItemCraftedEvent event) {
-		Entity entity = event.getPlayer();
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-			"x": "entity.getX()",
-			"y": "entity.getY()",
-			"z": "entity.getZ()",
-			"world": "entity.level",
+			"x": "event.getPlayer().getX()",
+			"y": "event.getPlayer().getY()",
+			"z": "event.getPlayer().getZ()",
+			"world": "event.getPlayer().level",
 			"entity": "event.getPlayer()",
 			"itemstack": "event.getCrafting()",
 			"event": "event"

--- a/plugins/generator-1.17.1/forge-1.17.1/triggers/item_destroyed.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/triggers/item_destroyed.java.ftl
@@ -1,16 +1,15 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onItemDestroyed(PlayerDestroyItemEvent event) {
-		Entity entity=event.getPlayer();
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-			"x": "entity.getX()",
-			"y": "entity.getY()",
-			"z": "entity.getZ()",
-			"world": "entity.level",
-			"entity": "entity",
-			"event": "event",
-			"itemstack": "event.getOriginal()"
+			"x": "event.getPlayer().getX()",
+			"y": "event.getPlayer().getY()",
+			"z": "event.getPlayer().getZ()",
+			"world": "event.getPlayer().level",
+			"entity": "event.getPlayer()",
+			"itemstack": "event.getOriginal()",
+			"event": "event"
 			}/>
 		</#compress></#assign>
 		execute(event<#if dependenciesCode?has_content>,</#if>${dependenciesCode});

--- a/plugins/generator-1.17.1/forge-1.17.1/triggers/item_smelted.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/triggers/item_smelted.java.ftl
@@ -1,14 +1,13 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onItemSmelted(PlayerEvent.ItemSmeltedEvent event) {
-		Entity entity = event.getPlayer();
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-			"x": "entity.getX()",
-			"y": "entity.getY()",
-			"z": "entity.getZ()",
-			"world": "entity.level",
-			"entity": "entity",
+			"x": "event.getPlayer().getX()",
+			"y": "event.getPlayer().getY()",
+			"z": "event.getPlayer().getZ()",
+			"world": "event.getPlayer().level",
+			"entity": "event.getPlayer()",
 			"itemstack": "event.getSmelting()",
 			"event": "event"
 			}/>

--- a/plugins/generator-1.17.1/forge-1.17.1/triggers/player_completes_advancement.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/triggers/player_completes_advancement.java.ftl
@@ -1,14 +1,13 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onAdvancement(AdvancementEvent event) {
-		Player entity=event.getPlayer();
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-			"x": "entity.getX()",
-			"y": "entity.getY()",
-			"z": "entity.getZ()",
-			"world": "entity.level",
-			"entity": "entity",
+			"x": "event.getPlayer().getX()",
+			"y": "event.getPlayer().getY()",
+			"z": "event.getPlayer().getZ()",
+			"world": "event.getPlayer().level",
+			"entity": "event.getPlayer()",
 			"advancement": "event.getAdvancement()",
 			"event": "event"
 			}/>

--- a/plugins/generator-1.17.1/forge-1.17.1/triggers/player_critical_hit.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/triggers/player_critical_hit.java.ftl
@@ -1,15 +1,14 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onPlayerCriticalHit(CriticalHitEvent event) {
-		Player sourceentity=event.getPlayer();
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-			"x": " sourceentity.getX()",
-			"y": " sourceentity.getY()",
-			"z": " sourceentity.getZ()",
-			"world": " sourceentity.level",
+			"x": "event.getPlayer().getX()",
+			"y": "event.getPlayer().getY()",
+			"z": "event.getPlayer().getZ()",
+			"world": "event.getPlayer().level",
 			"entity": "event.getTarget()",
-			"sourceentity": " sourceentity",
+			"sourceentity": "event.getPlayer()",
 			"damagemodifier": "event.getDamageModifier()",
 			"isvanillacritical": "event.isVanillaCritical()",
 			"event": "event"

--- a/plugins/generator-1.17.1/forge-1.17.1/triggers/player_fishes_item.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/triggers/player_fishes_item.java.ftl
@@ -1,14 +1,13 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onPlayerFishItem(ItemFishedEvent event) {
-		Player entity=event.getPlayer();
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-			"x": "entity.getX()",
-			"y": "entity.getY()",
-			"z": "entity.getZ()",
-			"world": "entity.level",
-			"entity": "entity",
+			"x": "event.getPlayer().getX()",
+			"y": "event.getPlayer().getY()",
+			"z": "event.getPlayer().getZ()",
+			"world": "event.getPlayer().level",
+			"entity": "event.getPlayer()",
 			"event": "event"
 			}/>
 		</#compress></#assign>

--- a/plugins/generator-1.17.1/forge-1.17.1/triggers/player_left_click_block.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/triggers/player_left_click_block.java.ftl
@@ -1,8 +1,7 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onLeftClickBlock(PlayerInteractEvent.LeftClickBlock event) {
-		Player entity=event.getPlayer();
-		if (event.getHand() != entity.getUsedItemHand())
+		if (event.getHand() != event.getPlayer().getUsedItemHand())
 			return;
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
@@ -10,7 +9,7 @@
 			"y": "event.getPos().getY()",
 			"z": "event.getPos().getZ()",
 			"world": "event.getWorld()",
-			"entity": "entity",
+			"entity": "event.getPlayer()",
 			"direction": "event.getFace()",
 			"blockstate": "event.getWorld().getBlockState(event.getPos())",
 			"event": "event"

--- a/plugins/generator-1.17.1/forge-1.17.1/triggers/player_log_in.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/triggers/player_log_in.java.ftl
@@ -1,14 +1,13 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onPlayerLoggedIn(PlayerEvent.PlayerLoggedInEvent event) {
-		Entity entity = event.getPlayer();
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-			"x": "entity.getX()",
-			"y": "entity.getY()",
-			"z": "entity.getZ()",
-			"world": "entity.level",
-			"entity": "entity",
+			"x": "event.getPlayer().getX()",
+			"y": "event.getPlayer().getY()",
+			"z": "event.getPlayer().getZ()",
+			"world": "event.getPlayer().level",
+			"entity": "event.getPlayer()",
 			"event": "event"
 			}/>
 		</#compress></#assign>

--- a/plugins/generator-1.17.1/forge-1.17.1/triggers/player_log_out.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/triggers/player_log_out.java.ftl
@@ -1,14 +1,13 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onPlayerLoggedOut(PlayerEvent.PlayerLoggedOutEvent event) {
-		Entity entity = event.getPlayer();
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-			"x": "entity.getX()",
-			"y": "entity.getY()",
-			"z": "entity.getZ()",
-			"world": "entity.level",
-			"entity": "entity",
+			"x": "event.getPlayer().getX()",
+			"y": "event.getPlayer().getY()",
+			"z": "event.getPlayer().getZ()",
+			"world": "event.getPlayer().level",
+			"entity": "event.getPlayer()",
 			"event": "event"
 			}/>
 		</#compress></#assign>

--- a/plugins/generator-1.17.1/forge-1.17.1/triggers/player_respawn.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/triggers/player_respawn.java.ftl
@@ -1,14 +1,13 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onPlayerRespawned(PlayerEvent.PlayerRespawnEvent event) {
-		Entity entity = event.getPlayer();
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-			"x": "entity.getX()",
-			"y": "entity.getY()",
-			"z": "entity.getZ()",
-			"world": "entity.level",
-			"entity": "entity",
+			"x": "event.getPlayer().getX()",
+			"y": "event.getPlayer().getY()",
+			"z": "event.getPlayer().getZ()",
+			"world": "event.getPlayer().level",
+			"entity": "event.getPlayer()",
 			"endconquered": "event.isEndConquered()",
 			"event": "event"
 			}/>

--- a/plugins/generator-1.17.1/forge-1.17.1/triggers/player_right_click_block.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/triggers/player_right_click_block.java.ftl
@@ -1,8 +1,7 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onRightClickBlock(PlayerInteractEvent.RightClickBlock event) {
-		Player entity=event.getPlayer();
-		if (event.getHand() != entity.getUsedItemHand())
+		if (event.getHand() != event.getPlayer().getUsedItemHand())
 			return;
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
@@ -10,7 +9,7 @@
 			"y": "event.getPos().getY()",
 			"z": "event.getPos().getZ()",
 			"world": "event.getWorld()",
-			"entity": "entity",
+			"entity": "event.getPlayer()",
 			"direction": "event.getFace()",
 			"blockstate": "event.getWorld().getBlockState(event.getPos())",
 			"event": "event"

--- a/plugins/generator-1.17.1/forge-1.17.1/triggers/player_right_click_entity.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/triggers/player_right_click_entity.java.ftl
@@ -1,8 +1,7 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onRightClickEntity(PlayerInteractEvent.EntityInteract event) {
-		Player sourceentity=event.getPlayer();
-		if (event.getHand() != sourceentity.getUsedItemHand())
+		if (event.getHand() != event.getPlayer().getUsedItemHand())
 			return;
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
@@ -11,7 +10,7 @@
 			"z": "event.getPos().getZ()",
 			"world": "event.getWorld()",
 			"entity": "event.getTarget()",
-			"sourceentity": " sourceentity",
+			"sourceentity": "event.getPlayer()",
 			"event": "event"
 			}/>
 		</#compress></#assign>

--- a/plugins/generator-1.17.1/forge-1.17.1/triggers/player_right_click_item.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/triggers/player_right_click_item.java.ftl
@@ -1,8 +1,7 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onRightClickItem(PlayerInteractEvent.RightClickItem event) {
-		Player entity=event.getPlayer();
-		if (event.getHand() != entity.getUsedItemHand())
+		if (event.getHand() != event.getPlayer().getUsedItemHand())
 			return;
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
@@ -10,7 +9,7 @@
 			"y": "event.getPos().getY()",
 			"z": "event.getPos().getZ()",
 			"world": "event.getWorld()",
-			"entity": "entity",
+			"entity": "event.getPlayer()",
 			"event": "event"
 			}/>
 		</#compress></#assign>

--- a/plugins/generator-1.17.1/forge-1.17.1/triggers/player_ticks.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/triggers/player_ticks.java.ftl
@@ -1,15 +1,14 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onPlayerTick(TickEvent.PlayerTickEvent event) {
-		if(event.phase == TickEvent.Phase.END){
-			Entity entity = event.player;
+		if (event.phase == TickEvent.Phase.END) {
 			<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-		    	"x": "entity.getX()",
-		    	"y": "entity.getY()",
-		    	"z": "entity.getZ()",
-				"world": "entity.level",
-				"entity": "entity",
+				"x": "event.player.getX()",
+				"y": "event.player.getY()",
+				"z": "event.player.getZ()",
+				"world": "event.player.level",
+				"entity": "event.player",
 				"event": "event"
 				}/>
 			</#compress></#assign>

--- a/plugins/generator-1.17.1/forge-1.17.1/triggers/player_use_hoe.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/triggers/player_use_hoe.java.ftl
@@ -1,15 +1,14 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onUseHoe(UseHoeEvent event) {
-		Player entity=event.getPlayer();
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
 			"x": "event.getContext().getClickedPos().getX()",
 			"y": "event.getContext().getClickedPos().getY()",
 			"z": "event.getContext().getClickedPos().getZ()",
-			"world": "entity.level",
-			"entity": "entity",
-			"blockstate": "entity.level.getBlockState(event.getContext().getClickedPos())",
+			"world": "event.getPlayer().level",
+			"entity": "event.getPlayer()",
+			"blockstate": "event.getPlayer().level.getBlockState(event.getContext().getClickedPos())",
 			"event": "event"
 			}/>
 		</#compress></#assign>

--- a/plugins/generator-1.17.1/forge-1.17.1/triggers/player_useitem_finish.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/triggers/player_useitem_finish.java.ftl
@@ -1,17 +1,16 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
-	@SubscribeEvent public static void onUseItemStart(LivingEntityUseItemEvent.Finish event) {
+	@SubscribeEvent public static void onUseItemFinish(LivingEntityUseItemEvent.Finish event) {
 		if (event != null && event.getEntity() != null) {
-			Entity entity = event.getEntity();
 			<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-				"x": "entity.getX()",
-            	"y": "entity.getY()",
-            	"z": "entity.getZ()",
+				"x": "event.getEntity().getX()",
+				"y": "event.getEntity().getY()",
+				"z": "event.getEntity().getZ()",
 				"itemstack": "event.getItem()",
 				"duration": "event.getDuration()",
-				"world": "entity.level",
-				"entity": "entity",
+				"world": "event.getEntity().level",
+				"entity": "event.getEntity()",
 				"event": "event"
 				}/>
 			</#compress></#assign>

--- a/plugins/generator-1.17.1/forge-1.17.1/triggers/player_useitem_start.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/triggers/player_useitem_start.java.ftl
@@ -2,16 +2,15 @@
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onUseItemStart(LivingEntityUseItemEvent.Start event) {
 		if (event != null && event.getEntity() != null) {
-			Entity entity = event.getEntity();
 			<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-				"x": "entity.getX()",
-            	"y": "entity.getY()",
-            	"z": "entity.getZ()",
+				"x": "event.getEntity().getX()",
+				"y": "event.getEntity().getY()",
+				"z": "event.getEntity().getZ()",
 				"itemstack": "event.getItem()",
 				"duration": "event.getDuration()",
-				"world": "entity.level",
-				"entity": "entity",
+				"world": "event.getEntity().level",
+				"entity": "event.getEntity()",
 				"event": "event"
 				}/>
 			</#compress></#assign>

--- a/plugins/generator-1.17.1/forge-1.17.1/triggers/player_useitem_stop.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/triggers/player_useitem_stop.java.ftl
@@ -1,17 +1,16 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
-	@SubscribeEvent public static void onUseItemStart(LivingEntityUseItemEvent.Stop event) {
+	@SubscribeEvent public static void onUseItemStop(LivingEntityUseItemEvent.Stop event) {
 		if (event != null && event.getEntity() != null) {
-			Entity entity = event.getEntity();
 			<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-				"x": "entity.getX()",
-            	"y": "entity.getY()",
-            	"z": "entity.getZ()",
+				"x": "event.getEntity().getX()",
+				"y": "event.getEntity().getY()",
+				"z": "event.getEntity().getZ()",
 				"itemstack": "event.getItem()",
 				"duration": "event.getDuration()",
-				"world": "entity.level",
-				"entity": "entity",
+				"world": "event.getEntity().level",
+				"entity": "event.getEntity()",
 				"event": "event"
 				}/>
 			</#compress></#assign>

--- a/plugins/generator-1.17.1/forge-1.17.1/triggers/player_wakes_up.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/triggers/player_wakes_up.java.ftl
@@ -1,14 +1,13 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onEntityEndSleep(PlayerWakeUpEvent event) {
-		Entity entity=event.getEntity();
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-			"x": "entity.getX()",
-        	"y": "entity.getY()",
-        	"z": "entity.getZ()",
-			"world": "entity.level",
-			"entity": "entity",
+			"x": "event.getEntity().getX()",
+			"y": "event.getEntity().getY()",
+			"z": "event.getEntity().getZ()",
+			"world": "event.getEntity().level",
+			"entity": "event.getEntity()",
 			"event": "event"
 			}/>
 		</#compress></#assign>

--- a/plugins/generator-1.17.1/forge-1.17.1/triggers/player_xp_change.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/triggers/player_xp_change.java.ftl
@@ -2,14 +2,13 @@
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onPlayerXPChange(PlayerXpEvent.XpChange event) {
 		if (event != null && event.getEntity() != null) {
-			Entity entity = event.getEntity();
 			<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-				"x": "entity.getX()",
-            	"y": "entity.getY()",
-            	"z": "entity.getZ()",
-				"world": "entity.level",
-				"entity": "entity",
+				"x": "event.getEntity().getX()",
+				"y": "event.getEntity().getY()",
+				"z": "event.getEntity().getZ()",
+				"world": "event.getEntity().level",
+				"entity": "event.getEntity()",
 				"amount": "event.getAmount()",
 				"event": "event"
 				}/>

--- a/plugins/generator-1.17.1/forge-1.17.1/triggers/player_xp_level_change.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/triggers/player_xp_level_change.java.ftl
@@ -2,14 +2,13 @@
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onPlayerXPLevelChange(PlayerXpEvent.LevelChange event) {
 		if (event != null && event.getEntity() != null) {
-			Entity entity = event.getEntity();
 			<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-				"x": "entity.getX()",
-            	"y": "entity.getY()",
-            	"z": "entity.getZ()",
-				"world": "entity.level",
-				"entity": "entity",
+				"x": "event.getEntity().getX()",
+				"y": "event.getEntity().getY()",
+				"z": "event.getEntity().getZ()",
+				"world": "event.getEntity().level",
+				"entity": "event.getEntity()",
 				"amount": "event.getLevels()",
 				"event": "event"
 				}/>

--- a/plugins/generator-1.18.1/forge-1.18.1/triggers/block_multiplace.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/triggers/block_multiplace.java.ftl
@@ -1,17 +1,16 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onBlockMultiPlace(BlockEvent.EntityMultiPlaceEvent event) {
-		Entity entity = event.getEntity();
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
 			"x": "event.getPos().getX()",
 			"y": "event.getPos().getY()",
 			"z": "event.getPos().getZ()",
-			"px": "entity.getX()",
-			"py": "entity.getY()",
-			"pz": "entity.getZ()",
+			"px": "event.getEntity().getX()",
+			"py": "event.getEntity().getY()",
+			"pz": "event.getEntity().getZ()",
 			"world": "event.getWorld()",
-			"entity": "entity",
+			"entity": "event.getEntity()",
 			"blockstate": "event.getState()",
 			"placedagainst": "event.getPlacedAgainst()",
 			"event": "event"

--- a/plugins/generator-1.18.1/forge-1.18.1/triggers/block_place.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/triggers/block_place.java.ftl
@@ -1,17 +1,16 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onBlockPlace(BlockEvent.EntityPlaceEvent event) {
-		Entity entity = event.getEntity();
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
 			"x": "event.getPos().getX()",
 			"y": "event.getPos().getY()",
 			"z": "event.getPos().getZ()",
-			"px": "entity.getX()",
-			"py": "entity.getY()",
-			"pz": "entity.getZ()",
+			"px": "event.getEntity().getX()",
+			"py": "event.getEntity().getY()",
+			"pz": "event.getEntity().getZ()",
 			"world": "event.getWorld()",
-			"entity": "entity",
+			"entity": "event.getEntity()",
 			"blockstate": "event.getState()",
 			"placedagainst": "event.getPlacedAgainst()",
 			"event": "event"

--- a/plugins/generator-1.18.1/forge-1.18.1/triggers/bonemeal_used.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/triggers/bonemeal_used.java.ftl
@@ -1,7 +1,6 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
-	@SubscribeEvent public static void onBonemeal(BonemealEvent event){
-		Player entity=event.getPlayer();
+	@SubscribeEvent public static void onBonemeal(BonemealEvent event) {
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
 			"x": "event.getPos().getX()",
@@ -9,7 +8,7 @@
 			"z": "event.getPos().getZ()",
 			"world": "event.getWorld()",
 			"itemstack": "event.getStack()",
-			"entity": "entity",
+			"entity": "event.getPlayer()",
 			"blockstate": "event.getBlock()",
 			"event": "event"
 			}/>

--- a/plugins/generator-1.18.1/forge-1.18.1/triggers/bucket_filled.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/triggers/bucket_filled.java.ftl
@@ -1,16 +1,15 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onBucketFill(FillBucketEvent event) {
-		Player entity=event.getPlayer();
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-			"x": "entity.getX()",
-			"y": "entity.getY()",
-			"z": "entity.getZ()",
+			"x": "event.getPlayer().getX()",
+			"y": "event.getPlayer().getY()",
+			"z": "event.getPlayer().getZ()",
 			"world": "event.getWorld()",
 			"itemstack": "event.getFilledBucket()",
 			"originalitemstack": "event.getEmptyBucket()",
-			"entity": "entity",
+			"entity": "event.getPlayer()",
 			"event": "event"
 			}/>
 		</#compress></#assign>

--- a/plugins/generator-1.18.1/forge-1.18.1/triggers/chat_sent.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/triggers/chat_sent.java.ftl
@@ -1,14 +1,13 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
-	@SubscribeEvent public static void onChat(ServerChatEvent event){
-		ServerPlayer entity=event.getPlayer();
+	@SubscribeEvent public static void onChat(ServerChatEvent event) {
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-			"x": "entity.getX()",
-			"y": "entity.getY()",
-			"z": "entity.getZ()",
-			"world": "entity.level",
-			"entity": "entity",
+			"x": "event.getPlayer().getX()",
+			"y": "event.getPlayer().getY()",
+			"z": "event.getPlayer().getZ()",
+			"world": "event.getPlayer().level",
+			"entity": "event.getPlayer()",
 			"text": "event.getMessage()",
 			"event": "event"
 			}/>

--- a/plugins/generator-1.18.1/forge-1.18.1/triggers/command_executed.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/triggers/command_executed.java.ftl
@@ -5,9 +5,9 @@
 		if (entity != null) {
 			<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-		    	"x": "entity.getX()",
-		    	"y": "entity.getY()",
-		    	"z": "entity.getZ()",
+				"x": "entity.getX()",
+				"y": "entity.getY()",
+				"z": "entity.getZ()",
 				"world": "entity.level",
 				"entity": "entity",
 				"command": "event.getParseResults().getReader().getString()",

--- a/plugins/generator-1.18.1/forge-1.18.1/triggers/entity_attacked.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/triggers/entity_attacked.java.ftl
@@ -2,15 +2,14 @@
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onEntityAttacked(LivingAttackEvent event) {
 		if (event!=null && event.getEntity()!=null) {
-			Entity entity=event.getEntity();
 			<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-		    	"x": "entity.getX()",
-		    	"y": "entity.getY()",
-		    	"z": "entity.getZ()",
+				"x": "event.getEntity().getX()",
+				"y": "event.getEntity().getY()",
+				"z": "event.getEntity().getZ()",
 				"amount": "event.getAmount()",
-				"world": "entity.level",
-				"entity": "entity",
+				"world": "event.getEntity().level",
+				"entity": "event.getEntity()",
 				"sourceentity": "event.getSource().getEntity()",
 				"imediatesourceentity": "event.getSource().getDirectEntity()",
 				"event": "event"

--- a/plugins/generator-1.18.1/forge-1.18.1/triggers/entity_dies.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/triggers/entity_dies.java.ftl
@@ -2,14 +2,13 @@
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onEntityDeath(LivingDeathEvent event) {
 		if (event!=null && event.getEntity()!=null) {
-			Entity entity=event.getEntity();
 			<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-		    	"x": "entity.getX()",
-		    	"y": "entity.getY()",
-		    	"z": "entity.getZ()",
-				"world": "entity.level",
-				"entity": "entity",
+				"x": "event.getEntity().getX()",
+				"y": "event.getEntity().getY()",
+				"z": "event.getEntity().getZ()",
+				"world": "event.getEntity().level",
+				"entity": "event.getEntity()",
 				"sourceentity": "event.getSource().getEntity()",
 				"event": "event"
 				}/>

--- a/plugins/generator-1.18.1/forge-1.18.1/triggers/entity_dropxp.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/triggers/entity_dropxp.java.ftl
@@ -2,17 +2,16 @@
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onLivingDropXp(LivingExperienceDropEvent event) {
 		if (event != null && event.getEntity() != null) {
-			Entity entity = event.getEntity();
 			<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-		    	"x": "entity.getX()",
-		    	"y": "entity.getY()",
-		    	"z": "entity.getZ()",
+				"x": "event.getEntity().getX()",
+				"y": "event.getEntity().getY()",
+				"z": "event.getEntity().getZ()",
 				"droppedexperience": "event.getDroppedExperience()",
 				"originalexperience": "event.getOriginalExperience()",
 				"sourceentity": "event.getAttackingPlayer()",
-				"world": "entity.level",
-				"entity": "entity",
+				"world": "event.getEntity().level",
+				"entity": "event.getEntity()",
 				"event": "event"
 				}/>
 			</#compress></#assign>

--- a/plugins/generator-1.18.1/forge-1.18.1/triggers/entity_falls.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/triggers/entity_falls.java.ftl
@@ -2,16 +2,15 @@
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onEntityFall(LivingFallEvent event) {
 		if (event != null && event.getEntity() != null) {
-			Entity entity = event.getEntity();
 			<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-		    	"x": "entity.getX()",
-		    	"y": "entity.getY()",
-		    	"z": "entity.getZ()",
+				"x": "event.getEntity().getX()",
+				"y": "event.getEntity().getY()",
+				"z": "event.getEntity().getZ()",
 				"damagemultiplier": "event.getDamageMultiplier()",
 				"distance": "event.getDistance()",
-				"world": "entity.level",
-				"entity": "entity",
+				"world": "event.getEntity().level",
+				"entity": "event.getEntity()",
 				"event": "event"
 				}/>
 			</#compress></#assign>

--- a/plugins/generator-1.18.1/forge-1.18.1/triggers/entity_grief.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/triggers/entity_grief.java.ftl
@@ -1,14 +1,13 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onEntityGrief(EntityMobGriefingEvent event) {
-		Entity entity=event.getEntity();
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-			"x": "entity.getX()",
-			"y": "entity.getY()",
-			"z": "entity.getZ()",
-			"world": "entity.level",
-			"entity": "entity",
+			"x": "event.getEntity().getX()",
+			"y": "event.getEntity().getY()",
+			"z": "event.getEntity().getZ()",
+			"world": "event.getEntity().level",
+			"entity": "event.getEntity()",
 			"event": "event"
 			}/>
 		</#compress></#assign>

--- a/plugins/generator-1.18.1/forge-1.18.1/triggers/entity_healed.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/triggers/entity_healed.java.ftl
@@ -1,15 +1,14 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onEntityHealed(LivingHealEvent event) {
-		Entity entity = event.getEntity();
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-			"x": "entity.getX()",
-			"y": "entity.getY()",
-			"z": "entity.getZ()",
+			"x": "event.getEntity().getX()",
+			"y": "event.getEntity().getY()",
+			"z": "event.getEntity().getZ()",
 			"amount": "event.getAmount()",
-			"world": "entity.level",
-			"entity": "entity",
+			"world": "event.getEntity().level",
+			"entity": "event.getEntity()",
 			"event": "event"
 			}/>
 		</#compress></#assign>

--- a/plugins/generator-1.18.1/forge-1.18.1/triggers/entity_item_pickup.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/triggers/entity_item_pickup.java.ftl
@@ -1,14 +1,13 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onPickup(EntityItemPickupEvent event) {
-	    Player entity = event.getPlayer();
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-			"x": "entity.getX()",
-			"y": "entity.getY()",
-			"z": "entity.getZ()",
-			"world": "entity.level",
-			"entity": "entity",
+			"x": "event.getPlayer().getX()",
+			"y": "event.getPlayer().getY()",
+			"z": "event.getPlayer().getZ()",
+			"world": "event.getPlayer().level",
+			"entity": "event.getPlayer()",
 			"itemstack": "event.getItem().getItem()",
 			"event": "event"
 			}/>

--- a/plugins/generator-1.18.1/forge-1.18.1/triggers/entity_joins_world.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/triggers/entity_joins_world.java.ftl
@@ -1,14 +1,13 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onEntityJoin(EntityJoinWorldEvent event) {
-		Entity entity=event.getEntity();
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-			"x": "entity.getX()",
-			"y": "entity.getY()",
-			"z": "entity.getZ()",
+			"x": "event.getEntity().getX()",
+			"y": "event.getEntity().getY()",
+			"z": "event.getEntity().getZ()",
 			"world": "event.getWorld()",
-			"entity": "entity",
+			"entity": "event.getEntity()",
 			"event": "event"
 			}/>
 		</#compress></#assign>

--- a/plugins/generator-1.18.1/forge-1.18.1/triggers/entity_jumps.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/triggers/entity_jumps.java.ftl
@@ -1,14 +1,13 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onEntityJump(LivingEvent.LivingJumpEvent event) {
-		LivingEntity entity=event.getEntityLiving();
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-			"x": "entity.getX()",
-			"y": "entity.getY()",
-			"z": "entity.getZ()",
-			"world": "entity.level",
-			"entity": "entity",
+			"x": "event.getEntityLiving().getX()",
+			"y": "event.getEntityLiving().getY()",
+			"z": "event.getEntityLiving().getZ()",
+			"world": "event.getEntityLiving().level",
+			"entity": "event.getEntityLiving()",
 			"event": "event"
 			}/>
 		</#compress></#assign>

--- a/plugins/generator-1.18.1/forge-1.18.1/triggers/entity_pickupxp.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/triggers/entity_pickupxp.java.ftl
@@ -2,14 +2,13 @@
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onPickupXP(PlayerXpEvent.PickupXp event) {
 		if (event != null && event.getEntity() != null) {
-			Entity entity = event.getEntity();
 			<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-            	"x": "entity.getX()",
-		    	"y": "entity.getY()",
-		    	"z": "entity.getZ()",
-		    	"world": "entity.level",
-				"entity": "entity",
+				"x": "event.getEntity().getX()",
+				"y": "event.getEntity().getY()",
+				"z": "event.getEntity().getZ()",
+				"world": "event.getEntity().level",
+				"entity": "event.getEntity()",
 				"event": "event"
 				}/>
 			</#compress></#assign>

--- a/plugins/generator-1.18.1/forge-1.18.1/triggers/entity_pre_hurt.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/triggers/entity_pre_hurt.java.ftl
@@ -2,15 +2,14 @@
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onEntityAttacked(LivingHurtEvent event) {
 		if (event != null && event.getEntity() != null) {
-			Entity entity = event.getEntity();
 			<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-		    	"x": "entity.getX()",
-		    	"y": "entity.getY()",
-		    	"z": "entity.getZ()",
-		    	"world": "entity.level",
+				"x": "event.getEntity().getX()",
+				"y": "event.getEntity().getY()",
+				"z": "event.getEntity().getZ()",
+				"world": "event.getEntity().level",
 				"amount": "event.getAmount()",
-				"entity": "entity",
+				"entity": "event.getEntity()",
 				"sourceentity": "event.getSource().getEntity()",
 				"event": "event"
 				}/>

--- a/plugins/generator-1.18.1/forge-1.18.1/triggers/entity_sets_attack_target.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/triggers/entity_sets_attack_target.java.ftl
@@ -1,15 +1,14 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onEntitySetsAttackTarget(LivingSetAttackTargetEvent event) {
-		LivingEntity sourceentity=event.getEntityLiving();
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-			"x": " sourceentity.getX()",
-			"y": " sourceentity.getY()",
-			"z": " sourceentity.getZ()",
-			"world": "sourceentity.level",
+			"x": "event.getEntityLiving().getX()",
+			"y": "event.getEntityLiving().getY()",
+			"z": "event.getEntityLiving().getZ()",
+			"world": "event.getEntityLiving().level",
 			"entity": "event.getTarget()",
-			"sourceentity": " sourceentity",
+			"sourceentity": "event.getEntityLiving()",
 			"event": "event"
 			}/>
 		</#compress></#assign>

--- a/plugins/generator-1.18.1/forge-1.18.1/triggers/entity_spawns.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/triggers/entity_spawns.java.ftl
@@ -1,14 +1,13 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onEntitySpawned(EntityJoinWorldEvent event) {
-		Entity entity=event.getEntity();
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-			"x": "entity.getX()",
-			"y": "entity.getY()",
-			"z": "entity.getZ()",
+			"x": "event.getEntity().getX()",
+			"y": "event.getEntity().getY()",
+			"z": "event.getEntity().getZ()",
 			"world": "event.getWorld()",
-			"entity": "entity",
+			"entity": "event.getEntity()",
 			"event": "event"
 			}/>
 		</#compress></#assign>

--- a/plugins/generator-1.18.1/forge-1.18.1/triggers/entity_struck_by_lightning.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/triggers/entity_struck_by_lightning.java.ftl
@@ -1,14 +1,13 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onEntityStruckByLightning(EntityStruckByLightningEvent event) {
-		Entity entity=event.getEntity();
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-			"x": "entity.getX()",
-			"y": "entity.getY()",
-			"z": "entity.getZ()",
-			"world": "entity.level",
-			"entity": "entity",
+			"x": "event.getEntity().getX()",
+			"y": "event.getEntity().getY()",
+			"z": "event.getEntity().getZ()",
+			"world": "event.getEntity().level",
+			"entity": "event.getEntity()",
 			"event": "event"
 			}/>
 		</#compress></#assign>

--- a/plugins/generator-1.18.1/forge-1.18.1/triggers/entity_tamed.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/triggers/entity_tamed.java.ftl
@@ -1,14 +1,13 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onEntityTamed(AnimalTameEvent event) {
-		Entity entity = event.getAnimal();
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-			"x": "entity.getX()",
-			"y": "entity.getY()",
-			"z": "entity.getZ()",
-			"world": "entity.level",
-			"entity": "entity",
+			"x": "event.getAnimal().getX()",
+			"y": "event.getAnimal().getY()",
+			"z": "event.getAnimal().getZ()",
+			"world": "event.getAnimal().level",
+			"entity": "event.getAnimal()",
 			"sourceentity": "event.getTamer()",
 			"event": "event"
 			}/>

--- a/plugins/generator-1.18.1/forge-1.18.1/triggers/entity_ticks.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/triggers/entity_ticks.java.ftl
@@ -1,14 +1,13 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
-	@SubscribeEvent public static void onEntityTick(LivingEvent.LivingUpdateEvent event){
-		Entity entity = event.getEntityLiving();
+	@SubscribeEvent public static void onEntityTick(LivingEvent.LivingUpdateEvent event) {
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-			"x": "entity.getX()",
-			"y": "entity.getY()",
-			"z": "entity.getZ()",
-			"world": "entity.level",
-			"entity": "entity",
+			"x": "event.getEntityLiving().getX()",
+			"y": "event.getEntityLiving().getY()",
+			"z": "event.getEntityLiving().getZ()",
+			"world": "event.getEntityLiving().level",
+			"entity": "event.getEntityLiving()",
 			"event": "event"
 			}/>
 		</#compress></#assign>

--- a/plugins/generator-1.18.1/forge-1.18.1/triggers/entity_travels_to_dimension.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/triggers/entity_travels_to_dimension.java.ftl
@@ -1,15 +1,14 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
-	@SubscribeEvent public static void onEntityTravelToDimension(EntityTravelToDimensionEvent event){
-		Entity entity=event.getEntity();
+	@SubscribeEvent public static void onEntityTravelToDimension(EntityTravelToDimensionEvent event) {
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-			"x": "entity.getX()",
-			"y": "entity.getY()",
-			"z": "entity.getZ()",
-			"world": "entity.level",
+			"x": "event.getEntity().getX()",
+			"y": "event.getEntity().getY()",
+			"z": "event.getEntity().getZ()",
+			"world": "event.getEntity().level",
 			"dimension": "event.getDimension()",
-			"entity": "entity",
+			"entity": "event.getEntity()",
 			"event": "event"
 			}/>
 		</#compress></#assign>

--- a/plugins/generator-1.18.1/forge-1.18.1/triggers/explosion_occurs.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/triggers/explosion_occurs.java.ftl
@@ -1,12 +1,11 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onExplode(ExplosionEvent.Detonate event) {
-		Explosion explosion = event.getExplosion();
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-			"x": "explosion.getPosition().x",
-			"y": "explosion.getPosition().y",
-			"z": "explosion.getPosition().z",
+			"x": "event.getExplosion().getPosition().x",
+			"y": "event.getExplosion().getPosition().y",
+			"z": "event.getExplosion().getPosition().z",
 			"world": "event.getWorld()",
 			"event": "event"
 			}/>

--- a/plugins/generator-1.18.1/forge-1.18.1/triggers/gem_dropped.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/triggers/gem_dropped.java.ftl
@@ -1,15 +1,14 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onGemDropped(ItemTossEvent event) {
-		Player entity=event.getPlayer();
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-			"x": "entity.getX()",
-			"y": "entity.getY()",
-			"z": "entity.getZ()",
-			"entity": "entity",
+			"x": "event.getPlayer().getX()",
+			"y": "event.getPlayer().getY()",
+			"z": "event.getPlayer().getZ()",
+			"world": "event.getPlayer().level",
+			"entity": "event.getPlayer()",
 			"itemstack": "event.getEntityItem().getItem()",
-			"world": "entity.level",
 			"event": "event"
 			}/>
 		</#compress></#assign>

--- a/plugins/generator-1.18.1/forge-1.18.1/triggers/gem_expired.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/triggers/gem_expired.java.ftl
@@ -1,16 +1,15 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onItemExpire(ItemExpireEvent event) {
-		Entity entity=event.getEntity();
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-			"x": "entity.getX()",
-			"y": "entity.getY()",
-			"z": "entity.getZ()",
-			"entity": "entity",
-			"world": "entity.level",
-			"event": "event",
-			"itemstack": "event.getEntityItem().getItem()"
+			"x": "event.getEntity().getX()",
+			"y": "event.getEntity().getY()",
+			"z": "event.getEntity().getZ()",
+			"world": "event.getEntity().level",
+			"entity": "event.getEntity()",
+			"itemstack": "event.getEntityItem().getItem()",
+			"event": "event"
 			}/>
 		</#compress></#assign>
 		execute(event<#if dependenciesCode?has_content>,</#if>${dependenciesCode});

--- a/plugins/generator-1.18.1/forge-1.18.1/triggers/item_crafted.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/triggers/item_crafted.java.ftl
@@ -1,13 +1,12 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure  {
 	@SubscribeEvent public static void onItemCrafted(PlayerEvent.ItemCraftedEvent event) {
-		Entity entity = event.getPlayer();
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-			"x": "entity.getX()",
-			"y": "entity.getY()",
-			"z": "entity.getZ()",
-			"world": "entity.level",
+			"x": "event.getPlayer().getX()",
+			"y": "event.getPlayer().getY()",
+			"z": "event.getPlayer().getZ()",
+			"world": "event.getPlayer().level",
 			"entity": "event.getPlayer()",
 			"itemstack": "event.getCrafting()",
 			"event": "event"

--- a/plugins/generator-1.18.1/forge-1.18.1/triggers/item_destroyed.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/triggers/item_destroyed.java.ftl
@@ -1,16 +1,15 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onItemDestroyed(PlayerDestroyItemEvent event) {
-		Entity entity=event.getPlayer();
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-			"x": "entity.getX()",
-			"y": "entity.getY()",
-			"z": "entity.getZ()",
-			"world": "entity.level",
-			"entity": "entity",
-			"event": "event",
-			"itemstack": "event.getOriginal()"
+			"x": "event.getPlayer().getX()",
+			"y": "event.getPlayer().getY()",
+			"z": "event.getPlayer().getZ()",
+			"world": "event.getPlayer().level",
+			"entity": "event.getPlayer()",
+			"itemstack": "event.getOriginal()",
+			"event": "event"
 			}/>
 		</#compress></#assign>
 		execute(event<#if dependenciesCode?has_content>,</#if>${dependenciesCode});

--- a/plugins/generator-1.18.1/forge-1.18.1/triggers/item_smelted.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/triggers/item_smelted.java.ftl
@@ -1,14 +1,13 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onItemSmelted(PlayerEvent.ItemSmeltedEvent event) {
-		Entity entity = event.getPlayer();
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-			"x": "entity.getX()",
-			"y": "entity.getY()",
-			"z": "entity.getZ()",
-			"world": "entity.level",
-			"entity": "entity",
+			"x": "event.getPlayer().getX()",
+			"y": "event.getPlayer().getY()",
+			"z": "event.getPlayer().getZ()",
+			"world": "event.getPlayer().level",
+			"entity": "event.getPlayer()",
 			"itemstack": "event.getSmelting()",
 			"event": "event"
 			}/>

--- a/plugins/generator-1.18.1/forge-1.18.1/triggers/player_completes_advancement.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/triggers/player_completes_advancement.java.ftl
@@ -1,14 +1,13 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onAdvancement(AdvancementEvent event) {
-		Player entity=event.getPlayer();
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-			"x": "entity.getX()",
-			"y": "entity.getY()",
-			"z": "entity.getZ()",
-			"world": "entity.level",
-			"entity": "entity",
+			"x": "event.getPlayer().getX()",
+			"y": "event.getPlayer().getY()",
+			"z": "event.getPlayer().getZ()",
+			"world": "event.getPlayer().level",
+			"entity": "event.getPlayer()",
 			"advancement": "event.getAdvancement()",
 			"event": "event"
 			}/>

--- a/plugins/generator-1.18.1/forge-1.18.1/triggers/player_critical_hit.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/triggers/player_critical_hit.java.ftl
@@ -1,15 +1,14 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onPlayerCriticalHit(CriticalHitEvent event) {
-		Player sourceentity=event.getPlayer();
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-			"x": " sourceentity.getX()",
-			"y": " sourceentity.getY()",
-			"z": " sourceentity.getZ()",
-			"world": " sourceentity.level",
+			"x": "event.getPlayer().getX()",
+			"y": "event.getPlayer().getY()",
+			"z": "event.getPlayer().getZ()",
+			"world": "event.getPlayer().level",
 			"entity": "event.getTarget()",
-			"sourceentity": " sourceentity",
+			"sourceentity": "event.getPlayer()",
 			"damagemodifier": "event.getDamageModifier()",
 			"isvanillacritical": "event.isVanillaCritical()",
 			"event": "event"

--- a/plugins/generator-1.18.1/forge-1.18.1/triggers/player_fishes_item.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/triggers/player_fishes_item.java.ftl
@@ -1,14 +1,13 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onPlayerFishItem(ItemFishedEvent event) {
-		Player entity=event.getPlayer();
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-			"x": "entity.getX()",
-			"y": "entity.getY()",
-			"z": "entity.getZ()",
-			"world": "entity.level",
-			"entity": "entity",
+			"x": "event.getPlayer().getX()",
+			"y": "event.getPlayer().getY()",
+			"z": "event.getPlayer().getZ()",
+			"world": "event.getPlayer().level",
+			"entity": "event.getPlayer()",
 			"event": "event"
 			}/>
 		</#compress></#assign>

--- a/plugins/generator-1.18.1/forge-1.18.1/triggers/player_left_click_block.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/triggers/player_left_click_block.java.ftl
@@ -1,8 +1,7 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onLeftClickBlock(PlayerInteractEvent.LeftClickBlock event) {
-		Player entity=event.getPlayer();
-		if (event.getHand() != entity.getUsedItemHand())
+		if (event.getHand() != event.getPlayer().getUsedItemHand())
 			return;
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
@@ -10,7 +9,7 @@
 			"y": "event.getPos().getY()",
 			"z": "event.getPos().getZ()",
 			"world": "event.getWorld()",
-			"entity": "entity",
+			"entity": "event.getPlayer()",
 			"direction": "event.getFace()",
 			"blockstate": "event.getWorld().getBlockState(event.getPos())",
 			"event": "event"

--- a/plugins/generator-1.18.1/forge-1.18.1/triggers/player_log_in.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/triggers/player_log_in.java.ftl
@@ -1,14 +1,13 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onPlayerLoggedIn(PlayerEvent.PlayerLoggedInEvent event) {
-		Entity entity = event.getPlayer();
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-			"x": "entity.getX()",
-			"y": "entity.getY()",
-			"z": "entity.getZ()",
-			"world": "entity.level",
-			"entity": "entity",
+			"x": "event.getPlayer().getX()",
+			"y": "event.getPlayer().getY()",
+			"z": "event.getPlayer().getZ()",
+			"world": "event.getPlayer().level",
+			"entity": "event.getPlayer()",
 			"event": "event"
 			}/>
 		</#compress></#assign>

--- a/plugins/generator-1.18.1/forge-1.18.1/triggers/player_log_out.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/triggers/player_log_out.java.ftl
@@ -1,14 +1,13 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onPlayerLoggedOut(PlayerEvent.PlayerLoggedOutEvent event) {
-		Entity entity = event.getPlayer();
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-			"x": "entity.getX()",
-			"y": "entity.getY()",
-			"z": "entity.getZ()",
-			"world": "entity.level",
-			"entity": "entity",
+			"x": "event.getPlayer().getX()",
+			"y": "event.getPlayer().getY()",
+			"z": "event.getPlayer().getZ()",
+			"world": "event.getPlayer().level",
+			"entity": "event.getPlayer()",
 			"event": "event"
 			}/>
 		</#compress></#assign>

--- a/plugins/generator-1.18.1/forge-1.18.1/triggers/player_respawn.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/triggers/player_respawn.java.ftl
@@ -1,14 +1,13 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onPlayerRespawned(PlayerEvent.PlayerRespawnEvent event) {
-		Entity entity = event.getPlayer();
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-			"x": "entity.getX()",
-			"y": "entity.getY()",
-			"z": "entity.getZ()",
-			"world": "entity.level",
-			"entity": "entity",
+			"x": "event.getPlayer().getX()",
+			"y": "event.getPlayer().getY()",
+			"z": "event.getPlayer().getZ()",
+			"world": "event.getPlayer().level",
+			"entity": "event.getPlayer()",
 			"endconquered": "event.isEndConquered()",
 			"event": "event"
 			}/>

--- a/plugins/generator-1.18.1/forge-1.18.1/triggers/player_right_click_block.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/triggers/player_right_click_block.java.ftl
@@ -1,8 +1,7 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onRightClickBlock(PlayerInteractEvent.RightClickBlock event) {
-		Player entity=event.getPlayer();
-		if (event.getHand() != entity.getUsedItemHand())
+		if (event.getHand() != event.getPlayer().getUsedItemHand())
 			return;
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
@@ -10,7 +9,7 @@
 			"y": "event.getPos().getY()",
 			"z": "event.getPos().getZ()",
 			"world": "event.getWorld()",
-			"entity": "entity",
+			"entity": "event.getPlayer()",
 			"direction": "event.getFace()",
 			"blockstate": "event.getWorld().getBlockState(event.getPos())",
 			"event": "event"

--- a/plugins/generator-1.18.1/forge-1.18.1/triggers/player_right_click_entity.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/triggers/player_right_click_entity.java.ftl
@@ -1,8 +1,7 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onRightClickEntity(PlayerInteractEvent.EntityInteract event) {
-		Player sourceentity=event.getPlayer();
-		if (event.getHand() != sourceentity.getUsedItemHand())
+		if (event.getHand() != event.getPlayer().getUsedItemHand())
 			return;
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
@@ -11,7 +10,7 @@
 			"z": "event.getPos().getZ()",
 			"world": "event.getWorld()",
 			"entity": "event.getTarget()",
-			"sourceentity": " sourceentity",
+			"sourceentity": "event.getPlayer()",
 			"event": "event"
 			}/>
 		</#compress></#assign>

--- a/plugins/generator-1.18.1/forge-1.18.1/triggers/player_right_click_item.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/triggers/player_right_click_item.java.ftl
@@ -1,8 +1,7 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onRightClickItem(PlayerInteractEvent.RightClickItem event) {
-		Player entity=event.getPlayer();
-		if (event.getHand() != entity.getUsedItemHand())
+		if (event.getHand() != event.getPlayer().getUsedItemHand())
 			return;
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
@@ -10,7 +9,7 @@
 			"y": "event.getPos().getY()",
 			"z": "event.getPos().getZ()",
 			"world": "event.getWorld()",
-			"entity": "entity",
+			"entity": "event.getPlayer()",
 			"event": "event"
 			}/>
 		</#compress></#assign>

--- a/plugins/generator-1.18.1/forge-1.18.1/triggers/player_ticks.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/triggers/player_ticks.java.ftl
@@ -1,15 +1,14 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onPlayerTick(TickEvent.PlayerTickEvent event) {
-		if(event.phase == TickEvent.Phase.END){
-			Entity entity = event.player;
+		if (event.phase == TickEvent.Phase.END) {
 			<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-		    	"x": "entity.getX()",
-		    	"y": "entity.getY()",
-		    	"z": "entity.getZ()",
-				"world": "entity.level",
-				"entity": "entity",
+				"x": "event.player.getX()",
+				"y": "event.player.getY()",
+				"z": "event.player.getZ()",
+				"world": "event.player.level",
+				"entity": "event.player",
 				"event": "event"
 				}/>
 			</#compress></#assign>

--- a/plugins/generator-1.18.1/forge-1.18.1/triggers/player_use_hoe.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/triggers/player_use_hoe.java.ftl
@@ -1,15 +1,14 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onUseHoe(UseHoeEvent event) {
-		Player entity=event.getPlayer();
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
 			"x": "event.getContext().getClickedPos().getX()",
 			"y": "event.getContext().getClickedPos().getY()",
 			"z": "event.getContext().getClickedPos().getZ()",
-			"world": "entity.level",
-			"entity": "entity",
-			"blockstate": "entity.level.getBlockState(event.getContext().getClickedPos())",
+			"world": "event.getPlayer().level",
+			"entity": "event.getPlayer()",
+			"blockstate": "event.getPlayer().level.getBlockState(event.getContext().getClickedPos())",
 			"event": "event"
 			}/>
 		</#compress></#assign>

--- a/plugins/generator-1.18.1/forge-1.18.1/triggers/player_useitem_finish.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/triggers/player_useitem_finish.java.ftl
@@ -1,17 +1,16 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
-	@SubscribeEvent public static void onUseItemStart(LivingEntityUseItemEvent.Finish event) {
+	@SubscribeEvent public static void onUseItemFinish(LivingEntityUseItemEvent.Finish event) {
 		if (event != null && event.getEntity() != null) {
-			Entity entity = event.getEntity();
 			<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-				"x": "entity.getX()",
-            	"y": "entity.getY()",
-            	"z": "entity.getZ()",
+				"x": "event.getEntity().getX()",
+				"y": "event.getEntity().getY()",
+				"z": "event.getEntity().getZ()",
 				"itemstack": "event.getItem()",
 				"duration": "event.getDuration()",
-				"world": "entity.level",
-				"entity": "entity",
+				"world": "event.getEntity().level",
+				"entity": "event.getEntity()",
 				"event": "event"
 				}/>
 			</#compress></#assign>

--- a/plugins/generator-1.18.1/forge-1.18.1/triggers/player_useitem_start.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/triggers/player_useitem_start.java.ftl
@@ -2,16 +2,15 @@
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onUseItemStart(LivingEntityUseItemEvent.Start event) {
 		if (event != null && event.getEntity() != null) {
-			Entity entity = event.getEntity();
 			<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-				"x": "entity.getX()",
-            	"y": "entity.getY()",
-            	"z": "entity.getZ()",
+				"x": "event.getEntity().getX()",
+				"y": "event.getEntity().getY()",
+				"z": "event.getEntity().getZ()",
 				"itemstack": "event.getItem()",
 				"duration": "event.getDuration()",
-				"world": "entity.level",
-				"entity": "entity",
+				"world": "event.getEntity().level",
+				"entity": "event.getEntity()",
 				"event": "event"
 				}/>
 			</#compress></#assign>

--- a/plugins/generator-1.18.1/forge-1.18.1/triggers/player_useitem_stop.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/triggers/player_useitem_stop.java.ftl
@@ -1,17 +1,16 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
-	@SubscribeEvent public static void onUseItemStart(LivingEntityUseItemEvent.Stop event) {
+	@SubscribeEvent public static void onUseItemStop(LivingEntityUseItemEvent.Stop event) {
 		if (event != null && event.getEntity() != null) {
-			Entity entity = event.getEntity();
 			<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-				"x": "entity.getX()",
-            	"y": "entity.getY()",
-            	"z": "entity.getZ()",
+				"x": "event.getEntity().getX()",
+				"y": "event.getEntity().getY()",
+				"z": "event.getEntity().getZ()",
 				"itemstack": "event.getItem()",
 				"duration": "event.getDuration()",
-				"world": "entity.level",
-				"entity": "entity",
+				"world": "event.getEntity().level",
+				"entity": "event.getEntity()",
 				"event": "event"
 				}/>
 			</#compress></#assign>

--- a/plugins/generator-1.18.1/forge-1.18.1/triggers/player_wakes_up.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/triggers/player_wakes_up.java.ftl
@@ -1,14 +1,13 @@
 <#include "procedures.java.ftl">
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onEntityEndSleep(PlayerWakeUpEvent event) {
-		Entity entity=event.getEntity();
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-			"x": "entity.getX()",
-        	"y": "entity.getY()",
-        	"z": "entity.getZ()",
-			"world": "entity.level",
-			"entity": "entity",
+			"x": "event.getEntity().getX()",
+			"y": "event.getEntity().getY()",
+			"z": "event.getEntity().getZ()",
+			"world": "event.getEntity().level",
+			"entity": "event.getEntity()",
 			"event": "event"
 			}/>
 		</#compress></#assign>

--- a/plugins/generator-1.18.1/forge-1.18.1/triggers/player_xp_change.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/triggers/player_xp_change.java.ftl
@@ -2,14 +2,13 @@
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onPlayerXPChange(PlayerXpEvent.XpChange event) {
 		if (event != null && event.getEntity() != null) {
-			Entity entity = event.getEntity();
 			<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-				"x": "entity.getX()",
-            	"y": "entity.getY()",
-            	"z": "entity.getZ()",
-				"world": "entity.level",
-				"entity": "entity",
+				"x": "event.getEntity().getX()",
+				"y": "event.getEntity().getY()",
+				"z": "event.getEntity().getZ()",
+				"world": "event.getEntity().level",
+				"entity": "event.getEntity()",
 				"amount": "event.getAmount()",
 				"event": "event"
 				}/>

--- a/plugins/generator-1.18.1/forge-1.18.1/triggers/player_xp_level_change.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/triggers/player_xp_level_change.java.ftl
@@ -2,14 +2,13 @@
 @Mod.EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onPlayerXPLevelChange(PlayerXpEvent.LevelChange event) {
 		if (event != null && event.getEntity() != null) {
-			Entity entity = event.getEntity();
 			<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-				"x": "entity.getX()",
-            	"y": "entity.getY()",
-            	"z": "entity.getZ()",
-				"world": "entity.level",
-				"entity": "entity",
+				"x": "event.getEntity().getX()",
+				"y": "event.getEntity().getY()",
+				"z": "event.getEntity().getZ()",
+				"world": "event.getEntity().level",
+				"entity": "event.getEntity()",
 				"amount": "event.getLevels()",
 				"event": "event"
 				}/>


### PR DESCRIPTION
This PR inlines entity variables used by procedure dependencies and replaces some stacks of 4 spaces ("    ") with tabs ("	").
>I have checked and double checked

...and 1.18 changes appear to be the same as 1.17 changes, so you only need to review first 47/94 files.