### PR TITLE
[1.18] Ported remaining entity management procedure blocks

### DIFF
--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_set_offhand_item.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_set_offhand_item.java.ftl
@@ -3,5 +3,5 @@ if(${input$entity} instanceof LivingEntity _entity) {
 	ItemStack _setstack = ${mappedMCItemToItemStackCode(input$item, 1)};
 	_setstack.setCount(${opt.toInt(input$amount)});
 	_entity.setItemInHand(InteractionHand.OFF_HAND, _setstack);
-	if (_entity instanceof Player _player) _player.getInventory().setChanged();
+	if (_entity instanceof ServerPlayer _serverPlayer) _serverPlayer.getInventory().setChanged();
 }

--- a/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_set_offhand_item.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/procedures/entity_set_offhand_item.java.ftl
@@ -3,5 +3,5 @@ if(${input$entity} instanceof LivingEntity _entity) {
 	ItemStack _setstack = ${mappedMCItemToItemStackCode(input$item, 1)};
 	_setstack.setCount(${opt.toInt(input$amount)});
 	_entity.setItemInHand(InteractionHand.OFF_HAND, _setstack);
-	if (_entity instanceof ServerPlayer _serverPlayer) _serverPlayer.getInventory().setChanged();
+	if (_entity instanceof Player _player) _player.getInventory().setChanged();
 }

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_override_fall.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_override_fall.java.ftl
@@ -1,0 +1,1 @@
+${input$entity}.fallDistance = ${opt.toFloat(input$height)};

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_remove_item.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_remove_item.java.ftl
@@ -1,0 +1,6 @@
+<#include "mcitems.ftl">
+if (${input$entity} instanceof Player _player) {
+	ItemStack _stktoremove = ${mappedMCItemToItemStackCode(input$item, 1)};
+	_player.getInventory()
+		.clearOrCountMatchingItems(p -> _stktoremove.getItem() == p.getItem(), ${opt.toInt(input$amount)}, _player.inventoryMenu.getCraftSlots());
+}

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_remove_recipe.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_remove_recipe.java.ftl
@@ -1,0 +1,3 @@
+<#include "mcelements.ftl">
+if (${input$entity} instanceof ServerPlayer _serverPlayer)
+	_serverPlayer.server.getRecipeManager().byKey(${toResourceLocation(input$recipe)}).ifPresent(_rec -> _serverPlayer.resetRecipes(Collections.singleton(_rec)));

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_remove_specific_potion_effect.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_remove_specific_potion_effect.java.ftl
@@ -1,0 +1,1 @@
+if (${input$entity} instanceof LivingEntity _entity) _entity.removeEffect(${generator.map(field$potion, "effects")});

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_remove_xp.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_remove_xp.java.ftl
@@ -1,0 +1,1 @@
+if (${input$entity} instanceof Player _player) _player.giveExperiencePoints(-(${opt.toInt(input$amount)}));

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_remove_xp_level.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_remove_xp_level.java.ftl
@@ -1,0 +1,1 @@
+if (${input$entity} instanceof Player _player) _player.giveExperienceLevels(-(${opt.toInt(input$xpamount)}));

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_run_function.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_run_function.java.ftl
@@ -1,0 +1,9 @@
+<#include "mcelements.ftl">
+{
+	Entity _ent = ${input$entity};
+	if (!_ent.level.isClientSide() && _ent.getServer() != null) {
+		Optional<CommandFunction> _fopt = _ent.getServer().getFunctions().get(${toResourceLocation(input$function)});
+		if (_fopt.isPresent())
+			_ent.getServer().getFunctions().execute(_fopt.get(), _ent.createCommandSourceStack());
+	}
+}

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_send_chat.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_send_chat.java.ftl
@@ -1,0 +1,2 @@
+if (${input$entity} instanceof Player _player && !_player.level.isClientSide())
+	_player.displayClientMessage(new TextComponent(${input$text}), ${input$actbar});

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_set_armor_slot_item.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_set_armor_slot_item.java.ftl
@@ -1,0 +1,9 @@
+<#include "mcitems.ftl">
+<#include "mcelements.ftl">
+if (${input$entity} instanceof LivingEntity _entity) {
+	if (_entity instanceof Player _player)
+		_player.getInventory().armor.set(${opt.toInt(input$slotid)}, ${mappedMCItemToItemStackCode(input$item, 1)});
+	else
+		_entity.setItemSlot(${toArmorSlot(input$slotid)}, ${mappedMCItemToItemStackCode(input$item, 1)});
+	if (_entity instanceof ServerPlayer _serverPlayer) _serverPlayer.getInventory().setChanged();
+}

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_set_display_name.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_set_display_name.java.ftl
@@ -1,0 +1,1 @@
+${input$entity}.setCustomName(new TextComponent(${input$displayname}));

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_set_fire.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_set_fire.java.ftl
@@ -1,0 +1,1 @@
+${input$entity}.setSecondsOnFire(${opt.toInt(input$seconds)});

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_set_flying.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_set_flying.java.ftl
@@ -1,0 +1,4 @@
+if (${input$entity} instanceof Player _player) {
+    _player.getAbilities().flying = ${input$condition};
+    _player.onUpdateAbilities();
+}

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_set_foodlevel.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_set_foodlevel.java.ftl
@@ -1,0 +1,1 @@
+if (${input$entity} instanceof Player _player) _player.getFoodData().setFoodLevel(${opt.toInt(input$foodlevel)});

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_set_gamemode.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_set_gamemode.java.ftl
@@ -1,0 +1,1 @@
+if (${input$entity} instanceof ServerPlayer _player) _player.setGameMode(GameType.${generator.map(field$gamemode, "gamemodes")});

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_set_health.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_set_health.java.ftl
@@ -1,0 +1,1 @@
+if (${input$entity} instanceof LivingEntity _entity) _entity.setHealth(${opt.toFloat(input$health)});

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_set_mainhand_item.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_set_mainhand_item.java.ftl
@@ -1,0 +1,7 @@
+<#include "mcitems.ftl">
+if (${input$entity} instanceof LivingEntity _entity) {
+	ItemStack _setstack = ${mappedMCItemToItemStackCode(input$item, 1)};
+	_setstack.setCount(${opt.toInt(input$amount)});
+	_entity.setItemInHand(InteractionHand.MAIN_HAND, _setstack);
+	if (_entity instanceof Player _player) _player.getInventory().setChanged();
+}

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_set_movement.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_set_movement.java.ftl
@@ -1,0 +1,1 @@
+${input$entity}.setDeltaMovement(new Vec3(${input$vx}, ${input$vy}, ${input$vz}));

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_set_nogravity.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_set_nogravity.java.ftl
@@ -1,0 +1,1 @@
+${input$entity}.setNoGravity(${input$gravityValue});

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_set_offhand_item.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_set_offhand_item.java.ftl
@@ -1,0 +1,7 @@
+<#include "mcitems.ftl">
+if (${input$entity} instanceof LivingEntity _entity) {
+	ItemStack _setstack = ${mappedMCItemToItemStackCode(input$item, 1)};
+	_setstack.setCount(${opt.toInt(input$amount)});
+	_entity.setItemInHand(InteractionHand.OFF_HAND, _setstack);
+	if (_entity instanceof ServerPlayer _serverPlayer) _serverPlayer.getInventory().setChanged();
+}

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_set_offhand_item.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_set_offhand_item.java.ftl
@@ -3,5 +3,5 @@ if (${input$entity} instanceof LivingEntity _entity) {
 	ItemStack _setstack = ${mappedMCItemToItemStackCode(input$item, 1)};
 	_setstack.setCount(${opt.toInt(input$amount)});
 	_entity.setItemInHand(InteractionHand.OFF_HAND, _setstack);
-	if (_entity instanceof ServerPlayer _serverPlayer) _serverPlayer.getInventory().setChanged();
+	if (_entity instanceof Player _player) _player.getInventory().setChanged();
 }

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_set_oxygen.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_set_oxygen.java.ftl
@@ -1,0 +1,1 @@
+${input$entity}.setAirSupply(${opt.toInt(input$air)});

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_set_rotation.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_set_rotation.java.ftl
@@ -1,0 +1,13 @@
+{
+    Entity _ent = ${input$entity};
+    _ent.setYRot(${opt.toFloat(input$yaw)});
+    _ent.setXRot(${opt.toFloat(input$pitch)});
+    _ent.setYBodyRot(_ent.getYRot());
+    _ent.setYHeadRot(_ent.getYRot());
+    _ent.yRotO = _ent.getYRot();
+    _ent.xRotO = _ent.getXRot();
+    if (_ent instanceof LivingEntity _entity) {
+        _entity.yBodyRotO = _entity.getYRot();
+        _entity.yHeadRotO = _entity.getYRot();
+    }
+}

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_set_saturation.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_set_saturation.java.ftl
@@ -1,0 +1,1 @@
+if (${input$entity} instanceof Player _player) _player.getFoodData().setSaturation(${opt.toFloat(input$amount)});

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_set_scoreboard_score.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_set_scoreboard_score.java.ftl
@@ -1,0 +1,8 @@
+if (${input$entity} instanceof Player _player) {
+	Scoreboard _sc = _player.getScoreboard();
+	Objective _so = _sc.getObjective(${input$score});
+	if (_so == null)
+		_so = _sc.addObjective(${input$score}, ObjectiveCriteria.DUMMY, new TextComponent(${input$score}), ObjectiveCriteria.RenderType.INTEGER);
+	Score _scr = _sc.getOrCreatePlayerScore(_player.getScoreboardName(), _so);
+	_scr.setScore(${opt.toInt(input$value)});
+}

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_set_slot.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_set_slot.java.ftl
@@ -1,0 +1,10 @@
+<#include "mcitems.ftl">
+{
+	final int _slotid = ${opt.toInt(input$slotid)};
+	final ItemStack _setstack = ${mappedMCItemToItemStackCode(input$slotitem, 1)};
+	_setstack.setCount(${opt.toInt(input$amount)});
+	${input$entity}.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null).ifPresent(capability -> {
+		if (capability instanceof IItemHandlerModifiable _modHandler)
+            _modHandler.setStackInSlot(_slotid, _setstack);
+	});
+}

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_set_sneaking.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_set_sneaking.java.ftl
@@ -1,0 +1,1 @@
+${input$entity}.setShiftKeyDown(${input$boolean});

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_set_spawn.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_set_spawn.java.ftl
@@ -1,0 +1,3 @@
+if (${input$entity} instanceof ServerPlayer _serverPlayer)
+	_serverPlayer.setRespawnPosition(_serverPlayer.level.dimension(),
+		new BlockPos((int) ${input$x}, (int) ${input$y}, (int) ${input$z}), _serverPlayer.getYRot(), true, false);

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_set_sprinting.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_set_sprinting.java.ftl
@@ -1,0 +1,1 @@
+${input$entity}.setSprinting(${input$boolean});

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_setinweb.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_setinweb.java.ftl
@@ -1,0 +1,1 @@
+${input$entity}.makeStuckInBlock(Blocks.AIR.defaultBlockState(), new Vec3(0.25, 0.05, 0.25));

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_swing_mainhand.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_swing_mainhand.java.ftl
@@ -1,0 +1,1 @@
+if (${input$entity} instanceof LivingEntity _entity) _entity.swing(InteractionHand.MAIN_HAND, true);

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_swing_offhand.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_swing_offhand.java.ftl
@@ -1,0 +1,1 @@
+if (${input$entity} instanceof LivingEntity _entity) _entity.swing(InteractionHand.OFF_HAND, true);

--- a/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_switch_dimension.java.ftl
+++ b/plugins/generator-1.18.1/forge-1.18.1/procedures/entity_switch_dimension.java.ftl
@@ -1,0 +1,25 @@
+<#if field$dimension??><#--Here for legacy reasons as field$dimension does not exist in older workspaces-->
+if (${input$entity} instanceof ServerPlayer _player && !_player.level.isClientSide()) {
+	<#if field$dimension=="Surface">
+		ResourceKey<Level> destinationType = Level.OVERWORLD;
+	<#elseif field$dimension=="Nether">
+		ResourceKey<Level> destinationType = Level.NETHER;
+	<#elseif field$dimension=="End">
+		ResourceKey<Level> destinationType = Level.END;
+	<#else>
+		ResourceKey<Level> destinationType = ResourceKey.create(Registry.DIMENSION_REGISTRY,
+			new ResourceLocation("${generator.getResourceLocationForModElement(field$dimension.replace("CUSTOM:", ""))}"));
+	</#if>
+	if (_player.level.dimension() == destinationType) return;
+
+	ServerLevel nextLevel = _player.server.getLevel(destinationType);
+	if (nextLevel != null) {
+		_player.connection.send(new ClientboundGameEventPacket(ClientboundGameEventPacket.WIN_GAME, 0));
+		_player.teleportTo(nextLevel, nextLevel.getSharedSpawnPos().getX(), nextLevel.getSharedSpawnPos().getY() + 1, nextLevel.getSharedSpawnPos().getZ(), _player.getYRot(), _player.getXRot());
+		_player.connection.send(new ClientboundPlayerAbilitiesPacket(_player.getAbilities()));
+		for (MobEffectInstance _effectinstance : _player.getActiveEffects())
+			_player.connection.send(new ClientboundUpdateMobEffectPacket(_player.getId(), _effectinstance));
+		_player.connection.send(new ClientboundLevelEventPacket(1032, BlockPos.ZERO, 0, false));
+	}
+}
+</#if>


### PR DESCRIPTION
Ports the following procedure blocks to Forge 1.18:
* entity_override_fall
* entity_remove_item
* entity_remove_recipe
* entity_remove_specific_potion_effect
* entity_remove_xp
* entity_remove_xp_level
* entity_run_function
* entity_send_chat
* entity_set_armor_slot_item
* entity_set_display_name
* entity_set_fire
* entity_set_flying
* entity_set_foodlevel
* entity_set_gamemode
* entity_set_health
* entity_set_mainhand_item
* entity_set_movement
* entity_set_nogravity
* entity_set_offhand_item
* entity_set_oxygen
* entity_set_rotation
* entity_set_saturation
* entity_set_scoreboard_score
* entity_set_slot
* entity_set_sneaking
* entity_set_spawn
* entity_set_sprinting
* entity_setinweb
* entity_swing_mainhand
* entity_swing_offhand
* entity_switch_dimension