### PR TITLE
Allow custom data list entries to have multiple mappings

### DIFF
--- a/plugins/generator-1.16.5/forge-1.16.5/mappings/entities.yaml
+++ b/plugins/generator-1.16.5/forge-1.16.5/mappings/entities.yaml
@@ -3,7 +3,10 @@ _default:
   - EntityType.ZOMBIE
   - zombie
 _mcreator_prefix: "CUSTOM:"
-_mcreator_map_template: "@NAMEEntity.CustomEntity"
+_mcreator_map_template:
+  - "@NAMEEntity.CustomEntity"
+  - "@NAMEEntity.entity"
+  - "@modid:@registryname"
 EntityAgeable: AgeableEntity
 EntityAmbientCreature: AmbientEntity
 EntityAnimal: AnimalEntity

--- a/plugins/generator-1.16.5/forge-1.16.5/mappings/projectiles.yaml
+++ b/plugins/generator-1.16.5/forge-1.16.5/mappings/projectiles.yaml
@@ -2,7 +2,9 @@ _default:
   - SnowballEntity
   - EntityType.SNOWBALL
 _mcreator_prefix: "CUSTOM:"
-_mcreator_map_template: "@NAMEItem.ArrowCustomEntity"
+_mcreator_map_template:
+  - "@NAMEItem.ArrowCustomEntity"
+  - "@NAMEItem.arrow"
 Snowball:
   - SnowballEntity
   - EntityType.SNOWBALL

--- a/plugins/generator-1.16.5/forge-1.16.5/procedures/spawn_entity.java.ftl
+++ b/plugins/generator-1.16.5/forge-1.16.5/procedures/spawn_entity.java.ftl
@@ -1,11 +1,7 @@
 <#assign entity = generator.map(field$entity, "entities", 1)!"null">
 <#if entity != "null">
 	if(world instanceof ServerWorld) {
-		<#if !entity.toString().contains(".CustomEntity")>
-			Entity entityToSpawn = new ${generator.map(field$entity, "entities", 0)}(${entity}, (World) world);
-		<#else>
-			Entity entityToSpawn = new ${entity}(${entity.toString().replace(".CustomEntity", "")}.entity, (World) world);
-		</#if>
+		Entity entityToSpawn = new ${generator.map(field$entity, "entities", 0)}(${entity}, (World) world);
 		entityToSpawn.setLocationAndAngles(${input$x}, ${input$y}, ${input$z}, world.getRandom().nextFloat() * 360F, 0);
 
 		if (entityToSpawn instanceof MobEntity)

--- a/plugins/generator-1.16.5/forge-1.16.5/procedures/spawn_entity_with_rotation.java.ftl
+++ b/plugins/generator-1.16.5/forge-1.16.5/procedures/spawn_entity_with_rotation.java.ftl
@@ -1,11 +1,7 @@
 <#assign entity = generator.map(field$entity, "entities", 1)!"null">
 <#if entity != "null">
 	if(world instanceof ServerWorld) {
-    	<#if !entity.toString().contains(".CustomEntity")>
-			Entity entityToSpawn = new ${generator.map(field$entity, "entities", 0)}(${entity}, (World) world);
-    	<#else>
-			Entity entityToSpawn = new ${entity}(${entity.toString().replace(".CustomEntity", "")}.entity, (World) world);
-    	</#if>
+		Entity entityToSpawn = new ${generator.map(field$entity, "entities", 0)}(${entity}, (World) world);
 		entityToSpawn.setLocationAndAngles(${input$x}, ${input$y}, ${input$z}, (float) ${input$yaw}, (float) ${input$pitch});
 		entityToSpawn.setRenderYawOffset((float) ${input$yaw});
 		entityToSpawn.setRotationYawHead((float) ${input$yaw});

--- a/plugins/generator-1.16.5/forge-1.16.5/procedures/spawn_entity_with_rotation_velocity.java.ftl
+++ b/plugins/generator-1.16.5/forge-1.16.5/procedures/spawn_entity_with_rotation_velocity.java.ftl
@@ -1,11 +1,7 @@
 <#assign entity = generator.map(field$entity, "entities", 1)!"null">
 <#if entity != "null">
 	if(world instanceof ServerWorld) {
-    	<#if !entity.toString().contains(".CustomEntity")>
-			Entity entityToSpawn = new ${generator.map(field$entity, "entities", 0)}(${entity}, (World) world);
-    	<#else>
-			Entity entityToSpawn = new ${entity}(${entity.toString().replace(".CustomEntity", "")}.entity, (World) world);
-    	</#if>
+		Entity entityToSpawn = new ${generator.map(field$entity, "entities", 0)}(${entity}, (World) world);
 		entityToSpawn.setLocationAndAngles(${input$x}, ${input$y}, ${input$z}, (float) ${input$yaw}, (float) ${input$pitch});
 		entityToSpawn.setRenderYawOffset((float) ${input$yaw});
 		entityToSpawn.setRotationYawHead((float) ${input$yaw});

--- a/plugins/generator-1.16.5/forge-1.16.5/templates/biome.java.ftl
+++ b/plugins/generator-1.16.5/forge-1.16.5/templates/biome.java.ftl
@@ -352,11 +352,7 @@ import java.util.HashMap;
 				<#list data.spawnEntries as spawnEntry>
 					<#assign entity = generator.map(spawnEntry.entity.getUnmappedValue(), "entities", 1)!"null">
 					<#if entity != "null">
-						<#if !entity.toString().contains(".CustomEntity")>
 						mobSpawnInfo.withSpawner(${generator.map(spawnEntry.spawnType, "mobspawntypes")}, new MobSpawnInfo.Spawners(${entity}, ${spawnEntry.weight}, ${spawnEntry.minGroup}, ${spawnEntry.maxGroup}));
-						<#else>
-						mobSpawnInfo.withSpawner(${generator.map(spawnEntry.spawnType, "mobspawntypes")}, new MobSpawnInfo.Spawners(${entity.toString().replace(".CustomEntity", "")}.entity, ${spawnEntry.weight}, ${spawnEntry.minGroup}, ${spawnEntry.maxGroup}));
-						</#if>
 					</#if>
 				</#list>
 

--- a/plugins/generator-1.16.5/forge-1.16.5/templates/json/tag.json.ftl
+++ b/plugins/generator-1.16.5/forge-1.16.5/templates/json/tag.json.ftl
@@ -17,11 +17,7 @@
           </#list>
       <#elseif data.type == "Entities">
           <#list w.filterBrokenReferences(data.entities) as value>
-            <#if value.getUnmappedValue().startsWith("CUSTOM:")>
-                "${generator.getResourceLocationForModElement(value.getUnmappedValue()?replace("CUSTOM:", ""))}"
-            <#else>
-                "${generator.map(value.getUnmappedValue(), "entities", 2)}"
-            </#if>
+            "${generator.map(value.getUnmappedValue(), "entities", 2)}"
             <#if value?has_next>,</#if>
           </#list>
       </#if>

--- a/plugins/generator-1.18.2/forge-1.18.2/mappings/entities.yaml
+++ b/plugins/generator-1.18.2/forge-1.18.2/mappings/entities.yaml
@@ -3,7 +3,10 @@ _default:
   - EntityType.ZOMBIE
   - zombie
 _mcreator_prefix: "CUSTOM:"
-_mcreator_map_template: "@NAMEEntity"
+_mcreator_map_template:
+  - "@NAMEEntity"
+  - "@JavaModNameEntities.@REGISTRYNAME.get()"
+  - "@modid:@registryname"
 EntityAgeable: AgeableMob
 EntityAmbientCreature: AmbientCreature
 EntityAnimal: Animal

--- a/plugins/generator-1.18.2/forge-1.18.2/mappings/projectiles.yaml
+++ b/plugins/generator-1.18.2/forge-1.18.2/mappings/projectiles.yaml
@@ -2,7 +2,9 @@ _default:
   - Snowball
   - EntityType.SNOWBALL
 _mcreator_prefix: "CUSTOM:"
-_mcreator_map_template: "@NAMEEntity"
+_mcreator_map_template:
+  - "@NAMEEntity"
+  - "@JavaModNameEntities.@REGISTRYNAME.get()"
 Snowball:
   - Snowball
   - EntityType.SNOWBALL

--- a/plugins/generator-1.18.2/forge-1.18.2/procedures/spawn_entity.java.ftl
+++ b/plugins/generator-1.18.2/forge-1.18.2/procedures/spawn_entity.java.ftl
@@ -1,11 +1,7 @@
 <#assign entity = generator.map(field$entity, "entities", 1)!"null">
 <#if entity != "null">
 if (world instanceof ServerLevel _level) {
-	<#if !field$entity?starts_with("CUSTOM:")>
 	Entity entityToSpawn = new ${generator.map(field$entity, "entities", 0)}(${entity}, _level);
-	<#else>
-	Entity entityToSpawn = new ${entity}(${JavaModName}Entities.${generator.getRegistryNameForModElement(field$entity?replace("CUSTOM:", ""))?upper_case}.get(), _level);
-	</#if>
 	entityToSpawn.moveTo(${input$x}, ${input$y}, ${input$z}, world.getRandom().nextFloat() * 360F, 0);
 
 	if (entityToSpawn instanceof Mob _mobToSpawn)

--- a/plugins/generator-1.18.2/forge-1.18.2/procedures/spawn_entity_with_rotation.java.ftl
+++ b/plugins/generator-1.18.2/forge-1.18.2/procedures/spawn_entity_with_rotation.java.ftl
@@ -1,11 +1,7 @@
 <#assign entity = generator.map(field$entity, "entities", 1)!"null">
 <#if entity != "null">
 if (world instanceof ServerLevel _level) {
-	<#if !field$entity?starts_with("CUSTOM:")>
 	Entity entityToSpawn = new ${generator.map(field$entity, "entities", 0)}(${entity}, _level);
-   	<#else>
-	Entity entityToSpawn = new ${entity}(${JavaModName}Entities.${generator.getRegistryNameForModElement(field$entity?replace("CUSTOM:", ""))?upper_case}.get(), _level);
-   	</#if>
 	entityToSpawn.moveTo(${input$x}, ${input$y}, ${input$z}, ${opt.toFloat(input$yaw)}, ${opt.toFloat(input$pitch)});
 	entityToSpawn.setYBodyRot(${opt.toFloat(input$yaw)});
 	entityToSpawn.setYHeadRot(${opt.toFloat(input$yaw)});

--- a/plugins/generator-1.18.2/forge-1.18.2/procedures/spawn_entity_with_rotation_velocity.java.ftl
+++ b/plugins/generator-1.18.2/forge-1.18.2/procedures/spawn_entity_with_rotation_velocity.java.ftl
@@ -1,11 +1,7 @@
 <#assign entity = generator.map(field$entity, "entities", 1)!"null">
 <#if entity != "null">
 if (world instanceof ServerLevel _level) {
-	<#if !field$entity?starts_with("CUSTOM:")>
 	Entity entityToSpawn = new ${generator.map(field$entity, "entities", 0)}(${entity}, _level);
-   	<#else>
-	Entity entityToSpawn = new ${entity}(${JavaModName}Entities.${generator.getRegistryNameForModElement(field$entity?replace("CUSTOM:", ""))?upper_case}.get(), _level);
-   	</#if>
 	entityToSpawn.moveTo(${input$x}, ${input$y}, ${input$z}, ${opt.toFloat(input$yaw)}, ${opt.toFloat(input$pitch)});
 	entityToSpawn.setYBodyRot(${opt.toFloat(input$yaw)});
 	entityToSpawn.setYHeadRot(${opt.toFloat(input$yaw)});

--- a/plugins/generator-1.18.2/forge-1.18.2/templates/biome/biome.java.ftl
+++ b/plugins/generator-1.18.2/forge-1.18.2/templates/biome/biome.java.ftl
@@ -295,18 +295,11 @@ public class ${name}Biome {
 
         MobSpawnSettings.Builder mobSpawnInfo = new MobSpawnSettings.Builder();
         <#list data.spawnEntries as spawnEntry>
-            <#if !spawnEntry.entity.getUnmappedValue().contains("CUSTOM:")>
-                <#assign entity = generator.map(spawnEntry.entity.getUnmappedValue(), "entities", 1)!"null">
-                <#if entity != "null">
-                mobSpawnInfo.addSpawn(${generator.map(spawnEntry.spawnType, "mobspawntypes")},
-		    	    new MobSpawnSettings.SpawnerData(${entity}, ${spawnEntry.weight}, ${spawnEntry.minGroup}, ${spawnEntry.maxGroup}));
-                </#if>
-            <#else>
-            mobSpawnInfo.addSpawn(${generator.map(spawnEntry.spawnType, "mobspawntypes")},
-                new MobSpawnSettings.SpawnerData(
-                    ${JavaModName}Entities.${generator.getRegistryNameForModElement(spawnEntry.entity.getUnmappedValue()?replace("CUSTOM:", ""))?upper_case}.get(),
-                    ${spawnEntry.weight}, ${spawnEntry.minGroup}, ${spawnEntry.maxGroup}));
-            </#if>
+			<#assign entity = generator.map(spawnEntry.entity.getUnmappedValue(), "entities", 1)!"null">
+			<#if entity != "null">
+			mobSpawnInfo.addSpawn(${generator.map(spawnEntry.spawnType, "mobspawntypes")},
+				new MobSpawnSettings.SpawnerData(${entity}, ${spawnEntry.weight}, ${spawnEntry.minGroup}, ${spawnEntry.maxGroup}));
+			</#if>
         </#list>
 
         return new Biome.BiomeBuilder()

--- a/plugins/generator-1.18.2/forge-1.18.2/templates/json/tag.json.ftl
+++ b/plugins/generator-1.18.2/forge-1.18.2/templates/json/tag.json.ftl
@@ -17,11 +17,7 @@
           </#list>
       <#elseif data.type == "Entities">
           <#list w.filterBrokenReferences(data.entities) as value>
-            <#if value.getUnmappedValue().startsWith("CUSTOM:")>
-                "${generator.getResourceLocationForModElement(value.getUnmappedValue()?replace("CUSTOM:", ""))}"
-            <#else>
-                "${generator.map(value.getUnmappedValue(), "entities", 2)}"
-            </#if>
+            "${generator.map(value.getUnmappedValue(), "entities", 2)}"
             <#if value?has_next>,</#if>
           </#list>
       </#if>

--- a/src/main/java/net/mcreator/generator/mapping/NameMapper.java
+++ b/src/main/java/net/mcreator/generator/mapping/NameMapper.java
@@ -72,15 +72,20 @@ public class NameMapper {
 
 		String mcreator_prefix = (String) mapping.get("_mcreator_prefix");
 		if (mcreator_prefix != null && origName.startsWith(mcreator_prefix)) {
-			String mcreator_map_template = (String) mapping.get("_mcreator_map_template");
-			if (mcreator_map_template != null) {
+			Object mcreator_map_template = mapping.get("_mcreator_map_template");
+			String toMapTemplate = null;
+			if (mcreator_map_template instanceof String)
+				toMapTemplate = (String) mcreator_map_template;
+			else if (mcreator_map_template instanceof List<?> mappingValuesList && mappingTable < mappingValuesList.size())
+				toMapTemplate = (String) mappingValuesList.get(mappingTable);
+
+			if (toMapTemplate != null) {
 				origName = origName.replace(mcreator_prefix, "");
 				String retval = GeneratorTokens.replaceTokens(workspace,
-						mcreator_map_template.replace("@NAME", origName)
+						toMapTemplate.replace("@NAME", origName)
 								.replace("@UPPERNAME", origName.toUpperCase(Locale.ENGLISH))
-								.replace("@name", origName.toLowerCase(Locale.ENGLISH)).replace("@NAME", origName));
-				if (mcreator_map_template.contains("@registryname") || mcreator_map_template.contains(
-						"@REGISTRYNAME")) {
+								.replace("@name", origName.toLowerCase(Locale.ENGLISH)));
+				if (toMapTemplate.contains("@registryname") || toMapTemplate.contains("@REGISTRYNAME")) {
 					ModElement element = workspace.getModElementByName(origName);
 					if (element != null) {
 						retval = retval.replace("@registryname", element.getRegistryName())


### PR DESCRIPTION
This PR allows data lists to use lists instead of strings in the `_mcreator_map_template` field. This simplifies the template of some procedures and elements, since custom entries no longer need a special handling.