### PR TITLE
Fix #3058

### DIFF
--- a/plugins/generator-1.16.5/forge-1.16.5/templates/itemextension.java.ftl
+++ b/plugins/generator-1.16.5/forge-1.16.5/templates/itemextension.java.ftl
@@ -38,7 +38,7 @@ package ${package}.item.extension;
 
 	<#if data.hasDispenseBehavior || data.compostLayerChance gt 0>
 		@SubscribeEvent
-		public void init(FMLCommonSetupEvent event) {
+		public static void init(FMLCommonSetupEvent event) {
 		    <#if data.compostLayerChance gt 0>
 		        ComposterBlock.CHANCES.put(${mappedMCItemToItem(data.item)}, ${data.compostLayerChance}f);
 		    </#if>


### PR DESCRIPTION
The missing `static` keyword affected the custom dispenser behaviour, but also the compost layer chance. It only affected Forge 1.16.5.