### PR TITLE
New biome categories

### DIFF
--- a/plugins/generator-1.16.5/forge-1.16.5/templates/biome.java.ftl
+++ b/plugins/generator-1.16.5/forge-1.16.5/templates/biome.java.ftl
@@ -362,7 +362,7 @@ import java.util.HashMap;
 
 				biome = new Biome.Builder()
 						.precipitation(Biome.RainType.<#if (data.rainingPossibility > 0)><#if (data.temperature > 0.15)>RAIN<#else>SNOW</#if><#else>NONE</#if>)
-						.category(Biome.Category.${data.biomeCategory})
+						.category(Biome.Category.${data.biomeCategory?replace("UNDERGROUND", "NONE")?replace("MOUNTAIN", "NONE")})
 						.depth(${data.baseHeight}f)
 						.scale(${data.heightVariation}f)
 						.temperature(${data.temperature}f)

--- a/plugins/generator-1.17.1/forge-1.17.1/templates/biome/biome.java.ftl
+++ b/plugins/generator-1.17.1/forge-1.17.1/templates/biome/biome.java.ftl
@@ -373,7 +373,7 @@ public class ${name}Biome {
 
         return new Biome.BiomeBuilder()
             .precipitation(Biome.Precipitation.<#if (data.rainingPossibility > 0)><#if (data.temperature > 0.15)>RAIN<#else>SNOW</#if><#else>NONE</#if>)
-            .biomeCategory(Biome.BiomeCategory.${data.biomeCategory})
+            .biomeCategory(Biome.BiomeCategory.${data.biomeCategory?replace("MOUNTAIN", "NONE")})
             .depth(${data.baseHeight}f)
             .scale(${data.heightVariation}f)
             .temperature(${data.temperature}f)

--- a/plugins/generator-datapack-1.16.x/datapack-1.16.x/templates/biome/biome.json.ftl
+++ b/plugins/generator-datapack-1.16.x/datapack-1.16.x/templates/biome/biome.json.ftl
@@ -5,7 +5,7 @@
     "precipitation": <#if (data.rainingPossibility > 0)><#if (data.temperature > 0.15)>"rain"<#else>"snow"</#if><#else>"none"</#if>,
     "temperature": ${data.temperature},
     "downfall": ${data.rainingPossibility},
-    "category": "${data.biomeCategory?replace("THEEND", "THE_END")?lower_case}",
+    "category": "${data.biomeCategory?replace("THEEND", "THE_END")?replace("UNDERGROUND", "NONE")?replace("MOUNTAIN", "NONE")?lower_case}",
 	"surface_builder": "${modid}:${registryname}",
 	"spawn_costs": {},
     "player_spawn_friendly": true,

--- a/plugins/generator-datapack-1.17.x/datapack-1.17.x/templates/biome/biome.json.ftl
+++ b/plugins/generator-datapack-1.17.x/datapack-1.17.x/templates/biome/biome.json.ftl
@@ -5,7 +5,7 @@
     "precipitation": <#if (data.rainingPossibility > 0)><#if (data.temperature > 0.15)>"rain"<#else>"snow"</#if><#else>"none"</#if>,
     "temperature": ${data.temperature},
     "downfall": ${data.rainingPossibility},
-    "category": "${data.biomeCategory?replace("THEEND", "THE_END")?lower_case}",
+    "category": "${data.biomeCategory?replace("THEEND", "THE_END")?replace("MOUNTAIN", "NONE")?lower_case}",
 	"surface_builder": "${modid}:${registryname}",
 	"spawn_costs": {},
     "player_spawn_friendly": true,

--- a/src/main/java/net/mcreator/ui/modgui/BiomeGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/BiomeGUI.java
@@ -130,7 +130,8 @@ public class BiomeGUI extends ModElementGUI<Biome> {
 
 	private final JComboBox<String> biomeCategory = new JComboBox<>(
 			new String[] { "NONE", "TAIGA", "EXTREME_HILLS", "JUNGLE", "MESA", "PLAINS", "SAVANNA", "ICY", "THEEND",
-					"BEACH", "FOREST", "OCEAN", "DESERT", "RIVER", "SWAMP", "MUSHROOM", "NETHER" });
+					"BEACH", "FOREST", "OCEAN", "DESERT", "RIVER", "SWAMP", "MUSHROOM", "NETHER", "UNDERGROUND",
+					"MOUNTAIN" });
 
 	private final JComboBox<String> vanillaTreeType = new JComboBox<>(
 			new String[] { "Default", "Big trees", "Birch trees", "Savanna trees", "Mega pine trees",


### PR DESCRIPTION
This PR adds UNDERGROUND and MOUNTAIN biome category types. First was introduced in MC 1.17.1, second - in MC 1.18.1, so in 1.16.x generators these categories get reset to NONE.
The only purpose of changing 1.17.1 generator files is to prevent failing tests in cases MOUNTAIN biome category was selected.