### PR TITLE
Fixed parentheses issue with division

### DIFF
--- a/src/main/java/net/mcreator/blockly/java/JavaKeywordsMap.java
+++ b/src/main/java/net/mcreator/blockly/java/JavaKeywordsMap.java
@@ -40,7 +40,7 @@ public final class JavaKeywordsMap {
 		put("ADD", "+");
 		put("MINUS", "-");
 		put("MULTIPLY", "*");
-		put("DIVIDE", "/");
+		put("DIVIDE", "/ "); // The space prevents accidental inline comments from int/float markers
 		put("MOD", "%");
 		put("BAND", "&");
 		put("BOR", "|");


### PR DESCRIPTION
This issue was caused by having an `/*@int*/` or `/*@float*/` marker right after the division sign, creating an inline comment. The extra space prevents this from happening