### PR TITLE
Disable the warning snapshot message option

### DIFF
--- a/plugins/mcreator-localization/lang/texts.properties
+++ b/plugins/mcreator-localization/lang/texts.properties
@@ -1343,6 +1343,8 @@ preferences.bedrock.silentReload=Silently reload open Bedrock Edition app
 preferences.bedrock.silentReload.description=Keep in mind that silent reload will not save any unsaved world progress so only use this with test worlds
 preferences.notifications.openWhatsNextPage=Show "What''s Next?" page when a new workspace is setting up
 preferences.notifications.openWhatsNextPage.description=Uncheck this to disable this page from showing up when making a new workspace
+preferences.notifications.snapshotMessage=Show the warning message for snapshots
+preferences.notifications.snapshotMessage.description=Uncheck this to disable the snapshot message at the launch of an MCreator snapshot version
 preferences.notifications.checkAndNotifyForUpdates=Notify about new major releases on MCreator launch
 preferences.notifications.checkAndNotifyForUpdates.description=Uncheck this box if you don''t want to be notified of major new updates. <br>\
   <b>WARNING: Note that you might miss important updates and bug fixes if you disable this option.

--- a/src/main/java/net/mcreator/preferences/PreferencesData.java
+++ b/src/main/java/net/mcreator/preferences/PreferencesData.java
@@ -64,6 +64,7 @@ public class PreferencesData {
 	public static class NotificationSettings {
 
 		@PreferencesEntry public boolean openWhatsNextPage = true;
+		@PreferencesEntry public boolean snapshotMessage = true;
 		@PreferencesEntry public boolean checkAndNotifyForUpdates = true;
 		@PreferencesEntry public boolean checkAndNotifyForPatches = true;
 		@PreferencesEntry public boolean checkAndNotifyForPluginUpdates = false;

--- a/src/main/java/net/mcreator/ui/MCreatorApplication.java
+++ b/src/main/java/net/mcreator/ui/MCreatorApplication.java
@@ -201,7 +201,7 @@ public final class MCreatorApplication {
 
 		workspaceSelector = new WorkspaceSelector(this, this::openWorkspaceInMCreator);
 
-		if (Launcher.version.isSnapshot()) {
+		if (Launcher.version.isSnapshot() && PreferencesManager.PREFERENCES.notifications.snapshotMessage) {
 			JOptionPane.showMessageDialog(splashScreen, L10N.t("action.eap_loading.text"),
 					L10N.t("action.eap_loading.title"), JOptionPane.WARNING_MESSAGE);
 		}


### PR DESCRIPTION
This PR simply adds a new preference entry to disable the warning message of snapshots. It is very annoying to develop plugins on a snapshot because of this message. You can not launch a snapshot and then, return to Intellij for your plugin as you need to wait to click on "Ok".