### PR TITLE
Forge 1.18.2 registry system fixes

### DIFF
--- a/plugins/generator-1.18.2/forge-1.18.2/templates/tool.java.ftl
+++ b/plugins/generator-1.18.2/forge-1.18.2/templates/tool.java.ftl
@@ -254,8 +254,8 @@ public class ${name}Item extends FishingRodItem {
 
 					@Override public boolean shouldStopFishing(Player player) {
 						if (!player.isRemoved() && player.isAlive() &&
-								(player.getMainHandItem().is(${JavaModName}Items.${data.getModElement().getRegistryNameUpper()}) ||
-								player.getOffhandItem().is(${JavaModName}Items.${data.getModElement().getRegistryNameUpper()}))
+								(player.getMainHandItem().is(${JavaModName}Items.${data.getModElement().getRegistryNameUpper()}.get()) ||
+								player.getOffhandItem().is(${JavaModName}Items.${data.getModElement().getRegistryNameUpper()}.get()))
 								&& !(this.distanceToSqr(player) > 1024)) {
 							return false;
 						} else {

--- a/src/test/java/net/mcreator/integration/TestWorkspaceDataProvider.java
+++ b/src/test/java/net/mcreator/integration/TestWorkspaceDataProvider.java
@@ -87,6 +87,7 @@ public class TestWorkspaceDataProvider {
 			generatableElements.add(getToolExample(me(workspace, type, "9"), "Special", random, true, false));
 			generatableElements.add(getToolExample(me(workspace, type, "10"), "MultiTool", random, true, false));
 			generatableElements.add(getToolExample(me(workspace, type, "11"), "Shears", random, true, false));
+			generatableElements.add(getToolExample(me(workspace, type, "12"), "Fishing rod", random, true, false));
 		} else if (type == ModElementType.FUEL || type == ModElementType.TAB) {
 			generatableElements.add(getExampleFor(me(workspace, type, "1"), random, true, true, 0));
 			generatableElements.add(getExampleFor(me(workspace, type, "2"), random, true, false, 1));
@@ -1592,13 +1593,13 @@ public class TestWorkspaceDataProvider {
 		return null;
 	}
 
-	private static GeneratableElement getToolExample(ModElement modElement, String recipeType, Random random,
+	private static GeneratableElement getToolExample(ModElement modElement, String toolType, Random random,
 			boolean _true, boolean emptyLists) {
 		Tool tool = new Tool(modElement);
 		tool.name = modElement.getName();
 		tool.creativeTab = new TabEntry(modElement.getWorkspace(),
 				getRandomDataListEntry(random, ElementUtil.loadAllTabs(modElement.getWorkspace())));
-		tool.toolType = recipeType;
+		tool.toolType = toolType;
 		tool.harvestLevel = 3;
 		tool.efficiency = 6;
 		tool.attackSpeed = 4.8;


### PR DESCRIPTION
1.18.2 release changed the registry system to some extent. When updating Forge version from 1.18.1 to 1.18.2, we forgot about some code parts that are using this system, which can lead to build errors. This PR is aimed at collecting fixes of these bugs into a single PR (if it gets too big, just consider it the continuation of #2444) before the second (in the worst case, third) snapshot and then getting merged into the master branch.

I'm starting with fixing custom fishing rods (this could not be detected because tests for this tool type were missing, added them as well).