### PR TITLE
[1.19.x] Ported the recipe mod element

### DIFF
--- a/plugins/generator-1.19.2/forge-1.19.2/recipe.definition.yaml
+++ b/plugins/generator-1.19.2/forge-1.19.2/recipe.definition.yaml
@@ -1,0 +1,33 @@
+templates:
+  - template: json/recipe/smelting.json.ftl
+    writer: json
+    name: "@RESROOT/data/@[getNamespace()]/recipes/@[getName()].json"
+    condition: "recipeType %= Smelting"
+  - template: json/recipe/blasting.json.ftl
+    writer: json
+    name: "@RESROOT/data/@[getNamespace()]/recipes/@[getName()].json"
+    condition: "recipeType %= Blasting"
+  - template: json/recipe/campfire_cooking.json.ftl
+    writer: json
+    name: "@RESROOT/data/@[getNamespace()]/recipes/@[getName()].json"
+    condition: "recipeType %= Campfire cooking"
+  - template: json/recipe/smoking.json.ftl
+    writer: json
+    name: "@RESROOT/data/@[getNamespace()]/recipes/@[getName()].json"
+    condition: "recipeType %= Smoking"
+  - template: json/recipe/crafting.json.ftl
+    writer: json
+    name: "@RESROOT/data/@[getNamespace()]/recipes/@[getName()].json"
+    condition: "recipeType %= Crafting"
+  - template: json/recipe/stonecutting.json.ftl
+    writer: json
+    name: "@RESROOT/data/@[getNamespace()]/recipes/@[getName()].json"
+    condition: "recipeType %= Stone cutting"
+  - template: json/recipe/smithing.json.ftl
+    writer: json
+    name: "@RESROOT/data/@[getNamespace()]/recipes/@[getName()].json"
+    condition: "recipeType %= Smithing"
+  - template: brewingrecipe.java.ftl
+    name: "@SRCROOT/@BASEPACKAGEPATH/recipes/brewing/@NAMEBrewingRecipe.java"
+    condition: "recipeType %= Brewing"
+    deleteWhenConditionFalse: true

--- a/plugins/generator-1.19.2/forge-1.19.2/templates/brewingrecipe.java.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/templates/brewingrecipe.java.ftl
@@ -1,0 +1,81 @@
+<#--
+ # MCreator (https://mcreator.net/)
+ # Copyright (C) 2012-2020, Pylo
+ # Copyright (C) 2020-2022, Pylo, opensource contributors
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # Additional permission for code generator templates (*.ftl files)
+ #
+ # As a special exception, you may create a larger work that contains part or
+ # all of the MCreator code generator templates (*.ftl files) and distribute
+ # that work under terms of your choice, so long as that work isn't itself a
+ # template for code generation. Alternatively, if you modify or redistribute
+ # the template itself, you may (at your option) remove this special exception,
+ # which will cause the template and the resulting code generator output files
+ # to be licensed under the GNU General Public License without this special
+ # exception.
+-->
+
+<#-- @formatter:off -->
+<#include "mcitems.ftl">
+
+package ${package}.recipes.brewing;
+
+@Mod.EventBusSubscriber(bus = Mod.EventBusSubscriber.Bus.MOD) public class ${name}BrewingRecipe implements IBrewingRecipe {
+
+	@SubscribeEvent public static void init(FMLCommonSetupEvent event) {
+		event.enqueueWork(() -> BrewingRecipeRegistry.addRecipe(new ${name}BrewingRecipe()));
+	}
+
+	@Override
+	public boolean isInput(ItemStack input) {
+		<#if data.brewingInputStack?starts_with("POTION:")>
+		Item inputItem = input.getItem();
+		return (inputItem == Items.POTION || inputItem == Items.SPLASH_POTION || inputItem == Items.LINGERING_POTION)
+			&& PotionUtils.getPotion(input) == ${generator.map(data.brewingInputStack?replace("POTION:",""), "potions")};
+		<#elseif data.brewingInputStack?starts_with("TAG:")>
+		return Ingredient.of(ItemTags.create(new ResourceLocation("${data.brewingInputStack?replace("TAG:","")}"))).test(input);
+		<#else>
+		return input.getItem() == ${mappedMCItemToItem(data.brewingInputStack)};
+		</#if>
+	}
+
+	@Override
+	public boolean isIngredient(ItemStack ingredient) {
+		<#if data.brewingIngredientStack?starts_with("TAG:")>
+		return Ingredient.of(ItemTags.create(new ResourceLocation("${data.brewingIngredientStack?replace("TAG:","")}"))).test(ingredient);
+		<#else>
+		return ingredient.getItem() == ${mappedMCItemToItem(data.brewingIngredientStack)};
+		</#if>
+	}
+
+	@Override
+	public ItemStack getOutput(ItemStack input, ItemStack ingredient) {
+		if (isInput(input) && isIngredient(ingredient)) {
+			<#if data.brewingReturnStack?starts_with("POTION:")>
+			return PotionUtils.setPotion(
+				<#if data.brewingInputStack?starts_with("POTION:")>
+				new ItemStack(input.getItem())
+				<#else>
+				new ItemStack(Items.POTION)
+				</#if>, ${generator.map(data.brewingReturnStack?replace("POTION:",""), "potions")});
+			<#else>
+			return ${mappedMCItemToItemStackCode(data.brewingReturnStack, 1)};
+			</#if>
+		}
+		return ItemStack.EMPTY;
+	}
+
+}

--- a/plugins/generator-1.19.2/forge-1.19.2/templates/json/recipe/blasting.json.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/templates/json/recipe/blasting.json.ftl
@@ -1,0 +1,13 @@
+<#-- @formatter:off -->
+<#include "../../mcitems.ftl">
+{
+    <#if data.group?has_content>"group": "${data.group}",</#if>
+    "type": "minecraft:blasting",
+    "experience": ${data.xpReward},
+	"cookingtime": ${data.cookingTime},
+    "ingredient": {
+      ${mappedMCItemToIngameItemName(data.blastingInputStack)}
+    },
+    "result": "${mappedMCItemToIngameNameNoTags(data.blastingReturnStack)}"
+}
+<#-- @formatter:on -->

--- a/plugins/generator-1.19.2/forge-1.19.2/templates/json/recipe/campfire_cooking.json.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/templates/json/recipe/campfire_cooking.json.ftl
@@ -1,0 +1,13 @@
+<#-- @formatter:off -->
+<#include "../../mcitems.ftl">
+{
+    <#if data.group?has_content>"group": "${data.group}",</#if>
+    "type": "minecraft:campfire_cooking",
+    "experience": ${data.xpReward},
+	"cookingtime": ${data.cookingTime},
+    "ingredient": {
+      ${mappedMCItemToIngameItemName(data.campfireCookingInputStack)}
+    },
+    "result": "${mappedMCItemToIngameNameNoTags(data.campfireCookingReturnStack)}"
+}
+<#-- @formatter:on -->

--- a/plugins/generator-1.19.2/forge-1.19.2/templates/json/recipe/crafting.json.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/templates/json/recipe/crafting.json.ftl
@@ -1,0 +1,36 @@
+<#-- @formatter:off -->
+<#include "../../mcitems.ftl">
+{
+  <#if data.group?has_content>"group": "${data.group}",</#if>
+    <#if data.recipeShapeless>
+        "type": "minecraft:crafting_shapeless",
+        "ingredients": [
+          <#assign ingredients = "">
+          <#list data.recipeSlots as element>
+              <#if !element.isEmpty()>
+                  <#assign ingredients += "{${mappedMCItemToIngameItemName(element)}},">
+              </#if>
+          </#list>
+            ${ingredients[0..(ingredients?last_index_of(',') - 1)]}
+        ],
+    <#else>
+        "type": "minecraft:crafting_shaped",
+        <#assign recipeArray = data.getOptimisedRecipe()>
+        <#assign rm = [], i = 0>
+        "pattern": [
+        <#list recipeArray as rl>
+        		"<#list rl as re><#if !re.isEmpty()><#assign rm+=["\"${i}\": {${mappedMCItemToIngameItemName(re)}}"]/>${i}<#else> </#if><#assign i+=1></#list>"<#sep>,
+        </#list>
+        ],
+        "key": {
+        <#list rm as recipeMapping>
+            ${recipeMapping}<#sep>,
+        </#list>
+        },
+    </#if>
+    "result": {
+      ${mappedMCItemToIngameItemName(data.recipeReturnStack)},
+      "count": ${data.recipeRetstackSize}
+    }
+}
+<#-- @formatter:on -->

--- a/plugins/generator-1.19.2/forge-1.19.2/templates/json/recipe/smelting.json.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/templates/json/recipe/smelting.json.ftl
@@ -1,0 +1,13 @@
+<#-- @formatter:off -->
+<#include "../../mcitems.ftl">
+{
+    <#if data.group?has_content>"group": "${data.group}",</#if>
+    "type": "minecraft:smelting",
+    "experience": ${data.xpReward},
+	"cookingtime": ${data.cookingTime},
+    "ingredient": {
+      ${mappedMCItemToIngameItemName(data.smeltingInputStack)}
+    },
+    "result": "${mappedMCItemToIngameNameNoTags(data.smeltingReturnStack)}"
+}
+<#-- @formatter:on -->

--- a/plugins/generator-1.19.2/forge-1.19.2/templates/json/recipe/smithing.json.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/templates/json/recipe/smithing.json.ftl
@@ -1,0 +1,15 @@
+<#-- @formatter:off -->
+<#include "../../mcitems.ftl">
+{
+    "type": "minecraft:smithing",
+    "base": {
+      ${mappedMCItemToIngameItemName(data.smithingInputStack)}
+    },
+    "addition": {
+      ${mappedMCItemToIngameItemName(data.smithingInputAdditionStack)}
+    },
+    "result": {
+      ${mappedMCItemToIngameItemName(data.smithingReturnStack)}
+    }
+}
+<#-- @formatter:on -->

--- a/plugins/generator-1.19.2/forge-1.19.2/templates/json/recipe/smoking.json.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/templates/json/recipe/smoking.json.ftl
@@ -1,0 +1,13 @@
+<#-- @formatter:off -->
+<#include "../../mcitems.ftl">
+{
+    <#if data.group?has_content>"group": "${data.group}",</#if>
+    "type": "minecraft:smoking",
+    "experience": ${data.xpReward},
+	"cookingtime": ${data.cookingTime},
+    "ingredient": {
+      ${mappedMCItemToIngameItemName(data.smokingInputStack)}
+    },
+    "result": "${mappedMCItemToIngameNameNoTags(data.smokingReturnStack)}"
+}
+<#-- @formatter:on -->

--- a/plugins/generator-1.19.2/forge-1.19.2/templates/json/recipe/stonecutting.json.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/templates/json/recipe/stonecutting.json.ftl
@@ -1,0 +1,12 @@
+<#-- @formatter:off -->
+<#include "../../mcitems.ftl">
+{
+    <#if data.group?has_content>"group": "${data.group}",</#if>
+    "type": "minecraft:stonecutting",
+    "count": ${data.recipeRetstackSize},
+    "ingredient": {
+        ${mappedMCItemToIngameItemName(data.stoneCuttingInputStack)}
+    },
+    "result": "${mappedMCItemToIngameNameNoTags(data.stoneCuttingReturnStack)}"
+}
+<#-- @formatter:on -->


### PR DESCRIPTION
This PR ports the recipe mod element to 1.19.2. To reduce clutter, the .json templates are moved in a `recipe` subfolder. Some `<#if has_next>` checks are also replaced with `<#sep>`, but the code is the same otherwise.