### PR TITLE
Fix #3257

### DIFF
--- a/plugins/generator-1.19.2/forge-1.19.2/procedures/entity_execute_command.java.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/procedures/entity_execute_command.java.ftl
@@ -1,19 +1,1 @@
-{
-	Entity _ent = ${input$entity};
-	if(!_ent.level.isClientSide() && _ent.getServer() != null) {
-		CommandSourceStack _css = new CommandSourceStack(
-			_ent, _ent.position(), _ent.getRotationVector(),
-			_ent.level instanceof ServerLevel ? (ServerLevel) _ent.level : null, 4,
-			_ent.getName().getString(), _ent.getDisplayName(), _ent.level.getServer(), _ent,
-			true, (c, s, r) -> {}, EntityAnchorArgument.Anchor.FEET, CommandSigningContext.ANONYMOUS, TaskChainer.IMMEDIATE
-		) {
-			@Override @Nullable public Entity getEntity() {
-				if (StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE).getCallerClass() == ForgeHooks.class)
-					return null; <#-- We hide the fact that we have commands source entity for ForgeHooks to bypass PermissionAPI (bug #3257) -->
-				return super.getEntity();
-			}
-		};
-		<#-- do not call .with methods on _css below or getEntity() will be overwritten with default -->
-		_ent.getServer().getCommands().performPrefixedCommand(_css, ${input$command});
-	}
-}
+{	Entity _ent = ${input$entity};	if(!_ent.level.isClientSide() && _ent.getServer() != null) {		CommandSourceStack _css = new CommandSourceStack(			CommandSource.NULL <#-- fix #3257 for 43.1.3+ -->, _ent.position(), _ent.getRotationVector(),			_ent.level instanceof ServerLevel ? (ServerLevel) _ent.level : null, 4,			_ent.getName().getString(), _ent.getDisplayName(), _ent.level.getServer(), _ent		) {			<#-- fix #3257 for 43.1.1, this fix will not be needed on FG 44.x.x+ as CommandSource.NULL fix above is enough -->			@Override @Nullable public Entity getEntity() {				if (StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE).getCallerClass() == ForgeHooks.class)					return null; <#-- We hide the fact that we have commands source entity for ForgeHooks to bypass PermissionAPI (bug #3257) -->				return super.getEntity();			}		};		<#-- do not call .with methods on _css below or getEntity() will be overwritten with default -->		_ent.getServer().getCommands().performPrefixedCommand(_css, ${input$command});	}}

--- a/plugins/generator-1.19.2/forge-1.19.2/procedures/entity_execute_command.java.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/procedures/entity_execute_command.java.ftl
@@ -1,1 +1,19 @@
-{	Entity _ent = ${input$entity};	if(!_ent.level.isClientSide() && _ent.getServer() != null) {		CommandSourceStack _css = new CommandSourceStack(			CommandSource.NULL <#-- fix #3257 for 43.1.3+ -->, _ent.position(), _ent.getRotationVector(),			_ent.level instanceof ServerLevel ? (ServerLevel) _ent.level : null, 4,			_ent.getName().getString(), _ent.getDisplayName(), _ent.level.getServer(), _ent		) {			<#-- fix #3257 for 43.1.1, this fix will not be needed on FG 44.x.x+ as CommandSource.NULL fix above is enough -->			@Override @Nullable public Entity getEntity() {				if (StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE).getCallerClass() == ForgeHooks.class)					return null; <#-- We hide the fact that we have commands source entity for ForgeHooks to bypass PermissionAPI (bug #3257) -->				return super.getEntity();			}		};		<#-- do not call .with methods on _css below or getEntity() will be overwritten with default -->		_ent.getServer().getCommands().performPrefixedCommand(_css, ${input$command});	}}
+{
+	Entity _ent = ${input$entity};
+	if(!_ent.level.isClientSide() && _ent.getServer() != null) {
+		CommandSourceStack _css = new CommandSourceStack(
+			CommandSource.NULL <#-- fix #3257 for 43.1.3+ -->, _ent.position(), _ent.getRotationVector(),
+			_ent.level instanceof ServerLevel ? (ServerLevel) _ent.level : null, 4,
+			_ent.getName().getString(), _ent.getDisplayName(), _ent.level.getServer(), _ent
+		) {
+			<#-- fix #3257 for 43.1.1, this fix will not be needed on FG 44.x.x+ as CommandSource.NULL fix above is enough -->
+			@Override @Nullable public Entity getEntity() {
+				if (StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE).getCallerClass() == ForgeHooks.class)
+					return null; <#-- We hide the fact that we have commands source entity for ForgeHooks to bypass PermissionAPI (bug #3257) -->
+				return super.getEntity();
+			}
+		};
+		<#-- do not call .with methods on _css below or getEntity() will be overwritten with default -->
+		_ent.getServer().getCommands().performPrefixedCommand(_css, ${input$command});
+	}
+}

--- a/plugins/generator-1.19.2/forge-1.19.2/procedures/entity_execute_command.java.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/procedures/entity_execute_command.java.ftl
@@ -1,19 +1,10 @@
 {
 	Entity _ent = ${input$entity};
 	if(!_ent.level.isClientSide() && _ent.getServer() != null) {
-		CommandSourceStack _css = new CommandSourceStack(
-			CommandSource.NULL <#-- fix #3257 for 43.1.3+ -->, _ent.position(), _ent.getRotationVector(),
+		_ent.getServer().getCommands().performPrefixedCommand(new CommandSourceStack(
+			CommandSource.NULL, _ent.position(), _ent.getRotationVector(),
 			_ent.level instanceof ServerLevel ? (ServerLevel) _ent.level : null, 4,
 			_ent.getName().getString(), _ent.getDisplayName(), _ent.level.getServer(), _ent
-		) {
-			<#-- fix #3257 for 43.1.1, this fix will not be needed on FG 44.x.x+ as CommandSource.NULL fix above is enough -->
-			@Override @Nullable public Entity getEntity() {
-				if (StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE).getCallerClass() == ForgeHooks.class)
-					return null; <#-- We hide the fact that we have commands source entity for ForgeHooks to bypass PermissionAPI (bug #3257) -->
-				return super.getEntity();
-			}
-		};
-		<#-- do not call .with methods on _css below or getEntity() will be overwritten with default -->
-		_ent.getServer().getCommands().performPrefixedCommand(_css, ${input$command});
+		), ${input$command});
 	}
 }

--- a/plugins/generator-1.19.2/forge-1.19.2/procedures/entity_execute_command.java.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/procedures/entity_execute_command.java.ftl
@@ -1,5 +1,19 @@
 {
 	Entity _ent = ${input$entity};
-	if(!_ent.level.isClientSide() && _ent.getServer() != null)
-		_ent.getServer().getCommands().performPrefixedCommand(_ent.createCommandSourceStack().withSuppressedOutput().withPermission(4), ${input$command});
+	if(!_ent.level.isClientSide() && _ent.getServer() != null) {
+		CommandSourceStack _css = new CommandSourceStack(
+			_ent, _ent.position(), _ent.getRotationVector(),
+			_ent.level instanceof ServerLevel ? (ServerLevel) _ent.level : null, 4,
+			_ent.getName().getString(), _ent.getDisplayName(), _ent.level.getServer(), _ent,
+			true, (c, s, r) -> {}, EntityAnchorArgument.Anchor.FEET, CommandSigningContext.ANONYMOUS, TaskChainer.IMMEDIATE
+		) {
+			@Override @Nullable public Entity getEntity() {
+				if (StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE).getCallerClass() == ForgeHooks.class)
+					return null; <#-- We hide the fact that we have commands source entity for ForgeHooks to bypass PermissionAPI (bug #3257) -->
+				return super.getEntity();
+			}
+		};
+		<#-- do not call .with methods on _css below or getEntity() will be overwritten with default -->
+		_ent.getServer().getCommands().performPrefixedCommand(_css, ${input$command});
+	}
 }


### PR DESCRIPTION
This PR fixes bug #3257 by hacking CommandSourceStack#getEntity to return null when called from ForgeHooks.

This way we bypass Forge Permissions API that controls permissions for commands instead of with permission level from CommandSourceStack, which is not considered in the case of ServerPlayer.

This is not a nice solution, but I did not find a non-hackish, "API" solution for this, unfortunately.

Changelog entry:

* [Bugfix, FG 1.19.2] Execute command as entity did not work for certain commands for players without cheats enabled

We can make code nicer if FG is bumped to .47, but then this code will not work for .1 users