### PR TITLE
Fix get controlling passenger always returning null

### DIFF
--- a/plugins/generator-1.18.2/forge-1.18.2/procedures/entity_get_controlling_passenger.java.ftl
+++ b/plugins/generator-1.18.2/forge-1.18.2/procedures/entity_get_controlling_passenger.java.ftl
@@ -1,1 +1,1 @@
-(${input$entity}.getControllingPassenger())
+(${input$entity}.getFirstPassenger())

--- a/plugins/generator-1.19.2/forge-1.19.2/procedures/entity_get_controlling_passenger.java.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/procedures/entity_get_controlling_passenger.java.ftl
@@ -1,1 +1,1 @@
-(${input$entity}.getControllingPassenger())
+(${input$entity}.getFirstPassenger())


### PR DESCRIPTION
seems like the method getControllingPassenger() always returns null, so Instead I replaced it with getFirstPassenger() which does the same thing it should have done.
![Screenshot_974](https://user-images.githubusercontent.com/112079900/208247333-481b1f5b-2579-4b46-a4e8-330638dad15f.png)
