### PR TITLE
Some name validators changes

### DIFF
--- a/src/main/java/net/mcreator/ui/browser/action/NewClassAction.java
+++ b/src/main/java/net/mcreator/ui/browser/action/NewClassAction.java
@@ -28,7 +28,7 @@ import net.mcreator.ui.validation.Validator;
 import net.mcreator.ui.validation.component.VTextField;
 import net.mcreator.ui.validation.optionpane.OptionPaneValidatior;
 import net.mcreator.ui.validation.optionpane.VOptionPane;
-import net.mcreator.ui.validation.validators.JavaMemeberNameValidator;
+import net.mcreator.ui.validation.validators.JavaMemberNameValidator;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -47,7 +47,7 @@ public class NewClassAction extends BasicAction {
 					L10N.t("workspace_file_browser.new_class.class_name"),
 					L10N.t("workspace_file_browser.new_class.class_name.title"), null, new OptionPaneValidatior() {
 						@Override public Validator.ValidationResult validate(JComponent component) {
-							return new JavaMemeberNameValidator((VTextField) component, true).validate();
+							return new JavaMemberNameValidator((VTextField) component, true).validate();
 						}
 					});
 

--- a/src/main/java/net/mcreator/ui/dialogs/TextureMappingDialog.java
+++ b/src/main/java/net/mcreator/ui/dialogs/TextureMappingDialog.java
@@ -30,7 +30,7 @@ import net.mcreator.ui.validation.Validator;
 import net.mcreator.ui.validation.component.VTextField;
 import net.mcreator.ui.validation.optionpane.OptionPaneValidatior;
 import net.mcreator.ui.validation.optionpane.VOptionPane;
-import net.mcreator.ui.validation.validators.JavaMemeberNameValidator;
+import net.mcreator.ui.validation.validators.JavaMemberNameValidator;
 import net.mcreator.workspace.resources.TexturedModel;
 
 import javax.swing.*;
@@ -85,7 +85,7 @@ public class TextureMappingDialog {
 							L10N.t("dialog.textures_mapping.enter_name_message"),
 							L10N.t("dialog.textures_mapping.enter_name_title"), null, new OptionPaneValidatior() {
 								@Override public Validator.ValidationResult validate(JComponent component) {
-									return new JavaMemeberNameValidator((VTextField) component, false).validate();
+									return new JavaMemberNameValidator((VTextField) component, false).validate();
 								}
 							});
 					if (mapping != null) {

--- a/src/main/java/net/mcreator/ui/dialogs/wysiwyg/CheckboxDialog.java
+++ b/src/main/java/net/mcreator/ui/dialogs/wysiwyg/CheckboxDialog.java
@@ -29,7 +29,7 @@ import net.mcreator.ui.init.L10N;
 import net.mcreator.ui.procedure.ProcedureSelector;
 import net.mcreator.ui.validation.Validator;
 import net.mcreator.ui.validation.component.VTextField;
-import net.mcreator.ui.validation.validators.JavaMemeberNameValidator;
+import net.mcreator.ui.validation.validators.JavaMemberNameValidator;
 import net.mcreator.ui.wysiwyg.WYSIWYGEditor;
 import net.mcreator.workspace.elements.VariableTypeLoader;
 
@@ -52,7 +52,7 @@ public class CheckboxDialog extends AbstractWYSIWYGDialog {
 		VTextField nameField = new VTextField(20);
 		nameField.setPreferredSize(new Dimension(200, 28));
 		nameField.enableRealtimeValidation();
-		Validator validator = new JavaMemeberNameValidator(nameField, false);
+		Validator validator = new JavaMemberNameValidator(nameField, false);
 		nameField.setValidator(() -> {
 			String textname = Transliteration.transliterateString(nameField.getText());
 			for (int i = 0; i < editor.list.getModel().getSize(); i++) {

--- a/src/main/java/net/mcreator/ui/dialogs/wysiwyg/TextFieldDialog.java
+++ b/src/main/java/net/mcreator/ui/dialogs/wysiwyg/TextFieldDialog.java
@@ -26,7 +26,7 @@ import net.mcreator.ui.component.util.PanelUtils;
 import net.mcreator.ui.init.L10N;
 import net.mcreator.ui.validation.Validator;
 import net.mcreator.ui.validation.component.VTextField;
-import net.mcreator.ui.validation.validators.JavaMemeberNameValidator;
+import net.mcreator.ui.validation.validators.JavaMemberNameValidator;
 import net.mcreator.ui.wysiwyg.WYSIWYGEditor;
 
 import javax.annotation.Nullable;
@@ -44,7 +44,7 @@ public class TextFieldDialog extends AbstractWYSIWYGDialog {
 		VTextField nameField = new VTextField(20);
 		nameField.setPreferredSize(new Dimension(200, 28));
 		nameField.enableRealtimeValidation();
-		Validator validator = new JavaMemeberNameValidator(nameField, false);
+		Validator validator = new JavaMemberNameValidator(nameField, false);
 		nameField.setValidator(() -> {
 			String textname = Transliteration.transliterateString(nameField.getText());
 			for (int i = 0; i < editor.list.getModel().getSize(); i++) {

--- a/src/main/java/net/mcreator/ui/modgui/ProcedureGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/ProcedureGUI.java
@@ -45,7 +45,7 @@ import net.mcreator.ui.validation.AggregatedValidationResult;
 import net.mcreator.ui.validation.Validator;
 import net.mcreator.ui.validation.component.VTextField;
 import net.mcreator.ui.validation.optionpane.OptionPaneValidatior;
-import net.mcreator.ui.validation.validators.JavaMemeberNameValidator;
+import net.mcreator.ui.validation.validators.JavaMemberNameValidator;
 import net.mcreator.workspace.elements.ModElement;
 import net.mcreator.workspace.elements.VariableElement;
 import net.mcreator.workspace.elements.VariableType;
@@ -380,7 +380,7 @@ public class ProcedureGUI extends ModElementGUI<net.mcreator.element.types.Proce
 			VariableElement element = NewVariableDialog.showNewVariableDialog(mcreator, false,
 					new OptionPaneValidatior() {
 						@Override public Validator.ValidationResult validate(JComponent component) {
-							Validator validator = new JavaMemeberNameValidator((VTextField) component, false);
+							Validator validator = new JavaMemberNameValidator((VTextField) component, false);
 							String textname = Transliteration.transliterateString(((VTextField) component).getText());
 							for (int i = 0; i < localVars.getSize(); i++) {
 								String nameinrow = localVars.get(i).getName();

--- a/src/main/java/net/mcreator/ui/validation/validators/JavaMemberNameValidator.java
+++ b/src/main/java/net/mcreator/ui/validation/validators/JavaMemberNameValidator.java
@@ -29,12 +29,12 @@ import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
 
-public class JavaMemeberNameValidator implements Validator {
+public class JavaMemberNameValidator implements Validator {
 
 	private final VTextField textField;
 	private final boolean firstLetterUppercase;
 
-	public JavaMemeberNameValidator(VTextField textField, boolean requireFirstLetterUppercase) {
+	public JavaMemberNameValidator(VTextField textField, boolean requireFirstLetterUppercase) {
 		this.textField = textField;
 		this.firstLetterUppercase = requireFirstLetterUppercase;
 	}

--- a/src/main/java/net/mcreator/ui/validation/validators/ModElementNameValidator.java
+++ b/src/main/java/net/mcreator/ui/validation/validators/ModElementNameValidator.java
@@ -27,7 +27,7 @@ import net.mcreator.workspace.elements.ModElement;
 
 import javax.annotation.Nonnull;
 
-public class ModElementNameValidator extends JavaMemeberNameValidator {
+public class ModElementNameValidator extends JavaMemberNameValidator {
 
 	private final VTextField textField;
 	private final Workspace workspace;

--- a/src/main/java/net/mcreator/ui/validation/validators/RegistryNameValidator.java
+++ b/src/main/java/net/mcreator/ui/validation/validators/RegistryNameValidator.java
@@ -22,6 +22,7 @@ import net.mcreator.ui.init.L10N;
 import net.mcreator.ui.validation.Validator;
 import net.mcreator.ui.validation.component.VComboBox;
 import net.mcreator.ui.validation.component.VTextField;
+import net.mcreator.util.StringUtils;
 
 import javax.swing.*;
 import java.util.Collections;
@@ -34,7 +35,7 @@ public class RegistryNameValidator implements Validator {
 
 	private boolean allowEmpty = false;
 
-	List<Character> validChars = Collections.singletonList('_');
+	private List<Character> validChars = Collections.singletonList('_');
 
 	private int maxLength = 64;
 
@@ -94,12 +95,8 @@ public class RegistryNameValidator implements Validator {
 		return Validator.ValidationResult.PASSED;
 	}
 
-	private static boolean isLCLetter(char c) {
-		return c >= 'a' && c <= 'z';
-	}
-
 	public static boolean isLCLetterOrDigit(char c) {
-		return isLCLetter(c) || (c >= '0' && c <= '9');
+		return StringUtils.isLowercaseLetter(c) || (c >= '0' && c <= '9');
 	}
 
 }

--- a/src/main/java/net/mcreator/ui/validation/validators/ResourceNameValidator.java
+++ b/src/main/java/net/mcreator/ui/validation/validators/ResourceNameValidator.java
@@ -26,7 +26,7 @@ public class ResourceNameValidator extends RegistryNameValidator {
 
 	public ResourceNameValidator(VTextField holder, String name) {
 		super(holder, name);
-		this.validChars = Arrays.asList('_', '/', '.', '-');
+		setValidChars(Arrays.asList('_', '/', '.', '-'));
 	}
 
 }

--- a/src/main/java/net/mcreator/ui/workspace/WorkspacePanelVariables.java
+++ b/src/main/java/net/mcreator/ui/workspace/WorkspacePanelVariables.java
@@ -31,7 +31,7 @@ import net.mcreator.ui.laf.SlickDarkScrollBarUI;
 import net.mcreator.ui.validation.Validator;
 import net.mcreator.ui.validation.component.VTextField;
 import net.mcreator.ui.validation.optionpane.OptionPaneValidatior;
-import net.mcreator.ui.validation.validators.JavaMemeberNameValidator;
+import net.mcreator.ui.validation.validators.JavaMemberNameValidator;
 import net.mcreator.util.DesktopUtils;
 import net.mcreator.workspace.Workspace;
 import net.mcreator.workspace.elements.VariableElement;
@@ -112,7 +112,7 @@ class WorkspacePanelVariables extends JPanel implements IReloadableFilterable {
 				} else if (modelColumn == 0) {
 					VTextField name = new VTextField();
 					name.enableRealtimeValidation();
-					Validator validator = new JavaMemeberNameValidator(name, false);
+					Validator validator = new JavaMemberNameValidator(name, false);
 					name.setValidator(() -> {
 						String textname = Transliteration.transliterateString(name.getText());
 						for (int i = 0; i < elements.getRowCount(); i++) {
@@ -226,7 +226,7 @@ class WorkspacePanelVariables extends JPanel implements IReloadableFilterable {
 			VariableElement element = NewVariableDialog.showNewVariableDialog(workspacePanel.getMcreator(), true,
 					new OptionPaneValidatior() {
 						@Override public ValidationResult validate(JComponent component) {
-							Validator validator = new JavaMemeberNameValidator((VTextField) component, false);
+							Validator validator = new JavaMemberNameValidator((VTextField) component, false);
 							String textname = Transliteration.transliterateString(((VTextField) component).getText());
 							for (int i = 0; i < elements.getRowCount(); i++) {
 								String nameinrow = (String) elements.getValueAt(i, 0);

--- a/src/main/java/net/mcreator/util/StringUtils.java
+++ b/src/main/java/net/mcreator/util/StringUtils.java
@@ -22,10 +22,12 @@ import org.apache.commons.text.WordUtils;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 public class StringUtils {
 
@@ -58,6 +60,10 @@ public class StringUtils {
 		return (c >= 'A' && c <= 'Z');
 	}
 
+	public static boolean isLowercaseLetter(char c) {
+		return (c >= 'a' && c <= 'z');
+	}
+
 	public static String uppercaseFirstLetter(String name) {
 		if (name.length() <= 1)
 			return name.toUpperCase(Locale.ENGLISH);
@@ -72,6 +78,10 @@ public class StringUtils {
 
 	public static String camelToSnake(String original) {
 		return underscoreReducer.matcher(String.join("_", namePartsSplitter.split(original))).replaceAll("");
+	}
+
+	public static String snakeToCamel(String original) {
+		return Arrays.stream(original.split("_")).map(StringUtils::uppercaseFirstLetter).collect(Collectors.joining());
 	}
 
 	public static String machineToReadableName(@Nonnull String input) {


### PR DESCRIPTION
Change log:
* Added `isLowercaseLetter()` and `snakeToCamel()` methods to `StringUtils`, opposed to existing `isUppercaseLetter()` and `camelToSnake()` methods;
* Renamed `JavaMemeberNameValidator` to `JavaMemberNameValidator`;
* Changed visibility of `RegistryNameValidator#validChars` field to _private_ by changing direct reference from another class to the setter method.