### PR TITLE
Added support for localizing Blockly toolbox category descriptions

### DIFF
--- a/src/main/java/net/mcreator/blockly/data/ExternalBlockLoader.java
+++ b/src/main/java/net/mcreator/blockly/data/ExternalBlockLoader.java
@@ -120,9 +120,8 @@ public class ExternalBlockLoader {
 
 		// setup lookup cache of loaded blocks
 		this.toolboxBlocks = new HashMap<>();
-		for (ToolboxBlock toolboxBlock : toolboxBlocksList) {
+		for (ToolboxBlock toolboxBlock : toolboxBlocksList)
 			toolboxBlocks.put(toolboxBlock.machine_name, toolboxBlock);
-		}
 
 		// generate JSON for loaded blocks
 		JsonArray blocksJSON = new JsonArray();
@@ -181,8 +180,8 @@ public class ExternalBlockLoader {
 			StringBuilder categoryBuilder = new StringBuilder();
 			categoryBuilder.append("<category name=\"").append(category.getName()).append("\" colour=\"")
 					.append(category.color).append("\">");
-			if (category.description != null) {
-				categoryBuilder.append("<label text=\"").append(category.description)
+			if (category.getDescription() != null) {
+				categoryBuilder.append("<label text=\"").append(category.getDescription())
 						.append("\" web-class=\"whlab\"/>");
 			}
 			for (ToolboxBlock toolboxBlock : toolboxBlocksList) {
@@ -201,9 +200,8 @@ public class ExternalBlockLoader {
 			}
 			categoryBuilder.append("</category>");
 
-			if (categoryBuilder.toString().contains("<block type=")) {
+			if (categoryBuilder.toString().contains("<block type="))
 				toolbox.get(category.api ? "apis" : "other").add(new Tuple<>(null, categoryBuilder.toString()));
-			}
 		}
 	}
 

--- a/src/main/java/net/mcreator/blockly/data/ToolboxCategory.java
+++ b/src/main/java/net/mcreator/blockly/data/ToolboxCategory.java
@@ -28,17 +28,23 @@ import java.awt.*;
 public class ToolboxCategory {
 	private static final Logger LOG = LogManager.getLogger("Toolbox category");
 
-	String id, name, description;
-
-	String color;
+	String id, name, description, color;
 	boolean api;
 
 	public String getName() {
-		String l10nname = L10N.t("blockly.category." + id);
-		if (l10nname != null)
-			return l10nname;
+		String localized_name = L10N.t("blockly.category." + id);
+		if (localized_name != null)
+			return localized_name;
 
 		return name;
+	}
+
+	public String getDescription() {
+		String localized_desc = L10N.t("blockly.category." + id + ".description");
+		if (localized_desc != null)
+			return localized_desc;
+
+		return description;
 	}
 
 	/**
@@ -55,7 +61,7 @@ public class ToolboxCategory {
 				return Color.decode(color);
 		} catch (Exception e) {
 			LOG.warn("The color for toolbox category " + getName()
-					+ " isn't formatted correctly. Using color black for it");
+					+ " isn't formatted correctly. Using black color for it");
 			return Color.BLACK;
 		}
 	}

--- a/src/main/java/net/mcreator/ui/init/L10N.java
+++ b/src/main/java/net/mcreator/ui/init/L10N.java
@@ -135,7 +135,7 @@ public class L10N {
 
 		if (rb.containsKey(key))
 			return MessageFormat.format(rb.getString(key), parameters);
-		else if (key.startsWith("blockly.") && key.endsWith(".tooltip"))
+		else if (key.startsWith("blockly.") && (key.endsWith(".tooltip") || key.endsWith(".description")))
 			return null;
 		else if (isTestingEnvironment)
 			throw new RuntimeException("Failed to load any translation for key: " + key);
@@ -151,7 +151,7 @@ public class L10N {
 
 		if (rb_en.containsKey(key))
 			return MessageFormat.format(rb_en.getString(key), parameters);
-		else if (key.startsWith("blockly.") && key.endsWith(".tooltip"))
+		else if (key.startsWith("blockly.") && (key.endsWith(".tooltip") || key.endsWith(".description")))
 			return null;
 		else if (isTestingEnvironment)
 			throw new RuntimeException("Failed to load any translation for key: " + key);


### PR DESCRIPTION
Addresses one of changes from #549, which enables toolbox categories in Blockly to have translated descriptions.