### PR TITLE
Change Mojang AB to Mojang Studios

### DIFF
--- a/src/main/java/net/mcreator/ui/SplashScreen.java
+++ b/src/main/java/net/mcreator/ui/SplashScreen.java
@@ -48,9 +48,9 @@ public class SplashScreen extends JWindow {
 		imagePanel.add(pylo);
 
 		JLabel label = new JLabel(
-				"<html><p>MCreator is a Minecraft mod making toolkit developed by Pylo. Minecraft is a registered</p>"
-						+ "<p style='margin-top:-2'>trademark of Mojang Studios. MCreator is not an official Minecraft product. "
-						+ "It is not approved<br>by or associated with Mojang Studios.");
+				"<html><p>MCreator is a Minecraft mod making toolkit developed by Pylo. Minecraft is a</p>"
+						+ "<p style='margin-top:-2'>registered trademark of Mojang. MCreator is not an official Minecraft product.</p>"
+						+ "<p style='margin-top:-2'>It is not approved by or associated with Mojang.</p>");
 		label.setFont(splashFont.deriveFont(10f));
 		label.setForeground(Color.white);
 		label.setBounds(30 + 10 - 4, 330 - 10 - 10, 500, 45);

--- a/src/main/java/net/mcreator/ui/SplashScreen.java
+++ b/src/main/java/net/mcreator/ui/SplashScreen.java
@@ -49,8 +49,8 @@ public class SplashScreen extends JWindow {
 
 		JLabel label = new JLabel(
 				"<html><p>MCreator is a Minecraft mod making toolkit developed by Pylo. Minecraft is a registered</p>"
-						+ "<p style='margin-top:-2'>trademark of Mojang AB. MCreator is not an official Minecraft product. "
-						+ "It is not approved<br>by or associated with Mojang AB.");
+						+ "<p style='margin-top:-2'>trademark of Mojang Studios. MCreator is not an official Minecraft product. "
+						+ "It is not approved<br>by or associated with Mojang Studios.");
 		label.setFont(splashFont.deriveFont(10f));
 		label.setForeground(Color.white);
 		label.setBounds(30 + 10 - 4, 330 - 10 - 10, 500, 45);


### PR DESCRIPTION
Mojang AB has been rebranded to Mojang Studios since 2020 however.

This PR will update it since you may have not notice before.

