### PR TITLE
Fixed bounding boxes of blocks without pitch rotation

### DIFF
--- a/plugins/generator-1.16.5/forge-1.16.5/utils/boundingboxes.java.ftl
+++ b/plugins/generator-1.16.5/forge-1.16.5/utils/boundingboxes.java.ftl
@@ -1,4 +1,4 @@
-<#macro makeBoundingBox positiveBoxes negativeBoxes noOffset facing pitchType="wall">
+<#macro makeBoundingBox positiveBoxes negativeBoxes noOffset facing pitchType="floor">
     return <#if negativeBoxes?size != 0>VoxelShapes.combineAndSimplify(</#if>
     VoxelShapes.or(
     <#list positiveBoxes as box>

--- a/plugins/generator-1.18.2/forge-1.18.2/utils/boundingboxes.java.ftl
+++ b/plugins/generator-1.18.2/forge-1.18.2/utils/boundingboxes.java.ftl
@@ -1,4 +1,4 @@
-<#macro makeBoundingBox positiveBoxes negativeBoxes noOffset facing pitchType="wall">
+<#macro makeBoundingBox positiveBoxes negativeBoxes noOffset facing pitchType="floor">
     return <#if negativeBoxes?size != 0>Shapes.join(</#if>
     <@mergeBoxes positiveBoxes, facing, pitchType/>
     <#if negativeBoxes?size != 0>


### PR DESCRIPTION
Fixes an issue introduced by #2516, when custom blocks without pitch rotation could appear with wrong bounding boxes.