### PR TITLE
Fixed shadow blocks hiding replacement normal blocks

### DIFF
--- a/src/main/java/net/mcreator/blockly/BlocklyBlockUtil.java
+++ b/src/main/java/net/mcreator/blockly/BlocklyBlockUtil.java
@@ -124,7 +124,7 @@ public class BlocklyBlockUtil {
 	 * @return The type of the block attached to the input, or null if no block is attached
 	 */
 	public static String getInputBlockType(Element input) {
-		List<Element> outputBlocks = XMLUtil.getChildrenWithName(input, "block", "shadow");
+		List<Element> outputBlocks = XMLUtil.getChildrenWithName(input, new String[] { "block" }, "shadow");
 		return outputBlocks.size() < 1 ? null : outputBlocks.get(0).getAttribute("type");
 	}
 

--- a/src/main/java/net/mcreator/blockly/BlocklyToCode.java
+++ b/src/main/java/net/mcreator/blockly/BlocklyToCode.java
@@ -168,7 +168,7 @@ public abstract class BlocklyToCode implements IGeneratorProvider {
 	}
 
 	public final void processOutputBlock(Element condition) throws TemplateGeneratorException {
-		List<Element> conditionBlocks = XMLUtil.getChildrenWithName(condition, "block", "shadow");
+		List<Element> conditionBlocks = XMLUtil.getChildrenWithName(condition, new String[] { "block" }, "shadow");
 		if (conditionBlocks.size() < 1)
 			return;
 		Element block = conditionBlocks.get(0);

--- a/src/main/java/net/mcreator/util/XMLUtil.java
+++ b/src/main/java/net/mcreator/util/XMLUtil.java
@@ -33,14 +33,26 @@ public class XMLUtil {
 	}
 
 	public static List<Element> getChildrenWithName(Element element, String... names) {
+		return getChildrenWithName(element, names, null);
+	}
+
+	public static List<Element> getChildrenWithName(Element element, String[] names, String fallback) {
 		List<Element> elements = new ArrayList<>();
 		NodeList nodeList = element.getChildNodes();
 		for (int i = 0; i < nodeList.getLength(); i++) {
 			Node node = nodeList.item(i);
 			if (node.getNodeType() == Node.ELEMENT_NODE) {
-				if (names == null || (names.length == 1 && names[0].equals(node.getNodeName())) || ArrayUtils.contains(
-						names, node.getNodeName()))
+				if (names == null || ArrayUtils.contains(names, node.getNodeName()))
 					elements.add((Element) node);
+			}
+		}
+		if (elements.isEmpty() && fallback != null) {
+			for (int i = 0; i < nodeList.getLength(); i++) {
+				Node node = nodeList.item(i);
+				if (node.getNodeType() == Node.ELEMENT_NODE) {
+					if (fallback.equals(node.getNodeName()))
+						elements.add((Element) node);
+				}
 			}
 		}
 		return elements;


### PR DESCRIPTION
In cases of a shadow block attached to a procedure block input by toolbox XML, normal blocks attached to the same input over the shadow block would be permanently invisible because shadow block is always defined inside the XML and defined earlier than the replacement normal block. This PR fixes the problem by adding a variant of `XMLUtil.getChildrenWithName()` that takes a fallback node name along with other parameters. ~If this seems sub-optimal/smelly, feel free to suggest your own fix approaches.~