### PR TITLE
Fix for the Mac-OS "Create Texture From Scratch" blank window freeze.

### DIFF
--- a/src/main/java/net/mcreator/ui/dialogs/BlockItemTextureSelector.java
+++ b/src/main/java/net/mcreator/ui/dialogs/BlockItemTextureSelector.java
@@ -124,9 +124,9 @@ public class BlockItemTextureSelector extends MCreatorDialog {
 		createTx2.setFont(naprej.getFont());
 		createTx2.setIcon(UIRES.get("18px.add"));
 		createTx2.addActionListener(event -> {
-			setVisible(false);
 			NewImageDialog newImageDialog = new NewImageDialog(mcreator);
 			newImageDialog.setVisible(true);
+			setVisible(false);
 		});
 		pno.add(createTx2);
 


### PR DESCRIPTION
The freeze was caused by hiding the "texture selection" panel before making the "new image" sub-panel visible. Waiting to remove visibility until after the "new image" selection prevented the issue in my mac-os environment.

This edit does change behavior slightly. The selection window will now remain open underneath the "New Image" modal until you make a selection. (but the window below is disabled)

I've tested this edit on Mac-OS Monterey and Windows 10.
Here's a video of the problem and the proposed change: https://youtu.be/VDro6IxCTZg