### PR TITLE
[3rd 2022.3 patch] Fix #3317

### DIFF
--- a/plugins/generator-1.19.2/forge-1.19.2/templates/json/block_item.json.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/templates/json/block_item.json.ftl
@@ -4,10 +4,8 @@
   "parent": "item/generated",
   "textures": {
     "layer0": "${modid}:items/${data.itemTexture}"
-  }
-  <#if !(data.blockBase?has_content && data.blockBase == "Leaves")>
-  ,"render_type": "${data.getRenderType()}"
-  </#if>
+  },
+  "render_type": "translucent"
 }
 <#else>
 {

--- a/plugins/generator-1.19.2/forge-1.19.2/templates/json/txblock/button_item.json.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/templates/json/txblock/button_item.json.ftl
@@ -5,7 +5,7 @@
   "textures": {
     "layer0": "${modid}:items/${data.itemTexture}"
   },
-  "render_type": "${data.getRenderType()}"
+  "render_type": "translucent"
 }
 <#else>
 {

--- a/plugins/generator-1.19.2/forge-1.19.2/templates/json/txblock/fence_block_item.json.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/templates/json/txblock/fence_block_item.json.ftl
@@ -5,7 +5,7 @@
   "textures": {
     "layer0": "${modid}:items/${data.itemTexture}"
   },
-  "render_type": "${data.getRenderType()}"
+  "render_type": "translucent"
 }
 <#else>
 {

--- a/plugins/generator-1.19.2/forge-1.19.2/templates/json/txblock/fence_gate_item.json.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/templates/json/txblock/fence_gate_item.json.ftl
@@ -5,7 +5,7 @@
   "textures": {
     "layer0": "${modid}:items/${data.itemTexture}"
   },
-  "render_type": "${data.getRenderType()}"
+  "render_type": "translucent"
 }
 <#else>
 {

--- a/plugins/generator-1.19.2/forge-1.19.2/templates/json/txblock/pane_item.json.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/templates/json/txblock/pane_item.json.ftl
@@ -5,7 +5,7 @@
   "textures": {
     "layer0": "${modid}:items/${data.itemTexture}"
   },
-  "render_type": "${data.getRenderType()}"
+  "render_type": "translucent"
 }
 <#else>
 {

--- a/plugins/generator-1.19.2/forge-1.19.2/templates/json/txblock/pressure_plate_item.json.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/templates/json/txblock/pressure_plate_item.json.ftl
@@ -5,7 +5,7 @@
   "textures": {
     "layer0": "${modid}:items/${data.itemTexture}"
   },
-  "render_type": "${data.getRenderType()}"
+  "render_type": "translucent"
 }
 <#else>
 {


### PR DESCRIPTION
Fix #3317 + allows translucent textures for block item icon which was not possible before