### PR TITLE
Add a Forge-Fabric converter

### DIFF
--- a/plugins/mcreator-localization/lang/texts.properties
+++ b/plugins/mcreator-localization/lang/texts.properties
@@ -2579,6 +2579,9 @@ dialog.generator_selector.generator_status.stable=Stable
 dialog.generator_selector.features=Feature overview:
 dialog.generator_selector.mod_element_types=Supported mod element types:
 dialog.generator_selector.title=Generator selector
+dialog.generator_selector.confirm=<html>Are you sure you want to change the generator type? Forge and Fabric generators may have \
+  <br>differences in their usage of a few features. The selected generator may also have unsupported features. \
+  <br>If you continue, a backup will be made, but you should make your own backup too.
 dialog.generator_selector.coverage.textures=Textures
 dialog.generator_selector.coverage.sounds=Sounds
 dialog.generator_selector.coverage.sound_categories=Sound categories

--- a/src/main/java/net/mcreator/ui/dialogs/workspace/WorkspaceDialogs.java
+++ b/src/main/java/net/mcreator/ui/dialogs/workspace/WorkspaceDialogs.java
@@ -337,7 +337,7 @@ public class WorkspaceDialogs {
 				GeneratorConfiguration gc = GeneratorSelector.getGeneratorSelector(parent,
 						(GeneratorConfiguration) generator.getSelectedItem(),
 						workspace != null ? workspace.getGeneratorConfiguration().getGeneratorFlavor() : flavorFilter,
-						workspace == null);
+						workspace == null, workspace);
 				if (gc != null)
 					generator.setSelectedItem(gc);
 			});
@@ -347,7 +347,7 @@ public class WorkspaceDialogs {
 					GeneratorConfiguration gc = GeneratorSelector.getGeneratorSelector(parent,
 							(GeneratorConfiguration) generator.getSelectedItem(), workspace != null ?
 									workspace.getGeneratorConfiguration().getGeneratorFlavor() :
-									flavorFilter, workspace == null);
+									flavorFilter, workspace == null, workspace);
 					if (gc != null)
 						generator.setSelectedItem(gc);
 				}

--- a/src/main/java/net/mcreator/workspace/ShareableZIPManager.java
+++ b/src/main/java/net/mcreator/workspace/ShareableZIPManager.java
@@ -102,18 +102,22 @@ public class ShareableZIPManager {
 	}
 
 	public static void exportZIP(String title, File file, MCreator mcreator, boolean excludeRunDir) {
-		ProgressDialog dial = new ProgressDialog(mcreator, title);
+		exportZIP(title, file, mcreator.getWorkspaceFolder(), mcreator, excludeRunDir);
+	}
+
+	public static void exportZIP(String title, File file, File workspaceFolder, Window parent, boolean excludeRunDir) {
+		ProgressDialog dial = new ProgressDialog(parent, title);
 		Thread t = new Thread(() -> {
 			ProgressDialog.ProgressUnit p1 = new ProgressDialog.ProgressUnit("Compressing workspace");
 			dial.addProgress(p1);
 
 			try {
 				if (excludeRunDir) {
-					ZipIO.zipDir(mcreator.getWorkspaceFolder().getAbsolutePath(), file.getAbsolutePath(), ".gradle/",
+					ZipIO.zipDir(workspaceFolder.getAbsolutePath(), file.getAbsolutePath(), ".gradle/",
 							".mcreator/", "build/", "gradle/", "run/", "#build.gradle", "#gradlew", "#gradlew.bat",
 							"#mcreator.gradle", ".git/", "#.classpath", "#.project", ".idea/", ".settings/");
 				} else {
-					ZipIO.zipDir(mcreator.getWorkspaceFolder().getAbsolutePath(), file.getAbsolutePath(), ".gradle/",
+					ZipIO.zipDir(workspaceFolder.getAbsolutePath(), file.getAbsolutePath(), ".gradle/",
 							".mcreator/", "build/", "gradle/", "#build.gradle", "#gradlew", "#gradlew.bat",
 							"#mcreator.gradle", ".git/", "#.classpath", "#.project", ".idea/", ".settings/");
 				}

--- a/src/main/java/net/mcreator/workspace/Workspace.java
+++ b/src/main/java/net/mcreator/workspace/Workspace.java
@@ -408,7 +408,7 @@ public class Workspace implements Closeable, IGeneratorProvider {
 							"Unsupported generator", JOptionPane.WARNING_MESSAGE);
 					GeneratorConfiguration generatorConfiguration = GeneratorSelector.getGeneratorSelector(ui,
 							GeneratorConfiguration.getRecommendedGeneratorForFlavor(Generator.GENERATOR_CACHE.values(),
-									currentFlavor), currentFlavor, false);
+									currentFlavor), currentFlavor, true, null);
 					if (generatorConfiguration != null) {
 						retval.getWorkspaceSettings().setCurrentGenerator(generatorConfiguration.getGeneratorName());
 

--- a/src/test/java/net/mcreator/integration/ui/DialogsTest.java
+++ b/src/test/java/net/mcreator/integration/ui/DialogsTest.java
@@ -107,7 +107,7 @@ public class DialogsTest {
 	@Test public void testGeneratorSelectorDialog() throws Throwable {
 		UITestUtil.waitUntilWindowIsOpen(mcreator,
 				() -> GeneratorSelector.getGeneratorSelector(mcreator, mcreator.getGeneratorConfiguration(),
-						GeneratorFlavor.FORGE, true));
+						GeneratorFlavor.FORGE, true, null));
 	}
 
 	@Test public void testAboutDialog() throws Throwable {


### PR DESCRIPTION
This PR allows switching from a Forge generator to a Fabric generator and vice-versa.
When the generator flavor is changed, a warning/confirm message is shown. If the user continues, a full backup is automatically made so that the user can return at any time to the previous state.