### PR TITLE
Add some events for Java plugins

### DIFF
--- a/src/main/java/net/mcreator/plugin/PluginLoader.java
+++ b/src/main/java/net/mcreator/plugin/PluginLoader.java
@@ -24,6 +24,7 @@ import net.mcreator.io.FileIO;
 import net.mcreator.io.UserFolderManager;
 import net.mcreator.io.net.WebIO;
 import net.mcreator.io.zip.ZipIO;
+import net.mcreator.plugin.events.PluginLoadedEvent;
 import net.mcreator.preferences.PreferencesManager;
 import net.mcreator.ui.MCreatorApplication;
 import org.apache.logging.log4j.LogManager;
@@ -243,6 +244,7 @@ public class PluginLoader extends URLClassLoader {
 			return null;
 		}
 
+		MCREvent.event(new PluginLoadedEvent(plugin));
 		return plugin;
 	}
 

--- a/src/main/java/net/mcreator/plugin/events/PluginLoadedEvent.java
+++ b/src/main/java/net/mcreator/plugin/events/PluginLoadedEvent.java
@@ -1,0 +1,38 @@
+/*
+ * MCreator (https://mcreator.net/)
+ * Copyright (C) 2012-2020, Pylo
+ * Copyright (C) 2020-2022, Pylo, opensource contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package net.mcreator.plugin.events;
+
+import net.mcreator.plugin.MCREvent;
+import net.mcreator.plugin.Plugin;
+
+/**
+ * <p>Triggered when a {@link Plugin} is correctly loaded.</p>
+ */
+public class PluginLoadedEvent extends MCREvent {
+	private final Plugin plugin;
+
+	public PluginLoadedEvent(Plugin plugin) {
+		this.plugin = plugin;
+	}
+
+	public Plugin getPlugin() {
+		return plugin;
+	}
+}

--- a/src/main/java/net/mcreator/plugin/events/ThemeLoadedEvent.java
+++ b/src/main/java/net/mcreator/plugin/events/ThemeLoadedEvent.java
@@ -1,0 +1,38 @@
+/*
+ * MCreator (https://mcreator.net/)
+ * Copyright (C) 2012-2020, Pylo
+ * Copyright (C) 2020-2022, Pylo, opensource contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package net.mcreator.plugin.events;
+
+import net.mcreator.plugin.MCREvent;
+import net.mcreator.themes.Theme;
+
+/**
+ * <p>Triggered when a {@link net.mcreator.themes.Theme} is correctly loaded.</p>
+ */
+public class ThemeLoadedEvent extends MCREvent {
+	private final Theme theme;
+
+	public ThemeLoadedEvent(Theme theme) {
+		this.theme = theme;
+	}
+
+	public Theme getTheme() {
+		return theme;
+	}
+}

--- a/src/main/java/net/mcreator/plugin/events/ui/ModElementGUIEvent.java
+++ b/src/main/java/net/mcreator/plugin/events/ui/ModElementGUIEvent.java
@@ -1,0 +1,49 @@
+/*
+ * MCreator (https://mcreator.net/)
+ * Copyright (C) 2012-2020, Pylo
+ * Copyright (C) 2020-2022, Pylo, opensource contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package net.mcreator.plugin.events.ui;
+
+import net.mcreator.ui.MCreatorTabs;
+import net.mcreator.ui.modgui.ModElementGUI;
+
+public class ModElementGUIEvent extends TabEvents {
+
+	private final ModElementGUI<?> modElementGUI;
+
+	public ModElementGUIEvent(MCreatorTabs.Tab tab, ModElementGUI<?> modElementGUI) {
+		super(tab);
+		this.modElementGUI = modElementGUI;
+	}
+
+	public ModElementGUI<?> getModElementGUI() {
+		return modElementGUI;
+	}
+
+	public static class Pre extends ModElementGUIEvent {
+		public Pre(MCreatorTabs.Tab tab, ModElementGUI<?> modElementGUI) {
+			super(tab, modElementGUI);
+		}
+	}
+
+	public static class Post extends ModElementGUIEvent {
+		public Post(MCreatorTabs.Tab tab, ModElementGUI<?> modElementGUI) {
+			super(tab, modElementGUI);
+		}
+	}
+}

--- a/src/main/java/net/mcreator/plugin/events/ui/ModElementGUIEvent.java
+++ b/src/main/java/net/mcreator/plugin/events/ui/ModElementGUIEvent.java
@@ -22,6 +22,9 @@ package net.mcreator.plugin.events.ui;
 import net.mcreator.ui.MCreatorTabs;
 import net.mcreator.ui.modgui.ModElementGUI;
 
+/**
+ * <p>These events are triggered at different states of a {@link ModElementGUI} loading.</p>
+ */
 public class ModElementGUIEvent extends TabEvents {
 
 	private final ModElementGUI<?> modElementGUI;

--- a/src/main/java/net/mcreator/plugin/events/ui/TabEvents.java
+++ b/src/main/java/net/mcreator/plugin/events/ui/TabEvents.java
@@ -1,0 +1,57 @@
+/*
+ * MCreator (https://mcreator.net/)
+ * Copyright (C) 2012-2020, Pylo
+ * Copyright (C) 2020-2022, Pylo, opensource contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package net.mcreator.plugin.events.ui;
+
+import net.mcreator.plugin.MCREvent;
+import net.mcreator.ui.MCreatorTabs;
+
+public class TabEvents extends MCREvent {
+
+	private final MCreatorTabs.Tab tab;
+
+	public TabEvents(MCreatorTabs.Tab tab) {
+		this.tab = tab;
+	}
+
+	public MCreatorTabs.Tab getTab() {
+		return tab;
+	}
+
+	public static class AddTabEvent extends TabEvents {
+
+		public AddTabEvent(MCreatorTabs.Tab tab) {
+			super(tab);
+		}
+	}
+
+	public static class CloseTabEvent extends TabEvents {
+
+		public CloseTabEvent(MCreatorTabs.Tab tab) {
+			super(tab);
+		}
+	}
+
+	public static class ShowTabEvent extends TabEvents {
+
+		public ShowTabEvent(MCreatorTabs.Tab tab) {
+			super(tab);
+		}
+	}
+}

--- a/src/main/java/net/mcreator/plugin/events/ui/TabEvents.java
+++ b/src/main/java/net/mcreator/plugin/events/ui/TabEvents.java
@@ -22,6 +22,9 @@ package net.mcreator.plugin.events.ui;
 import net.mcreator.plugin.MCREvent;
 import net.mcreator.ui.MCreatorTabs;
 
+/**
+ * <p>Events for different actions of a {@link MCreatorTabs.Tab} component.</p>
+ */
 public class TabEvents extends MCREvent {
 
 	private final MCreatorTabs.Tab tab;
@@ -34,6 +37,9 @@ public class TabEvents extends MCREvent {
 		return tab;
 	}
 
+	/**
+	 * <p>Triggered when a {@link MCreatorTabs.Tab} is added to the UI.</p>
+	 */
 	public static class AddTabEvent extends TabEvents {
 
 		public AddTabEvent(MCreatorTabs.Tab tab) {
@@ -41,6 +47,9 @@ public class TabEvents extends MCREvent {
 		}
 	}
 
+	/**
+	 * <p>Triggered BEFORE the {@link MCreatorTabs.Tab} is closed by the user.</p>
+	 */
 	public static class CloseTabEvent extends TabEvents {
 
 		public CloseTabEvent(MCreatorTabs.Tab tab) {
@@ -48,6 +57,10 @@ public class TabEvents extends MCREvent {
 		}
 	}
 
+	/**
+	 * <p>Triggered when the user clicks on a {@link MCreatorTabs.Tab} and is shown.
+	 * This event is not triggered when the {@link MCreatorTabs.Tab} is added.</p>
+	 */
 	public static class ShowTabEvent extends TabEvents {
 
 		public ShowTabEvent(MCreatorTabs.Tab tab) {

--- a/src/main/java/net/mcreator/themes/ThemeLoader.java
+++ b/src/main/java/net/mcreator/themes/ThemeLoader.java
@@ -21,7 +21,9 @@ package net.mcreator.themes;
 
 import com.google.gson.Gson;
 import net.mcreator.io.FileIO;
+import net.mcreator.plugin.MCREvent;
 import net.mcreator.plugin.PluginLoader;
+import net.mcreator.plugin.events.ThemeLoadedEvent;
 import net.mcreator.preferences.PreferencesManager;
 import net.mcreator.ui.init.UIRES;
 import net.mcreator.util.image.ImageUtils;
@@ -69,6 +71,7 @@ public class ThemeLoader {
 						UIRES.getImageFromResourceID("themes/" + theme.getID() + "/icon.png").getImage(), 64)));
 
 			THEMES.add(theme);
+			MCREvent.event(new ThemeLoadedEvent(theme));
 		}
 
 		CURRENT_THEME = getTheme(PreferencesManager.PREFERENCES.hidden.uiTheme);

--- a/src/main/java/net/mcreator/ui/MCreatorTabs.java
+++ b/src/main/java/net/mcreator/ui/MCreatorTabs.java
@@ -169,8 +169,8 @@ public class MCreatorTabs {
 		tab.addMouseListener(new MouseAdapter() {
 			@Override public void mousePressed(MouseEvent mouseEvent) {
 				if (mouseEvent.getButton() == MouseEvent.BUTTON2 && !tab.ghost && tab.closeable) {
-					closeTab(tab);
 					MCREvent.event(new TabEvents.CloseTabEvent(tab));
+					closeTab(tab);
 				} else {
 					showTab(tab);
 					MCREvent.event(new TabEvents.ShowTabEvent(tab));

--- a/src/main/java/net/mcreator/ui/MCreatorTabs.java
+++ b/src/main/java/net/mcreator/ui/MCreatorTabs.java
@@ -18,6 +18,8 @@
 
 package net.mcreator.ui;
 
+import net.mcreator.plugin.MCREvent;
+import net.mcreator.plugin.events.ui.TabEvents;
 import net.mcreator.ui.component.JEmptyBox;
 import net.mcreator.ui.component.JScrollablePopupMenu;
 import net.mcreator.ui.component.util.ComponentUtils;
@@ -168,14 +170,17 @@ public class MCreatorTabs {
 			@Override public void mousePressed(MouseEvent mouseEvent) {
 				if (mouseEvent.getButton() == MouseEvent.BUTTON2 && !tab.ghost && tab.closeable) {
 					closeTab(tab);
+					MCREvent.event(new TabEvents.CloseTabEvent(tab));
 				} else {
 					showTab(tab);
+					MCREvent.event(new TabEvents.ShowTabEvent(tab));
 				}
 			}
 		});
 
 		container.add(tab.content, tab.identifier.toString());
 		showTab(tab);
+		MCREvent.event(new TabEvents.AddTabEvent(tab));
 
 		reloadTabStrip();
 	}

--- a/src/main/java/net/mcreator/ui/modgui/ModElementGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/ModElementGUI.java
@@ -20,6 +20,8 @@ package net.mcreator.ui.modgui;
 
 import net.mcreator.element.GeneratableElement;
 import net.mcreator.minecraft.MCItem;
+import net.mcreator.plugin.MCREvent;
+import net.mcreator.plugin.events.ui.ModElementGUIEvent;
 import net.mcreator.preferences.PreferencesManager;
 import net.mcreator.ui.MCreator;
 import net.mcreator.ui.MCreatorTabs;
@@ -105,6 +107,7 @@ public abstract class ModElementGUI<GE extends GeneratableElement> extends ViewB
 	}
 
 	@Override public ViewBase showView() {
+		MCREvent.event(new ModElementGUIEvent.Post(this.tabIn, this));
 		this.tabIn = new MCreatorTabs.Tab(this, modElement);
 
 		// reload data lists in a background thread
@@ -128,6 +131,7 @@ public abstract class ModElementGUI<GE extends GeneratableElement> extends ViewB
 			mcreator.mcreatorTabs.addTab(this.tabIn);
 			return this;
 		}
+		MCREvent.event(new ModElementGUIEvent.Post(existing, this));
 		return (ViewBase) existing.getContent();
 	}
 


### PR DESCRIPTION
This PR adds some new events to #2847. I tried to make classes similar to how Forge makes their events, so similar events will be inside the same class, to avoid duplicated ones.

New events:
- PluginLoadedEvent (triggered for each loaded plugin)
- ThemeLoadedEvent (triggered for each loaded UI theme)*
- Tab related events (Add/Close/Show)
- ModElementGUIEvent (Pre and Post)

*I wanted to give the plugin adding the loaded theme. However, due to how the system is made, this is not possible without adding code unrelated to this PR.