### PR TITLE
Disable "Follow entity" AI goal for water entities

### DIFF
--- a/plugins/generator-1.18.2/forge-1.18.2/aitasks/follow_entity.java.ftl
+++ b/plugins/generator-1.18.2/forge-1.18.2/aitasks/follow_entity.java.ftl
@@ -1,2 +1,4 @@
 <#include "aiconditions.java.ftl">
+<#if !data.waterMob || data.flyingMob>
 this.goalSelector.addGoal(${customBlockIndex+1}, new FollowMobGoal(this, (float)${field$speed}, ${field$maxrange}, ${field$followarea})<@conditionCode field$condition/>);
+</#if>


### PR DESCRIPTION
This PR fixes #3116. Water entities do not support the "Follow entity" goal, similar to the "Follow owner" issue