### PR TITLE
Minor MCItem refactoring

### DIFF
--- a/plugins/generator-1.18.2/forge-1.18.2/utils/mcitems.ftl
+++ b/plugins/generator-1.18.2/forge-1.18.2/utils/mcitems.ftl
@@ -70,10 +70,6 @@
     <#return (extension?has_content)?then("_" + extension, "")>
 </#function>
 
-<#function removePrefixAndExtension mappedBlock>
-    <#return mappedBlock?keep_after(":")?keep_before_last(".")>
-</#function>
-
 <#function mappedMCItemToIngameItemName mappedBlock>
     <#if mappedBlock.getUnmappedValue().startsWith("CUSTOM:")>
         <#assign customelement = generator.getRegistryNameFromFullName(mappedBlock.getUnmappedValue())!""/>
@@ -123,7 +119,7 @@
 <#function mappedMCItemToBlockStateJSON mappedBlock>
     <#if mappedBlock.getUnmappedValue().startsWith("CUSTOM:")>
         <#assign mcitemresourcepath = mappedMCItemToIngameNameNoTags(mappedBlock)/>
-        <#assign ge = w.getWorkspace().getModElementByName(removePrefixAndExtension(mappedBlock.getUnmappedValue()))/>
+        <#assign ge = w.getWorkspace().getModElementByName(generator.getElementPlainName(mappedBlock.getUnmappedValue()))/>
         <#if ge??>
             <#assign ge = ge.getGeneratableElement() />
 

--- a/plugins/generator-1.18.2/forge-1.18.2/utils/mcitems.ftl
+++ b/plugins/generator-1.18.2/forge-1.18.2/utils/mcitems.ftl
@@ -66,17 +66,17 @@
 </#function>
 
 <#function transformExtension mappedBlock>
-    <#return (mappedBlock.toString().contains(".helmet"))?then("_helmet", "")
-    + (mappedBlock.toString().contains(".body"))?then("_chestplate", "")
-    + (mappedBlock.toString().contains(".legs"))?then("_leggings", "")
-    + (mappedBlock.toString().contains(".boots"))?then("_boots", "")
-    + (mappedBlock.toString().contains(".bucket"))?then("_bucket", "")>
+    <#assign extension = mappedBlock?keep_after_last(".")?replace("body", "chestplate")?replace("legs", "leggings")>
+    <#return (extension?has_content)?then("_" + extension, "")>
+</#function>
+
+<#function removePrefixAndExtension mappedBlock>
+    <#return mappedBlock?keep_after(":")?keep_before_last(".")>
 </#function>
 
 <#function mappedMCItemToIngameItemName mappedBlock>
     <#if mappedBlock.getUnmappedValue().startsWith("CUSTOM:")>
-        <#assign customelement = generator.getRegistryNameForModElement(mappedBlock.getUnmappedValue().replace("CUSTOM:", "")
-        .replace(".helmet", "").replace(".body", "").replace(".legs", "").replace(".boots", "").replace(".bucket", ""))!""/>
+        <#assign customelement = generator.getRegistryNameFromFullName(mappedBlock.getUnmappedValue())!""/>
         <#if customelement?has_content>
             <#return "\"item\": \"" + "${modid}:" + customelement
             + transformExtension(mappedBlock)
@@ -100,8 +100,7 @@
 
 <#function mappedMCItemToIngameNameNoTags mappedBlock>
     <#if mappedBlock.getUnmappedValue().startsWith("CUSTOM:")>
-        <#assign customelement = generator.getRegistryNameForModElement(mappedBlock.getUnmappedValue().replace("CUSTOM:", "")
-        .replace(".helmet", "").replace(".body", "").replace(".legs", "").replace(".boots", "").replace(".bucket", ""))!""/>
+        <#assign customelement = generator.getRegistryNameFromFullName(mappedBlock.getUnmappedValue())!""/>
         <#if customelement?has_content>
             <#return "${modid}:" + customelement + transformExtension(mappedBlock)>
         <#else>
@@ -124,8 +123,7 @@
 <#function mappedMCItemToBlockStateJSON mappedBlock>
     <#if mappedBlock.getUnmappedValue().startsWith("CUSTOM:")>
         <#assign mcitemresourcepath = mappedMCItemToIngameNameNoTags(mappedBlock)/>
-        <#assign ge = w.getWorkspace().getModElementByName(mappedBlock.getUnmappedValue().replace("CUSTOM:", "")
-        .replace(".helmet", "").replace(".body", "").replace(".legs", "").replace(".boots", "").replace(".bucket", ""))/>
+        <#assign ge = w.getWorkspace().getModElementByName(removePrefixAndExtension(mappedBlock.getUnmappedValue()))/>
         <#if ge??>
             <#assign ge = ge.getGeneratableElement() />
 

--- a/plugins/generator-1.19.2/forge-1.19.2/utils/mcitems.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/utils/mcitems.ftl
@@ -70,10 +70,6 @@
     <#return (extension?has_content)?then("_" + extension, "")>
 </#function>
 
-<#function removePrefixAndExtension mappedBlock>
-    <#return mappedBlock?keep_after(":")?keep_before_last(".")>
-</#function>
-
 <#function mappedMCItemToIngameItemName mappedBlock>
     <#if mappedBlock.getUnmappedValue().startsWith("CUSTOM:")>
         <#assign customelement = generator.getRegistryNameFromFullName(mappedBlock.getUnmappedValue())!""/>
@@ -123,7 +119,7 @@
 <#function mappedMCItemToBlockStateJSON mappedBlock>
     <#if mappedBlock.getUnmappedValue().startsWith("CUSTOM:")>
         <#assign mcitemresourcepath = mappedMCItemToIngameNameNoTags(mappedBlock)/>
-        <#assign ge = w.getWorkspace().getModElementByName(removePrefixAndExtension(mappedBlock.getUnmappedValue()))/>
+        <#assign ge = w.getWorkspace().getModElementByName(generator.getElementPlainName(mappedBlock.getUnmappedValue()))/>
         <#if ge??>
             <#assign ge = ge.getGeneratableElement() />
 

--- a/plugins/generator-1.19.2/forge-1.19.2/utils/mcitems.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/utils/mcitems.ftl
@@ -66,17 +66,17 @@
 </#function>
 
 <#function transformExtension mappedBlock>
-    <#return (mappedBlock.toString().contains(".helmet"))?then("_helmet", "")
-    + (mappedBlock.toString().contains(".body"))?then("_chestplate", "")
-    + (mappedBlock.toString().contains(".legs"))?then("_leggings", "")
-    + (mappedBlock.toString().contains(".boots"))?then("_boots", "")
-    + (mappedBlock.toString().contains(".bucket"))?then("_bucket", "")>
+    <#assign extension = mappedBlock?keep_after_last(".")?replace("body", "chestplate")?replace("legs", "leggings")>
+    <#return (extension?has_content)?then("_" + extension, "")>
+</#function>
+
+<#function removePrefixAndExtension mappedBlock>
+    <#return mappedBlock?keep_after(":")?keep_before_last(".")>
 </#function>
 
 <#function mappedMCItemToIngameItemName mappedBlock>
     <#if mappedBlock.getUnmappedValue().startsWith("CUSTOM:")>
-        <#assign customelement = generator.getRegistryNameForModElement(mappedBlock.getUnmappedValue().replace("CUSTOM:", "")
-        .replace(".helmet", "").replace(".body", "").replace(".legs", "").replace(".boots", "").replace(".bucket", ""))!""/>
+        <#assign customelement = generator.getRegistryNameFromFullName(mappedBlock.getUnmappedValue())!""/>
         <#if customelement?has_content>
             <#return "\"item\": \"" + "${modid}:" + customelement
             + transformExtension(mappedBlock)
@@ -100,8 +100,7 @@
 
 <#function mappedMCItemToIngameNameNoTags mappedBlock>
     <#if mappedBlock.getUnmappedValue().startsWith("CUSTOM:")>
-        <#assign customelement = generator.getRegistryNameForModElement(mappedBlock.getUnmappedValue().replace("CUSTOM:", "")
-        .replace(".helmet", "").replace(".body", "").replace(".legs", "").replace(".boots", "").replace(".bucket", ""))!""/>
+        <#assign customelement = generator.getRegistryNameFromFullName(mappedBlock.getUnmappedValue())!""/>
         <#if customelement?has_content>
             <#return "${modid}:" + customelement + transformExtension(mappedBlock)>
         <#else>
@@ -124,8 +123,7 @@
 <#function mappedMCItemToBlockStateJSON mappedBlock>
     <#if mappedBlock.getUnmappedValue().startsWith("CUSTOM:")>
         <#assign mcitemresourcepath = mappedMCItemToIngameNameNoTags(mappedBlock)/>
-        <#assign ge = w.getWorkspace().getModElementByName(mappedBlock.getUnmappedValue().replace("CUSTOM:", "")
-        .replace(".helmet", "").replace(".body", "").replace(".legs", "").replace(".boots", "").replace(".bucket", ""))/>
+        <#assign ge = w.getWorkspace().getModElementByName(removePrefixAndExtension(mappedBlock.getUnmappedValue()))/>
         <#if ge??>
             <#assign ge = ge.getGeneratableElement() />
 

--- a/plugins/generator-addon-1.19.x/addon-1.19.x/utils/mcitems.ftl
+++ b/plugins/generator-addon-1.19.x/addon-1.19.x/utils/mcitems.ftl
@@ -10,17 +10,17 @@
     </#if>
 </#function>
 
+<#function transformExtension mappedBlock>
+    <#assign extension = mappedBlock?keep_after_last(".")?replace("body", "chestplate")?replace("legs", "leggings")>
+    <#return (extension?has_content)?then("_" + extension, "")>
+</#function>
+
 <#function mappedMCItemToIngameItemName mappedBlock skipDefaultMetadata=false>
     <#if mappedBlock.toString().startsWith("CUSTOM:")>
-        <#assign customelement = generator.getRegistryNameForModElement(mappedBlock.toString().replace("CUSTOM:", "")
-        .replace(".helmet", "").replace(".body", "").replace(".legs", "").replace(".boots", "").replace(".bucket", ""))!""/>
+        <#assign customelement = generator.getRegistryNameFromFullName(mappedBlock.getUnmappedValue())!""/>
         <#if customelement?has_content>
             <#return "\"item\": \"" + "${modid}:" + customelement
-            + (mappedBlock.getUnmappedValue().contains(".helmet"))?then("_helmet", "")
-            + (mappedBlock.getUnmappedValue().contains(".body"))?then("_chestplate", "")
-            + (mappedBlock.getUnmappedValue().contains(".legs"))?then("_leggings", "")
-            + (mappedBlock.getUnmappedValue().contains(".boots"))?then("_boots", "")
-            + (mappedBlock.getUnmappedValue().contains(".bucket"))?then("_bucket", "")
+            + transformExtension(mappedBlock.getUnmappedValue())
             + "\"">
         <#else>
             <#return "\"item\": \"minecraft:air\"">
@@ -42,15 +42,9 @@
 
 <#function mappedMCItemToIngameNameNoTags mappedBlock>
     <#if mappedBlock.getUnmappedValue().startsWith("CUSTOM:")>
-        <#assign customelement = generator.getRegistryNameForModElement(mappedBlock.getUnmappedValue().replace("CUSTOM:", "")
-        .replace(".helmet", "").replace(".body", "").replace(".legs", "").replace(".boots", "").replace(".bucket", ""))!""/>
+        <#assign customelement = generator.getRegistryNameFromFullName(mappedBlock.getUnmappedValue())!""/>
         <#if customelement?has_content>
-            <#return "${modid}:" + customelement
-            + (mappedBlock.getUnmappedValue().contains(".helmet"))?then("_helmet", "")
-            + (mappedBlock.getUnmappedValue().contains(".body"))?then("_chestplate", "")
-            + (mappedBlock.getUnmappedValue().contains(".legs"))?then("_leggings", "")
-            + (mappedBlock.getUnmappedValue().contains(".boots"))?then("_boots", "")
-            + (mappedBlock.getUnmappedValue().contains(".bucket"))?then("_bucket", "")>
+            <#return "${modid}:" + customelement + transformExtension(mappedBlock.getUnmappedValue())>
         <#else>
             <#return "minecraft:air">
         </#if>

--- a/src/main/java/net/mcreator/generator/GeneratorWrapper.java
+++ b/src/main/java/net/mcreator/generator/GeneratorWrapper.java
@@ -25,6 +25,7 @@ import net.mcreator.generator.mapping.NameMapper;
 import net.mcreator.workspace.Workspace;
 import net.mcreator.workspace.elements.ModElement;
 import net.mcreator.workspace.elements.VariableElement;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -71,12 +72,7 @@ import java.util.stream.Collectors;
 	}
 
 	public String getRegistryNameFromFullName(String elementName) {
-		try {
-			return generator.getWorkspace().getModElementByName(getElementPlainName(elementName)).getRegistryName();
-		} catch (Exception e) {
-			generator.getLogger().warn("Failed to determine registry name for: " + elementName, e);
-			return NameMapper.UNKNOWN_ELEMENT;
-		}
+		return getRegistryNameForModElement(getElementPlainName(elementName));
 	}
 
 	public boolean isBlock(String elementName) {
@@ -89,9 +85,13 @@ import java.util.stream.Collectors;
 		}
 	}
 
+	/**
+	 * Removes the "CUSTOM:" prefix and any eventual suffix (if present, it's after the last .)
+	 * @param elementName The name to convert
+	 * @return The plain name of the element
+	 */
 	public String getElementPlainName(String elementName) {
-		return elementName.replace("CUSTOM:", "").replace(".block", "").replace(".helmet", "").replace(".body", "")
-				.replace(".legs", "").replace(".boots", "").replace(".bucket", "");
+		return StringUtils.substringBeforeLast(elementName.replace("CUSTOM:",""), ".");
 	}
 
 	public String getRegistryNameForModElement(String modElement) {

--- a/src/main/java/net/mcreator/minecraft/DataListEntry.java
+++ b/src/main/java/net/mcreator/minecraft/DataListEntry.java
@@ -89,7 +89,7 @@ public class DataListEntry implements Comparable<DataListEntry> {
 
 	public String getDescription() {
 		if (description == null)
-			return "No description for entry " + getReadableName() + " found";
+			return "";
 		return description;
 	}
 

--- a/src/main/java/net/mcreator/minecraft/MCItem.java
+++ b/src/main/java/net/mcreator/minecraft/MCItem.java
@@ -30,6 +30,7 @@ import net.mcreator.workspace.Workspace;
 import net.mcreator.workspace.elements.ModElement;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.swing.*;
 import java.awt.*;
 import java.io.File;
@@ -151,11 +152,15 @@ public class MCItem extends DataListEntry {
 	public static final class Custom extends MCItem {
 
 		public Custom(ModElement element, String fieldName, String type) {
+			this(element, fieldName, type, null);
+		}
+
+		public Custom(ModElement element, String fieldName, String type, @Nullable String description) {
 			super("CUSTOM:" + element.getName() + (fieldName == null ? "" : ("." + fieldName)));
 			setReadableName(element.getName() + " - " + element.getType().getReadableName());
 			setIcon(getBlockIconBasedOnName(element.getWorkspace(), getName()));
 			setType(type);
-			setDescription(element.getType().getDescription());
+			setDescription(description);
 		}
 
 		@Override public boolean isSupportedInWorkspace(Workspace workspace) {

--- a/src/main/java/net/mcreator/ui/dialogs/MCItemSelectorDialog.java
+++ b/src/main/java/net/mcreator/ui/dialogs/MCItemSelectorDialog.java
@@ -201,7 +201,7 @@ public class MCItemSelectorDialog extends SearchableSelectorDialog<MCItem> {
 		public Component getListCellRendererComponent(JList<? extends MCItem> list, MCItem value, int index,
 				boolean isSelected, boolean cellHasFocus) {
 			setToolTipText("<html>" + value.getReadableName() +
-					(value.getDescription().isEmpty()? "" : ("<br><small>" + value.getDescription())));
+					(value.getDescription().isEmpty() ? "" : ("<br><small>" + value.getDescription())));
 			if (value.icon.getIconWidth() != 32)
 				setIcon(new ImageIcon(ImageUtils.resize(value.icon.getImage(), 32)));
 			else

--- a/src/main/java/net/mcreator/ui/dialogs/MCItemSelectorDialog.java
+++ b/src/main/java/net/mcreator/ui/dialogs/MCItemSelectorDialog.java
@@ -200,7 +200,8 @@ public class MCItemSelectorDialog extends SearchableSelectorDialog<MCItem> {
 		@Override
 		public Component getListCellRendererComponent(JList<? extends MCItem> list, MCItem value, int index,
 				boolean isSelected, boolean cellHasFocus) {
-			setToolTipText("<html>" + value.getReadableName() + "<br><small>" + value.getDescription());
+			setToolTipText("<html>" + value.getReadableName() +
+					(value.getDescription().isEmpty()? "" : ("<br><small>" + value.getDescription())));
 			if (value.icon.getIconWidth() != 32)
 				setIcon(new ImageIcon(ImageUtils.resize(value.icon.getImage(), 32)));
 			else

--- a/src/main/java/net/mcreator/workspace/elements/ModElement.java
+++ b/src/main/java/net/mcreator/workspace/elements/ModElement.java
@@ -116,24 +116,24 @@ public class ModElement implements Serializable, IWorkspaceProvider, IGeneratorP
 
 		if (getType() == ModElementType.DIMENSION) {
 			if (getMetadata("ep") != null && (Boolean) getMetadata("ep"))
-				mcItems.add(new MCItem.Custom(this, null, "item"));
+				mcItems.add(new MCItem.Custom(this, null, "item", "Portal igniter"));
 		} else if (getType().getRecipeType() == RecipeType.ITEM) {
 			mcItems.add(new MCItem.Custom(this, null, "item"));
 		} else if (getType().getRecipeType() == RecipeType.BLOCK) {
 			mcItems.add(new MCItem.Custom(this, null, "block"));
 		} else if (getType().getRecipeType() == RecipeType.BUCKET) {
-			mcItems.add(new MCItem.Custom(this, null, "block"));
+			mcItems.add(new MCItem.Custom(this, null, "block", "Fluid block"));
 			if (getMetadata("gb") != null && (Boolean) getMetadata("gb"))
-				mcItems.add(new MCItem.Custom(this, "bucket", "item"));
+				mcItems.add(new MCItem.Custom(this, "bucket", "item", "Fluid bucket"));
 		} else if (getType().getBaseType() == BaseType.ARMOR) {
 			if (getMetadata("eh") != null && (Boolean) getMetadata("eh"))
-				mcItems.add(new MCItem.Custom(this, "helmet", "item"));
+				mcItems.add(new MCItem.Custom(this, "helmet", "item", "Helmet"));
 			if (getMetadata("ec") != null && (Boolean) getMetadata("ec"))
-				mcItems.add(new MCItem.Custom(this, "body", "item"));
+				mcItems.add(new MCItem.Custom(this, "body", "item", "Chestplate"));
 			if (getMetadata("el") != null && (Boolean) getMetadata("el"))
-				mcItems.add(new MCItem.Custom(this, "legs", "item"));
+				mcItems.add(new MCItem.Custom(this, "legs", "item", "Leggings"));
 			if (getMetadata("eb") != null && (Boolean) getMetadata("eb"))
-				mcItems.add(new MCItem.Custom(this, "boots", "item"));
+				mcItems.add(new MCItem.Custom(this, "boots", "item", "Boots"));
 		}
 	}
 


### PR DESCRIPTION
- Replaced the "No description found" message with an empty string. MCItems without a description now display only their name in the selector tooltip
- Added optional description field for custom MCItems. Some special cases (portal igniters, armor pieces, fluid block/items) now have a specific description. Other custom MCItems no longer have one (instead of borrowing the element type description)
- The MCItem extension (`.bucket`, `.helmet`...) functions are more generic, instead of hardcoding all the current possible cases