### PR TITLE
[1.19.x] Ported the potion mod element, fixed issue with potions without effects

### DIFF
--- a/plugins/generator-1.18.2/forge-1.18.2/templates/elementinits/potions.java.ftl
+++ b/plugins/generator-1.18.2/forge-1.18.2/templates/elementinits/potions.java.ftl
@@ -1,7 +1,7 @@
 <#--
  # MCreator (https://mcreator.net/)
  # Copyright (C) 2012-2020, Pylo
- # Copyright (C) 2020-2021, Pylo, opensource contributors
+ # Copyright (C) 2020-2022, Pylo, opensource contributors
  #
  # This program is free software: you can redistribute it and/or modify
  # it under the terms of the GNU General Public License as published by
@@ -41,7 +41,7 @@ public class ${JavaModName}Potions {
 	public static final DeferredRegister<Potion> REGISTRY = DeferredRegister.create(ForgeRegistries.POTIONS, ${JavaModName}.MODID);
 
     <#list potions as potion>
-    <#if potion.effects?has_content><#-- #2988, seems this can become null -->
+    <#if potion.effects??><#-- #2988, seems this can become null -->
         public static final RegistryObject<Potion> ${potion.getModElement().getRegistryNameUpper()} = REGISTRY.register("${potion.getModElement().getRegistryName()}", () -> new Potion(
             <#list potion.effects as effect>
             new MobEffectInstance(${effect.effect}, ${effect.duration}, ${effect.amplifier}, ${effect.ambient}, ${effect.showParticles})<#if effect?has_next>,</#if>

--- a/plugins/generator-1.19.2/forge-1.19.2/potion.definition.yaml
+++ b/plugins/generator-1.19.2/forge-1.19.2/potion.definition.yaml
@@ -1,0 +1,13 @@
+global_templates:
+  - template: elementinits/potions.java.ftl
+    name: "@SRCROOT/@BASEPACKAGEPATH/init/@JavaModNamePotions.java"
+
+localizationkeys:
+  - key: item.minecraft.potion.effect.@registryname
+    mapto: potionName
+  - key: item.minecraft.splash_potion.effect.@registryname
+    mapto: splashName
+  - key: item.minecraft.lingering_potion.effect.@registryname
+    mapto: lingeringName
+  - key: item.minecraft.tipped_arrow.effect.@registryname
+    mapto: arrowName

--- a/plugins/generator-1.19.2/forge-1.19.2/templates/elementinits/potions.java.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/templates/elementinits/potions.java.ftl
@@ -41,7 +41,7 @@ public class ${JavaModName}Potions {
 	public static final DeferredRegister<Potion> REGISTRY = DeferredRegister.create(ForgeRegistries.POTIONS, ${JavaModName}.MODID);
 
 	<#list potions as potion>
-	<#if potion.effects?has_content><#-- #2988, seems this can become null -->
+	<#if potion.effects??><#-- #2988, seems this can become null -->
 		public static final RegistryObject<Potion> ${potion.getModElement().getRegistryNameUpper()} = REGISTRY.register("${potion.getModElement().getRegistryName()}", () -> new Potion(
 			<#list potion.effects as effect>
 			new MobEffectInstance(${effect.effect}, ${effect.duration}, ${effect.amplifier}, ${effect.ambient}, ${effect.showParticles})<#sep>,

--- a/plugins/generator-1.19.2/forge-1.19.2/templates/elementinits/potions.java.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/templates/elementinits/potions.java.ftl
@@ -1,0 +1,54 @@
+<#--
+ # MCreator (https://mcreator.net/)
+ # Copyright (C) 2012-2020, Pylo
+ # Copyright (C) 2020-2022, Pylo, opensource contributors
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # Additional permission for code generator templates (*.ftl files)
+ #
+ # As a special exception, you may create a larger work that contains part or
+ # all of the MCreator code generator templates (*.ftl files) and distribute
+ # that work under terms of your choice, so long as that work isn't itself a
+ # template for code generation. Alternatively, if you modify or redistribute
+ # the template itself, you may (at your option) remove this special exception,
+ # which will cause the template and the resulting code generator output files
+ # to be licensed under the GNU General Public License without this special
+ # exception.
+-->
+
+<#-- @formatter:off -->
+
+/*
+ *    MCreator note: This file will be REGENERATED on each build.
+ */
+
+package ${package}.init;
+
+public class ${JavaModName}Potions {
+
+	public static final DeferredRegister<Potion> REGISTRY = DeferredRegister.create(ForgeRegistries.POTIONS, ${JavaModName}.MODID);
+
+	<#list potions as potion>
+	<#if potion.effects?has_content><#-- #2988, seems this can become null -->
+		public static final RegistryObject<Potion> ${potion.getModElement().getRegistryNameUpper()} = REGISTRY.register("${potion.getModElement().getRegistryName()}", () -> new Potion(
+			<#list potion.effects as effect>
+			new MobEffectInstance(${effect.effect}, ${effect.duration}, ${effect.amplifier}, ${effect.ambient}, ${effect.showParticles})<#sep>,
+			</#list>));
+	</#if>
+	</#list>
+
+}
+
+<#-- @formatter:on -->

--- a/plugins/generator-1.19.2/forge-1.19.2/templates/modbase/mod.java.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/templates/modbase/mod.java.ftl
@@ -36,6 +36,7 @@ import org.apache.logging.log4j.Logger;
 		IEventBus bus = FMLJavaModLoadingContext.get().getModEventBus();
 		<#if w.hasSounds()>${JavaModName}Sounds.REGISTRY.register(bus);</#if>
 		<#if w.hasElementsOfType("painting")>${JavaModName}Paintings.REGISTRY.register(bus);</#if>
+		<#if w.hasElementsOfType("potion")>${JavaModName}Potions.REGISTRY.register(bus);</#if>
 	}
 
 	public static <T> void addNetworkMessage(Class<T> messageType, BiConsumer<T, FriendlyByteBuf> encoder, Function<FriendlyByteBuf, T> decoder,


### PR DESCRIPTION
This PR ports the potion element to 1.19.2, with no changes other than indentation and using <#sep>. 
This PR also fixes an issue where potions with no effects wouldn't be registered, by replacing the `?has_content` check with a `??` check.