### PR TITLE
Minor procedure fixes

### DIFF
--- a/plugins/generator-1.18.2/forge-1.18.2/procedures/block_fluidtank_check_fill.java.ftl
+++ b/plugins/generator-1.18.2/forge-1.18.2/procedures/block_fluidtank_check_fill.java.ftl
@@ -10,7 +10,7 @@
 				<#assign fluid = field$fluid?replace("CUSTOM:", "")>
 				_retval.set(capability.fill(new FluidStack(${JavaModName}Fluids.${fluid?ends_with(":Flowing")?then("FLOWING_","")}${generator.getRegistryNameForModElement(fluid?remove_ending(":Flowing"))?upper_case}.get(), amount), IFluidHandler.FluidAction.SIMULATE))
 				<#else>
-				_retval.set(capability.fill(new FluidStack(Fluids.${generator.map(field$fluid, "fluid")}, amount), IFluidHandler.FluidAction.SIMULATE))
+				_retval.set(capability.fill(new FluidStack(Fluids.${generator.map(field$fluid, "fluids")}, amount), IFluidHandler.FluidAction.SIMULATE))
 				</#if>
 		);
 		return _retval.get();

--- a/plugins/generator-1.18.2/forge-1.18.2/procedures/block_fluidtank_fill.java.ftl
+++ b/plugins/generator-1.18.2/forge-1.18.2/procedures/block_fluidtank_fill.java.ftl
@@ -10,7 +10,7 @@
 			<#assign fluid = field$fluid?replace("CUSTOM:", "")>
 			capability.fill(new FluidStack(${JavaModName}Fluids.${fluid?ends_with(":Flowing")?then("FLOWING_","")}${generator.getRegistryNameForModElement(fluid?remove_ending(":Flowing"))?upper_case}.get(), _amount), IFluidHandler.FluidAction.EXECUTE)
 			<#else>
-			capability.fill(new FluidStack(Fluids.${generator.map(field$fluid, "fluid")}, _amount), IFluidHandler.FluidAction.EXECUTE)
+			capability.fill(new FluidStack(Fluids.${generator.map(field$fluid, "fluids")}, _amount), IFluidHandler.FluidAction.EXECUTE)
 			</#if>
 		);
 }

--- a/plugins/generator-1.19.2/forge-1.19.2/procedures/block_fluidtank_check_fill.java.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/procedures/block_fluidtank_check_fill.java.ftl
@@ -10,7 +10,7 @@
 				<#assign fluid = field$fluid?replace("CUSTOM:", "")>
 				_retval.set(capability.fill(new FluidStack(${JavaModName}Fluids.${fluid?ends_with(":Flowing")?then("FLOWING_","")}${generator.getRegistryNameForModElement(fluid?remove_ending(":Flowing"))?upper_case}.get(), amount), IFluidHandler.FluidAction.SIMULATE))
 				<#else>
-				_retval.set(capability.fill(new FluidStack(Fluids.${generator.map(field$fluid, "fluid")}, amount), IFluidHandler.FluidAction.SIMULATE))
+				_retval.set(capability.fill(new FluidStack(Fluids.${generator.map(field$fluid, "fluids")}, amount), IFluidHandler.FluidAction.SIMULATE))
 				</#if>
 		);
 		return _retval.get();

--- a/plugins/generator-1.19.2/forge-1.19.2/procedures/block_fluidtank_fill.java.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/procedures/block_fluidtank_fill.java.ftl
@@ -10,7 +10,7 @@
 			<#assign fluid = field$fluid?replace("CUSTOM:", "")>
 			capability.fill(new FluidStack(${JavaModName}Fluids.${fluid?ends_with(":Flowing")?then("FLOWING_","")}${generator.getRegistryNameForModElement(fluid?remove_ending(":Flowing"))?upper_case}.get(), _amount), IFluidHandler.FluidAction.EXECUTE)
 			<#else>
-			capability.fill(new FluidStack(Fluids.${generator.map(field$fluid, "fluid")}, _amount), IFluidHandler.FluidAction.EXECUTE)
+			capability.fill(new FluidStack(Fluids.${generator.map(field$fluid, "fluids")}, _amount), IFluidHandler.FluidAction.EXECUTE)
 			</#if>
 		);
 }

--- a/src/main/java/net/mcreator/blockly/java/blocks/GetVariableBlock.java
+++ b/src/main/java/net/mcreator/blockly/java/blocks/GetVariableBlock.java
@@ -126,7 +126,7 @@ public class GetVariableBlock implements IBlockGenerator {
 			}
 		} else {
 			master.addCompileNote(new BlocklyCompileNote(BlocklyCompileNote.Type.ERROR,
-					L10N.t("blockly.errors.variables.improperly_defined", L10N.t("blockly.block.get"))));
+					L10N.t("blockly.errors.variables.improperly_defined", L10N.t("blockly.block.get_var"))));
 		}
 	}
 

--- a/src/main/java/net/mcreator/blockly/java/blocks/SetVariableBlock.java
+++ b/src/main/java/net/mcreator/blockly/java/blocks/SetVariableBlock.java
@@ -142,7 +142,7 @@ public class SetVariableBlock implements IBlockGenerator {
 			}
 		} else {
 			master.addCompileNote(new BlocklyCompileNote(BlocklyCompileNote.Type.WARNING,
-					L10N.t("blockly.errors.variables.improperly_defined", L10N.t("blockly.block.set")) + L10N.t(
+					L10N.t("blockly.errors.variables.improperly_defined", L10N.t("blockly.block.set_var")) + L10N.t(
 							"blockly.warnings.skip")));
 		}
 	}


### PR DESCRIPTION
- Some procedure blocks were incorrectly trying to map dropdown entries to the `fluid` datalist, despite it being named `fluids`. This didn't cause issues since the entry name was the same as the mapped value.
- Fixed an incorrect warning message for "Get/Set variable" blocks