### PR TITLE
Stricter checks on local variable names

### DIFF
--- a/plugins/mcreator-localization/lang/texts.properties
+++ b/plugins/mcreator-localization/lang/texts.properties
@@ -2738,6 +2738,7 @@ gradle.errors.build_failed=<html><b>MCreator detected Gradle failed to properly 
   listed on the help page and do as instructed to resolve this problem.
 gradle.errors.build_failed.title=Gradle build failed
 validators.only_number_list=Only number list allowed
+validators.java_name.cannot_start_with_underscore=Name can''t start with underscore
 validators.java_name.needs_name=Name can''t be empty
 validators.java_name.invalid_name=Invalid name
 validators.java_name.reserved_keywords=Name contains reserved Java keywords

--- a/plugins/mcreator-localization/lang/texts.properties
+++ b/plugins/mcreator-localization/lang/texts.properties
@@ -2205,6 +2205,7 @@ elementgui.procedure.global_trigger_unsupported=Selected global trigger is not s
 elementgui.procedure.global_trigger_not_activated=Selected global trigger requires {0} enabled in workspace settings, or the current generator does not support it
 elementgui.procedure.global_trigger_tick_based={0} global trigger is tick event based. Keep in mind that running too complex or demanding procedures each tick can severely impact game performance.
 elementgui.procedure.global_trigger_does_not_exist=Your procedure uses a global trigger that does not exist
+elementgui.procedure.variable_name_clashes_with_dep=Name of variable "{0}" clashes with name of dependency
 elementgui.procedure.return_type=Return type
 elementgui.procedure.local_variables=Local variables
 elementgui.procedure.name_already_exists_dep=This name already exists as a procedure dependency

--- a/src/main/java/net/mcreator/ui/modgui/ProcedureGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/ProcedureGUI.java
@@ -131,6 +131,17 @@ public class ProcedureGUI extends ModElementGUI<net.mcreator.element.types.Proce
 			hasResultTriggerLabel.setIcon(null);
 			sideTriggerLabel.setIcon(null);
 
+			// Check that no local variable has the same name as one of the dependencies
+			for (var dependency : dependenciesArrayList) {
+				for (int i = 0; i < localVars.getSize(); i++) {
+					if (dependency.getName().equals(localVars.get(i).getName())) {
+						compileNotesArrayList.add(new BlocklyCompileNote(BlocklyCompileNote.Type.ERROR,
+								L10N.t("elementgui.procedure.variable_name_clashes_with_dep", dependency.getName())));
+						break; // We found a match, there's no need to check the other variables
+					}
+				}
+			}
+
 			if (isEditingMode() && dependenciesBeforeEdit == null) {
 				dependenciesBeforeEdit = new ArrayList<>(dependenciesArrayList);
 			} else if (dependenciesBeforeEdit != null) {

--- a/src/main/java/net/mcreator/ui/modgui/ProcedureGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/ProcedureGUI.java
@@ -380,7 +380,7 @@ public class ProcedureGUI extends ModElementGUI<net.mcreator.element.types.Proce
 			VariableElement element = NewVariableDialog.showNewVariableDialog(mcreator, false,
 					new OptionPaneValidatior() {
 						@Override public Validator.ValidationResult validate(JComponent component) {
-							Validator validator = new JavaMemberNameValidator((VTextField) component, false);
+							Validator validator = new JavaMemberNameValidator((VTextField) component, false, false);
 							String textname = Transliteration.transliterateString(((VTextField) component).getText());
 							for (int i = 0; i < localVars.getSize(); i++) {
 								String nameinrow = localVars.get(i).getName();

--- a/src/main/java/net/mcreator/ui/validation/validators/JavaMemberNameValidator.java
+++ b/src/main/java/net/mcreator/ui/validation/validators/JavaMemberNameValidator.java
@@ -33,10 +33,17 @@ public class JavaMemberNameValidator implements Validator {
 
 	private final VTextField textField;
 	private final boolean firstLetterUppercase;
+	private final boolean allowInitialUnderscore;
 
 	public JavaMemberNameValidator(VTextField textField, boolean requireFirstLetterUppercase) {
+		this(textField, requireFirstLetterUppercase, true);
+	}
+
+	public JavaMemberNameValidator(VTextField textField, boolean requireFirstLetterUppercase,
+			boolean allowInitialUnderscore) {
 		this.textField = textField;
 		this.firstLetterUppercase = requireFirstLetterUppercase;
+		this.allowInitialUnderscore = allowInitialUnderscore;
 	}
 
 	@Override public ValidationResult validate() {
@@ -45,6 +52,10 @@ public class JavaMemberNameValidator implements Validator {
 		if (text == null || text.length() == 0)
 			return new Validator.ValidationResult(Validator.ValidationResultType.ERROR,
 					L10N.t("validators.java_name.needs_name"));
+
+		if (!allowInitialUnderscore && text.charAt(0) == '_')
+			return new Validator.ValidationResult(Validator.ValidationResultType.ERROR,
+					L10N.t("validators.java_name.cannot_start_with_underscore"));
 
 		if (firstLetterUppercase && Character.isLowerCase(text.charAt(0))) {
 			if (text.length() > 1)


### PR DESCRIPTION
- Local variable names cannot start with underscores anymore, to prevent clashes with pattern variables in procedure blocks
- Added a compilation error for when a local variable has the same name as one of the dependencies