### PR TITLE
Localization keys for a list of entries

### DIFF
--- a/src/main/java/net/mcreator/generator/GeneratorTokens.java
+++ b/src/main/java/net/mcreator/generator/GeneratorTokens.java
@@ -18,7 +18,6 @@
 
 package net.mcreator.generator;
 
-import net.mcreator.element.GeneratableElement;
 import net.mcreator.workspace.Workspace;
 import net.mcreator.workspace.settings.WorkspaceSettings;
 import org.apache.logging.log4j.LogManager;
@@ -58,7 +57,7 @@ public class GeneratorTokens {
 
 	private static final Pattern brackets = Pattern.compile("@\\[(.*?)]");
 
-	static String replaceVariableTokens(GeneratableElement element, String rawname) {
+	static String replaceVariableTokens(Object element, String rawname) {
 		if (containsVariableTokens(rawname)) {
 			Matcher m = brackets.matcher(rawname);
 			while (m.find()) {


### PR DESCRIPTION
This PR adds an optional `fromlist` field support for `localizationkeys`. If thisfield is defined, given `key` and `mapto` are processed with data extracted from entries in the specified list on the `GeneratableElement`, otherwise the element itself is processed as always before.