### PR TITLE
[1.19.x] Ported the ranged item mod element

### DIFF
--- a/plugins/generator-1.19.2/forge-1.19.2/common.entities.yaml
+++ b/plugins/generator-1.19.2/forge-1.19.2/common.entities.yaml
@@ -1,0 +1,5 @@
+global_templates:
+  - template: elementinits/entities.java.ftl
+    name: "@SRCROOT/@BASEPACKAGEPATH/init/@JavaModNameEntities.java"
+  - template: elementinits/entityrenderers.java.ftl
+    name: "@SRCROOT/@BASEPACKAGEPATH/init/@JavaModNameEntityRenderers.java"

--- a/plugins/generator-1.19.2/forge-1.19.2/rangeditem.definition.yaml
+++ b/plugins/generator-1.19.2/forge-1.19.2/rangeditem.definition.yaml
@@ -1,0 +1,26 @@
+templates:
+  - template: rangeditem/rangeditem.java.ftl
+    name: "@SRCROOT/@BASEPACKAGEPATH/item/@NAMEItem.java"
+  - template: rangeditem/projectile_entity.java.ftl
+    name: "@SRCROOT/@BASEPACKAGEPATH/entity/@NAMEEntity.java"
+  - template: rangeditem/projectile_renderer.java.ftl
+    name: "@SRCROOT/@BASEPACKAGEPATH/client/renderer/@NAMERenderer.java"
+    condition: isCustomModel()
+    deleteWhenConditionFalse: true
+  - template: json/rangeditem.json.ftl
+    writer: json
+    condition: "renderType #= 0"
+    name: "@MODASSETSROOT/models/item/@registryname.json"
+  - template: json/item_cmodel.json.ftl
+    writer: json
+    condition: "renderType #= 1"
+    name: "@MODASSETSROOT/models/item/@registryname.json"
+  - template: json/item_cmodel_obj.json.ftl
+    writer: json
+    condition: "renderType #= 2"
+    variables: "type=item"
+    name: "@MODASSETSROOT/models/item/@registryname.json"
+
+localizationkeys:
+  - key: item.@modid.@registryname
+    mapto: name

--- a/plugins/generator-1.19.2/forge-1.19.2/templates/elementinits/entities.java.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/templates/elementinits/entities.java.ftl
@@ -1,0 +1,57 @@
+<#--
+ # MCreator (https://mcreator.net/)
+ # Copyright (C) 2012-2020, Pylo
+ # Copyright (C) 2020-2022, Pylo, opensource contributors
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # Additional permission for code generator templates (*.ftl files)
+ #
+ # As a special exception, you may create a larger work that contains part or
+ # all of the MCreator code generator templates (*.ftl files) and distribute
+ # that work under terms of your choice, so long as that work isn't itself a
+ # template for code generation. Alternatively, if you modify or redistribute
+ # the template itself, you may (at your option) remove this special exception,
+ # which will cause the template and the resulting code generator output files
+ # to be licensed under the GNU General Public License without this special
+ # exception.
+-->
+
+<#-- @formatter:off -->
+
+/*
+ *    MCreator note: This file will be REGENERATED on each build.
+ */
+
+package ${package}.init;
+
+@Mod.EventBusSubscriber(bus = Mod.EventBusSubscriber.Bus.MOD) public class ${JavaModName}Entities {
+
+	public static final DeferredRegister<EntityType<?>> REGISTRY = DeferredRegister.create(ForgeRegistries.ENTITY_TYPES, ${JavaModName}.MODID);
+
+	<#list entities as entity>
+		<#if entity.getModElement().getTypeString() == "rangeditem">
+			public static final RegistryObject<EntityType<${entity.getModElement().getName()}Entity>> ${entity.getModElement().getRegistryNameUpper()} =
+				register("projectile_${entity.getModElement().getRegistryName()}", EntityType.Builder.<${entity.getModElement().getName()}Entity>
+					of(${entity.getModElement().getName()}Entity::new, MobCategory.MISC).setCustomClientFactory(${entity.getModElement().getName()}Entity::new)
+					.setShouldReceiveVelocityUpdates(true).setTrackingRange(64).setUpdateInterval(1).sized(0.5f, 0.5f));
+		</#if>
+	</#list>
+
+	private static <T extends Entity> RegistryObject<EntityType<T>> register(String registryname, EntityType.Builder<T> entityTypeBuilder) {
+		return REGISTRY.register(registryname, () -> (EntityType<T>) entityTypeBuilder.build(registryname));
+	}
+
+}
+<#-- @formatter:on -->

--- a/plugins/generator-1.19.2/forge-1.19.2/templates/elementinits/entityrenderers.java.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/templates/elementinits/entityrenderers.java.ftl
@@ -1,0 +1,53 @@
+<#--
+ # MCreator (https://mcreator.net/)
+ # Copyright (C) 2012-2020, Pylo
+ # Copyright (C) 2020-2022, Pylo, opensource contributors
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # Additional permission for code generator templates (*.ftl files)
+ #
+ # As a special exception, you may create a larger work that contains part or
+ # all of the MCreator code generator templates (*.ftl files) and distribute
+ # that work under terms of your choice, so long as that work isn't itself a
+ # template for code generation. Alternatively, if you modify or redistribute
+ # the template itself, you may (at your option) remove this special exception,
+ # which will cause the template and the resulting code generator output files
+ # to be licensed under the GNU General Public License without this special
+ # exception.
+-->
+
+<#-- @formatter:off -->
+
+/*
+ *    MCreator note: This file will be REGENERATED on each build.
+ */
+
+package ${package}.init;
+
+@Mod.EventBusSubscriber(bus = Mod.EventBusSubscriber.Bus.MOD, value = Dist.CLIENT) public class ${JavaModName}EntityRenderers {
+
+	@SubscribeEvent public static void registerEntityRenderers(EntityRenderersEvent.RegisterRenderers event) {
+		<#list entities as entity>
+			<#if entity.getModElement().getTypeString() == "rangeditem">
+				<#if entity.isCustomModel()>
+				event.registerEntityRenderer(${JavaModName}Entities.${entity.getModElement().getRegistryNameUpper()}.get(), ${entity.getModElement().getName()}Renderer::new);
+				<#else>
+				event.registerEntityRenderer(${JavaModName}Entities.${entity.getModElement().getRegistryNameUpper()}.get(), ThrownItemRenderer::new);
+				</#if>
+			</#if>
+		</#list>
+	}
+}
+<#-- @formatter:on -->

--- a/plugins/generator-1.19.2/forge-1.19.2/templates/json/rangeditem.json.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/templates/json/rangeditem.json.ftl
@@ -1,0 +1,76 @@
+{
+    "parent": "item/generated",
+    "textures": {
+      "layer0": "${modid}:items/${data.texture}"
+    },
+    "display": {
+      "thirdperson_righthand": {
+        "rotation": [
+          -80,
+          260,
+          -40
+        ],
+        "translation": [
+          -1,
+          -2,
+          2.5
+        ],
+        "scale": [
+          1,
+          1,
+          1
+        ]
+      },
+      "thirdperson_lefthand": {
+        "rotation": [
+          -80,
+          -280,
+          40
+        ],
+        "translation": [
+          -1,
+          -2,
+          2.5
+        ],
+        "scale": [
+          1,
+          1,
+          1
+        ]
+      },
+      "firstperson_righthand": {
+        "rotation": [
+          0,
+          -90,
+          25
+        ],
+        "translation": [
+          1.13,
+          3.2,
+          1.13
+        ],
+        "scale": [
+          1,
+          1,
+          1
+        ]
+      },
+      "firstperson_lefthand": {
+        "rotation": [
+          0,
+          90,
+          -25
+        ],
+        "translation": [
+          1.13,
+          3.2,
+          1.13
+        ],
+        "scale": [
+          1,
+          1,
+          1
+        ]
+      }
+    }
+}

--- a/plugins/generator-1.19.2/forge-1.19.2/templates/modbase/mod.java.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/templates/modbase/mod.java.ftl
@@ -37,6 +37,7 @@ import org.apache.logging.log4j.Logger;
 		<#if w.hasSounds()>${JavaModName}Sounds.REGISTRY.register(bus);</#if>
 		<#if w.hasElementsOfBaseType("block")>${JavaModName}Blocks.REGISTRY.register(bus);</#if>
 		<#if w.hasElementsOfBaseType("item")>${JavaModName}Items.REGISTRY.register(bus);</#if>
+		<#if w.hasElementsOfBaseType("entity")>${JavaModName}Entities.REGISTRY.register(bus);</#if>
 		<#if w.hasElementsOfBaseType("blockentity")>${JavaModName}BlockEntities.REGISTRY.register(bus);</#if>
 		<#if w.hasElementsOfBaseType("feature")>${JavaModName}Features.REGISTRY.register(bus);</#if>
 		<#if w.hasElementsOfType("fluid")>${JavaModName}Fluids.REGISTRY.register(bus);

--- a/plugins/generator-1.19.2/forge-1.19.2/templates/rangeditem/projectile_entity.java.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/templates/rangeditem/projectile_entity.java.ftl
@@ -1,0 +1,186 @@
+<#--
+ # MCreator (https://mcreator.net/)
+ # Copyright (C) 2012-2020, Pylo
+ # Copyright (C) 2020-2022, Pylo, opensource contributors
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # Additional permission for code generator templates (*.ftl files)
+ #
+ # As a special exception, you may create a larger work that contains part or
+ # all of the MCreator code generator templates (*.ftl files) and distribute
+ # that work under terms of your choice, so long as that work isn't itself a
+ # template for code generation. Alternatively, if you modify or redistribute
+ # the template itself, you may (at your option) remove this special exception,
+ # which will cause the template and the resulting code generator output files
+ # to be licensed under the GNU General Public License without this special
+ # exception.
+-->
+
+<#-- @formatter:off -->
+<#include "../mcitems.ftl">
+<#include "../procedures.java.ftl">
+
+package ${package}.entity;
+
+<#compress>
+@OnlyIn(value = Dist.CLIENT, _interface = ItemSupplier.class)
+public class ${name}Entity extends AbstractArrow implements ItemSupplier {
+
+	public ${name}Entity(PlayMessages.SpawnEntity packet, Level world) {
+		super(${JavaModName}Entities.${data.getModElement().getRegistryNameUpper()}.get(), world);
+	}
+
+	public ${name}Entity(EntityType<? extends ${name}Entity> type, Level world) {
+		super(type, world);
+	}
+
+	public ${name}Entity(EntityType<? extends ${name}Entity> type, double x, double y, double z, Level world) {
+		super(type, x, y, z, world);
+	}
+
+	public ${name}Entity(EntityType<? extends ${name}Entity> type, LivingEntity entity, Level world) {
+		super(type, entity, world);
+	}
+
+	@Override public Packet<?> getAddEntityPacket() {
+		return NetworkHooks.getEntitySpawningPacket(this);
+	}
+
+	@Override @OnlyIn(Dist.CLIENT) public ItemStack getItem() {
+		<#if !data.bulletItemTexture.isEmpty()>
+		return ${mappedMCItemToItemStackCode(data.bulletItemTexture, 1)};
+		<#else>
+		return ItemStack.EMPTY;
+		</#if>
+	}
+
+	@Override protected ItemStack getPickupItem() {
+		<#if !data.ammoItem.isEmpty()>
+		return ${mappedMCItemToItemStackCode(data.ammoItem, 1)};
+		<#else>
+		return ItemStack.EMPTY;
+		</#if>
+	}
+
+	@Override protected void doPostHurtEffects(LivingEntity entity) {
+		super.doPostHurtEffects(entity);
+		entity.setArrowCount(entity.getArrowCount() - 1); <#-- #53957 -->
+	}
+
+	<#if hasProcedure(data.onBulletHitsPlayer)>
+	@Override public void playerTouch(Player entity) {
+		super.playerTouch(entity);
+		<@procedureCode data.onBulletHitsPlayer, {
+			"x": "this.getX()",
+			"y": "this.getY()",
+			"z": "this.getZ()",
+			"entity": "entity",
+			"sourceentity": "this.getOwner()",
+			"immediatesourceentity": "this",
+			"world": "this.level"
+		}/>
+	}
+	</#if>
+
+	<#if hasProcedure(data.onBulletHitsEntity)>
+	@Override public void onHitEntity(EntityHitResult entityHitResult) {
+		super.onHitEntity(entityHitResult);
+		<@procedureCode data.onBulletHitsEntity, {
+			"x": "this.getX()",
+			"y": "this.getY()",
+			"z": "this.getZ()",
+			"entity": "entityHitResult.getEntity()",
+			"sourceentity": "this.getOwner()",
+			"immediatesourceentity": "this",
+			"world": "this.level"
+		}/>
+	}
+	</#if>
+
+	<#if hasProcedure(data.onBulletHitsBlock)>
+	@Override public void onHitBlock(BlockHitResult blockHitResult) {
+		super.onHitBlock(blockHitResult);
+		<@procedureCode data.onBulletHitsBlock, {
+			"x": "blockHitResult.getBlockPos().getX()",
+			"y": "blockHitResult.getBlockPos().getY()",
+			"z": "blockHitResult.getBlockPos().getZ()",
+			"entity": "this.getOwner()",
+			"immediatesourceentity": "this",
+			"world": "this.level"
+		}/>
+	}
+	</#if>
+
+	@Override public void tick() {
+		super.tick();
+
+		<#if hasProcedure(data.onBulletFlyingTick)>
+			<@procedureCode data.onBulletFlyingTick, {
+				"x": "this.getX()",
+				"y": "this.getY()",
+				"z": "this.getZ()",
+				"world": "this.level",
+				"entity": "this.getOwner()",
+				"immediatesourceentity": "this"
+			}/>
+		</#if>
+
+		if (this.inGround)
+			this.discard();
+	}
+
+	public static ${name}Entity shoot(Level world, LivingEntity entity, RandomSource random, float power, double damage, int knockback) {
+		${name}Entity entityarrow = new ${name}Entity(${JavaModName}Entities.${data.getModElement().getRegistryNameUpper()}.get(), entity, world);
+		entityarrow.shoot(entity.getViewVector(1).x, entity.getViewVector(1).y, entity.getViewVector(1).z, power * 2, 0);
+		entityarrow.setSilent(true);
+		entityarrow.setCritArrow(${data.bulletParticles});
+		entityarrow.setBaseDamage(damage);
+		entityarrow.setKnockback(knockback);
+		<#if data.bulletIgnitesFire>
+			entityarrow.setSecondsOnFire(100);
+		</#if>
+		world.addFreshEntity(entityarrow);
+
+		world.playSound(null, entity.getX(), entity.getY(), entity.getZ(), ForgeRegistries.SOUND_EVENTS
+				.getValue(new ResourceLocation("${data.actionSound}")), SoundSource.PLAYERS, 1, 1f / (random.nextFloat() * 0.5f + 1) + (power / 2));
+
+		return entityarrow;
+	}
+
+	public static ${name}Entity shoot(LivingEntity entity, LivingEntity target) {
+		${name}Entity entityarrow = new ${name}Entity(${JavaModName}Entities.${data.getModElement().getRegistryNameUpper()}.get(), entity, entity.level);
+		double dx = target.getX() - entity.getX();
+		double dy = target.getY() + target.getEyeHeight() - 1.1;
+		double dz = target.getZ() - entity.getZ();
+		entityarrow.shoot(dx, dy - entityarrow.getY() + Math.hypot(dx, dz) * 0.2F, dz, ${data.bulletPower}f * 2, 12.0F);
+
+		entityarrow.setSilent(true);
+		entityarrow.setBaseDamage(${data.bulletDamage});
+		entityarrow.setKnockback(${data.bulletKnockback});
+		entityarrow.setCritArrow(${data.bulletParticles});
+		<#if data.bulletIgnitesFire>
+			entityarrow.setSecondsOnFire(100);
+		</#if>
+		entity.level.addFreshEntity(entityarrow);
+		entity.level.playSound(null, entity.getX(), entity.getY(), entity.getZ(), ForgeRegistries.SOUND_EVENTS
+				.getValue(new ResourceLocation("${data.actionSound}")), SoundSource.PLAYERS, 1, 1f / (RandomSource.create().nextFloat() * 0.5f + 1));
+
+		return entityarrow;
+	}
+
+}
+</#compress>
+
+<#-- @formatter:on -->

--- a/plugins/generator-1.19.2/forge-1.19.2/templates/rangeditem/projectile_renderer.java.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/templates/rangeditem/projectile_renderer.java.ftl
@@ -1,0 +1,61 @@
+<#--
+ # MCreator (https://mcreator.net/)
+ # Copyright (C) 2012-2020, Pylo
+ # Copyright (C) 2020-2022, Pylo, opensource contributors
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # Additional permission for code generator templates (*.ftl files)
+ #
+ # As a special exception, you may create a larger work that contains part or
+ # all of the MCreator code generator templates (*.ftl files) and distribute
+ # that work under terms of your choice, so long as that work isn't itself a
+ # template for code generation. Alternatively, if you modify or redistribute
+ # the template itself, you may (at your option) remove this special exception,
+ # which will cause the template and the resulting code generator output files
+ # to be licensed under the GNU General Public License without this special
+ # exception.
+-->
+
+<#-- @formatter:off -->
+package ${package}.client.renderer;
+
+public class ${name}Renderer extends EntityRenderer<${name}Entity> {
+
+	private static final ResourceLocation texture = new ResourceLocation("${modid}:textures/entities/${data.customBulletModelTexture}");
+
+	private final ${data.bulletModel} model;
+
+	public ${name}Renderer(EntityRendererProvider.Context context) {
+		super(context);
+		model = new ${data.bulletModel}(context.bakeLayer(${data.bulletModel}.LAYER_LOCATION));
+	}
+
+	@Override public void render(${name}Entity entityIn, float entityYaw, float partialTicks, PoseStack poseStack, MultiBufferSource bufferIn, int packedLightIn) {
+		VertexConsumer vb = bufferIn.getBuffer(RenderType.entityCutout(this.getTextureLocation(entityIn)));
+		poseStack.pushPose();
+		poseStack.mulPose(Vector3f.YP.rotationDegrees(Mth.lerp(partialTicks, entityIn.yRotO, entityIn.getYRot()) - 90));
+		poseStack.mulPose(Vector3f.ZP.rotationDegrees(90 + Mth.lerp(partialTicks, entityIn.xRotO, entityIn.getXRot())));
+		model.renderToBuffer(poseStack, vb, packedLightIn, OverlayTexture.NO_OVERLAY, 1, 1, 1, 0.0625f);
+		poseStack.popPose();
+
+		super.render(entityIn, entityYaw, partialTicks, poseStack, bufferIn, packedLightIn);
+	}
+
+	@Override public ResourceLocation getTextureLocation(${name}Entity entity) {
+		return texture;
+	}
+
+}
+<#-- @formatter:on -->

--- a/plugins/generator-1.19.2/forge-1.19.2/templates/rangeditem/rangeditem.java.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/templates/rangeditem/rangeditem.java.ftl
@@ -1,0 +1,170 @@
+<#--
+ # MCreator (https://mcreator.net/)
+ # Copyright (C) 2012-2020, Pylo
+ # Copyright (C) 2020-2022, Pylo, opensource contributors
+ # 
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ # 
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ # 
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ # 
+ # Additional permission for code generator templates (*.ftl files)
+ # 
+ # As a special exception, you may create a larger work that contains part or 
+ # all of the MCreator code generator templates (*.ftl files) and distribute 
+ # that work under terms of your choice, so long as that work isn't itself a 
+ # template for code generation. Alternatively, if you modify or redistribute 
+ # the template itself, you may (at your option) remove this special exception, 
+ # which will cause the template and the resulting code generator output files 
+ # to be licensed under the GNU General Public License without this special 
+ # exception.
+-->
+
+<#-- @formatter:off -->
+<#include "../mcitems.ftl">
+<#include "../triggers.java.ftl">
+<#include "../procedures.java.ftl">
+
+package ${package}.item;
+
+import net.minecraft.world.entity.ai.attributes.Attribute;
+import net.minecraft.world.entity.ai.attributes.Attributes;
+
+<#compress>
+public class ${name}Item extends Item {
+
+	public ${name}Item() {
+		super(new Item.Properties().tab(${data.creativeTab})<#if data.usageCount != 0>.durability(${data.usageCount})<#else>.stacksTo(${data.stackSize})</#if>);
+	}
+
+	@Override public InteractionResultHolder<ItemStack> use(Level world, Player entity, InteractionHand hand) {
+		entity.startUsingItem(hand);
+		return new InteractionResultHolder(InteractionResult.SUCCESS, entity.getItemInHand(hand));
+	}
+
+	<@onEntitySwing data.onEntitySwing/>
+
+	<#if data.specialInfo?has_content>
+	@Override public void appendHoverText(ItemStack itemstack, Level world, List<Component> list, TooltipFlag flag) {
+		super.appendHoverText(itemstack, world, list, flag);
+		<#list data.specialInfo as entry>
+		list.add(Component.literal("${JavaConventions.escapeStringForJava(entry)}"));
+		</#list>
+	}
+	</#if>
+
+	@Override public UseAnim getUseAnimation(ItemStack itemstack) {
+		return UseAnim.${data.animation?upper_case};
+	}
+
+	@Override public int getUseDuration(ItemStack itemstack) {
+		return 72000;
+	}
+
+	<#if data.hasGlow>
+	<@hasGlow data.glowCondition/>
+	</#if>
+
+	<#if data.enableMeleeDamage>
+		@Override public Multimap<Attribute, AttributeModifier> getDefaultAttributeModifiers(EquipmentSlot slot) {
+			if (slot == EquipmentSlot.MAINHAND) {
+				ImmutableMultimap.Builder<Attribute, AttributeModifier> builder = ImmutableMultimap.builder();
+				builder.putAll(super.getDefaultAttributeModifiers(slot));
+				builder.put(Attributes.ATTACK_DAMAGE, new AttributeModifier(BASE_ATTACK_DAMAGE_UUID, "Ranged item modifier", (double) ${data.damageVsEntity - 2}, AttributeModifier.Operation.ADDITION));
+				builder.put(Attributes.ATTACK_SPEED, new AttributeModifier(BASE_ATTACK_SPEED_UUID, "Ranged item modifier", -2.4, AttributeModifier.Operation.ADDITION));
+				return builder.build();
+			}
+			return super.getDefaultAttributeModifiers(slot);
+		}
+	</#if>
+
+	<#if data.shootConstantly>
+		@Override public void onUsingTick(ItemStack itemstack, LivingEntity entityLiving, int count) {
+			Level world = entityLiving.level;
+			if (!world.isClientSide() && entityLiving instanceof ServerPlayer entity) {
+				double x = entity.getX();
+				double y = entity.getY();
+				double z = entity.getZ();
+				if (<@procedureOBJToConditionCode data.useCondition/>) {
+					<@arrowShootCode/>
+					entity.releaseUsingItem();
+				}
+			}
+		}
+	<#else>
+		@Override
+		public void releaseUsing(ItemStack itemstack, Level world, LivingEntity entityLiving, int timeLeft) {
+			if (!world.isClientSide() && entityLiving instanceof ServerPlayer entity) {
+				double x = entity.getX();
+				double y = entity.getY();
+				double z = entity.getZ();
+				if (<@procedureOBJToConditionCode data.useCondition/>) {
+					<@arrowShootCode/>
+				}
+			}
+		}
+	</#if>
+
+}
+</#compress>
+
+<#macro arrowShootCode>
+	<#if !data.ammoItem.isEmpty()>
+	ItemStack stack = ProjectileWeaponItem.getHeldProjectile(entity, e -> e.getItem() == ${mappedMCItemToItem(data.ammoItem)});
+
+	if(stack == ItemStack.EMPTY) {
+		for (int i = 0; i < entity.getInventory().items.size(); i++) {
+			ItemStack teststack = entity.getInventory().items.get(i);
+			if(teststack != null && teststack.getItem() == ${mappedMCItemToItem(data.ammoItem)}) {
+				stack = teststack;
+				break;
+			}
+		}
+	}
+
+	if (entity.getAbilities().instabuild || stack != ItemStack.EMPTY) {
+	</#if>
+
+	${name}Entity entityarrow = ${name}Entity.shoot(world, entity, world.getRandom(), ${data.bulletPower}f, ${data.bulletDamage}, ${data.bulletKnockback});
+
+	itemstack.hurtAndBreak(1, entity, e -> e.broadcastBreakEvent(entity.getUsedItemHand()));
+
+	<#if !data.ammoItem.isEmpty()>
+	if (entity.getAbilities().instabuild) {
+		entityarrow.pickup = AbstractArrow.Pickup.CREATIVE_ONLY;
+	} else {
+		if (${mappedMCItemToItemStackCode(data.ammoItem, 1)}.isDamageableItem()){
+			if (stack.hurt(1, world.getRandom(), entity)) {
+				stack.shrink(1);
+				stack.setDamageValue(0);
+				if (stack.isEmpty())
+					entity.getInventory().removeItem(stack);
+			}
+		} else{
+			stack.shrink(1);
+			if (stack.isEmpty())
+				entity.getInventory().removeItem(stack);
+		}
+	}
+	<#else>
+	entityarrow.pickup = AbstractArrow.Pickup.DISALLOWED;
+	</#if>
+
+	<#if hasProcedure(data.onRangedItemUsed)>
+		<@procedureOBJToCode data.onRangedItemUsed/>
+	</#if>
+
+	<#if !data.ammoItem.isEmpty()>
+	}
+	</#if>
+</#macro>
+
+<#-- @formatter:on -->


### PR DESCRIPTION
This PR ports the ranged item mod element to 1.19, with almost no changes from 1.18. The common entity files only support custom projectiles, and will need to be edited for the living entity mod element.