### PR TITLE
Fix compilation errors with blockstate procedures in some situations

### DIFF
--- a/plugins/generator-1.18.2/forge-1.18.2/procedures/blockstate_get_boolean_property.java.ftl
+++ b/plugins/generator-1.18.2/forge-1.18.2/procedures/blockstate_get_boolean_property.java.ftl
@@ -1,2 +1,2 @@
 <#include "mcitems.ftl">
-(${mappedBlockToBlock(input$block)}.getStateDefinition().getProperty(${input$property}) instanceof BooleanProperty _getbp && ${mappedBlockToBlockStateCode(input$block)}.getValue(_getbp))
+(${mappedBlockToBlock(input$block)}.getStateDefinition().getProperty(${input$property}) instanceof BooleanProperty _getbp${customBlockIndex} && ${mappedBlockToBlockStateCode(input$block)}.getValue(_getbp${customBlockIndex}))

--- a/plugins/generator-1.18.2/forge-1.18.2/procedures/blockstate_get_boolean_property.java.ftl
+++ b/plugins/generator-1.18.2/forge-1.18.2/procedures/blockstate_get_boolean_property.java.ftl
@@ -1,2 +1,2 @@
 <#include "mcitems.ftl">
-(${mappedBlockToBlock(input$block)}.getStateDefinition().getProperty(${input$property}) instanceof BooleanProperty _bp && ${mappedBlockToBlockStateCode(input$block)}.getValue(_bp))
+(${mappedBlockToBlock(input$block)}.getStateDefinition().getProperty(${input$property}) instanceof BooleanProperty _getbp && ${mappedBlockToBlockStateCode(input$block)}.getValue(_getbp))

--- a/plugins/generator-1.18.2/forge-1.18.2/procedures/blockstate_get_enum_property.java.ftl
+++ b/plugins/generator-1.18.2/forge-1.18.2/procedures/blockstate_get_enum_property.java.ftl
@@ -1,2 +1,2 @@
 <#include "mcitems.ftl">
-(${mappedBlockToBlock(input$block)}.getStateDefinition().getProperty(${input$property}) instanceof EnumProperty _ep ? ${mappedBlockToBlockStateCode(input$block)}.getValue(_ep).toString() : "")
+(${mappedBlockToBlock(input$block)}.getStateDefinition().getProperty(${input$property}) instanceof EnumProperty _getep${customBlockIndex} ? ${mappedBlockToBlockStateCode(input$block)}.getValue(_getep${customBlockIndex}).toString() : "")

--- a/plugins/generator-1.18.2/forge-1.18.2/procedures/blockstate_get_integer_property.java.ftl
+++ b/plugins/generator-1.18.2/forge-1.18.2/procedures/blockstate_get_integer_property.java.ftl
@@ -1,2 +1,2 @@
 <#include "mcitems.ftl">
-/*@int*/(${mappedBlockToBlock(input$block)}.getStateDefinition().getProperty(${input$property}) instanceof IntegerProperty _ip ? ${mappedBlockToBlockStateCode(input$block)}.getValue(_ip) : -1)
+/*@int*/(${mappedBlockToBlock(input$block)}.getStateDefinition().getProperty(${input$property}) instanceof IntegerProperty _getip${customBlockIndex} ? ${mappedBlockToBlockStateCode(input$block)}.getValue(_getip${customBlockIndex}) : -1)

--- a/plugins/generator-1.18.2/forge-1.18.2/procedures/blockstate_with_boolean_property.java.ftl
+++ b/plugins/generator-1.18.2/forge-1.18.2/procedures/blockstate_with_boolean_property.java.ftl
@@ -1,3 +1,3 @@
 <#include "mcitems.ftl">
-/*@BlockState*/(${mappedBlockToBlock(input$block)}.getStateDefinition().getProperty(${input$property}) instanceof BooleanProperty _bp ?
-    ${mappedBlockToBlockStateCode(input$block)}.setValue(_bp, ${input$value}) : ${mappedBlockToBlockStateCode(input$block)})
+/*@BlockState*/(${mappedBlockToBlock(input$block)}.getStateDefinition().getProperty(${input$property}) instanceof BooleanProperty _withbp ?
+    ${mappedBlockToBlockStateCode(input$block)}.setValue(_withbp, ${input$value}) : ${mappedBlockToBlockStateCode(input$block)})

--- a/plugins/generator-1.18.2/forge-1.18.2/procedures/blockstate_with_boolean_property.java.ftl
+++ b/plugins/generator-1.18.2/forge-1.18.2/procedures/blockstate_with_boolean_property.java.ftl
@@ -1,3 +1,3 @@
 <#include "mcitems.ftl">
-/*@BlockState*/(${mappedBlockToBlock(input$block)}.getStateDefinition().getProperty(${input$property}) instanceof BooleanProperty _withbp ?
-    ${mappedBlockToBlockStateCode(input$block)}.setValue(_withbp, ${input$value}) : ${mappedBlockToBlockStateCode(input$block)})
+/*@BlockState*/(${mappedBlockToBlock(input$block)}.getStateDefinition().getProperty(${input$property}) instanceof BooleanProperty _withbp${customBlockIndex} ?
+    ${mappedBlockToBlockStateCode(input$block)}.setValue(_withbp${customBlockIndex}, ${input$value}) : ${mappedBlockToBlockStateCode(input$block)})


### PR DESCRIPTION
This PR renames the pattern variables of the "Get/With boolean property" blocks to avoid compilation errors with procedures like "Set NBT logic tag of block".
This bug was reported on https://mcreator.net/forum/89071/get-logic-block-property-error