### PR TITLE
Fix #2718

### DIFF
--- a/src/main/java/net/mcreator/element/converter/fv28/FoodToItemConverter.java
+++ b/src/main/java/net/mcreator/element/converter/fv28/FoodToItemConverter.java
@@ -64,8 +64,9 @@ public class FoodToItemConverter implements IConverter {
 			item.isAlwaysEdible = food.get("isAlwaysEdible").getAsBoolean();
 			item.isMeat = food.get("forDogs").getAsBoolean();
 			item.useDuration = food.get("eatingSpeed").getAsInt();
-			item.eatResultItem = new MItemBlock(workspace,
-					food.get("resultItem").getAsJsonObject().get("value").getAsString());
+			if (food.get("resultItem") != null)
+				item.eatResultItem = new MItemBlock(workspace,
+						food.get("resultItem").getAsJsonObject().get("value").getAsString());
 			item.animation = food.get("animation").getAsString();
 			item.hasGlow = food.get("hasGlow").getAsBoolean();
 			if (food.get("glowCondition") != null)


### PR DESCRIPTION
This PR should fix #2718. I could not test properly as I was not able to use the workspace though. However, when looking into the elements folder, I noticed some food mod elements did not specify `eatingResult`, which made the converter fail. This PR adds a condition to check if `eatingResult` is null.