### PR TITLE
Add missing French tips

### DIFF
--- a/plugins/mcreator-localization/help/fr_FR/biome/generate_bastion_remnants.md
+++ b/plugins/mcreator-localization/help/fr_FR/biome/generate_bastion_remnants.md
@@ -1,0 +1,1 @@
+Sélectionner ce paramètre pour générer des vestiges de bastion dans le biome.

--- a/plugins/mcreator-localization/help/fr_FR/biome/generate_buried_treasures.md
+++ b/plugins/mcreator-localization/help/fr_FR/biome/generate_buried_treasures.md
@@ -1,0 +1,1 @@
+Sélectionner ce paramètre pour générer des trésors enfouis dans le biome.

--- a/plugins/mcreator-localization/help/fr_FR/biome/generate_end_cities.md
+++ b/plugins/mcreator-localization/help/fr_FR/biome/generate_end_cities.md
@@ -1,0 +1,1 @@
+Sélectionner ce paramètre pour générer des cités de l'End dans le biome.

--- a/plugins/mcreator-localization/help/fr_FR/biome/generate_mineshafts_mesa.md
+++ b/plugins/mcreator-localization/help/fr_FR/biome/generate_mineshafts_mesa.md
@@ -1,1 +1,1 @@
-Sélectionner ce paramètre pour générer des puits de mine abandonné du Mesa (Badlands) dans le biome.
+Sélectionner ce paramètre pour générer des puits de mine abandonnés du Mesa (Badlands) dans le biome.

--- a/plugins/mcreator-localization/help/fr_FR/biome/generate_mineshafts_mesa.md
+++ b/plugins/mcreator-localization/help/fr_FR/biome/generate_mineshafts_mesa.md
@@ -1,0 +1,1 @@
+Sélectionner ce paramètre pour générer des puits de mine abandonné du Mesa (Badlands) dans le biome.

--- a/plugins/mcreator-localization/help/fr_FR/biome/generate_nether.md
+++ b/plugins/mcreator-localization/help/fr_FR/biome/generate_nether.md
@@ -1,0 +1,1 @@
+Cocher cette case pour générer le biome dans le Nether.

--- a/plugins/mcreator-localization/help/fr_FR/biome/generate_nether_bridges.md
+++ b/plugins/mcreator-localization/help/fr_FR/biome/generate_nether_bridges.md
@@ -1,0 +1,1 @@
+Sélectionner ce paramètre pour générer des forteresses du Nether dans le biome.

--- a/plugins/mcreator-localization/help/fr_FR/biome/generate_nether_fossils.md
+++ b/plugins/mcreator-localization/help/fr_FR/biome/generate_nether_fossils.md
@@ -1,0 +1,1 @@
+Sélectionner ce paramètre pour générer des fossiles du Nether dans le biome.

--- a/plugins/mcreator-localization/help/fr_FR/biome/generate_ocean_monuments.md
+++ b/plugins/mcreator-localization/help/fr_FR/biome/generate_ocean_monuments.md
@@ -1,1 +1,1 @@
-Utilisez ce paramètre pour avoir des Temples de l'Océan dans votre biome.
+Sélectionner ce paramètre pour avoir des temples de l'océan.

--- a/plugins/mcreator-localization/help/fr_FR/biome/generate_ocean_ruins.md
+++ b/plugins/mcreator-localization/help/fr_FR/biome/generate_ocean_ruins.md
@@ -1,4 +1,4 @@
-Utilisez ce paramètre pour avoir des Ruines Océaniques dans votre biome.
+Sélectionner ce paramètre pour avoir des ruines océaniques.
 * NONE: Aucune Ruine Océanique ne sera générée.
 * COLD: Les Ruines Océaniques faites de pierre se génèreront.
 * WARM: Les Ruines Océaniques faites de grès peuvent se génèrent.

--- a/plugins/mcreator-localization/help/fr_FR/biome/generate_overworld_caves.md
+++ b/plugins/mcreator-localization/help/fr_FR/biome/generate_overworld_caves.md
@@ -1,0 +1,1 @@
+Cocher cette case pour générer le biome dans les grottes de l'Overworld.

--- a/plugins/mcreator-localization/help/fr_FR/biome/generate_pillager_outposts.md
+++ b/plugins/mcreator-localization/help/fr_FR/biome/generate_pillager_outposts.md
@@ -1,1 +1,1 @@
-Utilisez ce paramètre pour avoir des Avant-postes de Pilleurs dans votre biome.
+Sélectionner ce paramètre pour avoir des avant-postes de pilleurs.

--- a/plugins/mcreator-localization/help/fr_FR/biome/generate_ruined_portals.md
+++ b/plugins/mcreator-localization/help/fr_FR/biome/generate_ruined_portals.md
@@ -1,0 +1,1 @@
+Sélectionner ce paramètre pour générer des ruines de portail du Nether.

--- a/plugins/mcreator-localization/help/fr_FR/biome/generate_shipwrecks.md
+++ b/plugins/mcreator-localization/help/fr_FR/biome/generate_shipwrecks.md
@@ -1,1 +1,1 @@
-Utilisez ce paramètre pour avoir des Épaves dans votre biome.
+Sélectionner ce paramètre pour avoir des épaves dans le biome.

--- a/plugins/mcreator-localization/help/fr_FR/biome/generate_shipwrecks_beached.md
+++ b/plugins/mcreator-localization/help/fr_FR/biome/generate_shipwrecks_beached.md
@@ -1,0 +1,1 @@
+Sélectionner ce paramètre pour avoir des épaves échouées.

--- a/plugins/mcreator-localization/help/fr_FR/biome/generate_strongholds.md
+++ b/plugins/mcreator-localization/help/fr_FR/biome/generate_strongholds.md
@@ -1,1 +1,1 @@
-Utilisez ce paramètre pour avoir des Forts dans votre biome.
+Sélectionner ce paramètre pour avoir des forts (Strongholds).

--- a/plugins/mcreator-localization/help/fr_FR/biome/generate_swamp_huts.md
+++ b/plugins/mcreator-localization/help/fr_FR/biome/generate_swamp_huts.md
@@ -1,0 +1,1 @@
+Sélectionner ce paramètre pour avoir des cabanes des marais.

--- a/plugins/mcreator-localization/help/fr_FR/biome/underwater_block.md
+++ b/plugins/mcreator-localization/help/fr_FR/biome/underwater_block.md
@@ -1,1 +1,1 @@
-This parameter controls the block that generates under the water. Most vanilla biomes use dirt or gravel block for this.
+Ce paramètre conrôle le bloc généré sous l'eau. La plupart des biomes vanilla utilisent la terre, le gravier ou le sable (océans chauds) pour ceci.

--- a/plugins/mcreator-localization/help/fr_FR/biome/underwater_block.md
+++ b/plugins/mcreator-localization/help/fr_FR/biome/underwater_block.md
@@ -1,0 +1,1 @@
+This parameter controls the block that generates under the water. Most vanilla biomes use dirt or gravel block for this.

--- a/plugins/mcreator-localization/help/fr_FR/block/is_item_tinted.md
+++ b/plugins/mcreator-localization/help/fr_FR/block/is_item_tinted.md
@@ -1,0 +1,4 @@
+Si cette option est cochée, une teinte fixe sera appliquée au bloc tant qu'il est dans l'inventaire,
+correspondant au type de teinte.
+
+La teinte est également appliquée lorsqu'une texture d'élément est spécifiée.

--- a/plugins/mcreator-localization/help/fr_FR/block/placing_condition.md
+++ b/plugins/mcreator-localization/help/fr_FR/block/placing_condition.md
@@ -1,0 +1,4 @@
+Cette condition détermine si ce bloc peut être placé à une position spécifique. Si celle-ci
+n'est plus valide, le bloc sera détruit lorsqu'il aura reçu une mise à jour de bloc.
+
+REMARQUE : Cette condition n'est pas vérifiée lors de la génération du monde.

--- a/plugins/mcreator-localization/help/fr_FR/block/tint_type.md
+++ b/plugins/mcreator-localization/help/fr_FR/block/tint_type.md
@@ -1,0 +1,5 @@
+Cette option applique une teinte au bloc en fonction des couleurs du biome, similaire à l'herbe, aux feuilles et à l'eau.
+Pour de meilleurs résultats, les faces teintées doivent utiliser une texture en niveaux de gris.
+
+REMARQUE : Le type de teinte de brouillard n'est disponible que dans Minecraft 1.16.x et les versions ultérieures,
+et est par défaut le brouillard de l'eau dans les anciennes versions.

--- a/plugins/mcreator-localization/help/fr_FR/fluid/bucket_texture.md
+++ b/plugins/mcreator-localization/help/fr_FR/fluid/bucket_texture.md
@@ -1,0 +1,1 @@
+Cette propriété facultative changera la texture du sceau dans l'inventaire, remplaçant celle générée automatiquement.

--- a/plugins/mcreator-localization/help/fr_FR/fluid/can_multiply.md
+++ b/plugins/mcreator-localization/help/fr_FR/fluid/can_multiply.md
@@ -1,0 +1,2 @@
+Si cette option est activée, les sources de fluides peuvent créer plus de sources, similaires à l'eau. Cela permet d'avoir une
+source infinie.

--- a/plugins/mcreator-localization/help/fr_FR/fluid/drip_particle.md
+++ b/plugins/mcreator-localization/help/fr_FR/fluid/drip_particle.md
@@ -1,0 +1,1 @@
+Ce paramètre contrôle la particule que le fluide va générer lorsqu'il s'égoutte d'un bloc.

--- a/plugins/mcreator-localization/help/fr_FR/fluid/empty_sound.md
+++ b/plugins/mcreator-localization/help/fr_FR/fluid/empty_sound.md
@@ -1,0 +1,2 @@
+Ce paramètre contrôle le son qui sera joué lorsque le seau est vidé. Si aucun son n'est sélectionné, le son par défaut
+du sceau sera joué.

--- a/plugins/mcreator-localization/help/fr_FR/fluid/flow_rate.md
+++ b/plugins/mcreator-localization/help/fr_FR/fluid/flow_rate.md
@@ -1,0 +1,4 @@
+Ce paramètre détermine le nombre de ticks nécessaires pour que le fluide se propage à un autre bloc. Plus cette valeur est élevée, 
+plus le fluide se déplacera lentement.
+
+Les valeurs par défaut sont 5 pour l'eau, 30 pour la lave dans l'Overworld et 10 pour la lave dans le Nether.

--- a/plugins/mcreator-localization/help/fr_FR/fluid/level_decrease.md
+++ b/plugins/mcreator-localization/help/fr_FR/fluid/level_decrease.md
@@ -1,4 +1,5 @@
-Ce paramètre détermine de combien le niveau de ce fluide diminue pour chaque bloc auquel il se propage. Avec des valeurs plus élevées,
+Ce paramètre détermine de combien le niveau de ce fluide diminue pour chaque bloc sur lequel il se propage. Avec des valeurs plus élevées,
+
 le fluide couvrira une zone plus petite.
 
 Cette valeur est 1 pour l'eau et la lave dans le Nether, 2 pour la lave dans l'Overworld.

--- a/plugins/mcreator-localization/help/fr_FR/fluid/level_decrease.md
+++ b/plugins/mcreator-localization/help/fr_FR/fluid/level_decrease.md
@@ -1,0 +1,4 @@
+Ce paramètre détermine de combien le niveau de ce fluide diminue pour chaque bloc auquel il se propage. Avec des valeurs plus élevées,
+le fluide couvrira une zone plus petite.
+
+Cette valeur est 1 pour l'eau et la lave dans le Nether, 2 pour la lave dans l'Overworld.

--- a/plugins/mcreator-localization/help/fr_FR/fluid/slope_find_distance.md
+++ b/plugins/mcreator-localization/help/fr_FR/fluid/slope_find_distance.md
@@ -1,0 +1,2 @@
+Ce paramètre détermine à quelle distance une pente peut affecter l'étalement de ce fluide. Au lieu de se répandre uniformément,
+le fluide va essayer d'atteindre la pente. Avec des valeurs inférieures, le fluide couvrira généralement de plus grandes surfaces si le sol est inégal.

--- a/plugins/mcreator-localization/help/fr_FR/fluid/spawn_drip_particles.md
+++ b/plugins/mcreator-localization/help/fr_FR/fluid/spawn_drip_particles.md
@@ -1,0 +1,1 @@
+Si cette option est activée, le fluide générera des particules lorsqu'il se trouve au-dessus d'un bloc solide et qu'il y a de l'air en dessous.

--- a/plugins/mcreator-localization/help/fr_FR/fluid/temperature.md
+++ b/plugins/mcreator-localization/help/fr_FR/fluid/temperature.md
@@ -1,0 +1,3 @@
+Il s'agit de la température de votre fluide, mesurée en Kelvin (K). Plus la valeur est élevée, plus votre fluide sera chaud.
+
+La valeur par défaut est 300K, ce qui correspond à la température ambiante.

--- a/plugins/mcreator-localization/help/fr_FR/item/result_item.md
+++ b/plugins/mcreator-localization/help/fr_FR/item/result_item.md
@@ -1,0 +1,1 @@
+Ce paramètre définit quel item doit être ajouté à l'inventaire de l'entité qui a mangé cette nourriture.

--- a/plugins/mcreator-localization/help/fr_FR/overlay/overlay_target.md
+++ b/plugins/mcreator-localization/help/fr_FR/overlay/overlay_target.md
@@ -1,0 +1,5 @@
+La cible de l'overlay spécifie sur quel écran cet overlay doit être dessiné.
+
+Utilisez Ingame pour les overlays tels que les barres de faim et les overlays en forme de citrouille.
+
+Utilisez d'autres cibles pour superposer d'autres écrans spécifiques.

--- a/plugins/mcreator-localization/help/fr_FR/particle/angular_acceleration.md
+++ b/plugins/mcreator-localization/help/fr_FR/particle/angular_acceleration.md
@@ -1,0 +1,1 @@
+Ce paramètre contrôle l'accélération de rotation de la particule.

--- a/plugins/mcreator-localization/help/fr_FR/particle/angular_velocity.md
+++ b/plugins/mcreator-localization/help/fr_FR/particle/angular_velocity.md
@@ -1,4 +1,5 @@
 Ce paramètre contrôle la vitesse de rotation initiale de la particule.
-Des valeurs négatives signifient une rotation dans le sens inverse des aiguilles d'une montre.
+Des valeurs négatives correspondent à une rotation dans le sens inverse des aiguilles d'une montre.
+
 
 Une valeur de 0,314 correspond à peu près à 1 rotation par seconde.

--- a/plugins/mcreator-localization/help/fr_FR/particle/angular_velocity.md
+++ b/plugins/mcreator-localization/help/fr_FR/particle/angular_velocity.md
@@ -1,0 +1,4 @@
+Ce paramètre contrôle la vitesse de rotation initiale de la particule.
+Des valeurs négatives signifient une rotation dans le sens inverse des aiguilles d'une montre.
+
+Une valeur de 0,314 correspond à peu près à 1 rotation par seconde.


### PR DESCRIPTION
It adds all the missing French tips I didn't translate with time.

I'm not sure if @Max094Reikeb wants to review them before they are merged, but my grammar should not have any problem.
Note: I also changed a bit some biome-related tips to match the new ones.