### PR TITLE
Some fixes to the 1.18 generator

### DIFF
--- a/plugins/generator-1.18.2/forge-1.18.2/templates/elementinits/items.java.ftl
+++ b/plugins/generator-1.18.2/forge-1.18.2/templates/elementinits/items.java.ftl
@@ -37,6 +37,7 @@
 package ${package}.init;
 
 <#assign hasBlocks = false>
+<#assign hasDoubleBlocks = false>
 
 public class ${JavaModName}Items {
 
@@ -67,9 +68,15 @@ public class ${JavaModName}Items {
             public static final RegistryObject<Item> ${item.getModElement().getRegistryNameUpper()}_BUCKET =
                 REGISTRY.register("${item.getModElement().getRegistryName()}_bucket", () -> new ${item.getModElement().getName()}Item());
         <#elseif item.getModElement().getType().getBaseType()?string == "BLOCK">
-            <#assign hasBlocks = true>
-            public static final RegistryObject<Item> ${item.getModElement().getRegistryNameUpper()} =
-                block(${JavaModName}Blocks.${item.getModElement().getRegistryNameUpper()}, ${item.creativeTab});
+            <#if (item.getModElement().getTypeString() == "block" && item.isDoubleBlock()) || (item.getModElement().getTypeString() == "plant" && item.isDoubleBlock())>
+                <#assign hasDoubleBlocks = true>
+                public static final RegistryObject<Item> ${item.getModElement().getRegistryNameUpper()} =
+                    doubleBlock(${JavaModName}Blocks.${item.getModElement().getRegistryNameUpper()}, ${item.creativeTab});
+            <#else>
+                <#assign hasBlocks = true>
+                public static final RegistryObject<Item> ${item.getModElement().getRegistryNameUpper()} =
+                    block(${JavaModName}Blocks.${item.getModElement().getRegistryNameUpper()}, ${item.creativeTab});
+            </#if>
         <#elseif item.getModElement().getTypeString() == "livingentity">
             public static final RegistryObject<Item> ${item.getModElement().getRegistryNameUpper()} =
                 REGISTRY.register("${item.getModElement().getRegistryName()}_spawn_egg", () -> new ForgeSpawnEggItem(${JavaModName}Entities.${item.getModElement().getRegistryNameUpper()},
@@ -84,6 +91,12 @@ public class ${JavaModName}Items {
     <#if hasBlocks>
 	private static RegistryObject<Item> block(RegistryObject<Block> block, CreativeModeTab tab) {
 		return REGISTRY.register(block.getId().getPath(), () -> new BlockItem(block.get(), new Item.Properties().tab(tab)));
+	}
+    </#if>
+
+    <#if hasDoubleBlocks>
+	private static RegistryObject<Item> doubleBlock(RegistryObject<Block> block, CreativeModeTab tab) {
+		return REGISTRY.register(block.getId().getPath(), () -> new DoubleHighBlockItem(block.get(), new Item.Properties().tab(tab)));
 	}
     </#if>
 

--- a/plugins/generator-1.18.2/forge-1.18.2/templates/potioneffect.java.ftl
+++ b/plugins/generator-1.18.2/forge-1.18.2/templates/potioneffect.java.ftl
@@ -38,7 +38,6 @@ public class ${name}MobEffect extends MobEffect {
 
 	public ${name}MobEffect() {
 		super(MobEffectCategory.<#if data.isBad>HARMFUL<#elseif data.isBenefitical>BENEFICIAL<#else>NEUTRAL</#if>, ${data.color.getRGB()});
-		setRegistryName("${registryname}");
 	}
 
 	@Override public String getDescriptionId() {

--- a/src/main/java/net/mcreator/element/types/Block.java
+++ b/src/main/java/net/mcreator/element/types/Block.java
@@ -225,6 +225,10 @@ import java.util.stream.Collectors;
 		return !"No tint".equals(tintType);
 	}
 
+	public boolean isDoubleBlock() {
+		return "Door".equals(blockBase);
+	}
+
 	public boolean shouldOpenGUIOnRightClick() {
 		return guiBoundTo != null && !guiBoundTo.equals("<NONE>") && openGUIOnRightClick;
 	}

--- a/src/main/java/net/mcreator/element/types/Plant.java
+++ b/src/main/java/net/mcreator/element/types/Plant.java
@@ -184,6 +184,10 @@ import java.util.stream.Collectors;
 		return !"No tint".equals(tintType);
 	}
 
+	public boolean isDoubleBlock() {
+		return "double".equals(plantType);
+	}
+
 	@Override public @Nonnull List<BoxEntry> getValidBoundingBoxes() {
 		return boundingBoxes.stream().filter(BoxEntry::isNotEmpty).collect(Collectors.toList());
 	}


### PR DESCRIPTION
- Fixed potion effects being registered twice, preventing the game from loading
- Fixed doors and double plants having the wrong block item