### PR TITLE
Minor data list entries refactoring

### DIFF
--- a/src/main/java/net/mcreator/generator/GeneratorWrapper.java
+++ b/src/main/java/net/mcreator/generator/GeneratorWrapper.java
@@ -20,10 +20,8 @@ package net.mcreator.generator;
 
 import net.mcreator.element.GeneratableElement;
 import net.mcreator.element.NamespacedGeneratableElement;
-import net.mcreator.element.RecipeType;
 import net.mcreator.element.parts.Procedure;
 import net.mcreator.generator.mapping.NameMapper;
-import net.mcreator.util.FilenameUtilsPatched;
 import net.mcreator.workspace.Workspace;
 import net.mcreator.workspace.elements.ModElement;
 import net.mcreator.workspace.elements.VariableElement;
@@ -72,49 +70,28 @@ import java.util.stream.Collectors;
 		}).collect(Collectors.toList());
 	}
 
-	public RecipeType getRecipeElementType(String elementName) {
-		try {
-			return generator.getWorkspace().getModElementByName(getElementPlainName(elementName)).getType()
-					.getRecipeType();
-		} catch (Exception e) {
-			generator.getLogger().warn("Failed to determine recipe type for: " + elementName, e);
-			return RecipeType.NONE;
-		}
-	}
-
 	public String getRegistryNameFromFullName(String elementName) {
 		try {
 			return generator.getWorkspace().getModElementByName(getElementPlainName(elementName)).getRegistryName();
 		} catch (Exception e) {
-			generator.getLogger().warn("Failed to determine recipe type for: " + elementName, e);
+			generator.getLogger().warn("Failed to determine registry name for: " + elementName, e);
 			return NameMapper.UNKNOWN_ELEMENT;
 		}
 	}
 
 	public boolean isBlock(String elementName) {
-		String ext = getElementExtension(elementName);
-		if (ext.equals("helmet") || ext.equals("body") || ext.equals("legs") || ext.equals("boots") || ext.equals(
-				"bucket"))
+		ModElement element = getWorkspace().getModElementByName(getElementPlainName(elementName));
+		if (element != null)
+			return element.getMCItems().stream().anyMatch(e -> e.getName().equals(elementName) && e.getType().equals("block"));
+		else {
+			generator.getLogger().warn("Failed to determine mod element for: " + elementName);
 			return false;
-
-		return this.isRecipeTypeBlockOrBucket(elementName);
-	}
-
-	public boolean isRecipeTypeBlockOrBucket(String elementName) {
-		RecipeType recipeType = this.getRecipeElementType(elementName);
-		return recipeType == RecipeType.BLOCK || recipeType == RecipeType.BUCKET;
+		}
 	}
 
 	public String getElementPlainName(String elementName) {
 		return elementName.replace("CUSTOM:", "").replace(".block", "").replace(".helmet", "").replace(".body", "")
 				.replace(".legs", "").replace(".boots", "").replace(".bucket", "");
-	}
-
-	public String getElementExtension(String elementName) {
-		if (elementName.contains(".")) {
-			return FilenameUtilsPatched.getExtension(elementName);
-		}
-		return elementName;
 	}
 
 	public String getRegistryNameForModElement(String modElement) {

--- a/src/main/java/net/mcreator/minecraft/DataListEntry.java
+++ b/src/main/java/net/mcreator/minecraft/DataListEntry.java
@@ -184,7 +184,6 @@ public class DataListEntry implements Comparable<DataListEntry> {
 
 			this.modElement = modElement;
 
-			setType("mcreator");
 			setDescription(modElement.getType().getDescription());
 		}
 

--- a/src/main/java/net/mcreator/minecraft/ElementUtil.java
+++ b/src/main/java/net/mcreator/minecraft/ElementUtil.java
@@ -114,7 +114,7 @@ public class ElementUtil {
 		List<MCItem> elements = new ArrayList<>();
 		workspace.getModElements().stream().filter(element -> element.getType().getBaseType() == BaseType.BLOCK)
 				.forEach(modElement -> elements.addAll(
-						modElement.getMCItems().stream().filter(e -> !e.getName().endsWith(".bucket")).toList()));
+						modElement.getMCItems().stream().filter(e -> e.getType().equals("block")).toList()));
 		elements.addAll(
 				DataListLoader.loadDataList("blocksitems").stream().filter(e -> e.isSupportedInWorkspace(workspace))
 						.filter(typeMatches("block")).map(e -> (MCItem) e).filter(MCItem::hasNoSubtypes).toList());

--- a/src/main/java/net/mcreator/minecraft/MCItem.java
+++ b/src/main/java/net/mcreator/minecraft/MCItem.java
@@ -150,11 +150,11 @@ public class MCItem extends DataListEntry {
 
 	public static final class Custom extends MCItem {
 
-		public Custom(ModElement element, String fieldName) {
+		public Custom(ModElement element, String fieldName, String type) {
 			super("CUSTOM:" + element.getName() + (fieldName == null ? "" : ("." + fieldName)));
 			setReadableName(element.getName() + " - " + element.getType().getReadableName());
 			setIcon(getBlockIconBasedOnName(element.getWorkspace(), getName()));
-			setType("mcreator");
+			setType(type);
 			setDescription(element.getType().getDescription());
 		}
 

--- a/src/main/java/net/mcreator/workspace/elements/ModElement.java
+++ b/src/main/java/net/mcreator/workspace/elements/ModElement.java
@@ -116,22 +116,24 @@ public class ModElement implements Serializable, IWorkspaceProvider, IGeneratorP
 
 		if (getType() == ModElementType.DIMENSION) {
 			if (getMetadata("ep") != null && (Boolean) getMetadata("ep"))
-				mcItems.add(new MCItem.Custom(this, null));
-		} else if (getType().getRecipeType() == RecipeType.ITEM || getType().getRecipeType() == RecipeType.BLOCK) {
-			mcItems.add(new MCItem.Custom(this, null));
+				mcItems.add(new MCItem.Custom(this, null, "item"));
+		} else if (getType().getRecipeType() == RecipeType.ITEM) {
+			mcItems.add(new MCItem.Custom(this, null, "item"));
+		} else if (getType().getRecipeType() == RecipeType.BLOCK) {
+			mcItems.add(new MCItem.Custom(this, null, "block"));
 		} else if (getType().getRecipeType() == RecipeType.BUCKET) {
-			mcItems.add(new MCItem.Custom(this, null));
+			mcItems.add(new MCItem.Custom(this, null, "block"));
 			if (getMetadata("gb") != null && (Boolean) getMetadata("gb"))
-				mcItems.add(new MCItem.Custom(this, "bucket"));
+				mcItems.add(new MCItem.Custom(this, "bucket", "item"));
 		} else if (getType().getBaseType() == BaseType.ARMOR) {
 			if (getMetadata("eh") != null && (Boolean) getMetadata("eh"))
-				mcItems.add(new MCItem.Custom(this, "helmet"));
+				mcItems.add(new MCItem.Custom(this, "helmet", "item"));
 			if (getMetadata("ec") != null && (Boolean) getMetadata("ec"))
-				mcItems.add(new MCItem.Custom(this, "body"));
+				mcItems.add(new MCItem.Custom(this, "body", "item"));
 			if (getMetadata("el") != null && (Boolean) getMetadata("el"))
-				mcItems.add(new MCItem.Custom(this, "legs"));
+				mcItems.add(new MCItem.Custom(this, "legs", "item"));
 			if (getMetadata("eb") != null && (Boolean) getMetadata("eb"))
-				mcItems.add(new MCItem.Custom(this, "boots"));
+				mcItems.add(new MCItem.Custom(this, "boots", "item"));
 		}
 	}
 


### PR DESCRIPTION
- Custom data list entries no longer have their type set to "mcreator"
- Custom MCItems now have to specify a type, instead of using "mcreator"
- "isBlock" check now uses the MCItem type instead of the mod element recipe type
- Removed some no longer used methods, fixed wrong error message