### PR TITLE
Fix #2692

### DIFF
--- a/plugins/generator-1.18.2/forge-1.18.2/templates/block/oregen.java.ftl
+++ b/plugins/generator-1.18.2/forge-1.18.2/templates/block/oregen.java.ftl
@@ -47,7 +47,8 @@ public class ${name}Feature extends OreFeature {
 		);
 		PLACED_FEATURE = PlacementUtils.register("${modid}:${registryname}", CONFIGURED_FEATURE, List.of(
 				CountPlacement.of(${data.frequencyPerChunks}), InSquarePlacement.spread(),
-				HeightRangePlacement.${data.generationShape?lower_case}(VerticalAnchor.absolute(${data.minGenerateHeight}), VerticalAnchor.absolute(${data.maxGenerateHeight}))
+				HeightRangePlacement.${data.generationShape?lower_case}(VerticalAnchor.absolute(${data.minGenerateHeight}), VerticalAnchor.absolute(${data.maxGenerateHeight})),
+				BiomeFilter.biome()
 		));
 		return FEATURE;
 	}

--- a/plugins/generator-1.18.2/forge-1.18.2/templates/fluid/fluidgen.java.ftl
+++ b/plugins/generator-1.18.2/forge-1.18.2/templates/fluid/fluidgen.java.ftl
@@ -52,7 +52,8 @@ public class ${name}Feature extends LakeFeature {
 				RarityFilter.onAverageOnceEvery(${data.frequencyOnChunks}),
 				InSquarePlacement.spread(),
 				PlacementUtils.RANGE_BOTTOM_TO_MAX_TERRAIN_HEIGHT,
-				EnvironmentScanPlacement.scanningFor(Direction.DOWN, BlockPredicate.not(BlockPredicate.ONLY_IN_AIR_PREDICATE), 32)
+				EnvironmentScanPlacement.scanningFor(Direction.DOWN, BlockPredicate.not(BlockPredicate.ONLY_IN_AIR_PREDICATE), 32),
+				BiomeFilter.biome()
 		));
 		return FEATURE;
 	}

--- a/plugins/generator-1.18.2/forge-1.18.2/templates/plant/plantgen.java.ftl
+++ b/plugins/generator-1.18.2/forge-1.18.2/templates/plant/plantgen.java.ftl
@@ -62,19 +62,19 @@ public class ${name}Feature extends RandomPatchFeature {
 		);
 		PLACED_FEATURE = PlacementUtils.register("${modid}:${registryname}", CONFIGURED_FEATURE,
 				List.of(
+			CountPlacement.of(${data.frequencyOnChunks}),
 			<#if (data.plantType == "normal" && data.staticPlantGenerationType == "Flower") ||
 			(data.plantType == "double" && data.doublePlantGenerationType == "Flower") ||
 			data.plantType == "growapable">
 			RarityFilter.onAverageOnceEvery(32),
 			</#if>
-						InSquarePlacement.spread(),
-						PlacementUtils.HEIGHTMAP<#if
+			InSquarePlacement.spread(),
+			PlacementUtils.HEIGHTMAP<#if
 				(data.plantType == "normal" && data.staticPlantGenerationType == "Grass") ||
 				(data.plantType == "double" && data.doublePlantGenerationType == "Grass") ||
 				data.plantType == "growapable">_WORLD_SURFACE</#if>,
-						CountPlacement.of(${data.frequencyOnChunks})
-				)
-		);
+			 BiomeFilter.biome()
+		));
 		return FEATURE;
 	}
 

--- a/plugins/generator-1.18.2/forge-1.18.2/templates/structure.java.ftl
+++ b/plugins/generator-1.18.2/forge-1.18.2/templates/structure.java.ftl
@@ -43,7 +43,7 @@ public class ${name}Feature extends Feature<NoneFeatureConfiguration> {
 	public static Feature<?> feature() {
 		FEATURE = new ${name}Feature();
 		CONFIGURED_FEATURE = FeatureUtils.register("${modid}:${registryname}", FEATURE, FeatureConfiguration.NONE);
-		PLACED_FEATURE = PlacementUtils.register("${modid}:${registryname}", CONFIGURED_FEATURE, List.of());
+		PLACED_FEATURE = PlacementUtils.register("${modid}:${registryname}", CONFIGURED_FEATURE, List.of(BiomeFilter.biome()));
 		return FEATURE;
 	}
 


### PR DESCRIPTION
- Added the missing biome filters to plants, structures, lakes and ores
- Moved the count placement of plants at the beginning, to prevent having multiple patches centered in the same block