### PR TITLE
[1.18] Ported remaining entity data procedure blocks

### DIFF
--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_potioneffectlevel.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_potioneffectlevel.java.ftl
@@ -1,0 +1,2 @@
+/*@int*/(${input$entity} instanceof LivingEntity _livEnt && _livEnt.hasEffect(${generator.map(field$potion, "effects")}) ?
+    _livEnt.getEffect(${generator.map(field$potion, "effects")}).getAmplifier() : 0)

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_potioneffectremaining.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_potioneffectremaining.java.ftl
@@ -1,0 +1,2 @@
+/*@int*/(${input$entity} instanceof LivingEntity _livEnt && _livEnt.hasEffect(${generator.map(field$potion, "effects")}) ?
+    _livEnt.getEffect(${generator.map(field$potion, "effects")}).getDuration() : 0)

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_size_height.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_size_height.java.ftl
@@ -1,0 +1,1 @@
+/*@float*/(${input$entity}.getBbHeight())

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_size_width.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_size_width.java.ftl
@@ -1,0 +1,1 @@
+/*@float*/(${input$entity}.getBbWidth())

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_submerged_height.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_submerged_height.java.ftl
@@ -1,0 +1,9 @@
+(new Object() {
+    public double getSubmergedHeight(Entity _entity) {
+        for (net.minecraft.tags.Tag<Fluid> _fldtag : FluidTags.getStaticTags()) {
+            if (_entity.level.getFluidState(entity.blockPosition()).is(_fldtag))
+                return _entity.getFluidHeight(_fldtag);
+        }
+        return 0;
+    }
+}.getSubmergedHeight(${input$entity}))

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_xplevel.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_xplevel.java.ftl
@@ -1,0 +1,1 @@
+/*@int*/(${input$entity} instanceof Player _plr ? _plr.experienceLevel : 0)


### PR DESCRIPTION
Ports the following procedure blocks to Forge 1.18:
* entity_potioneffectlevel
* entity_potioneffectremaining
* entity_size_height
* entity_size_width
* entity_submerged_height
* entity_xplevel