### PR TITLE
Fix particle and effect textures

### DIFF
--- a/plugins/mcreator-localization/help/default/painting/texture.md
+++ b/plugins/mcreator-localization/help/default/painting/texture.md
@@ -1,1 +1,3 @@
 Select a texture that should be used as a foreground of this painting.
+
+IMPORTANT: If the texture name differs from the element's registry name, a copy of the texture will be made.

--- a/plugins/mcreator-localization/help/default/particle/texture.md
+++ b/plugins/mcreator-localization/help/default/particle/texture.md
@@ -3,3 +3,5 @@ the texture will be randomly selected from one of the possible tiles in the stri
 
 When animated texture parameter is enabled, particle will be animated
 in the sequence of texture tiles.
+
+IMPORTANT: If the texture name differs from the element's registry name, a copy of the texture will be made.

--- a/plugins/mcreator-localization/help/default/potioneffect/icon.md
+++ b/plugins/mcreator-localization/help/default/potioneffect/icon.md
@@ -1,1 +1,3 @@
 This parameter controls the icon displayed inside the player's inventory when the potion is active.
+
+IMPORTANT: If the texture name differs from the element's registry name, a copy of the texture will be made.

--- a/plugins/mcreator-localization/help/fr_FR/painting/texture.md
+++ b/plugins/mcreator-localization/help/fr_FR/painting/texture.md
@@ -1,1 +1,3 @@
 Sélectionnez une texture qui doit être utilisée comme premier plan de ce tableau.
+
+IMPORTANT : Si le nom de la texture diffère du nom de registre de l'élément, une copie de la texture sera effectuée.

--- a/plugins/mcreator-localization/help/fr_FR/particle/texture.md
+++ b/plugins/mcreator-localization/help/fr_FR/particle/texture.md
@@ -3,3 +3,5 @@ la texture sera choisie au hasard parmi l'un des tile possibles de la bande.
 
 Lorsque le paramètre de texture animée est activé, la particule sera animée
 dans la séquence des tiles de texture.
+
+IMPORTANT : Si le nom de la texture diffère du nom de registre de l'élément, une copie de la texture sera effectuée.

--- a/plugins/mcreator-localization/help/fr_FR/potioneffect/icon.md
+++ b/plugins/mcreator-localization/help/fr_FR/potioneffect/icon.md
@@ -1,1 +1,3 @@
 Ce paramètre contrôle l'icône affichée dans l'inventaire du joueur lorsque la potion est active.
+
+IMPORTANT : Si le nom de la texture diffère du nom de registre de l'élément, une copie de la texture sera effectuée.

--- a/src/main/java/net/mcreator/element/types/Particle.java
+++ b/src/main/java/net/mcreator/element/types/Particle.java
@@ -88,7 +88,7 @@ public class Particle extends GeneratableElement {
 					|| original.getIconHeight() % original.getIconWidth() != 0) {
 				FileIO.copyFile(originalTextureFileLocation,
 						new File(getModElement().getFolderManager().getTexturesFolder(TextureType.PARTICLE),
-								"particle/" + getModElement().getRegistryName() + ".png"));
+								getModElement().getRegistryName() + ".png"));
 			} else {
 				try {
 					TiledImageUtils tiu = new TiledImageUtils(ImageUtils.toBufferedImage(original.getImage()),
@@ -97,7 +97,7 @@ public class Particle extends GeneratableElement {
 					for (int i = 1; i <= tiles; i++) {
 						ImageIO.write(ImageUtils.toBufferedImage(tiu.getIcon(1, i).getImage()), "png",
 								new File(getModElement().getFolderManager().getTexturesFolder(TextureType.PARTICLE),
-										"particle/" + getModElement().getRegistryName() + "_" + i + ".png"));
+										getModElement().getRegistryName() + "_" + i + ".png"));
 					}
 				} catch (InvalidTileSizeException | IOException ignored) {
 				}

--- a/src/main/java/net/mcreator/element/types/PotionEffect.java
+++ b/src/main/java/net/mcreator/element/types/PotionEffect.java
@@ -63,7 +63,7 @@ import java.io.File;
 				.getTextureFile(FilenameUtilsPatched.removeExtension(icon), TextureType.EFFECT);
 		File newLocation = new File(
 				getModElement().getWorkspace().getFolderManager().getTexturesFolder(TextureType.EFFECT),
-				"mob_effect/" + getModElement().getRegistryName() + ".png");
+				getModElement().getRegistryName() + ".png");
 		FileIO.copyFile(originalTextureFileLocation, newLocation);
 	}
 


### PR DESCRIPTION
Same as in #2944:

I also fixed a bug related to particles and potion effects introduced in #2537. Textures were moved to a subfolder (e.g. `textures/particle/particle/` instead of `textures/particle/`) causing a non-texture effect when the texture's name and the registry name were different (I wrote the same name during my tests of the last feature, which wasn't the case this time).