### PR TITLE
Added transparency control to JColor

### DIFF
--- a/src/main/java/net/mcreator/ui/component/JColor.java
+++ b/src/main/java/net/mcreator/ui/component/JColor.java
@@ -37,6 +37,7 @@ public class JColor extends JPanel {
 	private final JButton bt1 = new JButton("...");
 
 	private final boolean allowNullColor;
+	private final boolean allowTransparency;
 
 	private JDialog dialog = null;
 
@@ -45,6 +46,10 @@ public class JColor extends JPanel {
 	}
 
 	public JColor(Window window, boolean allowNullColor) {
+		this(window, allowNullColor, true);
+	}
+
+	public JColor(Window window, boolean allowNullColor, boolean allowTransparency) {
 		setLayout(new BorderLayout(2, 0));
 		fl1.setText("255,255,255");
 		fl1.setBackground(Color.white);
@@ -68,6 +73,7 @@ public class JColor extends JPanel {
 		});
 
 		this.allowNullColor = allowNullColor;
+		this.allowTransparency = allowTransparency;
 
 		if (allowNullColor) {
 			setColor(null);
@@ -97,7 +103,7 @@ public class JColor extends JPanel {
 		if (c == null && !allowNullColor)
 			c = Color.white;
 
-		currentColor = c;
+		currentColor = allowTransparency || c == null ? c : new Color(c.getRGB(), false);
 
 		if (currentColor == null) {
 			fl1.setOpaque(false);

--- a/src/main/java/net/mcreator/ui/component/JColor.java
+++ b/src/main/java/net/mcreator/ui/component/JColor.java
@@ -22,6 +22,7 @@ import net.mcreator.ui.component.util.PanelUtils;
 import net.mcreator.ui.init.UIRES;
 
 import javax.swing.*;
+import javax.swing.colorchooser.AbstractColorChooserPanel;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -40,14 +41,6 @@ public class JColor extends JPanel {
 	private final boolean allowTransparency;
 
 	private JDialog dialog = null;
-
-	public JColor(Window window) {
-		this(window, false);
-	}
-
-	public JColor(Window window, boolean allowNullColor) {
-		this(window, allowNullColor, true);
-	}
 
 	public JColor(Window window, boolean allowNullColor, boolean allowTransparency) {
 		setLayout(new BorderLayout(2, 0));
@@ -85,6 +78,9 @@ public class JColor extends JPanel {
 		} else {
 			add("East", bt1);
 		}
+
+		for (AbstractColorChooserPanel panel : colorChooser.getChooserPanels())
+			panel.setColorTransparencySelectionEnabled(allowTransparency);
 
 		setOpaque(false);
 	}

--- a/src/main/java/net/mcreator/ui/dialogs/imageeditor/FromTemplateDialog.java
+++ b/src/main/java/net/mcreator/ui/dialogs/imageeditor/FromTemplateDialog.java
@@ -88,9 +88,9 @@ public class FromTemplateDialog extends MCreatorDialog {
 		templatesSorted = new ArrayList<>(ImageMakerTexturesCache.CACHE.keySet());
 		templatesSorted.sort(Comparator.comparing(resourcePointer -> resourcePointer.identifier.toString()));
 
-		col1 = new JColor(window);
-		col2 = new JColor(window);
-		col4 = new JColor(window);
+		col1 = new JColor(window, false, true);
+		col2 = new JColor(window, false, true);
+		col4 = new JColor(window, false, true);
 
 		JPanel settings = new JPanel(new BorderLayout());
 		JPanel controls = new JPanel(new BorderLayout());

--- a/src/main/java/net/mcreator/ui/dialogs/imageeditor/NewImageDialog.java
+++ b/src/main/java/net/mcreator/ui/dialogs/imageeditor/NewImageDialog.java
@@ -68,7 +68,7 @@ public class NewImageDialog extends MCreatorDialog {
 
 		//Filler settings
 		JPanel colorSettings = new JPanel(new GridLayout(1, 2, 5, 5));
-		JColor colorChoser = new JColor(window);
+		JColor colorChoser = new JColor(window, false, true);
 		colorSettings.add(L10N.label("dialog.imageeditor.base_color"));
 		colorSettings.add(colorChoser);
 

--- a/src/main/java/net/mcreator/ui/dialogs/imageeditor/NewLayerDialog.java
+++ b/src/main/java/net/mcreator/ui/dialogs/imageeditor/NewLayerDialog.java
@@ -64,7 +64,7 @@ public class NewLayerDialog extends MCreatorDialog {
 
 		//Filler settings
 		JPanel colorSettings = new JPanel(new GridLayout(1, 2, 5, 5));
-		JColor colorChoser = new JColor(window);
+		JColor colorChoser = new JColor(window, false, true);
 		colorSettings.add(L10N.label("dialog.imageeditor.base_color"));
 		colorSettings.add(colorChoser);
 

--- a/src/main/java/net/mcreator/ui/dialogs/imageeditor/RecolorDialog.java
+++ b/src/main/java/net/mcreator/ui/dialogs/imageeditor/RecolorDialog.java
@@ -45,7 +45,7 @@ public class RecolorDialog extends MCreatorDialog {
 
 		JPanel colorSettings = new JPanel();
 		colorSettings.setLayout(new BoxLayout(colorSettings, BoxLayout.X_AXIS));
-		JColor colorChooser = new JColor(window);
+		JColor colorChooser = new JColor(window, false, true);
 		colorChooser.setColor(colorSelector.getForegroundColor());
 		colorSettings.add(L10N.label("dialog.imageeditor.color"));
 		colorSettings.add(Box.createRigidArea(new Dimension(25, 0)));

--- a/src/main/java/net/mcreator/ui/dialogs/preferences/PreferencesDialog.java
+++ b/src/main/java/net/mcreator/ui/dialogs/preferences/PreferencesDialog.java
@@ -284,7 +284,7 @@ public class PreferencesDialog extends MCreatorDialog {
 			placeInside.add(PanelUtils.westAndEastElement(label, box), cons);
 			return box;
 		} else if (actualField.getType().equals(Color.class)) {
-			JColor box = new JColor(parent);
+			JColor box = new JColor(parent, false, false);
 			if (entry.visualWidth() != -1)
 				box.setPreferredSize(new Dimension(entry.visualWidth(), 0));
 			box.setColor((Color) value);

--- a/src/main/java/net/mcreator/ui/dialogs/tools/ArmorPackMakerTool.java
+++ b/src/main/java/net/mcreator/ui/dialogs/tools/ArmorPackMakerTool.java
@@ -62,7 +62,7 @@ public class ArmorPackMakerTool {
 		JPanel props = new JPanel(new GridLayout(4, 2, 5, 5));
 
 		VTextField name = new VTextField(25);
-		JColor color = new JColor(mcreator, false, true);
+		JColor color = new JColor(mcreator, false, false);
 		JSpinner power = new JSpinner(new SpinnerNumberModel(1, 0.1, 10, 0.1));
 		MCItemHolder base = new MCItemHolder(mcreator, ElementUtil::loadBlocksAndItems);
 

--- a/src/main/java/net/mcreator/ui/dialogs/tools/ArmorPackMakerTool.java
+++ b/src/main/java/net/mcreator/ui/dialogs/tools/ArmorPackMakerTool.java
@@ -62,7 +62,7 @@ public class ArmorPackMakerTool {
 		JPanel props = new JPanel(new GridLayout(4, 2, 5, 5));
 
 		VTextField name = new VTextField(25);
-		JColor color = new JColor(mcreator);
+		JColor color = new JColor(mcreator, false, true);
 		JSpinner power = new JSpinner(new SpinnerNumberModel(1, 0.1, 10, 0.1));
 		MCItemHolder base = new MCItemHolder(mcreator, ElementUtil::loadBlocksAndItems);
 

--- a/src/main/java/net/mcreator/ui/dialogs/tools/MaterialPackMakerTool.java
+++ b/src/main/java/net/mcreator/ui/dialogs/tools/MaterialPackMakerTool.java
@@ -52,7 +52,7 @@ public class MaterialPackMakerTool {
 		JPanel props = new JPanel(new GridLayout(4, 2, 5, 5));
 
 		VTextField name = new VTextField(25);
-		JColor color = new JColor(mcreator, false, true);
+		JColor color = new JColor(mcreator, false, false);
 		JSpinner power = new JSpinner(new SpinnerNumberModel(1, 0.1, 10, 0.1));
 		JComboBox<String> type = new JComboBox<>(new String[] { "Gem based", "Dust based", "Ingot based" });
 

--- a/src/main/java/net/mcreator/ui/dialogs/tools/MaterialPackMakerTool.java
+++ b/src/main/java/net/mcreator/ui/dialogs/tools/MaterialPackMakerTool.java
@@ -52,7 +52,7 @@ public class MaterialPackMakerTool {
 		JPanel props = new JPanel(new GridLayout(4, 2, 5, 5));
 
 		VTextField name = new VTextField(25);
-		JColor color = new JColor(mcreator);
+		JColor color = new JColor(mcreator, false, true);
 		JSpinner power = new JSpinner(new SpinnerNumberModel(1, 0.1, 10, 0.1));
 		JComboBox<String> type = new JComboBox<>(new String[] { "Gem based", "Dust based", "Ingot based" });
 

--- a/src/main/java/net/mcreator/ui/dialogs/tools/OrePackMakerTool.java
+++ b/src/main/java/net/mcreator/ui/dialogs/tools/OrePackMakerTool.java
@@ -70,7 +70,7 @@ public class OrePackMakerTool {
 		JPanel props = new JPanel(new GridLayout(4, 2, 5, 5));
 
 		VTextField name = new VTextField(25);
-		JColor color = new JColor(mcreator);
+		JColor color = new JColor(mcreator, false, true);
 		JSpinner power = new JSpinner(new SpinnerNumberModel(1, 0.1, 10, 0.1));
 		JComboBox<String> type = new JComboBox<>(new String[] { "Gem based", "Dust based", "Ingot based" });
 

--- a/src/main/java/net/mcreator/ui/dialogs/tools/OrePackMakerTool.java
+++ b/src/main/java/net/mcreator/ui/dialogs/tools/OrePackMakerTool.java
@@ -70,7 +70,7 @@ public class OrePackMakerTool {
 		JPanel props = new JPanel(new GridLayout(4, 2, 5, 5));
 
 		VTextField name = new VTextField(25);
-		JColor color = new JColor(mcreator, false, true);
+		JColor color = new JColor(mcreator, false, false);
 		JSpinner power = new JSpinner(new SpinnerNumberModel(1, 0.1, 10, 0.1));
 		JComboBox<String> type = new JComboBox<>(new String[] { "Gem based", "Dust based", "Ingot based" });
 

--- a/src/main/java/net/mcreator/ui/dialogs/tools/ToolPackMakerTool.java
+++ b/src/main/java/net/mcreator/ui/dialogs/tools/ToolPackMakerTool.java
@@ -67,7 +67,7 @@ public class ToolPackMakerTool {
 		JPanel props = new JPanel(new GridLayout(4, 2, 5, 5));
 
 		VTextField name = new VTextField(25);
-		JColor color = new JColor(mcreator);
+		JColor color = new JColor(mcreator, false, true);
 		JSpinner power = new JSpinner(new SpinnerNumberModel(1, 0.1, 10, 0.1));
 		MCItemHolder base = new MCItemHolder(mcreator, ElementUtil::loadBlocksAndItems);
 

--- a/src/main/java/net/mcreator/ui/dialogs/tools/ToolPackMakerTool.java
+++ b/src/main/java/net/mcreator/ui/dialogs/tools/ToolPackMakerTool.java
@@ -67,7 +67,7 @@ public class ToolPackMakerTool {
 		JPanel props = new JPanel(new GridLayout(4, 2, 5, 5));
 
 		VTextField name = new VTextField(25);
-		JColor color = new JColor(mcreator, false, true);
+		JColor color = new JColor(mcreator, false, false);
 		JSpinner power = new JSpinner(new SpinnerNumberModel(1, 0.1, 10, 0.1));
 		MCItemHolder base = new MCItemHolder(mcreator, ElementUtil::loadBlocksAndItems);
 

--- a/src/main/java/net/mcreator/ui/dialogs/tools/WoodPackMakerTool.java
+++ b/src/main/java/net/mcreator/ui/dialogs/tools/WoodPackMakerTool.java
@@ -69,7 +69,7 @@ public class WoodPackMakerTool {
 		JPanel props = new JPanel(new GridLayout(4, 2, 5, 5));
 
 		VTextField name = new VTextField(25);
-		JColor color = new JColor(mcreator, false, true);
+		JColor color = new JColor(mcreator, false, false);
 		JSpinner power = new JSpinner(new SpinnerNumberModel(1, 0.1, 10, 0.1));
 
 		name.enableRealtimeValidation();

--- a/src/main/java/net/mcreator/ui/dialogs/tools/WoodPackMakerTool.java
+++ b/src/main/java/net/mcreator/ui/dialogs/tools/WoodPackMakerTool.java
@@ -69,7 +69,7 @@ public class WoodPackMakerTool {
 		JPanel props = new JPanel(new GridLayout(4, 2, 5, 5));
 
 		VTextField name = new VTextField(25);
-		JColor color = new JColor(mcreator);
+		JColor color = new JColor(mcreator, false, true);
 		JSpinner power = new JSpinner(new SpinnerNumberModel(1, 0.1, 10, 0.1));
 
 		name.enableRealtimeValidation();

--- a/src/main/java/net/mcreator/ui/dialogs/wysiwyg/InputSlotDialog.java
+++ b/src/main/java/net/mcreator/ui/dialogs/wysiwyg/InputSlotDialog.java
@@ -73,7 +73,7 @@ public class InputSlotDialog extends AbstractWYSIWYGDialog {
 		slotID.setText("0");
 		options.add(PanelUtils.join(FlowLayout.LEFT, L10N.label("dialog.gui.slot_id"), slotID));
 
-		JColor color = new JColor(editor.mcreator);
+		JColor color = new JColor(editor.mcreator, false, true);
 		options.add(PanelUtils.join(FlowLayout.LEFT, L10N.label("dialog.gui.slot_custom_color"), color));
 
 		MCItemHolder limit = new MCItemHolder(editor.mcreator, ElementUtil::loadBlocksAndItems);

--- a/src/main/java/net/mcreator/ui/dialogs/wysiwyg/InputSlotDialog.java
+++ b/src/main/java/net/mcreator/ui/dialogs/wysiwyg/InputSlotDialog.java
@@ -73,7 +73,7 @@ public class InputSlotDialog extends AbstractWYSIWYGDialog {
 		slotID.setText("0");
 		options.add(PanelUtils.join(FlowLayout.LEFT, L10N.label("dialog.gui.slot_id"), slotID));
 
-		JColor color = new JColor(editor.mcreator, false, true);
+		JColor color = new JColor(editor.mcreator, false, false);
 		options.add(PanelUtils.join(FlowLayout.LEFT, L10N.label("dialog.gui.slot_custom_color"), color));
 
 		MCItemHolder limit = new MCItemHolder(editor.mcreator, ElementUtil::loadBlocksAndItems);

--- a/src/main/java/net/mcreator/ui/dialogs/wysiwyg/LabelDialog.java
+++ b/src/main/java/net/mcreator/ui/dialogs/wysiwyg/LabelDialog.java
@@ -67,7 +67,7 @@ public class LabelDialog extends AbstractWYSIWYGDialog {
 
 		setTitle(L10N.t("dialog.gui.label_component_title"));
 
-		final JColor cola = new JColor(editor.mcreator, false, true);
+		final JColor cola = new JColor(editor.mcreator, false, false);
 
 		if (editor.renderBgLayer.isSelected()) {
 			cola.setColor(new Color(60, 60, 60));

--- a/src/main/java/net/mcreator/ui/dialogs/wysiwyg/LabelDialog.java
+++ b/src/main/java/net/mcreator/ui/dialogs/wysiwyg/LabelDialog.java
@@ -67,7 +67,7 @@ public class LabelDialog extends AbstractWYSIWYGDialog {
 
 		setTitle(L10N.t("dialog.gui.label_component_title"));
 
-		final JColor cola = new JColor(editor.mcreator);
+		final JColor cola = new JColor(editor.mcreator, false, true);
 
 		if (editor.renderBgLayer.isSelected()) {
 			cola.setColor(new Color(60, 60, 60));

--- a/src/main/java/net/mcreator/ui/dialogs/wysiwyg/OutputSlotDialog.java
+++ b/src/main/java/net/mcreator/ui/dialogs/wysiwyg/OutputSlotDialog.java
@@ -78,7 +78,7 @@ public class OutputSlotDialog extends AbstractWYSIWYGDialog {
 
 		dropItemsWhenNotBound.setSelected(true);
 
-		final JColor color = new JColor(editor.mcreator, false, true);
+		final JColor color = new JColor(editor.mcreator, false, false);
 		options.add(PanelUtils.join(FlowLayout.LEFT, L10N.label("dialog.gui.slot_custom_color"), color));
 
 		ProcedureSelector eh = new ProcedureSelector(IHelpContext.NONE.withEntry("gui/when_slot_changed"),

--- a/src/main/java/net/mcreator/ui/dialogs/wysiwyg/OutputSlotDialog.java
+++ b/src/main/java/net/mcreator/ui/dialogs/wysiwyg/OutputSlotDialog.java
@@ -78,7 +78,7 @@ public class OutputSlotDialog extends AbstractWYSIWYGDialog {
 
 		dropItemsWhenNotBound.setSelected(true);
 
-		final JColor color = new JColor(editor.mcreator);
+		final JColor color = new JColor(editor.mcreator, false, true);
 		options.add(PanelUtils.join(FlowLayout.LEFT, L10N.label("dialog.gui.slot_custom_color"), color));
 
 		ProcedureSelector eh = new ProcedureSelector(IHelpContext.NONE.withEntry("gui/when_slot_changed"),

--- a/src/main/java/net/mcreator/ui/modgui/BiomeGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/BiomeGUI.java
@@ -113,11 +113,11 @@ public class BiomeGUI extends ModElementGUI<Biome> {
 	private MCItemHolder treeBranch;
 	private MCItemHolder treeFruits;
 
-	private final JColor airColor = new JColor(mcreator, true);
-	private final JColor grassColor = new JColor(mcreator, true);
-	private final JColor foliageColor = new JColor(mcreator, true);
-	private final JColor waterColor = new JColor(mcreator, true);
-	private final JColor waterFogColor = new JColor(mcreator, true);
+	private final JColor airColor = new JColor(mcreator, true, false);
+	private final JColor grassColor = new JColor(mcreator, true, false);
+	private final JColor foliageColor = new JColor(mcreator, true, false);
+	private final JColor waterColor = new JColor(mcreator, true, false);
+	private final JColor waterFogColor = new JColor(mcreator, true, false);
 
 	private final SoundSelector ambientSound = new SoundSelector(mcreator);
 	private final SoundSelector moodSound = new SoundSelector(mcreator);

--- a/src/main/java/net/mcreator/ui/modgui/BlockGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/BlockGUI.java
@@ -126,7 +126,7 @@ public class BlockGUI extends ModElementGUI<Block> {
 
 	private final JSpinner enchantPowerBonus = new JSpinner(new SpinnerNumberModel(0, 0, 1024, 0.1));
 
-	private final JColor beaconColorModifier = new JColor(mcreator, true);
+	private final JColor beaconColorModifier = new JColor(mcreator, true, false);
 
 	private final JCheckBox hasGravity = L10N.checkbox("elementgui.common.enable");
 	private final JCheckBox isWaterloggable = L10N.checkbox("elementgui.common.enable");

--- a/src/main/java/net/mcreator/ui/modgui/DimensionGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/DimensionGUI.java
@@ -80,7 +80,7 @@ public class DimensionGUI extends ModElementGUI<Dimension> {
 	private final JCheckBox enablePortal = L10N.checkbox("elementgui.dimension.enable_portal");
 
 	private final SoundSelector portalSound = new SoundSelector(mcreator);
-	private final JColor airColor = new JColor(mcreator, true);
+	private final JColor airColor = new JColor(mcreator, true, false);
 
 	private final DataListComboBox portalParticles = new DataListComboBox(mcreator);
 

--- a/src/main/java/net/mcreator/ui/modgui/LivingEntityGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/LivingEntityGUI.java
@@ -171,8 +171,8 @@ public class LivingEntityGUI extends ModElementGUI<LivingEntity> {
 	private final JTextField mobLabel = new JTextField();
 
 	private final JCheckBox spawnInDungeons = L10N.checkbox("elementgui.living_entity.spawn_dungeons");
-	private final JColor spawnEggBaseColor = new JColor(mcreator);
-	private final JColor spawnEggDotColor = new JColor(mcreator);
+	private final JColor spawnEggBaseColor = new JColor(mcreator, false, true);
+	private final JColor spawnEggDotColor = new JColor(mcreator, false, true);
 
 	private static final Model biped = new Model.BuiltInModel("Biped");
 	private static final Model chicken = new Model.BuiltInModel("Chicken");

--- a/src/main/java/net/mcreator/ui/modgui/LivingEntityGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/LivingEntityGUI.java
@@ -171,8 +171,8 @@ public class LivingEntityGUI extends ModElementGUI<LivingEntity> {
 	private final JTextField mobLabel = new JTextField();
 
 	private final JCheckBox spawnInDungeons = L10N.checkbox("elementgui.living_entity.spawn_dungeons");
-	private final JColor spawnEggBaseColor = new JColor(mcreator, false, true);
-	private final JColor spawnEggDotColor = new JColor(mcreator, false, true);
+	private final JColor spawnEggBaseColor = new JColor(mcreator, false, false);
+	private final JColor spawnEggDotColor = new JColor(mcreator, false, false);
 
 	private static final Model biped = new Model.BuiltInModel("Biped");
 	private static final Model chicken = new Model.BuiltInModel("Chicken");

--- a/src/main/java/net/mcreator/ui/modgui/PotionEffectGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/PotionEffectGUI.java
@@ -57,7 +57,7 @@ import java.util.stream.Collectors;
 public class PotionEffectGUI extends ModElementGUI<PotionEffect> {
 
 	private final VTextField effectName = new VTextField(20);
-	private final JColor color = new JColor(mcreator);
+	private final JColor color = new JColor(mcreator, false, true);
 	private final VComboBox<String> icon = new SearchableComboBox<>();
 
 	private final JCheckBox isInstant = L10N.checkbox("elementgui.potioneffect.is_instant");

--- a/src/main/java/net/mcreator/ui/modgui/PotionEffectGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/PotionEffectGUI.java
@@ -57,7 +57,7 @@ import java.util.stream.Collectors;
 public class PotionEffectGUI extends ModElementGUI<PotionEffect> {
 
 	private final VTextField effectName = new VTextField(20);
-	private final JColor color = new JColor(mcreator, false, true);
+	private final JColor color = new JColor(mcreator, false, false);
 	private final VComboBox<String> icon = new SearchableComboBox<>();
 
 	private final JCheckBox isInstant = L10N.checkbox("elementgui.potioneffect.is_instant");

--- a/src/main/java/net/mcreator/ui/views/AnimationMakerView.java
+++ b/src/main/java/net/mcreator/ui/views/AnimationMakerView.java
@@ -399,7 +399,7 @@ public class AnimationMakerView extends ViewBase {
 		JComboBox<ResourcePointer> types = new JComboBox<>();
 		templatesSorted.forEach(types::addItem);
 
-		JColor colors = new JColor(mcreator);
+		JColor colors = new JColor(mcreator, false, true);
 		JCheckBox cbox = new JCheckBox();
 		ActionListener al = event -> {
 			try {
@@ -461,7 +461,7 @@ public class AnimationMakerView extends ViewBase {
 						getFont().deriveFont(12.0f), Color.gray));
 
 		JButton selectFile = new JButton("...");
-		JColor colors = new JColor(mcreator);
+		JColor colors = new JColor(mcreator, false, true);
 		JCheckBox cbox = new JCheckBox();
 		JCheckBox cbox2 = new JCheckBox();
 

--- a/src/main/java/net/mcreator/ui/views/ArmorImageMakerView.java
+++ b/src/main/java/net/mcreator/ui/views/ArmorImageMakerView.java
@@ -53,7 +53,7 @@ public class ArmorImageMakerView extends ViewBase {
 	public ArmorImageMakerView(final MCreator fra) {
 		super(fra);
 
-		col = new JColor(fra);
+		col = new JColor(fra, false, true);
 
 		str.setSelectedItem("Standard");
 		col.setOpaque(false);


### PR DESCRIPTION
This PR closes #2873 by adding `allowTransparency` parameter to one of JColor constructors which defines whether to respect transparency of the updated color or not.