### PR TITLE
Add 3 height parameters for dimensions

### DIFF
--- a/plugins/generator-1.16.5/forge-1.16.5/dimension.definition.yaml
+++ b/plugins/generator-1.16.5/forge-1.16.5/dimension.definition.yaml
@@ -41,6 +41,8 @@ templates:
     condition: enablePortal
     deleteWhenConditionFalse: true
 
+field_exclusions: [minHeight, height]
+
 localizationkeys:
   - key: item.@modid.@registryname
     mapto: igniterName

--- a/plugins/generator-1.16.5/forge-1.16.5/templates/json/dimension/dimension_type.json.ftl
+++ b/plugins/generator-1.16.5/forge-1.16.5/templates/json/dimension/dimension_type.json.ftl
@@ -9,9 +9,9 @@
   "has_ceiling": ${data.worldGenType == "Nether like gen"},
   "coordinate_scale": 1,
   "ambient_light": <#if data.isDark>0<#else>0.5</#if>,
-  "logical_height": 256,
+  "logical_height": ${data.logicalHeight},
   "infiniburn": "minecraft:infiniburn_overworld",
-  "min_y": 0,
-  "height": 256,
+  "min_y": 0, <#-- Minecraft does not support custom heights in this version -->
+  "height": 256, <#-- Minecraft does not support custom heights in this version -->
   "effects": "${modid}:${registryname}"
 }

--- a/plugins/generator-1.16.5/forge-1.16.5/templates/json/dimension/dimension_type.json.ftl
+++ b/plugins/generator-1.16.5/forge-1.16.5/templates/json/dimension/dimension_type.json.ftl
@@ -11,7 +11,7 @@
   "ambient_light": <#if data.isDark>0<#else>0.5</#if>,
   "logical_height": ${data.logicalHeight},
   "infiniburn": "minecraft:infiniburn_overworld",
-  "min_y": 0, <#-- Minecraft does not support custom heights in this version -->
-  "height": 256, <#-- Minecraft does not support custom heights in this version -->
+  "min_y": 0,
+  "height": 256,
   "effects": "${modid}:${registryname}"
 }

--- a/plugins/generator-1.18.2/forge-1.18.2/templates/json/dimension/dimension_end.json.ftl
+++ b/plugins/generator-1.18.2/forge-1.18.2/templates/json/dimension/dimension_end.json.ftl
@@ -21,8 +21,8 @@
       "default_block": ${mappedMCItemToBlockStateJSON(data.mainFillerBlock)},
       "default_fluid": ${mappedMCItemToBlockStateJSON(data.fluidBlock)},
       "noise": {
-        "min_y": 0,
-        "height": 128,
+        "min_y": ${data.minHeight},
+        "height": ${data.height},
         "size_horizontal": 2,
         "size_vertical": 1,
         "island_noise_override": true,

--- a/plugins/generator-1.18.2/forge-1.18.2/templates/json/dimension/dimension_nether.json.ftl
+++ b/plugins/generator-1.18.2/forge-1.18.2/templates/json/dimension/dimension_nether.json.ftl
@@ -22,8 +22,8 @@
       "default_block": ${mappedMCItemToBlockStateJSON(data.mainFillerBlock)},
       "default_fluid": ${mappedMCItemToBlockStateJSON(data.fluidBlock)},
       "noise": {
-        "min_y": 0,
-        "height": 128,
+        "min_y": ${data.minHeight},
+        "height": ${data.height},
         "size_horizontal": 1,
         "size_vertical": 2,
         "sampling": {

--- a/plugins/generator-1.18.2/forge-1.18.2/templates/json/dimension/dimension_overworld.json.ftl
+++ b/plugins/generator-1.18.2/forge-1.18.2/templates/json/dimension/dimension_overworld.json.ftl
@@ -21,8 +21,8 @@
       "default_block": ${mappedMCItemToBlockStateJSON(data.mainFillerBlock)},
       "default_fluid": ${mappedMCItemToBlockStateJSON(data.fluidBlock)},
       "noise": {
-        "min_y": -64,
-        "height": 384,
+        "min_y": ${data.minHeight},
+        "height": ${data.height},
         "size_horizontal": 1,
         "size_vertical": 2,
         "sampling": {

--- a/plugins/generator-1.18.2/forge-1.18.2/templates/json/dimension/dimension_type.json.ftl
+++ b/plugins/generator-1.18.2/forge-1.18.2/templates/json/dimension/dimension_type.json.ftl
@@ -9,14 +9,9 @@
   "has_ceiling": ${data.worldGenType == "Nether like gen"},
   "coordinate_scale": 1,
   "ambient_light": <#if data.isDark>0<#else>0.5</#if>,
-  "logical_height": 256,
+  "logical_height": ${data.logicalHeight},
   "infiniburn": "#minecraft:infiniburn_overworld",
-  <#if data.worldGenType == "Normal world gen">
-  "min_y": -64,
-  "height": 384,
-  <#else>
-  "min_y": 0,
-  "height": 256,
-  </#if>
+  "min_y": ${data.minHeight},
+  "height": ${data.height},
   "effects": "<#if data.hasFog>minecraft:the_nether<#else>minecraft:overworld</#if>"
 }

--- a/plugins/generator-datapack-1.16.x/datapack-1.16.x/dimension.definition.yaml
+++ b/plugins/generator-datapack-1.16.x/datapack-1.16.x/dimension.definition.yaml
@@ -16,4 +16,4 @@ templates:
     name: "@MODDATAROOT/dimension/@registryname.json"
 
 field_inclusions: [mainFillerBlock, fluidBlock, biomesInDimension, imitateOverworldBehaviour, canRespawnHere,
-                   hasFog, isDark, doesWaterVaporize, sleepResult, hasSkyLight, imitateOverworldBehaviour, worldGenType]
+                   hasFog, isDark, doesWaterVaporize, sleepResult, hasSkyLight, imitateOverworldBehaviour, worldGenType, logicalHeight]

--- a/plugins/generator-datapack-1.16.x/datapack-1.16.x/templates/dimension/dimension_type.json.ftl
+++ b/plugins/generator-datapack-1.16.x/datapack-1.16.x/templates/dimension/dimension_type.json.ftl
@@ -11,7 +11,7 @@
   "ambient_light": <#if data.isDark>0<#else>0.5</#if>,
   "logical_height": ${data.logicalHeight},
   "infiniburn": "minecraft:infiniburn_overworld",
-  "min_y": 0, <#-- Minecraft does not support custom heights in this version -->
-  "height": 256, <#-- Minecraft does not support custom heights in this version -->
+  "min_y": 0,
+  "height": 256
   "effects": "<#if data.hasFog>minecraft:the_nether<#else>minecraft:overworld</#if>"
 }

--- a/plugins/generator-datapack-1.16.x/datapack-1.16.x/templates/dimension/dimension_type.json.ftl
+++ b/plugins/generator-datapack-1.16.x/datapack-1.16.x/templates/dimension/dimension_type.json.ftl
@@ -9,9 +9,9 @@
   "has_ceiling": ${data.worldGenType == "Nether like gen"},
   "coordinate_scale": 1,
   "ambient_light": <#if data.isDark>0<#else>0.5</#if>,
-  "logical_height": 256,
+  "logical_height": ${data.logicalHeight},
   "infiniburn": "minecraft:infiniburn_overworld",
-  "min_y": 0,
-  "height": 256,
+  "min_y": 0, <#-- Minecraft does not support custom heights in this version -->
+  "height": 256, <#-- Minecraft does not support custom heights in this version -->
   "effects": "<#if data.hasFog>minecraft:the_nether<#else>minecraft:overworld</#if>"
 }

--- a/plugins/generator-datapack-1.16.x/datapack-1.16.x/templates/dimension/dimension_type.json.ftl
+++ b/plugins/generator-datapack-1.16.x/datapack-1.16.x/templates/dimension/dimension_type.json.ftl
@@ -12,6 +12,6 @@
   "logical_height": ${data.logicalHeight},
   "infiniburn": "minecraft:infiniburn_overworld",
   "min_y": 0,
-  "height": 256
+  "height": 256,
   "effects": "<#if data.hasFog>minecraft:the_nether<#else>minecraft:overworld</#if>"
 }

--- a/plugins/generator-datapack-1.18.x/datapack-1.18.x/templates/dimension/dimension_type.json.ftl
+++ b/plugins/generator-datapack-1.18.x/datapack-1.18.x/templates/dimension/dimension_type.json.ftl
@@ -9,14 +9,9 @@
   "has_ceiling": ${data.worldGenType == "Nether like gen"},
   "coordinate_scale": 1,
   "ambient_light": <#if data.isDark>0<#else>0.5</#if>,
-  "logical_height": 256,
+  "logical_height": ${data.logicalHeight},
   "infiniburn": "#minecraft:infiniburn_overworld",
-  <#if data.worldGenType == "Normal world gen">
-  "min_y": -64,
-  "height": 384,
-  <#else>
-  "min_y": 0,
-  "height": 256,
-  </#if>
+  "min_y": ${data.minHeight},
+  "height": ${data.height},
   "effects": "<#if data.hasFog>minecraft:the_nether<#else>minecraft:overworld</#if>"
 }

--- a/plugins/mcreator-localization/help/default/dimension/height.md
+++ b/plugins/mcreator-localization/help/default/dimension/height.md
@@ -3,8 +3,9 @@ To get the maximal height, you need to add the minimum height to this number.
 
 This value needs to be a multiple of 16.
 
-NOTE: Only available in Minecraft 1.18.x and higher
-
+**Vanilla values:**
 - **Overworld**: 384
 - **Nether**: 256
 - **The End**: 256
+
+NOTE: Only available in Minecraft 1.18.x and higher

--- a/plugins/mcreator-localization/help/default/dimension/height.md
+++ b/plugins/mcreator-localization/help/default/dimension/height.md
@@ -1,0 +1,10 @@
+The total height in which blocks can exist within this dimension.
+To get the maximal height, you need to add the minimum height to this number.
+
+This value needs to be a multiple of 16.
+
+NOTE: Only available in Minecraft 1.18.x and higher
+
+- **Overworld**: 384
+- **Nether**: 256
+- **The End**: 256

--- a/plugins/mcreator-localization/help/default/dimension/logical_height.md
+++ b/plugins/mcreator-localization/help/default/dimension/logical_height.md
@@ -1,0 +1,6 @@
+The maximum height to which chorus fruits and nether portals can bring players within this dimension.
+This value can not be higher than the height of the dimension.
+
+- **Overworld**: 256
+- **Nether**: 128
+- **The End**: 256

--- a/plugins/mcreator-localization/help/default/dimension/logical_height.md
+++ b/plugins/mcreator-localization/help/default/dimension/logical_height.md
@@ -1,6 +1,7 @@
 The maximum height to which chorus fruits and nether portals can bring players within this dimension.
 This value can not be higher than the height of the dimension.
 
+**Vanilla values:**
 - **Overworld**: 256
 - **Nether**: 128
 - **The End**: 256

--- a/plugins/mcreator-localization/help/default/dimension/min_height.md
+++ b/plugins/mcreator-localization/help/default/dimension/min_height.md
@@ -1,0 +1,8 @@
+This is the minimum height the world will generate at. The bedrock will start generating at this layer.
+This value needs to be a multiple of 16.
+
+NOTE: Only available in Minecraft 1.18.x and higher
+
+- **Overworld**: -64
+- **Nether**: 0
+- **The End**: 0

--- a/plugins/mcreator-localization/help/default/dimension/min_height.md
+++ b/plugins/mcreator-localization/help/default/dimension/min_height.md
@@ -1,8 +1,9 @@
 This is the minimum height the world will generate at. The bedrock will start generating at this layer.
 This value needs to be a multiple of 16.
 
-NOTE: Only available in Minecraft 1.18.x and higher
-
+**Vanilla values:**
 - **Overworld**: -64
 - **Nether**: 0
 - **The End**: 0
+
+NOTE: Only available in Minecraft 1.18.x and higher

--- a/plugins/mcreator-localization/help/fr_FR/dimension/height.md
+++ b/plugins/mcreator-localization/help/fr_FR/dimension/height.md
@@ -1,0 +1,10 @@
+La hauteur totale dans laquelle les blocs peuvent exister à l'intérieur de cette dimension.
+Pour obtenir la hauteur maximale, vous devez ajouter la hauteur minimale à ce nombre.
+
+Cette valeur doit être un multiple de 16.
+
+NOTE: Disponible seulement pour Minecraft 1.18.x et plus
+
+- **Overworld**: 384
+- **Nether**: 256
+- **The End**: 256

--- a/plugins/mcreator-localization/help/fr_FR/dimension/logical_height.md
+++ b/plugins/mcreator-localization/help/fr_FR/dimension/logical_height.md
@@ -1,0 +1,6 @@
+The maximum height to which chorus fruits and nether portals can bring players within this dimension.
+This value can not be higher than the height of the dimension.
+
+- **Overworld**: 256
+- **Nether**: 128
+- **The End**: 256

--- a/plugins/mcreator-localization/help/fr_FR/dimension/min_height.md
+++ b/plugins/mcreator-localization/help/fr_FR/dimension/min_height.md
@@ -1,0 +1,9 @@
+C'est la hauteur minimale à laquelle le monde sera généré. La ouche de Bedrock commencera à se générer à cette couche.
+
+Cette valeur doit être un multiple de 16.
+
+NOTE: Disponible seulement pour Minecraft 1.18.x et plus
+
+- **Overworld**: -64
+- **Nether**: 0
+- **The End**: 0

--- a/plugins/mcreator-localization/lang/texts.properties
+++ b/plugins/mcreator-localization/lang/texts.properties
@@ -1828,6 +1828,11 @@ elementgui.dimension.biomes_in=Biomes in this dimension:
 elementgui.dimension.main_filler_block=<html>Main filler block:<br><small>Normal, Nether, End
 elementgui.dimension.fluid_block=<html>Fluid block:<br><small>Normal, Nether, End
 elementgui.dimension.sleep_result=Sleep attempt result:
+elementgui.dimension.min_height=Minimal height:
+elementgui.dimension.height=<html>Height:<br><small>Max height = min height + height
+elementgui.dimension.logical_height=Logical height:
+elementgui.dimension.error_logical_bigger_height=The logical height can not be bigger than the height of the dimension.
+elementgui.dimension.error_invalid_height_values=The minimal height or the maximal height is not a multiple of 16.
 elementgui.dimension.fog_air_color=<html>Sky / fog color override: <br><small>Leave DEFAULT for default handling per Minecraft version
 elementgui.dimension.enable_dimension_portal=Enable dimension portal:
 elementgui.dimension.portal_frame_block=Portal frame block:

--- a/src/main/java/net/mcreator/element/types/Dimension.java
+++ b/src/main/java/net/mcreator/element/types/Dimension.java
@@ -46,6 +46,9 @@ import java.util.List;
 	public MItemBlock fluidBlock;
 
 	public Color airColor;
+	public int minHeight;
+	public int height;
+	public int logicalHeight;
 	public boolean canRespawnHere;
 	public boolean hasFog;
 	public boolean isDark;

--- a/src/main/java/net/mcreator/ui/modgui/DimensionGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/DimensionGUI.java
@@ -68,6 +68,10 @@ public class DimensionGUI extends ModElementGUI<Dimension> {
 	private MCItemHolder mainFillerBlock;
 	private MCItemHolder fluidBlock;
 
+	private final JSpinner minHeight = new JSpinner(new SpinnerNumberModel(-64, -2032, 2016, 16));
+	private final JSpinner height = new JSpinner(new SpinnerNumberModel(384, 0, 4064, 16));
+	private final JSpinner logicalHeight = new JSpinner(new SpinnerNumberModel(256, 0, 2032, 1));
+
 	private final JCheckBox canRespawnHere = L10N.checkbox("elementgui.dimension.can_player_respawn");
 	private final JCheckBox hasFog = L10N.checkbox("elementgui.dimension.has_fog");
 	private final JCheckBox isDark = L10N.checkbox("elementgui.dimension.is_dark");
@@ -154,7 +158,7 @@ public class DimensionGUI extends ModElementGUI<Dimension> {
 				PanelUtils.join(FlowLayout.LEFT, L10N.label("elementgui.dimension.world_gen_type"), worldGenType),
 				PanelUtils.join(new JLabel(UIRES.get("dimension_types")))));
 
-		JPanel proper2 = new JPanel(new GridLayout(8, 2, 3, 3));
+		JPanel proper2 = new JPanel(new GridLayout(11, 2, 3, 3));
 		proper2.setOpaque(false);
 
 		airColor.setOpaque(false);
@@ -184,6 +188,18 @@ public class DimensionGUI extends ModElementGUI<Dimension> {
 		proper2.add(HelpUtils.wrapWithHelpButton(this.withEntry("dimension/sleep_result"),
 				L10N.label("elementgui.dimension.sleep_result")));
 		proper2.add(sleepResult);
+
+		proper2.add(HelpUtils.wrapWithHelpButton(this.withEntry("dimension/min_height"),
+				L10N.label("elementgui.dimension.min_height")));
+		proper2.add(minHeight);
+
+		proper2.add(HelpUtils.wrapWithHelpButton(this.withEntry("dimension/height"),
+				L10N.label("elementgui.dimension.height")));
+		proper2.add(height);
+
+		proper2.add(HelpUtils.wrapWithHelpButton(this.withEntry("dimension/logical_height"),
+				L10N.label("elementgui.dimension.logical_height")));
+		proper2.add(logicalHeight);
 
 		proper2.add(
 				HelpUtils.wrapWithHelpButton(this.withEntry("dimension/imitate_overworld"), imitateOverworldBehaviour));
@@ -350,10 +366,15 @@ public class DimensionGUI extends ModElementGUI<Dimension> {
 	}
 
 	@Override protected AggregatedValidationResult validatePage(int page) {
-		if (page == 0)
+		if (page == 0) {
+			if ((int) minHeight.getValue() % 16 != 0 || (int) height.getValue() % 16 != 0)
+				return new AggregatedValidationResult.FAIL(L10N.t("elementgui.dimension.error_invalid_height_values"));
+			else if ((int) logicalHeight.getValue() > (int) height.getValue())
+				return new AggregatedValidationResult.FAIL(L10N.t("elementgui.dimension.error_logical_bigger_height"));
 			return new AggregatedValidationResult(page2group);
-		else if (page == 1)
+		} else if (page == 1) {
 			return new AggregatedValidationResult(page1group);
+		}
 		return new AggregatedValidationResult.PASS();
 	}
 
@@ -371,6 +392,9 @@ public class DimensionGUI extends ModElementGUI<Dimension> {
 		portalParticles.setSelectedItem(dimension.portalParticles);
 		biomesInDimension.setListElements(dimension.biomesInDimension);
 		airColor.setColor(dimension.airColor);
+		minHeight.setValue(dimension.minHeight);
+		height.setValue(dimension.height);
+		logicalHeight.setValue(dimension.logicalHeight);
 		canRespawnHere.setSelected(dimension.canRespawnHere);
 		hasFog.setSelected(dimension.hasFog);
 		isDark.setSelected(dimension.isDark);
@@ -400,6 +424,9 @@ public class DimensionGUI extends ModElementGUI<Dimension> {
 		dimension.airColor = airColor.getColor();
 		dimension.canRespawnHere = canRespawnHere.isSelected();
 		dimension.hasFog = hasFog.isSelected();
+		dimension.minHeight = (int) minHeight.getValue();
+		dimension.height = (int) height.getValue();
+		dimension.logicalHeight = (int) logicalHeight.getValue();
 		dimension.isDark = isDark.isSelected();
 		dimension.imitateOverworldBehaviour = imitateOverworldBehaviour.isSelected();
 		dimension.hasSkyLight = hasSkyLight.isSelected();

--- a/src/test/java/net/mcreator/integration/TestWorkspaceDataProvider.java
+++ b/src/test/java/net/mcreator/integration/TestWorkspaceDataProvider.java
@@ -837,6 +837,9 @@ public class TestWorkspaceDataProvider {
 						new BiomeEntry(modElement.getWorkspace(), getRandomDataListEntry(random, biomes)));
 			}
 			dimension.airColor = Color.cyan;
+			dimension.logicalHeight = 1024;
+			dimension.minHeight = -1024;
+			dimension.height = 2048;
 			dimension.canRespawnHere = _true;
 			dimension.hasFog = _true;
 			dimension.hasSkyLight = !_true;


### PR DESCRIPTION
This PR adds 3 new parameters for custom dimensions, so they can define the minimum height, the height and the logical height. ([Explanations](https://minecraft.fandom.com/wiki/Custom_dimension#Syntax))

Logical height can be used by both MC versions. However, the minimum height and the height have been fully introduced with MC 1.18.

Data pack generators are also updated.