### PR TITLE
Adding translatable GUI elements and tooltip for items

### DIFF
--- a/plugins/generator-1.16.5/forge-1.16.5/templates/item.java.ftl
+++ b/plugins/generator-1.16.5/forge-1.16.5/templates/item.java.ftl
@@ -218,7 +218,7 @@ import net.minecraft.entity.ai.attributes.Attributes;
 		@Override public void addInformation(ItemStack itemstack, World world, List<ITextComponent> list, ITooltipFlag flag) {
 			super.addInformation(itemstack, world, list, flag);
 			<#list data.specialInfo as entry>
-			list.add(new StringTextComponent("${JavaConventions.escapeStringForJava(entry)}"));
+			list.add(new TranslationTextComponent("${JavaConventions.escapeStringForJava(entry)}"));
             </#list>
 		}
         </#if>

--- a/plugins/generator-1.18.2/forge-1.18.2/templates/gui/gui_window.java.ftl
+++ b/plugins/generator-1.18.2/forge-1.18.2/templates/gui/gui_window.java.ftl
@@ -140,7 +140,7 @@ public class ${name}Screen extends AbstractContainerScreen<${name}Menu> {
 				<#if hasProcedure(component.displayCondition)>
 				if (<@procedureOBJToConditionCode component.displayCondition/>)
 				</#if>
-		    	this.font.draw(poseStack, "${translateTokens(JavaConventions.escapeStringForJava(component.text))}",
+		    	this.font.draw(poseStack, new TranslatableComponent("${translateTokens(JavaConventions.escapeStringForJava(component.text))}"),
 					${(component.x - mx / 2)?int}, ${(component.y - my / 2)?int}, ${component.color.getRGB()});
 			</#if>
 		</#list>
@@ -160,7 +160,7 @@ public class ${name}Screen extends AbstractContainerScreen<${name}Menu> {
 		<#list data.components as component>
 			<#if component.getClass().getSimpleName() == "TextField">
 				${component.name} = new EditBox(this.font, this.leftPos + ${(component.x - mx/2)?int}, this.topPos + ${(component.y - my/2)?int},
-				${component.width}, ${component.height}, new TextComponent("${component.placeholder}"))
+				${component.width}, ${component.height}, new TranslatableComponent("${component.placeholder}"))
 				<#if component.placeholder?has_content>
 				{
 					{
@@ -191,7 +191,7 @@ public class ${name}Screen extends AbstractContainerScreen<${name}Menu> {
 				this.addWidget(this.${component.name});
 			<#elseif component.getClass().getSimpleName() == "Button">
 				this.addRenderableWidget(new Button(this.leftPos + ${(component.x - mx/2)?int}, this.topPos + ${(component.y - my/2)?int},
-					${component.width}, ${component.height}, new TextComponent("${component.text}"), e -> {
+					${component.width}, ${component.height}, new TranslatableComponent("${component.text}"), e -> {
 							<#if hasProcedure(component.onClick)>
 							if (<@procedureOBJToConditionCode component.displayCondition/>) {
 								${JavaModName}.PACKET_HANDLER.sendToServer(new ${name}ButtonMessage(${btid}, x, y, z));
@@ -211,7 +211,7 @@ public class ${name}Screen extends AbstractContainerScreen<${name}Menu> {
 				<#assign btid +=1>
 			<#elseif component.getClass().getSimpleName() == "Checkbox">
             	${component.name} = new Checkbox(this.leftPos + ${(component.x - mx/2)?int}, this.topPos + ${(component.y - my/2)?int},
-						150, 20, new TextComponent("${component.text}"), <#if hasProcedure(component.isCheckedProcedure)>
+						150, 20, new TranslatableComponent("${component.text}"), <#if hasProcedure(component.isCheckedProcedure)>
             	    <@procedureOBJToConditionCode component.isCheckedProcedure/><#else>false</#if>);
                 guistate.put("checkbox:${component.name}", ${component.name});
                 this.addRenderableWidget(${component.name});

--- a/plugins/generator-1.18.2/forge-1.18.2/templates/item/item.java.ftl
+++ b/plugins/generator-1.18.2/forge-1.18.2/templates/item/item.java.ftl
@@ -159,7 +159,7 @@ import javax.annotation.Nullable;
     @Override public void appendHoverText(ItemStack itemstack, Level world, List<Component> list, TooltipFlag flag) {
 		super.appendHoverText(itemstack, world, list, flag);
     	<#list data.specialInfo as entry>
-    	list.add(new TextComponent("${JavaConventions.escapeStringForJava(entry)}"));
+    	list.add(new TranslatableComponent("${JavaConventions.escapeStringForJava(entry)}"));
 		</#list>
 	}
 	</#if>


### PR DESCRIPTION
This PR adds the ability to use custom localization keys in GUI and item tooltips
- [x] Added support for keys localization of item tooltips (1.16.5)
- [x] Added support for keys localization of item tooltips (1.18.2)
- [ ] Added support for keys localization of GUI (1.16.5)
- [x] Added support for keys localization of GUI (1.18.2)