### PR TITLE
Small fixes

### DIFF
--- a/src/main/java/net/mcreator/blockly/data/ToolboxBlock.java
+++ b/src/main/java/net/mcreator/blockly/data/ToolboxBlock.java
@@ -65,6 +65,12 @@ import java.util.stream.Collectors;
 				Collections.emptyList();
 	}
 
+	public List<String> getAllInputs() {
+		return inputs != null ?
+				inputs.stream().map(IInput::name).collect(Collectors.toList()) :
+				Collections.emptyList();
+	}
+
 	@Nullable public List<StatementInput> getStatements() {
 		return statements;
 	}

--- a/src/main/java/net/mcreator/ui/minecraft/SpawnableEntityListField.java
+++ b/src/main/java/net/mcreator/ui/minecraft/SpawnableEntityListField.java
@@ -27,14 +27,14 @@ import net.mcreator.ui.init.L10N;
 
 import java.util.List;
 
-public class EntityListField extends JItemListField<EntityEntry> {
+public class SpawnableEntityListField extends JItemListField<EntityEntry> {
 
-	public EntityListField(MCreator mcreator) {
+	public SpawnableEntityListField(MCreator mcreator) {
 		super(mcreator);
 	}
 
 	@Override protected List<EntityEntry> getElementsToAdd() {
-		return DataListSelectorDialog.openMultiSelectorDialog(mcreator, ElementUtil::loadAllEntities,
+		return DataListSelectorDialog.openMultiSelectorDialog(mcreator, ElementUtil::loadAllSpawnableEntities,
 						L10N.t("dialog.list_field.entity_title"), L10N.t("dialog.list_field.entity_message")).stream()
 				.map(e -> new EntityEntry(mcreator.getWorkspace(), e)).toList();
 	}

--- a/src/main/java/net/mcreator/ui/modgui/BlockGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/BlockGUI.java
@@ -1051,8 +1051,8 @@ public class BlockGUI extends ModElementGUI<Block> {
 						PanelUtils.westAndEastElement(energyStorage,
 								PanelUtils.northAndCenterElement(fluidTank, new JEmptyBox())), 10, 10)));
 
-		hasInventory.addActionListener(e -> refreshFiledsTileEntity());
-		refreshFiledsTileEntity();
+		hasInventory.addActionListener(e -> refreshFieldsTileEntity());
+		refreshFieldsTileEntity();
 
 		props.setBorder(BorderFactory.createTitledBorder(
 				BorderFactory.createLineBorder((Color) UIManager.get("MCreatorLAF.BRIGHT_COLOR"), 1),
@@ -1230,7 +1230,7 @@ public class BlockGUI extends ModElementGUI<Block> {
 		updateSoundType();
 	}
 
-	private void refreshFiledsTileEntity() {
+	private void refreshFieldsTileEntity() {
 		inventorySize.setEnabled(hasInventory.isSelected());
 		inventoryStackSize.setEnabled(hasInventory.isSelected());
 		inventoryDropWhenDestroyed.setEnabled(hasInventory.isSelected());
@@ -1494,7 +1494,7 @@ public class BlockGUI extends ModElementGUI<Block> {
 		specialInfo.setText(
 				block.specialInfo.stream().map(info -> info.replace(",", "\\,")).collect(Collectors.joining(",")));
 
-		refreshFiledsTileEntity();
+		refreshFieldsTileEntity();
 		refreshRedstoneEmitted();
 
 		tickRate.setEnabled(!tickRandomly.isSelected());

--- a/src/main/java/net/mcreator/ui/modgui/TagGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/TagGUI.java
@@ -27,7 +27,7 @@ import net.mcreator.ui.MCreatorApplication;
 import net.mcreator.ui.component.util.PanelUtils;
 import net.mcreator.ui.help.HelpUtils;
 import net.mcreator.ui.init.L10N;
-import net.mcreator.ui.minecraft.EntityListField;
+import net.mcreator.ui.minecraft.SpawnableEntityListField;
 import net.mcreator.ui.minecraft.MCItemListField;
 import net.mcreator.ui.minecraft.ModElementListField;
 import net.mcreator.ui.validation.AggregatedValidationResult;
@@ -52,7 +52,7 @@ public class TagGUI extends ModElementGUI<Tag> {
 	private MCItemListField blocks;
 
 	private ModElementListField functions;
-	private EntityListField entities;
+	private SpawnableEntityListField entities;
 
 	private final VComboBox<String> name = new VComboBox<>();
 
@@ -69,7 +69,7 @@ public class TagGUI extends ModElementGUI<Tag> {
 		items = new MCItemListField(mcreator, ElementUtil::loadBlocksAndItems);
 		blocks = new MCItemListField(mcreator, ElementUtil::loadBlocks);
 		functions = new ModElementListField(mcreator, ModElementType.FUNCTION);
-		entities = new EntityListField(mcreator);
+		entities = new SpawnableEntityListField(mcreator);
 
 		name.setValidator(new TagsNameValidator<>(name, false));
 		name.enableRealtimeValidation();

--- a/src/test/java/net/mcreator/integration/generator/GTProcedureBlocks.java
+++ b/src/test/java/net/mcreator/integration/generator/GTProcedureBlocks.java
@@ -67,11 +67,11 @@ public class GTProcedureBlocks {
 				continue;
 			}
 
-			if (!procedureBlock.getInputs().isEmpty()) {
+			if (!procedureBlock.getAllInputs().isEmpty()) {
 				boolean templatesDefined = true;
 
 				if (procedureBlock.toolbox_init != null) {
-					for (String input : procedureBlock.getInputs()) {
+					for (String input : procedureBlock.getAllInputs()) {
 						boolean match = false;
 						for (String toolboxtemplate : procedureBlock.toolbox_init) {
 							if (toolboxtemplate.contains("<value name=\"" + input + "\">")) {


### PR DESCRIPTION
- The entity selector for entity tags no longer shows abstract entities (`LivingEntity` etc.), as they would default to zombie anyway. The class for the selector was also renamed to reflect this change.
- Fixed a typo in `BlockGUI.java`
- Fixed tests failing if a procedure block had empty advanced inputs, instead of skipping the block