### PR TITLE
Added missing coverage bar for villager professions

### DIFF
--- a/plugins/mcreator-localization/lang/texts.properties
+++ b/plugins/mcreator-localization/lang/texts.properties
@@ -2744,6 +2744,7 @@ dialog.generator_selector.coverage.projectiles=Projectiles
 dialog.generator_selector.coverage.step_sounds=Step sounds
 dialog.generator_selector.coverage.biome_dictionary=Biome dictionary
 dialog.generator_selector.coverage.plant_types=Plant types
+dialog.generator_selector.coverage.villager_professions=Villager professions
 dialog.generator_selector.element_coverage=Vanilla/Forge elements coverage (compared to the latest supported Minecraft version):
 dialog.generator_selector.procedure_coverage=Procedure system coverage:
 dialog.generator_selector.dev_gen_message=Switching current generator to a generator in development is not possible.

--- a/src/main/java/net/mcreator/ui/dialogs/workspace/GeneratorSelector.java
+++ b/src/main/java/net/mcreator/ui/dialogs/workspace/GeneratorSelector.java
@@ -151,6 +151,7 @@ public class GeneratorSelector {
 			addStatsBar(L10N.t(covpfx + "step_sounds"), "stepsounds", supportedElements, stats);
 			addStatsBar(L10N.t(covpfx + "plant_types"), "planttypes", supportedElements, stats);
 			addStatsBar(L10N.t(covpfx + "screens"), "screens", supportedElements, stats);
+			addStatsBar(L10N.t(covpfx + "villager_professions"), "villagerprofessions", supportedElements, stats);
 
 			if (generatorConfiguration.getGeneratorFlavor() == GeneratorFlavor.FORGE)
 				addStatsBar(L10N.t(covpfx + "biome_dictionary"), "biomedictionarytypes", supportedElements, stats);


### PR DESCRIPTION
This PR adds the coverage bar for the villager professions data list, which was missing from the generator selector