### PR TITLE
Replace the Blockly's isEmpty block for a custom one

### DIFF
--- a/plugins/mcreator-core/blockly/mcreator_blocks.js
+++ b/plugins/mcreator-core/blockly/mcreator_blocks.js
@@ -222,6 +222,17 @@ Blockly.Blocks['text_format_number'] = {
         this.setColour(160);
     }
 };
+Blockly.Blocks['text_is_empty'] = {
+    init: function () {
+        this.appendValueInput('text').setCheck('String')
+            .appendField(javabridge.t("blockly.block.text_is_empty"));
+        this.setInputsInline(true);
+        this.setPreviousStatement(false);
+        this.setNextStatement(false);
+        this.setOutput(true, 'Boolean');
+        this.setColour(210);
+    }
+};
 
 Blockly.Blocks['text_trim'] = {
     init: function () {

--- a/plugins/mcreator-core/blockly/mcreator_blocks.js
+++ b/plugins/mcreator-core/blockly/mcreator_blocks.js
@@ -222,6 +222,7 @@ Blockly.Blocks['text_format_number'] = {
         this.setColour(160);
     }
 };
+
 Blockly.Blocks['text_is_empty'] = {
     init: function () {
         this.appendValueInput('text').setCheck('String')

--- a/plugins/mcreator-localization/lang/texts.properties
+++ b/plugins/mcreator-localization/lang/texts.properties
@@ -1202,6 +1202,7 @@ blockly.block.text_substring.from=from position:
 blockly.block.text_substring.to=to position:
 blockly.block.text_format_number.format=Format number:
 blockly.block.text_format_number.as=as:
+blockly.block.text_is_empty=Is text empty:
 blockly.block.text_trim=Trim text:
 blockly.block.text_uppercase=Uppercase text:
 blockly.block.text_lowercase=Lowercase text:

--- a/src/main/java/net/mcreator/blockly/java/blocks/TextIsEmptyBlock.java
+++ b/src/main/java/net/mcreator/blockly/java/blocks/TextIsEmptyBlock.java
@@ -43,7 +43,7 @@ public class TextIsEmptyBlock implements IBlockGenerator {
 	}
 
 	@Override public String[] getSupportedBlocks() {
-		return new String[] { "text_isEmpty" };
+		return new String[] { "text_is_empty" };
 	}
 
 	@Override public BlockType getBlockType() {

--- a/src/main/resources/blockly/toolbox_procedure.xml
+++ b/src/main/resources/blockly/toolbox_procedure.xml
@@ -54,7 +54,7 @@
         <block type="text"/>
         <block type="text_join"/>
         <block type="text_length"/>
-        <block type="text_isEmpty"/>
+        <block type="text_is_empty"/>
         <block type="text_replace"/>
         <block type="text_substring"/>
         <block type="text_contains"/>


### PR DESCRIPTION
Replace the Blockly's isEmpty block for a custom one to have the correct color.

Note: I changed `isEmpty` by `is_empty` to follow our standards.