### PR TITLE
Code improvements, fixed typo in item extension definition file

### DIFF
--- a/plugins/generator-1.18.2/forge-1.18.2/itemextension.definition.yaml
+++ b/plugins/generator-1.18.2/forge-1.18.2/itemextension.definition.yaml
@@ -1,7 +1,6 @@
 templates:
   - template: dispensebehaviour.java.ftl
-    writer:  java
-    conditon: hasDispenseBehavior
+    condition: hasDispenseBehavior
     deleteWhenConditionFalse: true
     name: "@SRCROOT/@BASEPACKAGEPATH/item/extension/@NAMEItemExtension.java"
 

--- a/plugins/generator-1.18.2/forge-1.18.2/templates/dispensebehaviour.java.ftl
+++ b/plugins/generator-1.18.2/forge-1.18.2/templates/dispensebehaviour.java.ftl
@@ -35,10 +35,12 @@
 
 package ${package}.item.extension;
 
+<#compress>
 @Mod.EventBusSubscriber(bus = Mod.EventBusSubscriber.Bus.MOD) public class ${name}ItemExtension {
     	@SubscribeEvent public static void init(FMLCommonSetupEvent event) {
     		event.enqueueWork(() -> DispenserBlock.registerBehavior(${mappedMCItemToItem(data.item)}, new OptionalDispenseItemBehavior() {
     			public ItemStack execute(BlockSource blockSource, ItemStack stack) {
+    				<#assign hasSuccessCondition = hasProcedure(data.dispenseSuccessCondition)>
     				ItemStack itemstack = stack.copy();
     				Level world = blockSource.getLevel();
     				Direction direction = blockSource.getBlockState().getValue(DispenserBlock.FACING);
@@ -46,23 +48,26 @@ package ${package}.item.extension;
     				int y = blockSource.getPos().getY();
     				int z = blockSource.getPos().getZ();
 
+    				<#if hasSuccessCondition>
     				this.setSuccess(<@procedureOBJToConditionCode data.dispenseSuccessCondition/>);
+    				</#if>
 
     				<#if hasProcedure(data.dispenseResultItemstack)>
     					boolean success = this.isSuccess();
     					<#if hasReturnValueOf(data.dispenseResultItemstack, "itemstack")>
-
-    						return <@procedureOBJToItemstackCode data.dispenseResultItemstack/>;
+    						return <@procedureOBJToItemstackCode data.dispenseResultItemstack, false/>;
     					<#else>
     						<@procedureOBJToCode data.dispenseResultItemstack/>
-    						if(success) itemstack.shrink(1);
+    						<#if hasSuccessCondition>if(success)</#if>
+    						itemstack.shrink(1);
     						return itemstack;
     					</#if>
     				<#else>
-    					if(this.isSuccess()) itemstack.shrink(1);
+    					<#if hasSuccessCondition>if(this.isSuccess())</#if>
+    					itemstack.shrink(1);
     					return itemstack;
     				</#if>
     			}
     		}));
     	}
-}
+}</#compress>

--- a/plugins/generator-1.18.2/forge-1.18.2/templates/elementinits/fuels.java.ftl
+++ b/plugins/generator-1.18.2/forge-1.18.2/templates/elementinits/fuels.java.ftl
@@ -43,6 +43,7 @@ package ${package}.init;
 
 	@SubscribeEvent
 	public static void furnaceFuelBurnTimeEvent(FurnaceFuelBurnTimeEvent event) {
+		<#compress>
 		ItemStack itemstack = event.getItemStack();
 		<#list itemextensions as extension>
             <#if extension.enableFuel>
@@ -55,6 +56,7 @@ package ${package}.init;
                         </#if>
             </#if>
 		</#list>
+		</#compress>
 	}
 
 }

--- a/plugins/generator-1.18.2/forge-1.18.2/templates/item/item.java.ftl
+++ b/plugins/generator-1.18.2/forge-1.18.2/templates/item/item.java.ftl
@@ -135,18 +135,7 @@ public class ${name}Item extends Item {
 	</#if>
 
     <#if data.hasGlow>
-    @Override @OnlyIn(Dist.CLIENT) public boolean isFoil(ItemStack itemstack) {
-    	<#if hasProcedure(data.glowCondition)>
-    	Player entity = Minecraft.getInstance().player;
-    	Level world = entity.level;
-    	double x = entity.getX();
-    	double y = entity.getY();
-    	double z = entity.getZ();
-    	return <@procedureOBJToConditionCode data.glowCondition/>;
-		<#else>
-    	return true;
-		</#if>
-	}
+	<@hasGlow data.glowCondition/>
 	</#if>
 
 	<#if data.destroyAnyBlock>

--- a/plugins/generator-1.18.2/forge-1.18.2/templates/rangeditem/rangeditem.java.ftl
+++ b/plugins/generator-1.18.2/forge-1.18.2/templates/rangeditem/rangeditem.java.ftl
@@ -69,19 +69,7 @@ public class ${name}Item extends Item {
 	}
 
 	<#if data.hasGlow>
-	@Override @OnlyIn(Dist.CLIENT) public boolean isFoil(ItemStack itemstack) {
-	    <#if hasProcedure(data.glowCondition)>
-		Player entity = Minecraft.getInstance().player;
-		Level world = entity.level;
-		double x = entity.getX();
-		double y = entity.getY();
-		double z = entity.getZ();
-    	if (!(<@procedureOBJToConditionCode data.glowCondition/>)) {
-    	    return false;
-    	}
-    	</#if>
-		return true;
-	}
+	<@hasGlow data.glowCondition/>
     </#if>
 
 	<#if data.enableMeleeDamage>

--- a/plugins/generator-1.18.2/forge-1.18.2/templates/tool.java.ftl
+++ b/plugins/generator-1.18.2/forge-1.18.2/templates/tool.java.ftl
@@ -341,18 +341,7 @@ public class ${name}Item extends FishingRodItem {
 	<@onItemTick data.onItemInUseTick, data.onItemInInventoryTick/>
 
     <#if data.hasGlow>
-    	@Override @OnlyIn(Dist.CLIENT) public boolean isFoil(ItemStack itemstack) {
-    		<#if hasProcedure(data.glowCondition)>
-    		Player entity = Minecraft.getInstance().player;
-    		Level world = entity.level;
-    		double x = entity.getX();
-    		double y = entity.getY();
-    		double z = entity.getZ();
-    		return <@procedureOBJToConditionCode data.glowCondition/>;
-    		<#else>
-    		return true;
-    		</#if>
-    	}
+	<@hasGlow data.glowCondition/>
     </#if>
 </#macro>
 <#-- @formatter:on -->

--- a/plugins/generator-1.18.2/forge-1.18.2/utils/procedures.java.ftl
+++ b/plugins/generator-1.18.2/forge-1.18.2/utils/procedures.java.ftl
@@ -65,11 +65,12 @@
     </#if>
 </#macro>
 
-<#macro procedureOBJToItemstackCode object="">
+<#macro procedureOBJToItemstackCode object="" addMarker=true>
+    <#if addMarker>/*@ItemStack*/</#if>
     <#if hasProcedure(object)>
-        /*@ItemStack*/ <@procedureToRetvalCode name=object.getName() dependencies=object.getDependencies(generator.getWorkspace()) />
+        <@procedureToRetvalCode name=object.getName() dependencies=object.getDependencies(generator.getWorkspace()) />
     <#else>
-        /*@ItemStack*/ ItemStack.EMPTY
+        ItemStack.EMPTY
     </#if>
 </#macro>
 

--- a/plugins/generator-1.18.2/forge-1.18.2/utils/triggers.java.ftl
+++ b/plugins/generator-1.18.2/forge-1.18.2/utils/triggers.java.ftl
@@ -201,7 +201,7 @@
 @Override @OnlyIn(Dist.CLIENT) public boolean isFoil(ItemStack itemstack) {
    	<#if hasProcedure(procedure)>
     <#assign dependencies = procedure.getDependencies(generator.getWorkspace())>
-    <#if !(dependencies.isEmpty() || dependencies.size() == 1 && dependencies.get(0).getName() == "itemstack")>
+    <#if !(dependencies.isEmpty() || (dependencies.size() == 1 && dependencies.get(0).getName() == "itemstack"))>
    	Entity entity = Minecraft.getInstance().player;
    	</#if>
    	return <@procedureCode procedure, {

--- a/plugins/generator-1.18.2/forge-1.18.2/utils/triggers.java.ftl
+++ b/plugins/generator-1.18.2/forge-1.18.2/utils/triggers.java.ftl
@@ -197,6 +197,28 @@
 </#if>
 </#macro>
 
+<#macro hasGlow procedure="">
+@Override @OnlyIn(Dist.CLIENT) public boolean isFoil(ItemStack itemstack) {
+   	<#if hasProcedure(procedure)>
+    <#assign dependencies = procedure.getDependencies(generator.getWorkspace())>
+    <#if !(dependencies.isEmpty() || dependencies.size() == 1 && dependencies.get(0).getName() == "itemstack")>
+   	Entity entity = Minecraft.getInstance().player;
+   	</#if>
+   	return <@procedureCode procedure, {
+		"x": "entity.getX()",
+		"y": "entity.getY()",
+		"z": "entity.getZ()",
+		"entity": "entity",
+		"world": "entity.level",
+		"itemstack": "itemstack"
+   	}/>
+	<#else>
+   	return true;
+	</#if>
+}
+</#macro>
+
+
 <#-- Armor triggers -->
 <#macro onArmorTick procedure="">
 	<#if hasProcedure(procedure)>


### PR DESCRIPTION
- Fixed a typo in item extension definition file, which caused the dispense behavior class to always generate
- Improved the template for glow conditions and moved it to `triggers.ftl`
- Minor improvements to dispense behavior and fuel code