### PR TITLE
[1.19.x] Ported some block data procedures

### DIFF
--- a/plugins/generator-1.19.2/forge-1.19.2/procedures/block_is_fertilizable.java.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/procedures/block_is_fertilizable.java.ftl
@@ -1,0 +1,2 @@
+<#include "mcitems.ftl">
+(${mappedBlockToBlock(input$block)} instanceof BonemealableBlock)

--- a/plugins/generator-1.19.2/forge-1.19.2/procedures/block_is_fluid.java.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/procedures/block_is_fluid.java.ftl
@@ -1,0 +1,2 @@
+<#include "mcitems.ftl">
+(${mappedBlockToBlock(input$block)} instanceof LiquidBlock)

--- a/plugins/generator-1.19.2/forge-1.19.2/procedures/block_is_fluid_source.java.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/procedures/block_is_fluid_source.java.ftl
@@ -1,0 +1,2 @@
+<#include "mcitems.ftl">
+(${mappedBlockToBlockStateCode(input$block)}.getFluidState().isSource())

--- a/plugins/generator-1.19.2/forge-1.19.2/procedures/block_is_tagged_in.java.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/procedures/block_is_tagged_in.java.ftl
@@ -1,0 +1,3 @@
+<#include "mcelements.ftl">
+<#include "mcitems.ftl">
+(${mappedBlockToBlockStateCode(input$a)}.is(BlockTags.create(${toResourceLocation(input$b)})))

--- a/plugins/generator-1.19.2/forge-1.19.2/procedures/block_is_waterloggable.java.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/procedures/block_is_waterloggable.java.ftl
@@ -1,0 +1,2 @@
+<#include "mcitems.ftl">
+(${mappedBlockToBlock(input$block)} instanceof SimpleWaterloggedBlock)

--- a/plugins/generator-1.19.2/forge-1.19.2/procedures/block_random_from_tag.java.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/procedures/block_random_from_tag.java.ftl
@@ -1,0 +1,2 @@
+<#include "mcelements.ftl">
+(ForgeRegistries.BLOCKS.tags().getTag(BlockTags.create(${toResourceLocation(input$tag)})).getRandomElement(RandomSource.create()).orElseGet(() -> Blocks.AIR))

--- a/plugins/generator-1.19.2/forge-1.19.2/procedures/blockstate_from_deps.java.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/procedures/blockstate_from_deps.java.ftl
@@ -1,0 +1,1 @@
+/*@BlockState*/blockstate

--- a/plugins/generator-1.19.2/forge-1.19.2/procedures/blockstate_get_boolean_property.java.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/procedures/blockstate_get_boolean_property.java.ftl
@@ -1,0 +1,2 @@
+<#include "mcitems.ftl">
+(${mappedBlockToBlock(input$block)}.getStateDefinition().getProperty(${input$property}) instanceof BooleanProperty _getbp${customBlockIndex} && ${mappedBlockToBlockStateCode(input$block)}.getValue(_getbp${customBlockIndex}))

--- a/plugins/generator-1.19.2/forge-1.19.2/procedures/blockstate_get_direction.java.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/procedures/blockstate_get_direction.java.ftl
@@ -1,0 +1,9 @@
+<#include "mcitems.ftl">
+(new Object() {
+	public Direction getDirection(BlockState _bs) {
+		Property<?> _prop = _bs.getBlock().getStateDefinition().getProperty("facing");
+		if (_prop instanceof DirectionProperty _dp) return _bs.getValue(_dp);
+		_prop = _bs.getBlock().getStateDefinition().getProperty("axis");
+		return _prop instanceof EnumProperty _ep && _ep.getPossibleValues().toArray()[0] instanceof Direction.Axis ?
+			Direction.fromAxisAndDirection((Direction.Axis) _bs.getValue(_ep), Direction.AxisDirection.POSITIVE) : Direction.NORTH;
+}}.getDirection(${mappedBlockToBlockStateCode(input$block)}))

--- a/plugins/generator-1.19.2/forge-1.19.2/procedures/blockstate_get_enum_property.java.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/procedures/blockstate_get_enum_property.java.ftl
@@ -1,0 +1,2 @@
+<#include "mcitems.ftl">
+(${mappedBlockToBlock(input$block)}.getStateDefinition().getProperty(${input$property}) instanceof EnumProperty _getep${customBlockIndex} ? ${mappedBlockToBlockStateCode(input$block)}.getValue(_getep${customBlockIndex}).toString() : "")

--- a/plugins/generator-1.19.2/forge-1.19.2/procedures/blockstate_get_integer_property.java.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/procedures/blockstate_get_integer_property.java.ftl
@@ -1,0 +1,2 @@
+<#include "mcitems.ftl">
+/*@int*/(${mappedBlockToBlock(input$block)}.getStateDefinition().getProperty(${input$property}) instanceof IntegerProperty _getip${customBlockIndex} ? ${mappedBlockToBlockStateCode(input$block)}.getValue(_getip${customBlockIndex}) : -1)

--- a/plugins/generator-1.19.2/forge-1.19.2/procedures/blockstate_with_boolean_property.java.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/procedures/blockstate_with_boolean_property.java.ftl
@@ -1,0 +1,3 @@
+<#include "mcitems.ftl">
+/*@BlockState*/(${mappedBlockToBlock(input$block)}.getStateDefinition().getProperty(${input$property}) instanceof BooleanProperty _withbp${customBlockIndex} ?
+    ${mappedBlockToBlockStateCode(input$block)}.setValue(_withbp${customBlockIndex}, ${input$value}) : ${mappedBlockToBlockStateCode(input$block)})

--- a/plugins/generator-1.19.2/forge-1.19.2/procedures/blockstate_with_direction.java.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/procedures/blockstate_with_direction.java.ftl
@@ -1,0 +1,8 @@
+<#include "mcitems.ftl">
+/*@BlockState*/(new Object() {
+	public BlockState with(BlockState _bs, Direction newValue) {
+		Property<?> _prop = _bs.getBlock().getStateDefinition().getProperty("facing");
+		if (_prop instanceof DirectionProperty _dp && _dp.getPossibleValues().contains(newValue)) return _bs.setValue(_dp, newValue);
+		_prop = _bs.getBlock().getStateDefinition().getProperty("axis");
+		return _prop instanceof EnumProperty _ep && _ep.getPossibleValues().contains(newValue.getAxis()) ? _bs.setValue(_ep, newValue.getAxis()) : _bs;
+}}.with(${mappedBlockToBlockStateCode(input$block)}, ${input$value}))

--- a/plugins/generator-1.19.2/forge-1.19.2/procedures/blockstate_with_enum_property.java.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/procedures/blockstate_with_enum_property.java.ftl
@@ -1,0 +1,6 @@
+<#include "mcitems.ftl">
+/*@BlockState*/(new Object() {
+	public BlockState with(BlockState _bs, String _property, String _newValue) {
+		Property<?> _prop = _bs.getBlock().getStateDefinition().getProperty(_property);
+		return _prop instanceof EnumProperty _ep && _ep.getValue(_newValue).isPresent() ? _bs.setValue(_ep, (Enum) _ep.getValue(_newValue).get()) : _bs;
+}}.with(${mappedBlockToBlockStateCode(input$block)}, ${input$property}, ${input$value}))

--- a/plugins/generator-1.19.2/forge-1.19.2/procedures/blockstate_with_integer_property.java.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/procedures/blockstate_with_integer_property.java.ftl
@@ -1,0 +1,6 @@
+<#include "mcitems.ftl">
+/*@BlockState*/(new Object() {
+	public BlockState with(BlockState _bs, String _property, int _newValue) {
+		Property<?> _prop = _bs.getBlock().getStateDefinition().getProperty(_property);
+		return _prop instanceof IntegerProperty _ip && _prop.getPossibleValues().contains(_newValue) ? _bs.setValue(_ip, _newValue) : _bs;
+}}.with(${mappedBlockToBlockStateCode(input$block)}, ${input$property}, ${opt.toInt(input$value)}))

--- a/plugins/generator-1.19.2/forge-1.19.2/procedures/item_bucket_to_fluid.java.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/procedures/item_bucket_to_fluid.java.ftl
@@ -1,0 +1,2 @@
+<#include "mcitems.ftl">
+/*@BlockState*/(${mappedMCItemToItem(input$source)} instanceof BucketItem _bucket ? _bucket.getFluid().defaultFluidState().createLegacyBlock() : Blocks.AIR.defaultBlockState())

--- a/plugins/generator-1.19.2/forge-1.19.2/procedures/mcitem_to_block.java.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/procedures/mcitem_to_block.java.ftl
@@ -1,0 +1,2 @@
+<#include "mcitems.ftl">
+/*@BlockState*/(${mappedMCItemToItem(input$source)} instanceof BlockItem _bi ? _bi.getBlock().defaultBlockState() : Blocks.AIR.defaultBlockState())

--- a/plugins/generator-1.19.2/forge-1.19.2/procedures/world_data_blockat.java.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/procedures/world_data_blockat.java.ftl
@@ -1,0 +1,2 @@
+<#include "mcelements.ftl">
+/*@BlockState*/(world.getBlockState(${toBlockPos(input$x,input$y,input$z)}))

--- a/plugins/generator-1.19.2/forge-1.19.2/procedures/world_data_fluidat.java.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/procedures/world_data_fluidat.java.ftl
@@ -1,0 +1,2 @@
+<#include "mcelements.ftl">
+/*@BlockState*/(world.getFluidState(${toBlockPos(input$x,input$y,input$z)}).createLegacyBlock())


### PR DESCRIPTION
This PR ports the first half of the block data procedures. Code is the same as 1.18, except for `new Random()` -> `RandomSource.create()`