### PR TITLE
Add a pre generator loading event

### DIFF
--- a/src/main/java/net/mcreator/element/ModElementTypeLoader.java
+++ b/src/main/java/net/mcreator/element/ModElementTypeLoader.java
@@ -117,7 +117,7 @@ public class ModElementTypeLoader {
 				(mc, me, e) -> null, GeneratableElement.Unknown.class);
 	}
 
-	private static ModElementType<?> register(ModElementType<?> elementType) {
+	public static ModElementType<?> register(ModElementType<?> elementType) {
 		REGISTRY.add(elementType);
 		return elementType;
 	}

--- a/src/main/java/net/mcreator/plugin/events/PreGeneratorsLoadingEvent.java
+++ b/src/main/java/net/mcreator/plugin/events/PreGeneratorsLoadingEvent.java
@@ -1,0 +1,33 @@
+/*
+ * MCreator (https://mcreator.net/)
+ * Copyright (C) 2012-2020, Pylo
+ * Copyright (C) 2020-2022, Pylo, opensource contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package net.mcreator.plugin.events;
+
+import net.mcreator.ui.MCreatorApplication;
+
+/**
+ * <p>This event is triggered before generators are loaded. This event can be used to load custom {@link net.mcreator.element.ModElementType}.
+ * As it is triggered after plugins are loaded, except generators, this event can be used to create new features for plugins.</p>
+ */
+public class PreGeneratorsLoadingEvent extends ApplicationLoadedEvent {
+
+	public PreGeneratorsLoadingEvent(MCreatorApplication mcreatorApplication) {
+		super(mcreatorApplication);
+	}
+}

--- a/src/main/java/net/mcreator/ui/MCreatorApplication.java
+++ b/src/main/java/net/mcreator/ui/MCreatorApplication.java
@@ -34,6 +34,7 @@ import net.mcreator.minecraft.api.ModAPIManager;
 import net.mcreator.plugin.MCREvent;
 import net.mcreator.plugin.PluginLoader;
 import net.mcreator.plugin.events.ApplicationLoadedEvent;
+import net.mcreator.plugin.events.PreGeneratorsLoadingEvent;
 import net.mcreator.preferences.PreferencesManager;
 import net.mcreator.themes.ThemeLoader;
 import net.mcreator.ui.action.impl.AboutAction;
@@ -155,6 +156,8 @@ public final class MCreatorApplication {
 
 		splashScreen.setProgress(60, "Preloading resources");
 		TiledImageCache.loadAndTileImages();
+
+		MCREvent.event(new PreGeneratorsLoadingEvent(this));
 
 		splashScreen.setProgress(70, "Loading generators");
 


### PR DESCRIPTION
This event (for #2847) adds a new event triggered before generators are triggered, ut after everything else in plugins. It is required to create new mod element types or other plugin features.