### PR TITLE
FG bump to .47 to fix some bugs

### DIFF
--- a/plugins/generator-1.19.2/forge-1.19.2/generator.yaml
+++ b/plugins/generator-1.19.2/forge-1.19.2/generator.yaml
@@ -1,6 +1,6 @@
 name: Minecraft Forge for @minecraft (@buildfileversion)
 status: stable
-buildfileversion: 43.1.1
+buildfileversion: 43.1.47
 
 java_models:
   key: mojmap-1.19.x


### PR DESCRIPTION
Bump from RB to latest based on community feedback + bug with commands permission API. Awaiting decision.

ALT option: move to 43.1.3 that fixes this bug so we stay as close to RB as possible

Changelog entry:

* Updated Minecraft Forge for 1.19.2 to 43.1.47