### PR TITLE
Fixed `JEntriesList`s not running all listeners at once

### DIFF
--- a/src/main/java/net/mcreator/ui/minecraft/JEntriesList.java
+++ b/src/main/java/net/mcreator/ui/minecraft/JEntriesList.java
@@ -35,7 +35,6 @@ public abstract class JEntriesList extends JPanel {
 	protected final IHelpContext gui;
 
 	private final List<Consumer<JComponent>> entryListeners = new ArrayList<>();
-	private boolean updateRunning = false;
 
 	protected final JButton add = new JButton(UIRES.get("16px.add.gif"));
 
@@ -50,18 +49,7 @@ public abstract class JEntriesList extends JPanel {
 	}
 
 	protected void registerEntryUI(JComponent entry) {
-		for (Consumer<JComponent> l : entryListeners) {
-			if (!updateRunning) {
-				updateRunning = true;
-				new Thread(() -> {
-					try {
-						SwingUtilities.invokeAndWait(() -> l.accept(entry));
-					} catch (Exception ignored) {
-					}
-					updateRunning = false;
-				}).start();
-			}
-		}
+		entryListeners.forEach(l -> l.accept(entry));
 	}
 
 }

--- a/src/main/java/net/mcreator/ui/minecraft/JEntriesList.java
+++ b/src/main/java/net/mcreator/ui/minecraft/JEntriesList.java
@@ -36,7 +36,11 @@ public abstract class JEntriesList extends JPanel {
 
 	private final List<Consumer<JComponent>> entryListeners = new ArrayList<>();
 
-	protected final JButton add = new JButton(UIRES.get("16px.add.gif"));
+	protected final JButton add = new JButton(UIRES.get("16px.add.gif")) {
+		@Override public String getName() {
+			return "AddEntryButton";
+		}
+	};
 
 	public JEntriesList(MCreator mcreator, LayoutManager layout, IHelpContext gui) {
 		super(layout);

--- a/src/main/java/net/mcreator/ui/minecraft/JEntriesList.java
+++ b/src/main/java/net/mcreator/ui/minecraft/JEntriesList.java
@@ -35,6 +35,7 @@ public abstract class JEntriesList extends JPanel {
 	protected final IHelpContext gui;
 
 	private final List<Consumer<JComponent>> entryListeners = new ArrayList<>();
+	private boolean updateRunning = false;
 
 	protected final JButton add = new JButton(UIRES.get("16px.add.gif"));
 
@@ -49,7 +50,18 @@ public abstract class JEntriesList extends JPanel {
 	}
 
 	protected void registerEntryUI(JComponent entry) {
-		entryListeners.forEach(l -> l.accept(entry));
+		for (Consumer<JComponent> l : entryListeners) {
+			if (!updateRunning) {
+				updateRunning = true;
+				new Thread(() -> {
+					try {
+						SwingUtilities.invokeAndWait(() -> l.accept(entry));
+					} catch (Exception ignored) {
+					}
+					updateRunning = false;
+				}).start();
+			}
+		}
 	}
 
 }

--- a/src/main/java/net/mcreator/ui/modgui/ModElementChangedListener.java
+++ b/src/main/java/net/mcreator/ui/modgui/ModElementChangedListener.java
@@ -61,15 +61,13 @@ public interface ModElementChangedListener
 				listField.addChangeListener(this);
 			} else if (component instanceof JEntriesList entriesList) {
 				registerUI(entriesList);
-				entriesList.addEntryRegisterListener(c -> new Thread(() -> {
-					try {
-						SwingUtilities.invokeAndWait(() -> registerUI(c));
-					} catch (Exception ignored) {
-					}
+				entriesList.addEntryRegisterListener(c -> {
+					registerUI(c);
 					modElementChanged();
-				}).start());
+				});
 				component.addMouseListener(this);
-			} else if (component instanceof AbstractButton button) {
+			} else if (component instanceof AbstractButton button && !"AddEntryButton".equals(
+					button.getName())) { // this check resolves conflicts with JEntriesLists, letting their entries trigger the listener
 				button.addActionListener(this);
 			} else if (component instanceof JSpinner spinner) {
 				spinner.addChangeListener(this);

--- a/src/main/java/net/mcreator/ui/modgui/ModElementChangedListener.java
+++ b/src/main/java/net/mcreator/ui/modgui/ModElementChangedListener.java
@@ -61,10 +61,13 @@ public interface ModElementChangedListener
 				listField.addChangeListener(this);
 			} else if (component instanceof JEntriesList entriesList) {
 				registerUI(entriesList);
-				entriesList.addEntryRegisterListener(c -> {
-					registerUI(c);
+				entriesList.addEntryRegisterListener(c -> new Thread(() -> {
+					try {
+						SwingUtilities.invokeAndWait(() -> registerUI(c));
+					} catch (Exception ignored) {
+					}
 					modElementChanged();
-				});
+				}).start());
 				component.addMouseListener(this);
 			} else if (component instanceof AbstractButton button) {
 				button.addActionListener(this);


### PR DESCRIPTION
This PR fixes an issue with JEntriesLists when one of ME changed listeners prevents another from running because the first one is already running.
In fact, this is just an idea how to fix that, so you can even close this PR if you're aware of a better approach.