### PR TITLE
Changed properties encoding to MCreator's default (UTF-8)

### DIFF
--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding" defaultCharsetForPropertiesFiles="UTF-8" />
+</project>


### PR DESCRIPTION
This PR adds a configuration file for IDEA to use UTF-8 encoding for properties files.