### PR TITLE
Removed fishing bobber from spawnable entities

### DIFF
--- a/plugins/mcreator-core/datalists/entities.yaml
+++ b/plugins/mcreator-core/datalists/entities.yaml
@@ -346,7 +346,6 @@
   type: spawnable
 - EntityFishHook:
   readable_name: "Fishing bobber"
-  type: spawnable
 - EntityMonster:
   readable_name: "Monster entity"
 - EntityPiglin:


### PR DESCRIPTION
Removed the fishing bobber from the spawnable entities list, since it has no matching constructors (in 1.16)