### PR TITLE
[1.18] Ported spawning and block inventory procedure blocks

### DIFF
--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/block_inv_clear_slot.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/block_inv_clear_slot.java.ftl
@@ -1,0 +1,12 @@
+<#-- @formatter:off -->
+{
+	BlockEntity _ent = world.getBlockEntity(new BlockPos((int) ${input$x}, (int) ${input$y}, (int) ${input$z}));
+	if (_ent != null) {
+		final int _slotid = ${opt.toInt(input$slotid)};
+		_ent.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null).ifPresent(capability -> {
+			if (capability instanceof IItemHandlerModifiable)
+				((IItemHandlerModifiable) capability).setStackInSlot(_slotid, ItemStack.EMPTY);
+		});
+	}
+}
+<#-- @formatter:on -->

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/block_inv_damage_item.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/block_inv_damage_item.java.ftl
@@ -1,0 +1,19 @@
+<#-- @formatter:off -->
+{
+	BlockEntity _ent = world.getBlockEntity(new BlockPos((int) ${input$x}, (int) ${input$y}, (int) ${input$z}));
+	if (_ent != null) {
+		final int _slotid = ${opt.toInt(input$slotid)};
+		final int _amount = ${opt.toInt(input$amount)};
+		_ent.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null).ifPresent(capability -> {
+			if (capability instanceof IItemHandlerModifiable) {
+				ItemStack _stk = capability.getStackInSlot(_slotid).copy();
+				if (_stk.hurt(_amount, new Random(), null)) {
+    				_stk.shrink(1);
+    				_stk.setDamageValue(0);
+				}
+				((IItemHandlerModifiable) capability).setStackInSlot(_slotid, _stk);
+			}
+		});
+	}
+}
+<#-- @formatter:on -->

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/block_inv_get_amount_inslot.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/block_inv_get_amount_inslot.java.ftl
@@ -1,0 +1,12 @@
+<#-- @formatter:off -->
+/*@int*/(new Object() {
+	public int getAmount(LevelAccessor world, BlockPos pos, int slotid) {
+		AtomicInteger _retval = new AtomicInteger(0);
+		BlockEntity _ent = world.getBlockEntity(pos);
+		if (_ent != null)
+			_ent.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null)
+				.ifPresent(capability -> _retval.set(capability.getStackInSlot(slotid).getCount()));
+		return _retval.get();
+	}
+}.getAmount(world, new BlockPos((int) ${input$x}, (int) ${input$y}, (int) ${input$z}), ${opt.toInt(input$slotid)}))
+<#-- @formatter:on -->

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/block_inv_get_item_inslot.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/block_inv_get_item_inslot.java.ftl
@@ -1,0 +1,12 @@
+<#-- @formatter:off -->
+/*@ItemStack*/(new Object() {
+	public ItemStack getItemStack(LevelAccessor world, BlockPos pos, int slotid) {
+		AtomicReference<ItemStack> _retval = new AtomicReference<>(ItemStack.EMPTY);
+		BlockEntity _ent = world.getBlockEntity(pos);
+		if (_ent != null)
+			_ent.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null)
+				.ifPresent(capability -> _retval.set(capability.getStackInSlot(slotid).copy()));
+		return _retval.get();
+	}
+}.getItemStack(world, new BlockPos((int) ${input$x}, (int) ${input$y}, (int) ${input$z}), ${opt.toInt(input$slotid)}))
+<#-- @formatter:on -->

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/block_inv_remove_items.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/block_inv_remove_items.java.ftl
@@ -1,0 +1,16 @@
+<#-- @formatter:off -->
+{
+	BlockEntity _ent = world.getBlockEntity(new BlockPos((int) ${input$x}, (int) ${input$y}, (int) ${input$z}));
+	if (_ent != null) {
+		final int _slotid = ${opt.toInt(input$slotid)};
+		final int _amount = ${opt.toInt(input$amount)};
+		_ent.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null).ifPresent(capability -> {
+			if (capability instanceof IItemHandlerModifiable) {
+				ItemStack _stk = capability.getStackInSlot(_slotid).copy();
+				_stk.shrink(_amount);
+				((IItemHandlerModifiable) capability).setStackInSlot(_slotid, _stk);
+			}
+		});
+	}
+}
+<#-- @formatter:on -->

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/block_inv_set_items.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/block_inv_set_items.java.ftl
@@ -1,0 +1,15 @@
+<#include "mcitems.ftl">
+<#-- @formatter:off -->
+{
+	BlockEntity _ent = world.getBlockEntity(new BlockPos((int) ${input$x}, (int) ${input$y}, (int) ${input$z}));
+	if (_ent != null) {
+		final int _slotid = ${opt.toInt(input$slotid)};
+		final ItemStack _setstack = ${mappedMCItemToItemStackCode(input$item, 1)};
+		_setstack.setCount(${opt.toInt(input$amount)});
+		_ent.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null).ifPresent(capability -> {
+			if (capability instanceof IItemHandlerModifiable)
+				((IItemHandlerModifiable) capability).setStackInSlot(_slotid, _setstack);
+		});
+	}
+}
+<#-- @formatter:on -->

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/spawn_entity.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/spawn_entity.java.ftl
@@ -1,0 +1,16 @@
+<#assign entity = generator.map(field$entity, "entities", 1)!"null">
+<#if entity != "null">
+if (world instanceof ServerLevel _level) {
+	<#if !field$entity?starts_with("CUSTOM:")>
+	Entity entityToSpawn = new ${generator.map(field$entity, "entities", 0)}(${entity}, _level);
+	<#else>
+	Entity entityToSpawn = new ${entity}(${JavaModName}Entities.${generator.getRegistryNameForModElement(field$entity?replace("CUSTOM:", ""))?upper_case}, _level);
+	</#if>
+	entityToSpawn.moveTo(${input$x}, ${input$y}, ${input$z}, world.getRandom().nextFloat() * 360F, 0);
+
+	if (entityToSpawn instanceof Mob _mobToSpawn)
+		_mobToSpawn.finalizeSpawn(_level, world.getCurrentDifficultyAt(entityToSpawn.blockPosition()), MobSpawnType.MOB_SUMMONED, null, null);
+
+	world.addFreshEntity(entityToSpawn);
+}
+</#if>

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/spawn_entity_with_rotation.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/spawn_entity_with_rotation.java.ftl
@@ -1,0 +1,18 @@
+<#assign entity = generator.map(field$entity, "entities", 1)!"null">
+<#if entity != "null">
+if (world instanceof ServerLevel _level) {
+	<#if !field$entity?starts_with("CUSTOM:")>
+	Entity entityToSpawn = new ${generator.map(field$entity, "entities", 0)}(${entity}, _level);
+   	<#else>
+	Entity entityToSpawn = new ${entity}(${JavaModName}Entities.${generator.getRegistryNameForModElement(field$entity?replace("CUSTOM:", ""))?upper_case}, _level);
+   	</#if>
+	entityToSpawn.moveTo(${input$x}, ${input$y}, ${input$z}, ${opt.toFloat(input$yaw)}, ${opt.toFloat(input$pitch)});
+	entityToSpawn.setYBodyRot(${opt.toFloat(input$yaw)});
+	entityToSpawn.setYHeadRot(${opt.toFloat(input$yaw)});
+
+	if (entityToSpawn instanceof Mob _mobToSpawn)
+		_mobToSpawn.finalizeSpawn(_level, world.getCurrentDifficultyAt(entityToSpawn.blockPosition()), MobSpawnType.MOB_SUMMONED, null, null);
+
+	world.addFreshEntity(entityToSpawn);
+}
+</#if>

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/spawn_entity_with_rotation_velocity.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/spawn_entity_with_rotation_velocity.java.ftl
@@ -1,0 +1,19 @@
+<#assign entity = generator.map(field$entity, "entities", 1)!"null">
+<#if entity != "null">
+if (world instanceof ServerLevel _level) {
+	<#if !field$entity?starts_with("CUSTOM:")>
+	Entity entityToSpawn = new ${generator.map(field$entity, "entities", 0)}(${entity}, _level);
+   	<#else>
+	Entity entityToSpawn = new ${entity}(${JavaModName}Entities.${generator.getRegistryNameForModElement(field$entity?replace("CUSTOM:", ""))?upper_case}, _level);
+   	</#if>
+	entityToSpawn.moveTo(${input$x}, ${input$y}, ${input$z}, ${opt.toFloat(input$yaw)}, ${opt.toFloat(input$pitch)});
+	entityToSpawn.setYBodyRot(${opt.toFloat(input$yaw)});
+	entityToSpawn.setYHeadRot(${opt.toFloat(input$yaw)});
+	entityToSpawn.setDeltaMovement(${input$vx}, ${input$vy}, ${input$vz});
+
+	if (entityToSpawn instanceof Mob _mobToSpawn)
+		_mobToSpawn.finalizeSpawn(_level, world.getCurrentDifficultyAt(entityToSpawn.blockPosition()), MobSpawnType.MOB_SUMMONED, null, null);
+
+	world.addFreshEntity(entityToSpawn);
+}
+</#if>

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/spawn_gem.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/spawn_gem.java.ftl
@@ -1,0 +1,9 @@
+<#include "mcitems.ftl">
+if (world instanceof Level _level && !_level.isClientSide()) {
+	ItemEntity entityToSpawn = new ItemEntity(_level, ${input$x}, ${input$y}, ${input$z}, ${mappedMCItemToItemStackCode(input$block, 1)});
+	entityToSpawn.setPickUpDelay(${opt.toInt(input$pickUpDelay!10)});
+    <#if (field$despawn!true)?lower_case == "false">
+    entityToSpawn.setUnlimitedLifetime();
+    </#if>
+	_level.addFreshEntity(entityToSpawn);
+}

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/spawn_particle.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/spawn_particle.java.ftl
@@ -1,0 +1,1 @@
+world.addParticle(${generator.map(field$particle, "particles")}, ${input$x}, ${input$y}, ${input$z}, ${input$xs}, ${input$ys}, ${input$zs});

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/spawn_particle_multi.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/spawn_particle_multi.java.ftl
@@ -1,0 +1,2 @@
+if (world instanceof ServerLevel _level)
+	_level.sendParticles(${generator.map(field$particle, "particles")}, ${input$x}, ${input$y}, ${input$z}, ${opt.toInt(input$count)}, ${input$dx}, ${input$dy}, ${input$dz}, ${input$speed});

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/spawn_xporb.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/spawn_xporb.java.ftl
@@ -1,0 +1,2 @@
+if (world instanceof Level _level && !_level.isClientSide())
+	_level.addFreshEntity(new ExperienceOrb(_level, ${input$x}, ${input$y}, ${input$z}, ${opt.toInt(input$xpamount)}));


### PR DESCRIPTION
Ports the following procedure blocks to Forge 1.18:
* block_inv_clear_slot
* block_inv_damage_item
* block_inv_get_amount_inslot
* block_inv_get_item_inslot
* block_inv_remove_items
* block_inv_set_items
* spawn_entity
* spawn_entity_with_rotation
* spawn_entity_with_rotation_velocity
* spawn_gem
* spawn_particle
* spawn_particle_multi
* spawn_xporb