### PR TITLE
Set default fluid opacity to 1

### DIFF
--- a/src/main/java/net/mcreator/ui/modgui/FluidGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/FluidGUI.java
@@ -91,7 +91,7 @@ public class FluidGUI extends ModElementGUI<Fluid> {
 
 	private final JSpinner resistance = new JSpinner(new SpinnerNumberModel(100, 0, Integer.MAX_VALUE, 0.5));
 	private final JSpinner luminance = new JSpinner(new SpinnerNumberModel(0, 0, 15, 1));
-	private final JSpinner lightOpacity = new JSpinner(new SpinnerNumberModel(0, 0, 15, 1));
+	private final JSpinner lightOpacity = new JSpinner(new SpinnerNumberModel(1, 0, 15, 1));
 	private final JCheckBox emissiveRendering = L10N.checkbox("elementgui.common.enable");
 	private final JSpinner tickRate = new JSpinner(new SpinnerNumberModel(10, 0, 9999999, 1));
 	private final JSpinner flammability = new JSpinner(new SpinnerNumberModel(0, 0, 1024, 1));


### PR DESCRIPTION
This PR changes the fluid opacity spinner default value to 1, to match vanilla water behavior.