### PR TITLE
[1.19.x] Ported tab mod element

### DIFF
--- a/plugins/generator-1.19.2/forge-1.19.2/mappings/blocksitems.yaml
+++ b/plugins/generator-1.19.2/forge-1.19.2/mappings/blocksitems.yaml
@@ -1,0 +1,37 @@
+_mcreator_prefix: "CUSTOM:"
+_bypass_prefix:
+  - "TAG:"
+  - "POTION:"
+_default:
+  - Blocks.AIR
+  - "air"
+Blocks.AIR:
+  - Blocks.AIR
+  - "air"
+Blocks.STONE:
+  - Blocks.STONE
+  - "#forge:stone"
+Blocks.STONE#0:
+  - Blocks.STONE
+  - "stone"
+Blocks.STONE#1:
+  - Blocks.GRANITE
+  - "granite"
+Blocks.STONE#2:
+  - Blocks.POLISHED_GRANITE
+  - "polished_granite"
+Blocks.STONE#3:
+  - Blocks.DIORITE
+  - "diorite"
+Blocks.STONE#4:
+  - Blocks.POLISHED_DIORITE
+  - "polished_diorite"
+Blocks.STONE#5:
+  - Blocks.ANDESITE
+  - "andesite"
+Blocks.STONE#6:
+  - Blocks.POLISHED_ANDESITE
+  - "polished_andesite"
+Blocks.GRASS:
+  - Blocks.GRASS_BLOCK
+  - "grass_block"

--- a/plugins/generator-1.19.2/forge-1.19.2/tab.definition.yaml
+++ b/plugins/generator-1.19.2/forge-1.19.2/tab.definition.yaml
@@ -1,0 +1,8 @@
+localizationkeys:
+  - key: itemGroup.tab@registryname
+    mapto: name
+
+global_templates:
+  - template: elementinits/tabs.java.ftl
+    writer: java
+    name: "@SRCROOT/@BASEPACKAGEPATH/init/@JavaModNameTabs.java"

--- a/plugins/generator-1.19.2/forge-1.19.2/templates/elementinits/tabs.java.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/templates/elementinits/tabs.java.ftl
@@ -1,0 +1,63 @@
+<#--
+ # MCreator (https://mcreator.net/)
+ # Copyright (C) 2012-2020, Pylo
+ # Copyright (C) 2020-2022, Pylo, opensource contributors
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # Additional permission for code generator templates (*.ftl files)
+ #
+ # As a special exception, you may create a larger work that contains part or
+ # all of the MCreator code generator templates (*.ftl files) and distribute
+ # that work under terms of your choice, so long as that work isn't itself a
+ # template for code generation. Alternatively, if you modify or redistribute
+ # the template itself, you may (at your option) remove this special exception,
+ # which will cause the template and the resulting code generator output files
+ # to be licensed under the GNU General Public License without this special
+ # exception.
+-->
+
+<#-- @formatter:off -->
+
+<#include "../mcitems.ftl">
+
+/*
+ *    MCreator note: This file will be REGENERATED on each build.
+ */
+
+package ${package}.init;
+
+public class ${JavaModName}Tabs {
+
+    <#list tabs as tab>
+    public static CreativeModeTab TAB_${tab.getModElement().getRegistryNameUpper()};
+    </#list>
+
+	public static void load() {
+        <#list tabs as tab>
+        TAB_${tab.getModElement().getRegistryNameUpper()} = new CreativeModeTab("tab${tab.getModElement().getRegistryName()}") {
+			@Override public ItemStack makeIcon() {
+				return ${mappedMCItemToItemStackCode(tab.icon, 1)};
+			}
+
+			@Override public boolean hasSearchBar() {
+				return ${tab.showSearch};
+			}
+        }<#if tab.showSearch>.setBackgroundSuffix("item_search.png")</#if>;
+        </#list>
+    }
+
+}
+
+<#-- @formatter:on -->

--- a/plugins/generator-1.19.2/forge-1.19.2/templates/modbase/mod.java.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/templates/modbase/mod.java.ftl
@@ -31,6 +31,8 @@ import org.apache.logging.log4j.Logger;
 	private static int messageID = 0;
 
 	public ${JavaModName}() {
+		<#if w.hasElementsOfType("tab")>${JavaModName}Tabs.load();</#if>
+
 		IEventBus bus = FMLJavaModLoadingContext.get().getModEventBus();
 		<#if w.hasSounds()>${JavaModName}Sounds.REGISTRY.register(bus);</#if>
 		<#if w.hasElementsOfType("painting")>${JavaModName}Paintings.REGISTRY.register(bus);</#if>

--- a/plugins/generator-1.19.2/forge-1.19.2/utils/mcitems.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/utils/mcitems.ftl
@@ -1,0 +1,256 @@
+<#function mappedBlockToBlockStateCode mappedBlock>
+    <#if mappedBlock?starts_with("/*@BlockState*/")>
+        <#return mappedBlock?replace("/*@BlockState*/","")>
+    <#elseif mappedBlock?contains("/*@?*/")>
+        <#assign outputs = mappedBlock?keep_after("/*@?*/")?keep_before_last(")")>
+        <#return mappedBlock?keep_before("/*@?*/") + "?" + mappedBlockToBlockStateCode(outputs?keep_before("/*@:*/"))
+            + ":" + mappedBlockToBlockStateCode(outputs?keep_after("/*@:*/")) + ")">
+    <#else>
+        <#return mappedBlockToBlock(mappedBlock) + ".defaultBlockState()">
+    </#if>
+</#function>
+
+<#function mappedBlockToBlock mappedBlock>
+    <#if mappedBlock?starts_with("/*@BlockState*/")>
+        <#return mappedBlock?replace("/*@BlockState*/","") + ".getBlock()">
+    <#elseif mappedBlock?contains("/*@?*/")>
+        <#assign outputs = mappedBlock?keep_after("/*@?*/")?keep_before_last(")")>
+        <#return mappedBlock?keep_before("/*@?*/") + "?" + mappedBlockToBlock(outputs?keep_before("/*@:*/"))
+            + ":" + mappedBlockToBlock(outputs?keep_after("/*@:*/")) + ")">
+    <#elseif mappedBlock?starts_with("CUSTOM:")>
+        <#return mappedElementToRegistryEntry(mappedBlock)>
+    <#else>
+        <#return mappedBlock>
+    </#if>
+</#function>
+
+<#function mappedMCItemToItemStackCode mappedBlock amount=1>
+    <#if mappedBlock?starts_with("/*@ItemStack*/")>
+        <#return mappedBlock?replace("/*@ItemStack*/", "")>
+    <#elseif mappedBlock?contains("/*@?*/")>
+        <#assign outputs = mappedBlock?keep_after("/*@?*/")?keep_before_last(")")>
+        <#return mappedBlock?keep_before("/*@?*/") + "?" + mappedMCItemToItemStackCode(outputs?keep_before("/*@:*/"), amount)
+            + ":" + mappedMCItemToItemStackCode(outputs?keep_after("/*@:*/"), amount) + ")">
+    <#elseif mappedBlock?starts_with("CUSTOM:")>
+        <#return toItemStack(mappedElementToRegistryEntry(mappedBlock), amount)>
+    <#else>
+        <#return toItemStack(mappedBlock, amount)>
+    </#if>
+</#function>
+
+<#function toItemStack item amount>
+    <#if amount == 1>
+        <#return "new ItemStack(" + item + ")">
+    <#else>
+        <#return "new ItemStack(" + item + "," + (amount == amount?floor)?then(amount + ")","(int)(" + amount + "))")>
+    </#if>
+</#function>
+
+<#function mappedMCItemToItem mappedBlock>
+    <#if mappedBlock?starts_with("/*@ItemStack*/")>
+        <#return mappedBlock?replace("/*@ItemStack*/", "") + ".getItem()">
+    <#elseif mappedBlock?contains("/*@?*/")>
+        <#assign outputs = mappedBlock?keep_after("/*@?*/")?keep_before_last(")")>
+        <#return mappedBlock?keep_before("/*@?*/") + "?" + mappedMCItemToItem(outputs?keep_before("/*@:*/"))
+            + ":" + mappedMCItemToItem(outputs?keep_after("/*@:*/")) + ")">
+    <#elseif mappedBlock?starts_with("CUSTOM:")>
+        <#return mappedElementToRegistryEntry(mappedBlock) + generator.isBlock(mappedBlock)?then(".asItem()", "")>
+    <#else>
+        <#return mappedBlock + mappedBlock?contains("Blocks.")?then(".asItem()","")>
+    </#if>
+</#function>
+
+<#function mappedElementToRegistryEntry mappedElement>
+    <#return JavaModName + generator.isBlock(mappedElement)?then("Blocks", "Items") + "."
+    + generator.getRegistryNameFromFullName(mappedElement)?upper_case + transformExtension(mappedElement)?upper_case + ".get()">
+</#function>
+
+<#function transformExtension mappedBlock>
+    <#return (mappedBlock.toString().contains(".helmet"))?then("_helmet", "")
+    + (mappedBlock.toString().contains(".body"))?then("_chestplate", "")
+    + (mappedBlock.toString().contains(".legs"))?then("_leggings", "")
+    + (mappedBlock.toString().contains(".boots"))?then("_boots", "")
+    + (mappedBlock.toString().contains(".bucket"))?then("_bucket", "")>
+</#function>
+
+<#function mappedMCItemToIngameItemName mappedBlock>
+    <#if mappedBlock.getUnmappedValue().startsWith("CUSTOM:")>
+        <#assign customelement = generator.getRegistryNameForModElement(mappedBlock.getUnmappedValue().replace("CUSTOM:", "")
+        .replace(".helmet", "").replace(".body", "").replace(".legs", "").replace(".boots", "").replace(".bucket", ""))!""/>
+        <#if customelement?has_content>
+            <#return "\"item\": \"" + "${modid}:" + customelement
+            + transformExtension(mappedBlock)
+            + "\"">
+        <#else>
+            <#return "\"item\": \"minecraft:air\"">
+        </#if>
+    <#elseif mappedBlock.getUnmappedValue().startsWith("TAG:")>
+        <#return "\"tag\": \"" + mappedBlock.getUnmappedValue().replace("TAG:", "")?lower_case + "\"">
+    <#else>
+        <#assign mapped = generator.map(mappedBlock.getUnmappedValue(), "blocksitems", 1) />
+        <#if mapped.startsWith("#")>
+            <#return "\"tag\": \"" + mapped.replace("#", "") + "\"">
+        <#elseif mapped.contains(":")>
+            <#return "\"item\": \"" + mapped + "\"">
+        <#else>
+            <#return "\"item\": \"minecraft:" + mapped + "\"">
+        </#if>
+    </#if>
+</#function>
+
+<#function mappedMCItemToIngameNameNoTags mappedBlock>
+    <#if mappedBlock.getUnmappedValue().startsWith("CUSTOM:")>
+        <#assign customelement = generator.getRegistryNameForModElement(mappedBlock.getUnmappedValue().replace("CUSTOM:", "")
+        .replace(".helmet", "").replace(".body", "").replace(".legs", "").replace(".boots", "").replace(".bucket", ""))!""/>
+        <#if customelement?has_content>
+            <#return "${modid}:" + customelement + transformExtension(mappedBlock)>
+        <#else>
+            <#return "minecraft:air">
+        </#if>
+    <#elseif mappedBlock.getUnmappedValue().startsWith("TAG:")>
+        <#return "minecraft:air">
+    <#else>
+        <#assign mapped = generator.map(mappedBlock.getUnmappedValue(), "blocksitems", 1) />
+        <#if mapped.startsWith("#")>
+            <#return "minecraft:air">
+        <#elseif mapped.contains(":")>
+            <#return mapped>
+        <#else>
+            <#return "minecraft:" + mapped>
+        </#if>
+    </#if>
+</#function>
+
+<#function mappedMCItemToBlockStateJSON mappedBlock>
+    <#if mappedBlock.getUnmappedValue().startsWith("CUSTOM:")>
+        <#assign mcitemresourcepath = mappedMCItemToIngameNameNoTags(mappedBlock)/>
+        <#assign ge = w.getWorkspace().getModElementByName(mappedBlock.getUnmappedValue().replace("CUSTOM:", "")
+        .replace(".helmet", "").replace(".body", "").replace(".legs", "").replace(".boots", "").replace(".bucket", ""))/>
+        <#if ge??>
+            <#assign ge = ge.getGeneratableElement() />
+
+            <#assign properties = []>
+            <#if ge.getModElement().getType().getRegistryName() == "fluid">
+                <#assign properties += [{"name": "level", "value": 0}] />
+            <#elseif ge.getModElement().getType().getRegistryName() == "plant">
+                <#if ge.plantType == "growapable">
+                    <#assign properties += [{"name": "age", "value": 0}] />
+                <#elseif ge.plantType == "double">
+                    <#assign properties += [{"name": "half", "value": "lower"}] />
+                </#if>
+            <#elseif ge.getModElement().getType().getRegistryName() == "block">
+                <#if ge.blockBase?has_content && ge.blockBase == "Stairs">
+                    <#assign properties += [
+                    {"name": "facing", "value": "north"},
+                    {"name": "half", "value": "bottom"},
+                    {"name": "shape", "value": "straight"},
+                    {"name": "waterlogged", "value": "false"}
+                    ] />
+                <#elseif ge.blockBase?has_content && ge.blockBase == "Slab">
+                    <#assign properties += [
+                    {"name": "type", "value": "bottom"},
+                    {"name": "waterlogged", "value": "false"}
+                    ] />
+                <#elseif ge.blockBase?has_content && ge.blockBase == "Fence">
+                    <#assign properties += [
+                    {"name": "east", "value": "false"},
+                    {"name": "north", "value": "false"},
+                    {"name": "south", "value": "false"},
+                    {"name": "waterlogged", "value": "false"},
+                    {"name": "west", "value": "false"}
+                    ] />
+                <#elseif ge.blockBase?has_content && ge.blockBase == "Wall">
+                    <#assign properties += [
+                    {"name": "east", "value": "none"},
+                    {"name": "north", "value": "none"},
+                    {"name": "south", "value": "none"},
+                    {"name": "up", "value": "true"},
+                    {"name": "waterlogged", "value": "false"},
+                    {"name": "west", "value": "none"}
+                    ] />
+                <#elseif ge.blockBase?has_content && ge.blockBase == "Leaves">
+                    <#assign properties += [
+                    {"name": "distance", "value": "7"},
+                    {"name": "persistent", "value": "false"},
+                    {"name": "waterlogged", "value": "false"}
+                    ] />
+                <#elseif ge.blockBase?has_content && ge.blockBase == "TrapDoor">
+                    <#assign properties += [
+                    {"name": "facing", "value": "north"},
+                    {"name": "half", "value": "bottom"},
+                    {"name": "open", "value": "false"},
+                    {"name": "powered", "value": "false"},
+                    {"name": "waterlogged", "value": "false"}
+                    ] />
+                <#elseif ge.blockBase?has_content && ge.blockBase == "Pane">
+                    <#assign properties += [
+                    {"name": "east", "value": "false"},
+                    {"name": "north", "value": "false"},
+                    {"name": "south", "value": "false"},
+                    {"name": "waterlogged", "value": "false"},
+                    {"name": "west", "value": "false"}
+                    ] />
+                <#elseif ge.blockBase?has_content && ge.blockBase == "Door">
+                    <#assign properties += [
+                    {"name": "facing", "value": "north"},
+                    {"name": "half", "value": "lower"},
+                    {"name": "hinge", "value": "left"},
+                    {"name": "open", "value": "false"},
+                    {"name": "powered", "value": "false"}
+                    ] />
+                <#elseif ge.blockBase?has_content && ge.blockBase == "FenceGate">
+                    <#assign properties += [
+                    {"name": "facing", "value": "north"},
+                    {"name": "in_wall", "value": "false"},
+                    {"name": "open", "value": "false"},
+                    {"name": "powered", "value": "false"}
+                    ] />
+                <#else>
+                    <#if ge.isWaterloggable>
+                        <#assign properties += [{"name": "waterlogged", "value": "false"}] />
+                    </#if>
+
+                    <#if ge.rotationMode != 0 && ge.rotationMode != 5>
+                        <#assign properties += [{"name": "facing", "value": "north"}] />
+                    <#elseif ge.rotationMode == 5>
+                        <#assign properties += [{"name": "axis", "value": "y"}] />
+                    </#if>
+                </#if>
+            </#if>
+
+            <#if properties?has_content>
+                <#assign retval='{ "Name": "' + mcitemresourcepath + '", "Properties" : {'/>
+                <#list properties as property>
+                    <#assign retval = retval + '"' + property.name + '": "' + property.value + '"'/>
+                    <#if property?has_next>
+                        <#assign  retval = retval + ","/>
+                    </#if>
+                </#list>
+                <#return retval + "} }">
+            <#else>
+                <#return '{ "Name": "' + mcitemresourcepath + '" }'>
+            </#if>
+        </#if>
+    <#elseif !mappedBlock.getUnmappedValue().startsWith("TAG:")>
+        <#assign mapped = generator.map(mappedBlock.getUnmappedValue(), "blocksitems", 1) />
+        <#if !mapped.startsWith("#")>
+            <#if !mapped.contains(":")>
+                <#assign mapped = "minecraft:" + mapped />
+            </#if>
+            <#assign propertymap = fp.file("utils/defaultstates.json")?eval_json/>
+            <#if propertymap[mapped]?has_content>
+                <#assign retval='{ "Name": "' + mapped + '", "Properties" : {'/>
+                <#list propertymap[mapped] as property>
+                    <#assign retval = retval + '"' + property.name + '": "' + property.value + '"'/>
+                    <#if property?has_next>
+                        <#assign  retval = retval + ","/>
+                    </#if>
+                </#list>
+                <#return retval + "} }">
+            <#else>
+                <#return '{ "Name": "' + mapped + '" }'>
+            </#if>
+        </#if>
+    </#if>
+    <#return '{ "Name": "minecraft:air" }'>
+</#function>


### PR DESCRIPTION
This PR ports the tab mod element to 1.19.2. Part of the `blocksitems` datalist was also ported for testing purposes.
The `mcitems.ftl` file is the same as in 1.18.2, except for line 175 (added the waterlogged blockstate to custom leaves)