### PR TITLE
Added support for local entity variable type

### DIFF
--- a/plugins/generator-1.16.5/forge-1.16.5/variables/entity.yaml
+++ b/plugins/generator-1.16.5/forge-1.16.5/variables/entity.yaml
@@ -1,0 +1,6 @@
+defaultvalue: null
+scopes:
+  local:
+    init: ${var.getType().getJavaType(generator.getWorkspace())} ${var.getName()} = ${var.getType().getDefaultValue(generator.getWorkspace())};
+    get: ${name}
+    set: ${name} = ${opt.removeParentheses(value)};

--- a/plugins/generator-1.17.1/forge-1.17.1/variables/entity.yaml
+++ b/plugins/generator-1.17.1/forge-1.17.1/variables/entity.yaml
@@ -1,0 +1,6 @@
+defaultvalue: null
+scopes:
+  local:
+    init: ${var.getType().getJavaType(generator.getWorkspace())} ${var.getName()} = ${var.getType().getDefaultValue(generator.getWorkspace())};
+    get: ${name}
+    set: ${name} = ${opt.removeParentheses(value)};

--- a/plugins/generator-1.18.1/forge-1.18.1/variables/entity.yaml
+++ b/plugins/generator-1.18.1/forge-1.18.1/variables/entity.yaml
@@ -1,0 +1,6 @@
+defaultvalue: null
+scopes:
+  local:
+    init: ${var.getType().getJavaType(generator.getWorkspace())} ${var.getName()} = ${var.getType().getDefaultValue(generator.getWorkspace())};
+    get: ${name}
+    set: ${name} = ${opt.removeParentheses(value)};

--- a/plugins/mcreator-core/variables/actionresulttype.json
+++ b/plugins/mcreator-core/variables/actionresulttype.json
@@ -1,5 +1,5 @@
 {
   "color": 90,
   "blocklyVariableType": "ActionResultType",
-  "returnTypeOnly": true
+  "ignoredByCoverage": true
 }

--- a/plugins/mcreator-core/variables/entity.json
+++ b/plugins/mcreator-core/variables/entity.json
@@ -1,0 +1,6 @@
+{
+	"color": 195,
+	"blocklyVariableType": "Entity",
+	"nullable": true,
+	"ignoredByCoverage": true
+}

--- a/src/main/java/net/mcreator/generator/GeneratorStats.java
+++ b/src/main/java/net/mcreator/generator/GeneratorStats.java
@@ -130,7 +130,8 @@ public class GeneratorStats {
 			baseCoverageInfo.put("variables",
 					generatorConfiguration.getVariableTypes().getSupportedVariableTypes().size()
 							== VariableTypeLoader.INSTANCE.getAllVariableTypes().stream()
-							.filter(e -> !e.isReturnTypeOnly()).count() ? CoverageStatus.FULL : CoverageStatus.PARTIAL);
+							.filter(e -> !e.isIgnoredByCoverage()).count() ?
+							CoverageStatus.FULL : CoverageStatus.PARTIAL);
 		}
 
 		if (generatorConfiguration.getJavaModelsKey().equals("legacy")) {

--- a/src/main/java/net/mcreator/ui/blockly/BlocklyJavascriptTemplates.java
+++ b/src/main/java/net/mcreator/ui/blockly/BlocklyJavascriptTemplates.java
@@ -66,6 +66,35 @@ public class BlocklyJavascriptTemplates {
 					variableType.getBlocklyVariableType(), variableType.getColor());
 	}
 
+	// Same as the normal "Get variable" block, but with the NULL icon at the beginning
+	public static String nullableGetVariableBlock(VariableType variableType) {
+		return """
+			Blockly.defineBlocksWithJsonArray([{
+				"type": "variables_get_%s",
+				"message0": "%%2 %s %%1",
+				"args0": [
+					{
+						"type": "input_dummy",
+						"name": "var"
+					},
+					{
+						"type": "field_image",
+						"src": "./res/null.png",
+						"width": 8,
+						"height": 24
+					}
+				],
+				"extensions": [
+					"%s_variables"
+				],
+				"inputsInline": true,
+				"output": "%s",
+				"colour": "%s",
+				"mutator": "variable_entity_input"
+			}]);""".formatted(variableType.getName(), L10N.t("blockly.block.get_var"), variableType.getName(),
+				variableType.getBlocklyVariableType(), variableType.getColor());
+	}
+
 	public static String setVariableBlock(VariableType variableType) {
 		return """
 			Blockly.defineBlocksWithJsonArray([{
@@ -124,6 +153,30 @@ public class BlocklyJavascriptTemplates {
 				"colour": "%s"
 			}]);""".formatted(variableType.getName(), L10N.t("blockly.block.procedure_retval"), variableType.getName(),
 						variableType.getBlocklyVariableType(), variableType.getColor());
+	}
+
+	// Same as the "Procedure return value" block, but with the NULL icon at the beginning
+	public static String nullableProcedureReturnValueBlock(VariableType variableType) {
+		return """
+			Blockly.defineBlocksWithJsonArray([{
+				"type": "procedure_retval_%s",
+				"message0": "%%1 %s",
+				"args0": [
+					{
+						"type": "field_image",
+						"src": "./res/null.png",
+						"width": 8,
+						"height": 24
+					}
+				],
+				"extensions": [
+					"procedure_retval_%s"
+				],
+				"output": "%s",
+				"inputsInline": true,
+				"colour": "%s"
+			}]);""".formatted(variableType.getName(), L10N.t("blockly.block.procedure_retval"), variableType.getName(),
+				variableType.getBlocklyVariableType(), variableType.getColor());
 	}
 
 	public static String returnBlock(VariableType variableType) {

--- a/src/main/java/net/mcreator/workspace/elements/VariableType.java
+++ b/src/main/java/net/mcreator/workspace/elements/VariableType.java
@@ -35,7 +35,7 @@ import java.util.Map;
 	private String name;
 	private String color;
 	private String blocklyVariableType;
-	private boolean returnTypeOnly;
+	private boolean ignoredByCoverage;
 	private boolean nullable;
 
 	public void setName(String name) {
@@ -69,8 +69,8 @@ import java.util.Map;
 		}
 	}
 
-	public boolean isReturnTypeOnly() {
-		return returnTypeOnly;
+	public boolean isIgnoredByCoverage() {
+		return ignoredByCoverage;
 	}
 
 	public boolean isNullable() {

--- a/src/main/java/net/mcreator/workspace/elements/VariableType.java
+++ b/src/main/java/net/mcreator/workspace/elements/VariableType.java
@@ -36,6 +36,7 @@ import java.util.Map;
 	private String color;
 	private String blocklyVariableType;
 	private boolean returnTypeOnly;
+	private boolean nullable;
 
 	public void setName(String name) {
 		this.name = name;
@@ -70,6 +71,10 @@ import java.util.Map;
 
 	public boolean isReturnTypeOnly() {
 		return returnTypeOnly;
+	}
+
+	public boolean isNullable() {
+		return nullable;
 	}
 
 	public String getBlocklyVariableType() {

--- a/src/main/java/net/mcreator/workspace/elements/VariableTypeLoader.java
+++ b/src/main/java/net/mcreator/workspace/elements/VariableTypeLoader.java
@@ -65,10 +65,15 @@ public class VariableTypeLoader {
 			variableBlocklyJSBuilder.append(BlocklyJavascriptTemplates.procedureListExtensions(variableType));
 
 			//Then, we create the blocks related to variables
-			variableBlocklyJSBuilder.append(BlocklyJavascriptTemplates.getVariableBlock(variableType));
+			if (variableType.isNullable()) {
+				variableBlocklyJSBuilder.append(BlocklyJavascriptTemplates.nullableGetVariableBlock(variableType));
+				variableBlocklyJSBuilder.append(BlocklyJavascriptTemplates.nullableProcedureReturnValueBlock(variableType));
+			} else {
+				variableBlocklyJSBuilder.append(BlocklyJavascriptTemplates.getVariableBlock(variableType));
+				variableBlocklyJSBuilder.append(BlocklyJavascriptTemplates.procedureReturnValueBlock(variableType));
+			}
 			variableBlocklyJSBuilder.append(BlocklyJavascriptTemplates.setVariableBlock(variableType));
 			variableBlocklyJSBuilder.append(BlocklyJavascriptTemplates.customDependencyBlock(variableType));
-			variableBlocklyJSBuilder.append(BlocklyJavascriptTemplates.procedureReturnValueBlock(variableType));
 			variableBlocklyJSBuilder.append(BlocklyJavascriptTemplates.returnBlock(variableType));
 
 			//We check the type of the variable, if it is a global var, we instantiate it with this variable.

--- a/src/main/java/net/mcreator/workspace/elements/VariableTypeLoader.java
+++ b/src/main/java/net/mcreator/workspace/elements/VariableTypeLoader.java
@@ -85,6 +85,7 @@ public class VariableTypeLoader {
 				case "itemstack" -> BuiltInTypes.ITEMSTACK = variableType;
 				case "blockstate" -> BuiltInTypes.BLOCKSTATE = variableType;
 				case "actionresulttype" -> BuiltInTypes.ACTIONRESULTTYPE = variableType;
+				case "entity" -> BuiltInTypes.ENTITY = variableType;
 			}
 		}
 
@@ -130,5 +131,6 @@ public class VariableTypeLoader {
 		public static VariableType BLOCKSTATE;
 		public static VariableType ITEMSTACK;
 		public static VariableType ACTIONRESULTTYPE;
+		public static VariableType ENTITY;
 	}
 }


### PR DESCRIPTION
- Added a "nullable" field to variable types: if a variable is `nullable`, then its "Get variable" and "Procedure return value" blocks will have the NULL icon at the beginning
- Renamed the "returnTypeOnly" field to "ignoredByCoverage"
- Added support for local entity variable type