### PR TITLE
Follow Range for Entities

### DIFF
--- a/plugins/generator-1.16.5/forge-1.16.5/templates/livingentity.java.ftl
+++ b/plugins/generator-1.16.5/forge-1.16.5/templates/livingentity.java.ftl
@@ -164,6 +164,7 @@ import net.minecraft.block.material.Material;
 			ammma = ammma.createMutableAttribute(Attributes.MAX_HEALTH, ${data.health});
 			ammma = ammma.createMutableAttribute(Attributes.ARMOR, ${data.armorBaseValue});
 			ammma = ammma.createMutableAttribute(Attributes.ATTACK_DAMAGE, ${data.attackStrength});
+		    ammma = ammma.createMutableAttribute(Attributes.FOLLOW_RANGE, ${data.followRange});
 
 			<#if (data.knockbackResistance > 0)>
 			ammma = ammma.createMutableAttribute(Attributes.KNOCKBACK_RESISTANCE, ${data.knockbackResistance});

--- a/plugins/generator-1.18.2/forge-1.18.2/templates/livingentity/livingentity.java.ftl
+++ b/plugins/generator-1.18.2/forge-1.18.2/templates/livingentity/livingentity.java.ftl
@@ -806,6 +806,7 @@ public class ${name}Entity extends ${extendsClass} <#if data.ranged>implements R
 		builder = builder.add(Attributes.MAX_HEALTH, ${data.health});
 		builder = builder.add(Attributes.ARMOR, ${data.armorBaseValue});
 		builder = builder.add(Attributes.ATTACK_DAMAGE, ${data.attackStrength});
+		builder = builder.add(Attributes.FOLLOW_RANGE, ${data.followRange});
 
 		<#if (data.knockbackResistance > 0)>
 		builder = builder.add(Attributes.KNOCKBACK_RESISTANCE, ${data.knockbackResistance});

--- a/plugins/mcreator-localization/help/default/entity/follow_range.md
+++ b/plugins/mcreator-localization/help/default/entity/follow_range.md
@@ -1,0 +1,1 @@
+Follow range defines from which distance will mob notice/continue chasing player/target

--- a/plugins/mcreator-localization/lang/texts.properties
+++ b/plugins/mcreator-localization/lang/texts.properties
@@ -2124,6 +2124,7 @@ elementgui.living_entity.mob_drop=<html>Mob default drop:<br><small>Drop is opti
 elementgui.living_entity.movement_speed_tracking_range=Movement speed, tracking range: 
 elementgui.living_entity.attack_strenght_armor_value=Attack strength, armor protection base value: 
 elementgui.living_entity.knockback=Attack knockback, knockback resistance: 
+elementgui.living_entity.follow=Follow range: 
 elementgui.living_entity.equipment=<html>Equipment (optional: main hand, off hand, helmet, body, leggings, boots):<br><small>Only works for Biped and Zombie models
 elementgui.living_entity.is_immune_to=Entity immune to: 
 elementgui.living_entity.ridable=<html>Check to make this entity rideable by player<br><small>You can optionally turn on living entity controls too

--- a/src/main/java/net/mcreator/element/types/LivingEntity.java
+++ b/src/main/java/net/mcreator/element/types/LivingEntity.java
@@ -84,6 +84,7 @@ import java.util.Locale;
 	public double movementSpeed;
 	public double armorBaseValue;
 	public int trackingRange;
+	public int followRange;
 	public int health;
 	public int xpAmount;
 	public boolean waterMob;

--- a/src/main/java/net/mcreator/ui/modgui/LivingEntityGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/LivingEntityGUI.java
@@ -111,6 +111,7 @@ public class LivingEntityGUI extends ModElementGUI<LivingEntity> {
 	private final JSpinner attackKnockback = new JSpinner(new SpinnerNumberModel(0, 0, 1000, 0.1));
 
 	private final JSpinner trackingRange = new JSpinner(new SpinnerNumberModel(64, 0, 10000, 1));
+	private final JSpinner followRange = new JSpinner(new SpinnerNumberModel(16, 1, 512, 1));
 
 	private final JSpinner spawningProbability = new JSpinner(new SpinnerNumberModel(20, 1, 1000, 1));
 	private final JSpinner minNumberOfMobsPerGroup = new JSpinner(new SpinnerNumberModel(4, 1, 1000, 1));
@@ -374,7 +375,7 @@ public class LivingEntityGUI extends ModElementGUI<LivingEntity> {
 		JPanel pane5 = new JPanel(new BorderLayout(0, 0));
 		JPanel pane7 = new JPanel(new BorderLayout(0, 0));
 
-		JPanel subpane1 = new JPanel(new GridLayout(11, 2, 0, 2));
+		JPanel subpane1 = new JPanel(new GridLayout(12, 2, 0, 2));
 
 		immuneToFire.setOpaque(false);
 		immuneToArrows.setOpaque(false);
@@ -423,6 +424,10 @@ public class LivingEntityGUI extends ModElementGUI<LivingEntity> {
 		subpane1.add(PanelUtils.join(FlowLayout.LEFT, 0, 0,
 				HelpUtils.wrapWithHelpButton(this.withEntry("entity/attack_knockback"), attackKnockback),
 				HelpUtils.wrapWithHelpButton(this.withEntry("entity/knockback_resistance"), knockbackResistance)));
+
+		subpane1.add(L10N.label("elementgui.living_entity.follow"));
+		subpane1.add(PanelUtils.join(FlowLayout.LEFT, 0, 0,
+				HelpUtils.wrapWithHelpButton(this.withEntry("entity/follow_range"), followRange)));
 
 		subpane1.add(HelpUtils.wrapWithHelpButton(this.withEntry("entity/equipment"),
 				L10N.label("elementgui.living_entity.equipment")));
@@ -528,6 +533,7 @@ public class LivingEntityGUI extends ModElementGUI<LivingEntity> {
 		attackStrength.setPreferredSize(new Dimension(250, 32));
 		attackKnockback.setPreferredSize(new Dimension(250, 32));
 		knockbackResistance.setPreferredSize(new Dimension(250, 32));
+		followRange.setPreferredSize(new Dimension(250, 32));
 		health.setPreferredSize(new Dimension(250, 32));
 		xpAmount.setPreferredSize(new Dimension(250, 32));
 
@@ -970,6 +976,7 @@ public class LivingEntityGUI extends ModElementGUI<LivingEntity> {
 		equipmentBoots.setBlock(livingEntity.equipmentBoots);
 		health.setValue(livingEntity.health);
 		trackingRange.setValue(livingEntity.trackingRange);
+		followRange.setValue(livingEntity.followRange);
 		immuneToFire.setSelected(livingEntity.immuneToFire);
 		immuneToArrows.setSelected(livingEntity.immuneToArrows);
 		immuneToFallDamage.setSelected(livingEntity.immuneToFallDamage);
@@ -1091,6 +1098,7 @@ public class LivingEntityGUI extends ModElementGUI<LivingEntity> {
 		livingEntity.movementSpeed = (double) movementSpeed.getValue();
 		livingEntity.health = (int) health.getValue();
 		livingEntity.trackingRange = (int) trackingRange.getValue();
+		livingEntity.followRange = (int) followRange.getValue();
 		livingEntity.immuneToFire = immuneToFire.isSelected();
 		livingEntity.immuneToArrows = immuneToArrows.isSelected();
 		livingEntity.immuneToFallDamage = immuneToFallDamage.isSelected();


### PR DESCRIPTION
I implemented new property for entities. Follow Range. Defines how far will entity notice/chase its target.

This was something I hoped mcreator would add a long time ago and now that I know how to add it myself, here am I. Until now I had to always lock my entity to edit this parameter.