### PR TITLE
Fix #3251

### DIFF
--- a/plugins/generator-1.19.2/forge-1.19.2/procedures/wait.java.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/procedures/wait.java.ftl
@@ -1,31 +1,5 @@
 <#-- @formatter:off -->
-class ${parent.getName()}Wait${customBlockIndex} {
-	private int ticks = 0;
-	private float waitTicks;
-	private LevelAccessor world;
-
-	public void start(LevelAccessor world, int waitTicks) {
-		this.waitTicks = waitTicks;
-		this.world = world;
-
-		MinecraftForge.EVENT_BUS.register(${parent.getName()}Wait${customBlockIndex}.this);
-	}
-
-	@SubscribeEvent
-	public void tick(TickEvent.ServerTickEvent event) {
-		if (event.phase == TickEvent.Phase.END) {
-			${parent.getName()}Wait${customBlockIndex}.this.ticks += 1;
-			if (${parent.getName()}Wait${customBlockIndex}.this.ticks >= ${parent.getName()}Wait${customBlockIndex}.this.waitTicks)
-				run();
-		}
-	}
-
-	private void run() {
-		MinecraftForge.EVENT_BUS.unregister(${parent.getName()}Wait${customBlockIndex}.this);
-
-        ${statement$do}
-	}
-}
-
-new ${parent.getName()}Wait${customBlockIndex}().start(world, ${opt.toInt(input$ticks)});
+${JavaModName}.queueServerWork(${opt.toInt(input$ticks)}, () -> {
+	${statement$do}
+});
 <#-- @formatter:on -->

--- a/plugins/generator-1.19.2/forge-1.19.2/templates/modbase/mod.java.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/templates/modbase/mod.java.ftl
@@ -24,13 +24,9 @@ import org.apache.logging.log4j.Logger;
 
 	public static final String MODID = "${modid}";
 
-	private static final String PROTOCOL_VERSION = "1";
-	public static final SimpleChannel PACKET_HANDLER = NetworkRegistry.newSimpleChannel(new ResourceLocation(MODID, MODID),
-		() -> PROTOCOL_VERSION, PROTOCOL_VERSION::equals, PROTOCOL_VERSION::equals);
-
-	private static int messageID = 0;
-
 	public ${JavaModName}() {
+		MinecraftForge.EVENT_BUS.register(this);
+
 		<#if w.hasElementsOfType("tab")>${JavaModName}Tabs.load();</#if>
 
 		IEventBus bus = FMLJavaModLoadingContext.get().getModEventBus();
@@ -51,10 +47,35 @@ import org.apache.logging.log4j.Logger;
 		<#if w.hasElementsOfType("biome")>${JavaModName}Biomes.REGISTRY.register(bus);</#if>
 	}
 
+	private static final String PROTOCOL_VERSION = "1";
+	public static final SimpleChannel PACKET_HANDLER = NetworkRegistry.newSimpleChannel(new ResourceLocation(MODID, MODID),
+		() -> PROTOCOL_VERSION, PROTOCOL_VERSION::equals, PROTOCOL_VERSION::equals);
+
+	private static int messageID = 0;
+
 	public static <T> void addNetworkMessage(Class<T> messageType, BiConsumer<T, FriendlyByteBuf> encoder, Function<FriendlyByteBuf, T> decoder,
 										BiConsumer<T, Supplier<NetworkEvent.Context>> messageConsumer) {
 		PACKET_HANDLER.registerMessage(messageID, messageType, encoder, decoder, messageConsumer);
 		messageID++;
+	}
+
+	private static final List<AbstractMap.SimpleEntry<Runnable, Integer>> workQueue = new ArrayList<>();
+
+	public static void queueServerWork(int tick, Runnable action) {
+		workQueue.add(new AbstractMap.SimpleEntry(action, tick));
+	}
+
+	@SubscribeEvent public void tick(TickEvent.ServerTickEvent event) {
+		List<Runnable> actions = new ArrayList<>();
+		workQueue.removeIf(work -> {
+			work.setValue(work.getValue() - 1);
+			if (work.getValue() == 0) {
+				actions.add(work.getKey());
+				return true;
+			}
+			return false;
+		});
+		actions.forEach(Runnable::run);
 	}
 
 }


### PR DESCRIPTION
This PR fixes wait procedure block in 1.19.2 "properly".

Methods from main mod could also be in each procedure class using wait instead of this location, but then we have duplicated code so I decided to put it in main mod file.

Code could be generated only if there is any procedure using wait in the workspace, but scanning for this on each build of main mod file would be too resource heavy so I decided to go with the same option as network messages, where there is a method to register them if it is used or not.

Changelog entry:

* [Bugfix, FG 1.19.2] There were still some cases where wait procedure block did not work