### PR TITLE
Fix #3242

### DIFF
--- a/plugins/generator-1.18.2/forge-1.18.2/utils/triggers.java.ftl
+++ b/plugins/generator-1.18.2/forge-1.18.2/utils/triggers.java.ftl
@@ -165,8 +165,8 @@
 <#macro onItemUsedOnBlock procedure="">
 <#if hasProcedure(procedure)>
 @Override public InteractionResult useOn(UseOnContext context) {
-	InteractionResult retval = super.useOn(context);
-	<@procedureCodeWithOptResult procedure, "actionresulttype", "retval", {
+	super.useOn(context);
+	<@procedureCodeWithOptResult procedure, "actionresulttype", "InteractionResult.SUCCESS", {
 		"world": "context.getLevel()",
 		"x": "context.getClickedPos().getX()",
 		"y": "context.getClickedPos().getY()",
@@ -175,23 +175,6 @@
 		"entity": "context.getPlayer()",
 		"direction": "context.getClickedFace()",
 		"itemstack": "context.getItemInHand()"
-	}/>
-}
-</#if>
-</#macro>
-
-<#macro onItemUseFirst procedure="">
-<#if hasProcedure(procedure)>
-@Override public InteractionResult onItemUseFirst(ItemStack itemstack, UseOnContext context) {
-	<@procedureCodeWithOptResult procedure, "actionresulttype", "InteractionResult.PASS", {
-		"world": "context.getLevel()",
-		"x": "context.getClickedPos().getX()",
-		"y": "context.getClickedPos().getY()",
-		"z": "context.getClickedPos().getZ()",
-		"blockstate": "context.getLevel().getBlockState(context.getClickedPos())",
-		"entity": "context.getPlayer()",
-		"direction": "context.getClickedFace()",
-		"itemstack": "itemstack"
 	}/>
 }
 </#if>

--- a/plugins/generator-1.19.2/forge-1.19.2/utils/triggers.java.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/utils/triggers.java.ftl
@@ -165,8 +165,8 @@
 <#macro onItemUsedOnBlock procedure="">
 <#if hasProcedure(procedure)>
 @Override public InteractionResult useOn(UseOnContext context) {
-	InteractionResult retval = super.useOn(context);
-	<@procedureCodeWithOptResult procedure, "actionresulttype", "retval", {
+	super.useOn(context);
+	<@procedureCodeWithOptResult procedure, "actionresulttype", "InteractionResult.SUCCESS", {
 		"world": "context.getLevel()",
 		"x": "context.getClickedPos().getX()",
 		"y": "context.getClickedPos().getY()",
@@ -175,23 +175,6 @@
 		"entity": "context.getPlayer()",
 		"direction": "context.getClickedFace()",
 		"itemstack": "context.getItemInHand()"
-	}/>
-}
-</#if>
-</#macro>
-
-<#macro onItemUseFirst procedure="">
-<#if hasProcedure(procedure)>
-@Override public InteractionResult onItemUseFirst(ItemStack itemstack, UseOnContext context) {
-	<@procedureCodeWithOptResult procedure, "actionresulttype", "InteractionResult.PASS", {
-		"world": "context.getLevel()",
-		"x": "context.getClickedPos().getX()",
-		"y": "context.getClickedPos().getY()",
-		"z": "context.getClickedPos().getZ()",
-		"blockstate": "context.getLevel().getBlockState(context.getClickedPos())",
-		"entity": "context.getPlayer()",
-		"direction": "context.getClickedFace()",
-		"itemstack": "itemstack"
 	}/>
 }
 </#if>

--- a/src/main/java/net/mcreator/ui/procedure/ProcedureSelector.java
+++ b/src/main/java/net/mcreator/ui/procedure/ProcedureSelector.java
@@ -151,7 +151,7 @@ public class ProcedureSelector extends AbstractProcedureSelector {
 		JComponent procwrap;
 		if (returnType == VariableTypeLoader.BuiltInTypes.LOGIC) {
 			procwrap = PanelUtils.westAndCenterElement(actionLabel, procedures);
-		} else if (returnType == null) {
+		} else if (returnType == null || returnType == VariableTypeLoader.BuiltInTypes.ACTIONRESULTTYPE) {
 			actionLabel.setText(L10N.t("procedure.common.do"));
 			procwrap = PanelUtils.westAndCenterElement(actionLabel, procedures);
 		} else {
@@ -269,7 +269,7 @@ public class ProcedureSelector extends AbstractProcedureSelector {
 		if (returnType != null)
 			setBorder(BorderFactory.createCompoundBorder(
 					BorderFactory.createMatteBorder(1, 0, 1, 1, (Color) UIManager.get("MCreatorLAF.LIGHT_ACCENT")),
-					BorderFactory.createMatteBorder(0, 1, 0, 0, returnType.getBlocklyColor())));
+					BorderFactory.createMatteBorder(0, 5, 0, 0, returnType.getBlocklyColor())));
 
 		return (ProcedureSelector) retval;
 	}


### PR DESCRIPTION
This PR fixes the problem observed in #3242.

* [Bugfix] Certain procedures did not work in combination with the item right-clicked on the block procedure trigger

This PR will also require a release note:

* When a procedure without a return value of action result type is called on the item right clicked trigger, SUCCESS result is now returned instead of PASS