### PR TITLE
Changed tabbed pane colors to make scroll buttons visible

### DIFF
--- a/src/main/java/net/mcreator/ui/dialogs/TextureMappingDialog.java
+++ b/src/main/java/net/mcreator/ui/dialogs/TextureMappingDialog.java
@@ -73,7 +73,6 @@ public class TextureMappingDialog {
 
 		JTabbedPane pane = new JTabbedPane();
 		pane.setTabLayoutPolicy(JTabbedPane.SCROLL_TAB_LAYOUT);
-		pane.setForeground(Color.white);
 
 		if (supportMultiple) {
 			pane.addTab(L10N.t("dialog.textures_mapping.add_new"), null);

--- a/src/main/java/net/mcreator/ui/laf/MCreatorTheme.java
+++ b/src/main/java/net/mcreator/ui/laf/MCreatorTheme.java
@@ -266,7 +266,7 @@ public class MCreatorTheme extends OceanTheme {
 		table.put("TabbedPane.foreground", new ColorUIResource(colorScheme.getForegroundColor()));
 		table.put("TabbedPane.contentAreaColor", colorScheme.getBackgroundColor());
 		table.put("TabbedPane.contentBorderInsets", new Insets(4, 2, 3, 3));
-		table.put("TabbedPane.selected", MAIN_TINT);
+		table.put("TabbedPane.selected", colorScheme.getAltForegroundColor());
 		table.put("TabbedPane.selectedForeground", colorScheme.getSecondAltBackgroundColor());
 		table.put("TabbedPane.tabAreaBackground", colorScheme.getAltBackgroundColor());
 		table.put("TabbedPane.tabAreaInsets", new Insets(2, 2, 0, 6));

--- a/src/main/java/net/mcreator/ui/laf/MCreatorTheme.java
+++ b/src/main/java/net/mcreator/ui/laf/MCreatorTheme.java
@@ -266,8 +266,8 @@ public class MCreatorTheme extends OceanTheme {
 		table.put("TabbedPane.foreground", new ColorUIResource(colorScheme.getForegroundColor()));
 		table.put("TabbedPane.contentAreaColor", colorScheme.getBackgroundColor());
 		table.put("TabbedPane.contentBorderInsets", new Insets(4, 2, 3, 3));
-		table.put("TabbedPane.selected", colorScheme.getAltForegroundColor());
-		table.put("TabbedPane.selectedForeground", colorScheme.getSecondAltBackgroundColor());
+		table.put("TabbedPane.selected", colorScheme.getBackgroundColor());
+		table.put("TabbedPane.selectedForeground", colorScheme.getForegroundColor());
 		table.put("TabbedPane.tabAreaBackground", colorScheme.getAltBackgroundColor());
 		table.put("TabbedPane.tabAreaInsets", new Insets(2, 2, 0, 6));
 		table.put("TabbedPane.unselectedBackground", colorScheme.getBackgroundColor());

--- a/src/main/java/net/mcreator/ui/laf/MCreatorTheme.java
+++ b/src/main/java/net/mcreator/ui/laf/MCreatorTheme.java
@@ -263,9 +263,11 @@ public class MCreatorTheme extends OceanTheme {
 		table.put("RadioButton.icon", new RadioButtonIcon());
 		table.put("RadioButtonMenuItem.icon", new RadioButtonIcon());
 
+		table.put("TabbedPane.foreground", new ColorUIResource(colorScheme.getForegroundColor()));
 		table.put("TabbedPane.contentAreaColor", colorScheme.getBackgroundColor());
 		table.put("TabbedPane.contentBorderInsets", new Insets(4, 2, 3, 3));
-		table.put("TabbedPane.selected", colorScheme.getAltBackgroundColor());
+		table.put("TabbedPane.selected", MAIN_TINT);
+		table.put("TabbedPane.selectedForeground", colorScheme.getSecondAltBackgroundColor());
 		table.put("TabbedPane.tabAreaBackground", colorScheme.getAltBackgroundColor());
 		table.put("TabbedPane.tabAreaInsets", new Insets(2, 2, 0, 6));
 		table.put("TabbedPane.unselectedBackground", colorScheme.getBackgroundColor());

--- a/src/main/java/net/mcreator/ui/laf/MCreatorTheme.java
+++ b/src/main/java/net/mcreator/ui/laf/MCreatorTheme.java
@@ -263,11 +263,9 @@ public class MCreatorTheme extends OceanTheme {
 		table.put("RadioButton.icon", new RadioButtonIcon());
 		table.put("RadioButtonMenuItem.icon", new RadioButtonIcon());
 
-		table.put("TabbedPane.foreground", new ColorUIResource(colorScheme.getForegroundColor()));
 		table.put("TabbedPane.contentAreaColor", colorScheme.getBackgroundColor());
 		table.put("TabbedPane.contentBorderInsets", new Insets(4, 2, 3, 3));
 		table.put("TabbedPane.selected", colorScheme.getBackgroundColor());
-		table.put("TabbedPane.selectedForeground", colorScheme.getForegroundColor());
 		table.put("TabbedPane.tabAreaBackground", colorScheme.getAltBackgroundColor());
 		table.put("TabbedPane.tabAreaInsets", new Insets(2, 2, 0, 6));
 		table.put("TabbedPane.unselectedBackground", colorScheme.getBackgroundColor());

--- a/src/main/java/net/mcreator/ui/workspace/WorkspacePanelLocalizations.java
+++ b/src/main/java/net/mcreator/ui/workspace/WorkspacePanelLocalizations.java
@@ -66,7 +66,6 @@ class WorkspacePanelLocalizations extends JPanel implements IReloadableFilterabl
 		this.workspacePanel = workspacePanel;
 
 		pane = new JTabbedPane();
-		pane.setForeground(Color.white);
 		pane.setOpaque(false);
 		pane.setUI(new javax.swing.plaf.basic.BasicTabbedPaneUI() {
 			@Override protected void paintContentBorder(Graphics g, int tabPlacement, int selectedIndex) {


### PR DESCRIPTION
This PR changes some of predefined colors used by tabbed panes, so now:
* Scroll buttons are rendered properly (arrows are visible);
* Rendering of child elements matches such rendering of list objects (the background/foreground of selected tab is likely the same).