### PR TITLE
Fixed tree placement in custom biomes

### DIFF
--- a/plugins/generator-1.18.2/forge-1.18.2/templates/biome/biome.java.ftl
+++ b/plugins/generator-1.18.2/forge-1.18.2/templates/biome/biome.java.ftl
@@ -208,7 +208,9 @@ public class ${name}Biome {
                         .ignoreVines()
                     </#if>
                 </#if>
-            .build()), List.of(CountOnEveryLayerPlacement.of(${data.treesPerChunk}))));
+            .build()), List.of(CountPlacement.of(${data.treesPerChunk}), InSquarePlacement.spread(),
+                SurfaceWaterDepthFilter.forMaxDepth(0), PlacementUtils.HEIGHTMAP_OCEAN_FLOOR,
+                PlacementUtils.filteredByBlockSurvival(Blocks.OAK_SAPLING))));
         </#if>
 
         <#if (data.grassPerChunk > 0)>


### PR DESCRIPTION
Fixes #2477 
With this PR trees no longer generate underwater, in caves, or on top of each other. Since custom saplings aren't possible yet, oak saplings are used for the placement check