### PR TITLE
Minor fixes

### DIFF
--- a/plugins/mcreator-core/blockly/mcreator_extensions.js
+++ b/plugins/mcreator-core/blockly/mcreator_extensions.js
@@ -111,27 +111,6 @@ Blockly.Extensions.register('gui_list_provider',
             arrayToBlocklyDropDownArray(javabridge.getListOf("gui"))), 'guiname');
     });
 
-Blockly.Extensions.register('rangeditem_list_provider', // name is rangeditem for legacy reasons, is actually arrow list
-    function () {
-        this.appendDummyInput().appendField(new Blockly.FieldDropdown(
-            arrayToBlocklyDropDownArrayWithReadableNames(javabridge.getListOf("rangeditem"),
-                javabridge.getReadableListOf("rangeditem"))), 'rangeditem');
-    });
-
-Blockly.Extensions.register('throwableprojectile_list_provider',
-    function () {
-        this.appendDummyInput().appendField(new Blockly.FieldDropdown(
-            arrayToBlocklyDropDownArrayWithReadableNames(javabridge.getListOf("throwableprojectile"),
-                javabridge.getReadableListOf("throwableprojectile"))), 'throwableprojectile');
-    });
-
-Blockly.Extensions.register('fireballprojectile_list_provider',
-    function () {
-        this.appendDummyInput().appendField(new Blockly.FieldDropdown(
-            arrayToBlocklyDropDownArrayWithReadableNames(javabridge.getListOf("fireballprojectile"),
-                javabridge.getReadableListOf("fireballprojectile"))), 'fireballprojectile');
-    });
-
 Blockly.Extensions.register('dimension_list_provider',
     function () {
         this.appendDummyInput().appendField(new Blockly.FieldDropdown(

--- a/src/main/java/net/mcreator/ui/views/editor/image/layer/LayerPanel.java
+++ b/src/main/java/net/mcreator/ui/views/editor/image/layer/LayerPanel.java
@@ -271,7 +271,7 @@ public class LayerPanel extends JPanel {
 	private void canEdit(boolean can) {
 		editMeta.setEnabled(can);
 		toggleVisibility.setEnabled(can);
-		delete.setEnabled(can);
+		delete.setEnabled(can && canvas.size() > 1); // Disable the button if only one layer is present
 		duplicate.setEnabled(can);
 	}
 }


### PR DESCRIPTION
- Removed the unused Blockly extensions for projectile dropdowns, as they got replaced with data list selectors.
- Disabled the "Remove layer" button if only one layer is left. This prevents issues with the other layer options (e.g. renaming a "null" layer) if the layer list is empty.