### PR TITLE
Removed `deleteWhenConditionFalse` parameter

### DIFF
--- a/plugins/generator-1.18.2/forge-1.18.2/armor.definition.yaml
+++ b/plugins/generator-1.18.2/forge-1.18.2/armor.definition.yaml
@@ -4,25 +4,21 @@ templates:
   - template: json/item.json.ftl
     writer: json
     condition: enableHelmet
-    deleteWhenConditionFalse: true
     variables: "item=helmet"
     name: "@MODASSETSROOT/models/item/@registryname_helmet.json"
   - template: json/item.json.ftl
     writer: json
     condition: enableBody
-    deleteWhenConditionFalse: true
     variables: "item=body"
     name: "@MODASSETSROOT/models/item/@registryname_chestplate.json"
   - template: json/item.json.ftl
     writer: json
     condition: enableLeggings
-    deleteWhenConditionFalse: true
     variables: "item=leggings"
     name: "@MODASSETSROOT/models/item/@registryname_leggings.json"
   - template: json/item.json.ftl
     writer: json
     condition: enableBoots
-    deleteWhenConditionFalse: true
     variables: "item=boots"
     name: "@MODASSETSROOT/models/item/@registryname_boots.json"
 

--- a/plugins/generator-1.18.2/forge-1.18.2/biome.definition.yaml
+++ b/plugins/generator-1.18.2/forge-1.18.2/biome.definition.yaml
@@ -4,15 +4,12 @@ templates:
   - template: biome/tree_fruits_decorator.java.ftl
     name: "@SRCROOT/@BASEPACKAGEPATH/world/features/treedecorators/@NAMEFruitDecorator.java"
     condition: hasFruits()
-    deleteWhenConditionFalse: true
   - template: biome/tree_leave_decorator.java.ftl
     name: "@SRCROOT/@BASEPACKAGEPATH/world/features/treedecorators/@NAMELeaveDecorator.java"
     condition: hasVines()
-    deleteWhenConditionFalse: true
   - template: biome/tree_trunk_decorator.java.ftl
     name: "@SRCROOT/@BASEPACKAGEPATH/world/features/treedecorators/@NAMETrunkDecorator.java"
     condition: hasVines()
-    deleteWhenConditionFalse: true
 
 global_templates:
   - template: elementinits/biomes.java.ftl
@@ -22,187 +19,156 @@ global_templates:
     writer: json
     variables: "type=mineshaft"
     condition: ${w.hasBiomesWithStructure('mineshaft')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/mineshaft.json"
   - template: json/biometag.json.ftl
     writer: json
     variables: "type=igloo"
     condition: ${w.hasBiomesWithStructure('igloo')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/igloo.json"
   - template: json/biometag.json.ftl
     writer: json
     variables: "type=stronghold"
     condition: ${w.hasBiomesWithStructure('stronghold')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/stronghold.json"
   - template: json/biometag.json.ftl
     writer: json
     variables: "type=mineshaft_mesa"
     condition: ${w.hasBiomesWithStructure('mineshaft_mesa')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/mineshaft_mesa.json"
   - template: json/biometag.json.ftl
     writer: json
     variables: "type=pillager_outpost"
     condition: ${w.hasBiomesWithStructure('pillager_outpost')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/pillager_outpost.json"
   - template: json/biometag.json.ftl
     writer: json
     variables: "type=woodland_mansion"
     condition: ${w.hasBiomesWithStructure('woodland_mansion')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/woodland_mansion.json"
   - template: json/biometag.json.ftl
     writer: json
     variables: "type=jungle_temple"
     condition: ${w.hasBiomesWithStructure('jungle_temple')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/jungle_temple.json"
   - template: json/biometag.json.ftl
     writer: json
     variables: "type=desert_pyramid"
     condition: ${w.hasBiomesWithStructure('desert_pyramid')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/desert_pyramid.json"
   - template: json/biometag.json.ftl
     writer: json
     variables: "type=swamp_hut"
     condition: ${w.hasBiomesWithStructure('swamp_hut')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/swamp_hut.json"
   - template: json/biometag.json.ftl
     writer: json
     variables: "type=ocean_monument"
     condition: ${w.hasBiomesWithStructure('ocean_monument')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/ocean_monument.json"
   - template: json/biometag.json.ftl
     writer: json
     variables: "type=shipwreck"
     condition: ${w.hasBiomesWithStructure('shipwreck')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/shipwreck.json"
   - template: json/biometag.json.ftl
     writer: json
     variables: "type=shipwreck_beached"
     condition: ${w.hasBiomesWithStructure('shipwreck_beached')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/shipwreck_beached.json"
   - template: json/biometag.json.ftl
     writer: json
     variables: "type=buried_treasure"
     condition: ${w.hasBiomesWithStructure('buried_treasure')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/buried_treasure.json"
   - template: json/biometag.json.ftl
     writer: json
     variables: "type=nether_fortress"
     condition: ${w.hasBiomesWithStructure('nether_fortress')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/nether_fortress.json"
   - template: json/biometag.json.ftl
     writer: json
     variables: "type=nether_fossil"
     condition: ${w.hasBiomesWithStructure('nether_fossil')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/nether_fossil.json"
   - template: json/biometag.json.ftl
     writer: json
     variables: "type=bastion_remnant"
     condition: ${w.hasBiomesWithStructure('bastion_remnant')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/bastion_remnant.json"
   - template: json/biometag.json.ftl
     writer: json
     variables: "type=end_city"
     condition: ${w.hasBiomesWithStructure('end_city')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/end_city.json"
   - template: json/biometag.json.ftl
     writer: json
     variables: "type=village_desert"
     condition: ${w.hasBiomesWithStructure('village_desert')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/village_desert.json"
   - template: json/biometag.json.ftl
     writer: json
     variables: "type=village_plains"
     condition: ${w.hasBiomesWithStructure('village_plains')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/village_plains.json"
   - template: json/biometag.json.ftl
     writer: json
     variables: "type=village_savanna"
     condition: ${w.hasBiomesWithStructure('village_savanna')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/village_savanna.json"
   - template: json/biometag.json.ftl
     writer: json
     variables: "type=village_snowy"
     condition: ${w.hasBiomesWithStructure('village_snowy')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/village_snowy.json"
   - template: json/biometag.json.ftl
     writer: json
     variables: "type=village_taiga"
     condition: ${w.hasBiomesWithStructure('village_taiga')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/village_taiga.json"
   - template: json/biometag.json.ftl
     writer: json
     variables: "type=ocean_ruin_cold"
     condition: ${w.hasBiomesWithStructure('ocean_ruin_cold')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/ocean_ruin_cold.json"
   - template: json/biometag.json.ftl
     writer: json
     variables: "type=ocean_ruin_warm"
     condition: ${w.hasBiomesWithStructure('ocean_ruin_warm')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/ocean_ruin_warm.json"
   - template: json/biometag.json.ftl
     writer: json
     variables: "type=ruined_portal_standard"
     condition: ${w.hasBiomesWithStructure('ruined_portal_standard')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/ruined_portal_standard.json"
   - template: json/biometag.json.ftl
     writer: json
     variables: "type=ruined_portal_desert"
     condition: ${w.hasBiomesWithStructure('ruined_portal_desert')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/ruined_portal_desert.json"
   - template: json/biometag.json.ftl
     writer: json
     variables: "type=ruined_portal_jungle"
     condition: ${w.hasBiomesWithStructure('ruined_portal_jungle')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/ruined_portal_jungle.json"
   - template: json/biometag.json.ftl
     writer: json
     variables: "type=ruined_portal_swamp"
     condition: ${w.hasBiomesWithStructure('ruined_portal_swamp')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/ruined_portal_swamp.json"
   - template: json/biometag.json.ftl
     writer: json
     variables: "type=ruined_portal_mountain"
     condition: ${w.hasBiomesWithStructure('ruined_portal_mountain')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/ruined_portal_mountain.json"
   - template: json/biometag.json.ftl
     writer: json
     variables: "type=ruined_portal_ocean"
     condition: ${w.hasBiomesWithStructure('ruined_portal_ocean')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/ruined_portal_ocean.json"
   - template: json/biometag.json.ftl
     writer: json
     variables: "type=ruined_portal_nether"
     condition: ${w.hasBiomesWithStructure('ruined_portal_nether')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/ruined_portal_nether.json"
 
 localizationkeys:

--- a/plugins/generator-1.18.2/forge-1.18.2/block.definition.yaml
+++ b/plugins/generator-1.18.2/forge-1.18.2/block.definition.yaml
@@ -2,11 +2,9 @@ templates:
   - template: block/block.java.ftl
     name: "@SRCROOT/@BASEPACKAGEPATH/block/@NAMEBlock.java"
   - template: block/oregen.java.ftl
-    deleteWhenConditionFalse: true
     condition: doesGenerateInWorld()
     name: "@SRCROOT/@BASEPACKAGEPATH/world/features/ores/@NAMEFeature.java"
   - template: block/blockentity.java.ftl
-    deleteWhenConditionFalse: true
     condition: hasInventory
     name: "@SRCROOT/@BASEPACKAGEPATH/block/entity/@NAMEBlockEntity.java"
 
@@ -83,13 +81,11 @@ templates:
     name: "@MODASSETSROOT/models/block/@registryname.json"
   - template: json/block_model_tbs.json.ftl
     variables: "model=inner_stairs"
-    deleteWhenConditionFalse: true
     condition: "blockBase %= Stairs"
     writer: json
     name: "@MODASSETSROOT/models/block/@registryname_inner.json"
   - template: json/block_model_tbs.json.ftl
     variables: "model=outer_stairs"
-    deleteWhenConditionFalse: true
     condition: "blockBase %= Stairs"
     writer: json
     name: "@MODASSETSROOT/models/block/@registryname_outer.json"
@@ -109,13 +105,11 @@ templates:
     variables: "model=fence_side;txname=texture"
     name: "@MODASSETSROOT/models/block/@registryname.json"
   - template: json/block.json.ftl
-    deleteWhenConditionFalse: true
     condition: "blockBase %= Fence"
     writer: json
     variables: "model=fence_post;txname=texture"
     name: "@MODASSETSROOT/models/block/@registryname_post.json"
   - template: json/block.json.ftl
-    deleteWhenConditionFalse: true
     condition: "blockBase %= Fence"
     writer: json
     variables: "model=fence_inventory;txname=texture"
@@ -141,13 +135,11 @@ templates:
     variables: "model=template_wall_side_tall;txname=wall"
     name: "@MODASSETSROOT/models/block/@registryname_side_tall.json"
   - template: json/block.json.ftl
-    deleteWhenConditionFalse: true
     condition: "blockBase %= Wall"
     writer: json
     variables: "model=template_wall_post;txname=wall"
     name: "@MODASSETSROOT/models/block/@registryname_post.json"
   - template: json/block.json.ftl
-    deleteWhenConditionFalse: true
     condition: "blockBase %= Wall"
     writer: json
     variables: "model=wall_inventory;txname=wall"
@@ -168,13 +160,11 @@ templates:
     variables: "model=slab"
     name: "@MODASSETSROOT/models/block/@registryname.json"
   - template: json/block_model_tbs.json.ftl
-    deleteWhenConditionFalse: true
     condition: "blockBase %= Slab"
     writer: json
     variables: "model=slab_top"
     name: "@MODASSETSROOT/models/block/@registryname_top.json"
   - template: json/block_model_tbs.json.ftl
-    deleteWhenConditionFalse: true
     condition: "blockBase %= Slab"
     writer: json
     variables: "model=cube_bottom_top"
@@ -195,13 +185,11 @@ templates:
     variables: "model=template_orientable_trapdoor_bottom;txname=texture"
     name: "@MODASSETSROOT/models/block/@registryname.json"
   - template: json/block.json.ftl
-    deleteWhenConditionFalse: true
     condition: "blockBase %= TrapDoor"
     writer: json
     variables: "model=template_orientable_trapdoor_top;txname=texture"
     name: "@MODASSETSROOT/models/block/@registryname_top.json"
   - template: json/block.json.ftl
-    deleteWhenConditionFalse: true
     condition: "blockBase %= TrapDoor"
     writer: json
     variables: "model=template_orientable_trapdoor_open;txname=texture"
@@ -302,17 +290,14 @@ templates:
     writer: json
     name: "@MODASSETSROOT/models/block/@registryname.json"
   - template: json/txblock/fence_gate_open.json.ftl
-    deleteWhenConditionFalse: true
     condition: "blockBase %= FenceGate"
     writer: json
     name: "@MODASSETSROOT/models/block/@registryname_open.json"
   - template: json/txblock/fence_gate_wall.json.ftl
-    deleteWhenConditionFalse: true
     condition: "blockBase %= FenceGate"
     writer: json
     name: "@MODASSETSROOT/models/block/@registryname_wall.json"
   - template: json/txblock/fence_gate_wall_open.json.ftl
-    deleteWhenConditionFalse: true
     condition: "blockBase %= FenceGate"
     writer: json
     name: "@MODASSETSROOT/models/block/@registryname_wall_open.json"
@@ -345,7 +330,6 @@ templates:
     writer: json
     name: "@MODASSETSROOT/models/block/@registryname.json"
   - template: json/txblock/pressure_plate_down.json.ftl
-    deleteWhenConditionFalse: true
     condition: "blockBase %= PressurePlate"
     writer: json
     name: "@MODASSETSROOT/models/block/@registryname_down.json"
@@ -364,12 +348,10 @@ templates:
     writer: json
     name: "@MODASSETSROOT/models/block/@registryname.json"
   - template: json/txblock/button_pressed.json.ftl
-    deleteWhenConditionFalse: true
     condition: "blockBase %= Button"
     writer: json
     name: "@MODASSETSROOT/models/block/@registryname_pressed.json"
   - template: json/txblock/button_inventory.json.ftl
-    deleteWhenConditionFalse: true
     condition: "blockBase %= Button"
     writer: json
     name: "@MODASSETSROOT/models/block/@registryname_inventory.json"
@@ -383,23 +365,19 @@ global_templates:
     writer: json
     variables: "type=pickaxe"
     name: "@RESROOT/data/minecraft/tags/blocks/mineable/pickaxe.json"
-    deleteWhenConditionFalse: true
     condition: ${w.hasBlocksMineableWith('pickaxe')}
   - template: block/mineable_tag.json.ftl
     writer: json
     variables: "type=axe"
     name: "@RESROOT/data/minecraft/tags/blocks/mineable/axe.json"
-    deleteWhenConditionFalse: true
     condition: ${w.hasBlocksMineableWith('axe')}
   - template: block/mineable_tag.json.ftl
     writer: json
     variables: "type=shovel"
     name: "@RESROOT/data/minecraft/tags/blocks/mineable/shovel.json"
-    deleteWhenConditionFalse: true
     condition: ${w.hasBlocksMineableWith('shovel')}
   - template: block/mineable_tag.json.ftl
     writer: json
     variables: "type=hoe"
     name: "@RESROOT/data/minecraft/tags/blocks/mineable/hoe.json"
-    deleteWhenConditionFalse: true
     condition: ${w.hasBlocksMineableWith('hoe')}

--- a/plugins/generator-1.18.2/forge-1.18.2/dimension.definition.yaml
+++ b/plugins/generator-1.18.2/forge-1.18.2/dimension.definition.yaml
@@ -3,19 +3,15 @@ templates:
     name: "@SRCROOT/@BASEPACKAGEPATH/world/dimension/@NAMEDimension.java"
   - template: dimension/teleporter.java.ftl
     condition: enablePortal
-    deleteWhenConditionFalse: true
     name: "@SRCROOT/@BASEPACKAGEPATH/world/teleporter/@NAMETeleporter.java"
   - template: dimension/portalshape.java.ftl
     condition: enablePortal
-    deleteWhenConditionFalse: true
     name: "@SRCROOT/@BASEPACKAGEPATH/world/teleporter/@NAMEPortalShape.java"
   - template: dimension/blockportal.java.ftl
     condition: enablePortal
-    deleteWhenConditionFalse: true
     name: "@SRCROOT/@BASEPACKAGEPATH/block/@NAMEPortalBlock.java"
   - template: dimension/portaltrigger.java.ftl
     condition: enablePortal
-    deleteWhenConditionFalse: true
     name: "@SRCROOT/@BASEPACKAGEPATH/item/@NAMEItem.java"
   - template: json/dimension/dimension_type.json.ftl
     writer: json
@@ -36,22 +32,18 @@ templates:
     writer: json
     name: "@MODASSETSROOT/blockstates/@registryname_portal.json"
     condition: enablePortal
-    deleteWhenConditionFalse: true
   - template: json/dimension_portal_ew.json.ftl
     writer: json
     name: "@MODASSETSROOT/models/block/@registryname_portal_ew.json"
     condition: enablePortal
-    deleteWhenConditionFalse: true
   - template: json/dimension_portal_ns.json.ftl
     writer: json
     name: "@MODASSETSROOT/models/block/@registryname_portal_ns.json"
     condition: enablePortal
-    deleteWhenConditionFalse: true
   - template: json/item.json.ftl
     writer: json
     name: "@MODASSETSROOT/models/item/@registryname.json"
     condition: enablePortal
-    deleteWhenConditionFalse: true
 
 localizationkeys:
   - key: item.@modid.@registryname

--- a/plugins/generator-1.18.2/forge-1.18.2/fluid.definition.yaml
+++ b/plugins/generator-1.18.2/forge-1.18.2/fluid.definition.yaml
@@ -4,15 +4,12 @@ templates:
   - template: fluid/fluidblock.java.ftl
     name: "@SRCROOT/@BASEPACKAGEPATH/block/@NAMEBlock.java"
   - template: fluid/fluidattributes.java.ftl
-    deleteWhenConditionFalse: true
     condition: extendsFluidAttributes()
     name: "@SRCROOT/@BASEPACKAGEPATH/fluid/attributes/@NAMEFluidAttributes.java"
   - template: fluid/fluidbucket.java.ftl
-    deleteWhenConditionFalse: true
     condition: generateBucket
     name: "@SRCROOT/@BASEPACKAGEPATH/item/@NAMEItem.java"
   - template: fluid/fluidgen.java.ftl
-    deleteWhenConditionFalse: true
     condition: doesGenerateInWorld()
     name: "@SRCROOT/@BASEPACKAGEPATH/world/features/lakes/@NAMEFeature.java"
 
@@ -33,13 +30,11 @@ global_templates:
     writer: json
     variables: "type=water"
     condition: ${w.hasFluidsOfType('water')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/fluids/water.json"
   - template: json/fluidtag.json.ftl
     writer: json
     variables: "type=lava"
     condition: ${w.hasFluidsOfType('lava')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/fluids/lava.json"
 
 localizationkeys:

--- a/plugins/generator-1.18.2/forge-1.18.2/gui.definition.yaml
+++ b/plugins/generator-1.18.2/forge-1.18.2/gui.definition.yaml
@@ -6,11 +6,9 @@ templates:
   - template: gui/gui_msg_button.java.ftl
     name: "@SRCROOT/@BASEPACKAGEPATH/network/@NAMEButtonMessage.java"
     condition: hasButtonEvents()
-    deleteWhenConditionFalse: true
   - template: gui/gui_msg_slot.java.ftl
     name: "@SRCROOT/@BASEPACKAGEPATH/network/@NAMESlotMessage.java"
     condition: hasSlotEvents()
-    deleteWhenConditionFalse: true
 
 global_templates:
   - template: elementinits/menus.java.ftl

--- a/plugins/generator-1.18.2/forge-1.18.2/item.definition.yaml
+++ b/plugins/generator-1.18.2/forge-1.18.2/item.definition.yaml
@@ -4,7 +4,6 @@ templates:
   - template: item/item_container.java.ftl
     name: "@SRCROOT/@BASEPACKAGEPATH/item/inventory/@NAMEInventoryCapability.java"
     condition: hasInventory()
-    deleteWhenConditionFalse: true
   - template: json/item.json.ftl
     writer: json
     condition:

--- a/plugins/generator-1.18.2/forge-1.18.2/itemextension.definition.yaml
+++ b/plugins/generator-1.18.2/forge-1.18.2/itemextension.definition.yaml
@@ -1,17 +1,14 @@
 templates:
   - template: dispensebehaviour.java.ftl
     condition: hasDispenseBehavior
-    deleteWhenConditionFalse: true
     name: "@SRCROOT/@BASEPACKAGEPATH/item/extension/@NAMEItemExtension.java"
 
 global_templates:
   - template: elementinits/fuels.java.ftl
     writer: java
     condition: ${w.hasFuels()}
-    deleteWhenConditionFalse: true
     name: "@SRCROOT/@BASEPACKAGEPATH/init/@JavaModNameFuels.java"
   - template: elementinits/compostable_items.java.ftl
     writer: java
     condition: ${w.hasCompostableItems()}
-    deleteWhenConditionFalse: true
     name: "@SRCROOT/@BASEPACKAGEPATH/init/@JavaModNameCompostableItems.java"

--- a/plugins/generator-1.18.2/forge-1.18.2/livingentity.definition.yaml
+++ b/plugins/generator-1.18.2/forge-1.18.2/livingentity.definition.yaml
@@ -6,12 +6,10 @@ templates:
   - template: livingentity/livingentity_projectile.java.ftl
     name: "@SRCROOT/@BASEPACKAGEPATH/entity/@NAMEEntityProjectile.java"
     condition: hasCustomProjectile()
-    deleteWhenConditionFalse: true
   - template: json/spawn_egg.json.ftl
     writer: json
     name: "@MODASSETSROOT/models/item/@registryname_spawn_egg.json"
     condition: hasSpawnEgg
-    deleteWhenConditionFalse: true
 
 unmodifiable_ai_bases: [ Bat, MagmaCube, Slime ]
 

--- a/plugins/generator-1.18.2/forge-1.18.2/plant.definition.yaml
+++ b/plugins/generator-1.18.2/forge-1.18.2/plant.definition.yaml
@@ -2,11 +2,9 @@ templates:
   - template: plant/plant.java.ftl
     name: "@SRCROOT/@BASEPACKAGEPATH/block/@NAMEBlock.java"
   - template: plant/plantgen.java.ftl
-    deleteWhenConditionFalse: true
     condition: doesGenerateInWorld()
     name: "@SRCROOT/@BASEPACKAGEPATH/world/features/plants/@NAMEFeature.java"
   - template: plant/plantblockentity.java.ftl
-    deleteWhenConditionFalse: true
     condition: hasTileEntity
     name: "@SRCROOT/@BASEPACKAGEPATH/block/entity/@NAMEBlockEntity.java"
 

--- a/plugins/generator-1.18.2/forge-1.18.2/rangeditem.definition.yaml
+++ b/plugins/generator-1.18.2/forge-1.18.2/rangeditem.definition.yaml
@@ -6,7 +6,6 @@ templates:
   - template: rangeditem/projectile_renderer.java.ftl
     name: "@SRCROOT/@BASEPACKAGEPATH/client/renderer/@NAMERenderer.java"
     condition: isCustomModel()
-    deleteWhenConditionFalse: true
   - template: json/rangeditem.json.ftl
     writer: json
     condition: "renderType #= 0"

--- a/plugins/generator-1.18.2/forge-1.18.2/recipe.definition.yaml
+++ b/plugins/generator-1.18.2/forge-1.18.2/recipe.definition.yaml
@@ -30,4 +30,3 @@ templates:
   - template: brewingrecipe.java.ftl
     name: "@SRCROOT/@BASEPACKAGEPATH/recipes/brewing/@NAMEBrewingRecipe.java"
     condition: "recipeType %= Brewing"
-    deleteWhenConditionFalse: true

--- a/plugins/generator-1.19.2/forge-1.19.2/armor.definition.yaml
+++ b/plugins/generator-1.19.2/forge-1.19.2/armor.definition.yaml
@@ -4,25 +4,21 @@ templates:
   - template: json/item.json.ftl
     writer: json
     condition: enableHelmet
-    deleteWhenConditionFalse: true
     variables: "item=helmet"
     name: "@MODASSETSROOT/models/item/@registryname_helmet.json"
   - template: json/item.json.ftl
     writer: json
     condition: enableBody
-    deleteWhenConditionFalse: true
     variables: "item=body"
     name: "@MODASSETSROOT/models/item/@registryname_chestplate.json"
   - template: json/item.json.ftl
     writer: json
     condition: enableLeggings
-    deleteWhenConditionFalse: true
     variables: "item=leggings"
     name: "@MODASSETSROOT/models/item/@registryname_leggings.json"
   - template: json/item.json.ftl
     writer: json
     condition: enableBoots
-    deleteWhenConditionFalse: true
     variables: "item=boots"
     name: "@MODASSETSROOT/models/item/@registryname_boots.json"
 

--- a/plugins/generator-1.19.2/forge-1.19.2/biome.definition.yaml
+++ b/plugins/generator-1.19.2/forge-1.19.2/biome.definition.yaml
@@ -4,15 +4,12 @@ templates:
   - template: biome/tree_fruits_decorator.java.ftl
     name: "@SRCROOT/@BASEPACKAGEPATH/world/features/treedecorators/@NAMEFruitDecorator.java"
     condition: hasFruits()
-    deleteWhenConditionFalse: true
   - template: biome/tree_leave_decorator.java.ftl
     name: "@SRCROOT/@BASEPACKAGEPATH/world/features/treedecorators/@NAMELeaveDecorator.java"
     condition: hasVines()
-    deleteWhenConditionFalse: true
   - template: biome/tree_trunk_decorator.java.ftl
     name: "@SRCROOT/@BASEPACKAGEPATH/world/features/treedecorators/@NAMETrunkDecorator.java"
     condition: hasVines()
-    deleteWhenConditionFalse: true
 
 global_templates:
   - template: elementinits/biomes.java.ftl
@@ -22,187 +19,156 @@ global_templates:
     writer: json
     variables: "type=mineshaft"
     condition: ${w.hasBiomesWithStructure('mineshaft')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/mineshaft.json"
   - template: json/biometag.json.ftl
     writer: json
     variables: "type=igloo"
     condition: ${w.hasBiomesWithStructure('igloo')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/igloo.json"
   - template: json/biometag.json.ftl
     writer: json
     variables: "type=stronghold"
     condition: ${w.hasBiomesWithStructure('stronghold')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/stronghold.json"
   - template: json/biometag.json.ftl
     writer: json
     variables: "type=mineshaft_mesa"
     condition: ${w.hasBiomesWithStructure('mineshaft_mesa')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/mineshaft_mesa.json"
   - template: json/biometag.json.ftl
     writer: json
     variables: "type=pillager_outpost"
     condition: ${w.hasBiomesWithStructure('pillager_outpost')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/pillager_outpost.json"
   - template: json/biometag.json.ftl
     writer: json
     variables: "type=woodland_mansion"
     condition: ${w.hasBiomesWithStructure('woodland_mansion')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/woodland_mansion.json"
   - template: json/biometag.json.ftl
     writer: json
     variables: "type=jungle_temple"
     condition: ${w.hasBiomesWithStructure('jungle_temple')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/jungle_temple.json"
   - template: json/biometag.json.ftl
     writer: json
     variables: "type=desert_pyramid"
     condition: ${w.hasBiomesWithStructure('desert_pyramid')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/desert_pyramid.json"
   - template: json/biometag.json.ftl
     writer: json
     variables: "type=swamp_hut"
     condition: ${w.hasBiomesWithStructure('swamp_hut')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/swamp_hut.json"
   - template: json/biometag.json.ftl
     writer: json
     variables: "type=ocean_monument"
     condition: ${w.hasBiomesWithStructure('ocean_monument')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/ocean_monument.json"
   - template: json/biometag.json.ftl
     writer: json
     variables: "type=shipwreck"
     condition: ${w.hasBiomesWithStructure('shipwreck')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/shipwreck.json"
   - template: json/biometag.json.ftl
     writer: json
     variables: "type=shipwreck_beached"
     condition: ${w.hasBiomesWithStructure('shipwreck_beached')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/shipwreck_beached.json"
   - template: json/biometag.json.ftl
     writer: json
     variables: "type=buried_treasure"
     condition: ${w.hasBiomesWithStructure('buried_treasure')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/buried_treasure.json"
   - template: json/biometag.json.ftl
     writer: json
     variables: "type=nether_fortress"
     condition: ${w.hasBiomesWithStructure('nether_fortress')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/nether_fortress.json"
   - template: json/biometag.json.ftl
     writer: json
     variables: "type=nether_fossil"
     condition: ${w.hasBiomesWithStructure('nether_fossil')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/nether_fossil.json"
   - template: json/biometag.json.ftl
     writer: json
     variables: "type=bastion_remnant"
     condition: ${w.hasBiomesWithStructure('bastion_remnant')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/bastion_remnant.json"
   - template: json/biometag.json.ftl
     writer: json
     variables: "type=end_city"
     condition: ${w.hasBiomesWithStructure('end_city')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/end_city.json"
   - template: json/biometag.json.ftl
     writer: json
     variables: "type=village_desert"
     condition: ${w.hasBiomesWithStructure('village_desert')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/village_desert.json"
   - template: json/biometag.json.ftl
     writer: json
     variables: "type=village_plains"
     condition: ${w.hasBiomesWithStructure('village_plains')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/village_plains.json"
   - template: json/biometag.json.ftl
     writer: json
     variables: "type=village_savanna"
     condition: ${w.hasBiomesWithStructure('village_savanna')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/village_savanna.json"
   - template: json/biometag.json.ftl
     writer: json
     variables: "type=village_snowy"
     condition: ${w.hasBiomesWithStructure('village_snowy')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/village_snowy.json"
   - template: json/biometag.json.ftl
     writer: json
     variables: "type=village_taiga"
     condition: ${w.hasBiomesWithStructure('village_taiga')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/village_taiga.json"
   - template: json/biometag.json.ftl
     writer: json
     variables: "type=ocean_ruin_cold"
     condition: ${w.hasBiomesWithStructure('ocean_ruin_cold')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/ocean_ruin_cold.json"
   - template: json/biometag.json.ftl
     writer: json
     variables: "type=ocean_ruin_warm"
     condition: ${w.hasBiomesWithStructure('ocean_ruin_warm')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/ocean_ruin_warm.json"
   - template: json/biometag.json.ftl
     writer: json
     variables: "type=ruined_portal_standard"
     condition: ${w.hasBiomesWithStructure('ruined_portal_standard')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/ruined_portal_standard.json"
   - template: json/biometag.json.ftl
     writer: json
     variables: "type=ruined_portal_desert"
     condition: ${w.hasBiomesWithStructure('ruined_portal_desert')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/ruined_portal_desert.json"
   - template: json/biometag.json.ftl
     writer: json
     variables: "type=ruined_portal_jungle"
     condition: ${w.hasBiomesWithStructure('ruined_portal_jungle')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/ruined_portal_jungle.json"
   - template: json/biometag.json.ftl
     writer: json
     variables: "type=ruined_portal_swamp"
     condition: ${w.hasBiomesWithStructure('ruined_portal_swamp')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/ruined_portal_swamp.json"
   - template: json/biometag.json.ftl
     writer: json
     variables: "type=ruined_portal_mountain"
     condition: ${w.hasBiomesWithStructure('ruined_portal_mountain')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/ruined_portal_mountain.json"
   - template: json/biometag.json.ftl
     writer: json
     variables: "type=ruined_portal_ocean"
     condition: ${w.hasBiomesWithStructure('ruined_portal_ocean')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/ruined_portal_ocean.json"
   - template: json/biometag.json.ftl
     writer: json
     variables: "type=ruined_portal_nether"
     condition: ${w.hasBiomesWithStructure('ruined_portal_nether')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/ruined_portal_nether.json"
 
 localizationkeys:

--- a/plugins/generator-1.19.2/forge-1.19.2/block.definition.yaml
+++ b/plugins/generator-1.19.2/forge-1.19.2/block.definition.yaml
@@ -2,18 +2,15 @@ templates:
   - template: block/block.java.ftl
     name: "@SRCROOT/@BASEPACKAGEPATH/block/@NAMEBlock.java"
   - template: block/blockentity.java.ftl
-    deleteWhenConditionFalse: true
     condition: hasInventory
     name: "@SRCROOT/@BASEPACKAGEPATH/block/entity/@NAMEBlockEntity.java"
 
   # Worldgen
   - template: block/oregen.java.ftl
-    deleteWhenConditionFalse: true
     condition: doesGenerateInWorld()
     name: "@SRCROOT/@BASEPACKAGEPATH/world/features/ores/@NAMEFeature.java"
   - template: json/block_feature_biome_modifier.json.ftl
     writer: json
-    deleteWhenConditionFalse: true
     condition: doesGenerateInWorld()
     name: "@MODDATAROOT/forge/biome_modifier/@registryname_biome_modifier.json"
     variables: "step=underground_ores"
@@ -91,13 +88,11 @@ templates:
     name: "@MODASSETSROOT/models/block/@registryname.json"
   - template: json/block_model_tbs.json.ftl
     variables: "model=inner_stairs"
-    deleteWhenConditionFalse: true
     condition: "blockBase %= Stairs"
     writer: json
     name: "@MODASSETSROOT/models/block/@registryname_inner.json"
   - template: json/block_model_tbs.json.ftl
     variables: "model=outer_stairs"
-    deleteWhenConditionFalse: true
     condition: "blockBase %= Stairs"
     writer: json
     name: "@MODASSETSROOT/models/block/@registryname_outer.json"
@@ -117,13 +112,11 @@ templates:
     variables: "model=fence_side;txname=texture"
     name: "@MODASSETSROOT/models/block/@registryname.json"
   - template: json/block.json.ftl
-    deleteWhenConditionFalse: true
     condition: "blockBase %= Fence"
     writer: json
     variables: "model=fence_post;txname=texture"
     name: "@MODASSETSROOT/models/block/@registryname_post.json"
   - template: json/block.json.ftl
-    deleteWhenConditionFalse: true
     condition: "blockBase %= Fence"
     writer: json
     variables: "model=fence_inventory;txname=texture"
@@ -149,13 +142,11 @@ templates:
     variables: "model=template_wall_side_tall;txname=wall"
     name: "@MODASSETSROOT/models/block/@registryname_side_tall.json"
   - template: json/block.json.ftl
-    deleteWhenConditionFalse: true
     condition: "blockBase %= Wall"
     writer: json
     variables: "model=template_wall_post;txname=wall"
     name: "@MODASSETSROOT/models/block/@registryname_post.json"
   - template: json/block.json.ftl
-    deleteWhenConditionFalse: true
     condition: "blockBase %= Wall"
     writer: json
     variables: "model=wall_inventory;txname=wall"
@@ -176,13 +167,11 @@ templates:
     variables: "model=slab"
     name: "@MODASSETSROOT/models/block/@registryname.json"
   - template: json/block_model_tbs.json.ftl
-    deleteWhenConditionFalse: true
     condition: "blockBase %= Slab"
     writer: json
     variables: "model=slab_top"
     name: "@MODASSETSROOT/models/block/@registryname_top.json"
   - template: json/block_model_tbs.json.ftl
-    deleteWhenConditionFalse: true
     condition: "blockBase %= Slab"
     writer: json
     variables: "model=cube_bottom_top"
@@ -203,13 +192,11 @@ templates:
     variables: "model=template_orientable_trapdoor_bottom;txname=texture"
     name: "@MODASSETSROOT/models/block/@registryname.json"
   - template: json/block.json.ftl
-    deleteWhenConditionFalse: true
     condition: "blockBase %= TrapDoor"
     writer: json
     variables: "model=template_orientable_trapdoor_top;txname=texture"
     name: "@MODASSETSROOT/models/block/@registryname_top.json"
   - template: json/block.json.ftl
-    deleteWhenConditionFalse: true
     condition: "blockBase %= TrapDoor"
     writer: json
     variables: "model=template_orientable_trapdoor_open;txname=texture"
@@ -326,17 +313,14 @@ templates:
     writer: json
     name: "@MODASSETSROOT/models/block/@registryname.json"
   - template: json/txblock/fence_gate_open.json.ftl
-    deleteWhenConditionFalse: true
     condition: "blockBase %= FenceGate"
     writer: json
     name: "@MODASSETSROOT/models/block/@registryname_open.json"
   - template: json/txblock/fence_gate_wall.json.ftl
-    deleteWhenConditionFalse: true
     condition: "blockBase %= FenceGate"
     writer: json
     name: "@MODASSETSROOT/models/block/@registryname_wall.json"
   - template: json/txblock/fence_gate_wall_open.json.ftl
-    deleteWhenConditionFalse: true
     condition: "blockBase %= FenceGate"
     writer: json
     name: "@MODASSETSROOT/models/block/@registryname_wall_open.json"
@@ -369,7 +353,6 @@ templates:
     writer: json
     name: "@MODASSETSROOT/models/block/@registryname.json"
   - template: json/txblock/pressure_plate_down.json.ftl
-    deleteWhenConditionFalse: true
     condition: "blockBase %= PressurePlate"
     writer: json
     name: "@MODASSETSROOT/models/block/@registryname_down.json"
@@ -388,12 +371,10 @@ templates:
     writer: json
     name: "@MODASSETSROOT/models/block/@registryname.json"
   - template: json/txblock/button_pressed.json.ftl
-    deleteWhenConditionFalse: true
     condition: "blockBase %= Button"
     writer: json
     name: "@MODASSETSROOT/models/block/@registryname_pressed.json"
   - template: json/txblock/button_inventory.json.ftl
-    deleteWhenConditionFalse: true
     condition: "blockBase %= Button"
     writer: json
     name: "@MODASSETSROOT/models/block/@registryname_inventory.json"
@@ -407,23 +388,19 @@ global_templates:
     writer: json
     variables: "type=pickaxe"
     name: "@RESROOT/data/minecraft/tags/blocks/mineable/pickaxe.json"
-    deleteWhenConditionFalse: true
     condition: ${w.hasBlocksMineableWith('pickaxe')}
   - template: block/mineable_tag.json.ftl
     writer: json
     variables: "type=axe"
     name: "@RESROOT/data/minecraft/tags/blocks/mineable/axe.json"
-    deleteWhenConditionFalse: true
     condition: ${w.hasBlocksMineableWith('axe')}
   - template: block/mineable_tag.json.ftl
     writer: json
     variables: "type=shovel"
     name: "@RESROOT/data/minecraft/tags/blocks/mineable/shovel.json"
-    deleteWhenConditionFalse: true
     condition: ${w.hasBlocksMineableWith('shovel')}
   - template: block/mineable_tag.json.ftl
     writer: json
     variables: "type=hoe"
     name: "@RESROOT/data/minecraft/tags/blocks/mineable/hoe.json"
-    deleteWhenConditionFalse: true
     condition: ${w.hasBlocksMineableWith('hoe')}

--- a/plugins/generator-1.19.2/forge-1.19.2/dimension.definition.yaml
+++ b/plugins/generator-1.19.2/forge-1.19.2/dimension.definition.yaml
@@ -3,19 +3,15 @@ templates:
     name: "@SRCROOT/@BASEPACKAGEPATH/world/dimension/@NAMEDimension.java"
   - template: dimension/teleporter.java.ftl
     condition: enablePortal
-    deleteWhenConditionFalse: true
     name: "@SRCROOT/@BASEPACKAGEPATH/world/teleporter/@NAMETeleporter.java"
   - template: dimension/portalshape.java.ftl
     condition: enablePortal
-    deleteWhenConditionFalse: true
     name: "@SRCROOT/@BASEPACKAGEPATH/world/teleporter/@NAMEPortalShape.java"
   - template: dimension/blockportal.java.ftl
     condition: enablePortal
-    deleteWhenConditionFalse: true
     name: "@SRCROOT/@BASEPACKAGEPATH/block/@NAMEPortalBlock.java"
   - template: dimension/portaltrigger.java.ftl
     condition: enablePortal
-    deleteWhenConditionFalse: true
     name: "@SRCROOT/@BASEPACKAGEPATH/item/@NAMEItem.java"
 
   - template: json/dimension/dimension_type.json.ftl
@@ -38,22 +34,18 @@ templates:
     writer: json
     name: "@MODASSETSROOT/blockstates/@registryname_portal.json"
     condition: enablePortal
-    deleteWhenConditionFalse: true
   - template: json/dimension_portal_ew.json.ftl
     writer: json
     name: "@MODASSETSROOT/models/block/@registryname_portal_ew.json"
     condition: enablePortal
-    deleteWhenConditionFalse: true
   - template: json/dimension_portal_ns.json.ftl
     writer: json
     name: "@MODASSETSROOT/models/block/@registryname_portal_ns.json"
     condition: enablePortal
-    deleteWhenConditionFalse: true
   - template: json/item.json.ftl
     writer: json
     name: "@MODASSETSROOT/models/item/@registryname.json"
     condition: enablePortal
-    deleteWhenConditionFalse: true
 
 global_templates:
   - template: json/carvertag.json.ftl

--- a/plugins/generator-1.19.2/forge-1.19.2/fluid.definition.yaml
+++ b/plugins/generator-1.19.2/forge-1.19.2/fluid.definition.yaml
@@ -6,11 +6,9 @@ templates:
   - template: fluid/fluidtype.java.ftl
     name: "@SRCROOT/@BASEPACKAGEPATH/fluid/types/@NAMEFluidType.java"
   - template: fluid/fluidbucket.java.ftl
-    deleteWhenConditionFalse: true
     condition: generateBucket
     name: "@SRCROOT/@BASEPACKAGEPATH/item/@NAMEItem.java"
   - template: fluid/fluidgen.java.ftl
-    deleteWhenConditionFalse: true
     condition: doesGenerateInWorld()
     name: "@SRCROOT/@BASEPACKAGEPATH/world/features/lakes/@NAMEFeature.java"
 
@@ -25,7 +23,6 @@ templates:
     name: "@MODASSETSROOT/models/block/@registryname.json"
   - template: json/block_feature_biome_modifier.json.ftl
     writer: json
-    deleteWhenConditionFalse: true
     condition: doesGenerateInWorld()
     name: "@MODDATAROOT/forge/biome_modifier/@registryname_biome_modifier.json"
     variables: "step=lakes"

--- a/plugins/generator-1.19.2/forge-1.19.2/gui.definition.yaml
+++ b/plugins/generator-1.19.2/forge-1.19.2/gui.definition.yaml
@@ -6,11 +6,9 @@ templates:
   - template: gui/gui_msg_button.java.ftl
     name: "@SRCROOT/@BASEPACKAGEPATH/network/@NAMEButtonMessage.java"
     condition: hasButtonEvents()
-    deleteWhenConditionFalse: true
   - template: gui/gui_msg_slot.java.ftl
     name: "@SRCROOT/@BASEPACKAGEPATH/network/@NAMESlotMessage.java"
     condition: hasSlotEvents()
-    deleteWhenConditionFalse: true
 
 global_templates:
   - template: elementinits/menus.java.ftl

--- a/plugins/generator-1.19.2/forge-1.19.2/item.definition.yaml
+++ b/plugins/generator-1.19.2/forge-1.19.2/item.definition.yaml
@@ -4,7 +4,6 @@ templates:
   - template: item/item_container.java.ftl
     name: "@SRCROOT/@BASEPACKAGEPATH/item/inventory/@NAMEInventoryCapability.java"
     condition: hasInventory()
-    deleteWhenConditionFalse: true
   - template: json/item.json.ftl
     writer: json
     condition:

--- a/plugins/generator-1.19.2/forge-1.19.2/itemextension.definition.yaml
+++ b/plugins/generator-1.19.2/forge-1.19.2/itemextension.definition.yaml
@@ -1,17 +1,14 @@
 templates:
   - template: dispensebehaviour.java.ftl
     condition: hasDispenseBehavior
-    deleteWhenConditionFalse: true
     name: "@SRCROOT/@BASEPACKAGEPATH/item/extension/@NAMEItemExtension.java"
 
 global_templates:
   - template: elementinits/fuels.java.ftl
     writer: java
     condition: ${w.hasFuels()}
-    deleteWhenConditionFalse: true
     name: "@SRCROOT/@BASEPACKAGEPATH/init/@JavaModNameFuels.java"
   - template: elementinits/compostable_items.java.ftl
     writer: java
     condition: ${w.hasCompostableItems()}
-    deleteWhenConditionFalse: true
     name: "@SRCROOT/@BASEPACKAGEPATH/init/@JavaModNameCompostableItems.java"

--- a/plugins/generator-1.19.2/forge-1.19.2/livingentity.definition.yaml
+++ b/plugins/generator-1.19.2/forge-1.19.2/livingentity.definition.yaml
@@ -6,16 +6,13 @@ templates:
   - template: livingentity/livingentity_projectile.java.ftl
     name: "@SRCROOT/@BASEPACKAGEPATH/entity/@NAMEEntityProjectile.java"
     condition: hasCustomProjectile()
-    deleteWhenConditionFalse: true
   - template: json/spawn_egg.json.ftl
     writer: json
     name: "@MODASSETSROOT/models/item/@registryname_spawn_egg.json"
     condition: hasSpawnEgg
-    deleteWhenConditionFalse: true
 
   - template: livingentity/entity_spawn_biome_modifier.json.ftl
     writer: json
-    deleteWhenConditionFalse: true
     condition: spawnThisMob
     name: "@MODDATAROOT/forge/biome_modifier/@registryname_biome_modifier.json"
 

--- a/plugins/generator-1.19.2/forge-1.19.2/plant.definition.yaml
+++ b/plugins/generator-1.19.2/forge-1.19.2/plant.definition.yaml
@@ -2,11 +2,9 @@ templates:
   - template: plant/plant.java.ftl
     name: "@SRCROOT/@BASEPACKAGEPATH/block/@NAMEBlock.java"
   - template: plant/plantgen.java.ftl
-    deleteWhenConditionFalse: true
     condition: doesGenerateInWorld()
     name: "@SRCROOT/@BASEPACKAGEPATH/world/features/plants/@NAMEFeature.java"
   - template: plant/plantblockentity.java.ftl
-    deleteWhenConditionFalse: true
     condition: hasTileEntity
     name: "@SRCROOT/@BASEPACKAGEPATH/block/entity/@NAMEBlockEntity.java"
 
@@ -69,7 +67,6 @@ templates:
 
   - template: json/block_feature_biome_modifier.json.ftl
     writer: json
-    deleteWhenConditionFalse: true
     condition: doesGenerateInWorld()
     name: "@MODDATAROOT/forge/biome_modifier/@registryname_biome_modifier.json"
     variables: "step=vegetal_decoration"

--- a/plugins/generator-1.19.2/forge-1.19.2/rangeditem.definition.yaml
+++ b/plugins/generator-1.19.2/forge-1.19.2/rangeditem.definition.yaml
@@ -6,7 +6,6 @@ templates:
   - template: rangeditem/projectile_renderer.java.ftl
     name: "@SRCROOT/@BASEPACKAGEPATH/client/renderer/@NAMERenderer.java"
     condition: isCustomModel()
-    deleteWhenConditionFalse: true
   - template: json/rangeditem.json.ftl
     writer: json
     condition: "renderType #= 0"

--- a/plugins/generator-1.19.2/forge-1.19.2/recipe.definition.yaml
+++ b/plugins/generator-1.19.2/forge-1.19.2/recipe.definition.yaml
@@ -30,4 +30,3 @@ templates:
   - template: brewingrecipe.java.ftl
     name: "@SRCROOT/@BASEPACKAGEPATH/recipes/brewing/@NAMEBrewingRecipe.java"
     condition: "recipeType %= Brewing"
-    deleteWhenConditionFalse: true

--- a/plugins/generator-addon-1.19.x/addon-1.19.x/block.definition.yaml
+++ b/plugins/generator-addon-1.19.x/addon-1.19.x/block.definition.yaml
@@ -6,17 +6,14 @@ templates:
     writer: json
     name: "@SRCROOT/loot_tables/blocks/@modid_@registryname.json"
     condition: hasCustomDrop()
-    deleteWhenConditionFalse: true
   - template: block/block_ore_feature.json.ftl
     writer: json
     name: "@SRCROOT/features/@modid_@registryname_ore_feature.json"
     condition: isGeneratedInWorld()
-    deleteWhenConditionFalse: true
   - template: block/block_ore_feature_rule.json.ftl
     writer: json
     name: "@SRCROOT/feature_rules/@modid_@registryname_ore_feature_rule.json"
     condition: isGeneratedInWorld()
-    deleteWhenConditionFalse: true
 
 localizationkeys:
   - key: tile.@modid:@registryname.name

--- a/plugins/generator-addon-1.19.x/addon-1.19.x/livingentity.definition.yaml
+++ b/plugins/generator-addon-1.19.x/addon-1.19.x/livingentity.definition.yaml
@@ -5,12 +5,10 @@ templates:
   - template: entity/entity_spawn_rule.json.ftl
     writer: json
     condition: spawnThisMob
-    deleteWhenConditionFalse: true
     name: "@SRCROOT/spawn_rules/@registryname.json"
   - template: entity/entity_custom_loot.json.ftl
     writer: json
     name: "@SRCROOT/loot_tables/entities/@modid_@registryname.json"
-    deleteWhenConditionFalse: true
     condition: hasDrop()
 
 # entity models

--- a/plugins/generator-datapack-1.18.x/datapack-1.18.x/biome.definition.yaml
+++ b/plugins/generator-datapack-1.18.x/datapack-1.18.x/biome.definition.yaml
@@ -8,187 +8,156 @@ global_templates:
     writer: json
     variables: "type=mineshaft"
     condition: ${w.hasBiomesWithStructure('mineshaft')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/mineshaft.json"
   - template: biome/biometag.json.ftl
     writer: json
     variables: "type=igloo"
     condition: ${w.hasBiomesWithStructure('igloo')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/igloo.json"
   - template: biome/biometag.json.ftl
     writer: json
     variables: "type=stronghold"
     condition: ${w.hasBiomesWithStructure('stronghold')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/stronghold.json"
   - template: biome/biometag.json.ftl
     writer: json
     variables: "type=mineshaft_mesa"
     condition: ${w.hasBiomesWithStructure('mineshaft_mesa')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/mineshaft_mesa.json"
   - template: biome/biometag.json.ftl
     writer: json
     variables: "type=pillager_outpost"
     condition: ${w.hasBiomesWithStructure('pillager_outpost')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/pillager_outpost.json"
   - template: biome/biometag.json.ftl
     writer: json
     variables: "type=woodland_mansion"
     condition: ${w.hasBiomesWithStructure('woodland_mansion')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/woodland_mansion.json"
   - template: biome/biometag.json.ftl
     writer: json
     variables: "type=jungle_temple"
     condition: ${w.hasBiomesWithStructure('jungle_temple')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/jungle_temple.json"
   - template: biome/biometag.json.ftl
     writer: json
     variables: "type=desert_pyramid"
     condition: ${w.hasBiomesWithStructure('desert_pyramid')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/desert_pyramid.json"
   - template: biome/biometag.json.ftl
     writer: json
     variables: "type=swamp_hut"
     condition: ${w.hasBiomesWithStructure('swamp_hut')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/swamp_hut.json"
   - template: biome/biometag.json.ftl
     writer: json
     variables: "type=ocean_monument"
     condition: ${w.hasBiomesWithStructure('ocean_monument')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/ocean_monument.json"
   - template: biome/biometag.json.ftl
     writer: json
     variables: "type=shipwreck"
     condition: ${w.hasBiomesWithStructure('shipwreck')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/shipwreck.json"
   - template: biome/biometag.json.ftl
     writer: json
     variables: "type=shipwreck_beached"
     condition: ${w.hasBiomesWithStructure('shipwreck_beached')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/shipwreck_beached.json"
   - template: biome/biometag.json.ftl
     writer: json
     variables: "type=buried_treasure"
     condition: ${w.hasBiomesWithStructure('buried_treasure')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/buried_treasure.json"
   - template: biome/biometag.json.ftl
     writer: json
     variables: "type=nether_fortress"
     condition: ${w.hasBiomesWithStructure('nether_fortress')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/nether_fortress.json"
   - template: biome/biometag.json.ftl
     writer: json
     variables: "type=nether_fossil"
     condition: ${w.hasBiomesWithStructure('nether_fossil')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/nether_fossil.json"
   - template: biome/biometag.json.ftl
     writer: json
     variables: "type=bastion_remnant"
     condition: ${w.hasBiomesWithStructure('bastion_remnant')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/bastion_remnant.json"
   - template: biome/biometag.json.ftl
     writer: json
     variables: "type=end_city"
     condition: ${w.hasBiomesWithStructure('end_city')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/end_city.json"
   - template: biome/biometag.json.ftl
     writer: json
     variables: "type=village_desert"
     condition: ${w.hasBiomesWithStructure('village_desert')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/village_desert.json"
   - template: biome/biometag.json.ftl
     writer: json
     variables: "type=village_plains"
     condition: ${w.hasBiomesWithStructure('village_plains')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/village_plains.json"
   - template: biome/biometag.json.ftl
     writer: json
     variables: "type=village_savanna"
     condition: ${w.hasBiomesWithStructure('village_savanna')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/village_savanna.json"
   - template: biome/biometag.json.ftl
     writer: json
     variables: "type=village_snowy"
     condition: ${w.hasBiomesWithStructure('village_snowy')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/village_snowy.json"
   - template: biome/biometag.json.ftl
     writer: json
     variables: "type=village_taiga"
     condition: ${w.hasBiomesWithStructure('village_taiga')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/village_taiga.json"
   - template: biome/biometag.json.ftl
     writer: json
     variables: "type=ocean_ruin_cold"
     condition: ${w.hasBiomesWithStructure('ocean_ruin_cold')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/ocean_ruin_cold.json"
   - template: biome/biometag.json.ftl
     writer: json
     variables: "type=ocean_ruin_warm"
     condition: ${w.hasBiomesWithStructure('ocean_ruin_warm')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/ocean_ruin_warm.json"
   - template: biome/biometag.json.ftl
     writer: json
     variables: "type=ruined_portal_standard"
     condition: ${w.hasBiomesWithStructure('ruined_portal_standard')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/ruined_portal_standard.json"
   - template: biome/biometag.json.ftl
     writer: json
     variables: "type=ruined_portal_desert"
     condition: ${w.hasBiomesWithStructure('ruined_portal_desert')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/ruined_portal_desert.json"
   - template: biome/biometag.json.ftl
     writer: json
     variables: "type=ruined_portal_jungle"
     condition: ${w.hasBiomesWithStructure('ruined_portal_jungle')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/ruined_portal_jungle.json"
   - template: biome/biometag.json.ftl
     writer: json
     variables: "type=ruined_portal_swamp"
     condition: ${w.hasBiomesWithStructure('ruined_portal_swamp')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/ruined_portal_swamp.json"
   - template: biome/biometag.json.ftl
     writer: json
     variables: "type=ruined_portal_mountain"
     condition: ${w.hasBiomesWithStructure('ruined_portal_mountain')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/ruined_portal_mountain.json"
   - template: biome/biometag.json.ftl
     writer: json
     variables: "type=ruined_portal_ocean"
     condition: ${w.hasBiomesWithStructure('ruined_portal_ocean')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/ruined_portal_ocean.json"
   - template: biome/biometag.json.ftl
     writer: json
     variables: "type=ruined_portal_nether"
     condition: ${w.hasBiomesWithStructure('ruined_portal_nether')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/ruined_portal_nether.json"
 
 field_inclusions: [heightVariation, baseHeight, rainingPossibility, temperature,

--- a/plugins/generator-datapack-1.19.x/datapack-1.19.x/biome.definition.yaml
+++ b/plugins/generator-datapack-1.19.x/datapack-1.19.x/biome.definition.yaml
@@ -8,187 +8,156 @@ global_templates:
     writer: json
     variables: "type=mineshaft"
     condition: ${w.hasBiomesWithStructure('mineshaft')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/mineshaft.json"
   - template: biome/biometag.json.ftl
     writer: json
     variables: "type=igloo"
     condition: ${w.hasBiomesWithStructure('igloo')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/igloo.json"
   - template: biome/biometag.json.ftl
     writer: json
     variables: "type=stronghold"
     condition: ${w.hasBiomesWithStructure('stronghold')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/stronghold.json"
   - template: biome/biometag.json.ftl
     writer: json
     variables: "type=mineshaft_mesa"
     condition: ${w.hasBiomesWithStructure('mineshaft_mesa')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/mineshaft_mesa.json"
   - template: biome/biometag.json.ftl
     writer: json
     variables: "type=pillager_outpost"
     condition: ${w.hasBiomesWithStructure('pillager_outpost')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/pillager_outpost.json"
   - template: biome/biometag.json.ftl
     writer: json
     variables: "type=woodland_mansion"
     condition: ${w.hasBiomesWithStructure('woodland_mansion')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/woodland_mansion.json"
   - template: biome/biometag.json.ftl
     writer: json
     variables: "type=jungle_temple"
     condition: ${w.hasBiomesWithStructure('jungle_temple')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/jungle_temple.json"
   - template: biome/biometag.json.ftl
     writer: json
     variables: "type=desert_pyramid"
     condition: ${w.hasBiomesWithStructure('desert_pyramid')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/desert_pyramid.json"
   - template: biome/biometag.json.ftl
     writer: json
     variables: "type=swamp_hut"
     condition: ${w.hasBiomesWithStructure('swamp_hut')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/swamp_hut.json"
   - template: biome/biometag.json.ftl
     writer: json
     variables: "type=ocean_monument"
     condition: ${w.hasBiomesWithStructure('ocean_monument')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/ocean_monument.json"
   - template: biome/biometag.json.ftl
     writer: json
     variables: "type=shipwreck"
     condition: ${w.hasBiomesWithStructure('shipwreck')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/shipwreck.json"
   - template: biome/biometag.json.ftl
     writer: json
     variables: "type=shipwreck_beached"
     condition: ${w.hasBiomesWithStructure('shipwreck_beached')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/shipwreck_beached.json"
   - template: biome/biometag.json.ftl
     writer: json
     variables: "type=buried_treasure"
     condition: ${w.hasBiomesWithStructure('buried_treasure')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/buried_treasure.json"
   - template: biome/biometag.json.ftl
     writer: json
     variables: "type=nether_fortress"
     condition: ${w.hasBiomesWithStructure('nether_fortress')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/nether_fortress.json"
   - template: biome/biometag.json.ftl
     writer: json
     variables: "type=nether_fossil"
     condition: ${w.hasBiomesWithStructure('nether_fossil')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/nether_fossil.json"
   - template: biome/biometag.json.ftl
     writer: json
     variables: "type=bastion_remnant"
     condition: ${w.hasBiomesWithStructure('bastion_remnant')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/bastion_remnant.json"
   - template: biome/biometag.json.ftl
     writer: json
     variables: "type=end_city"
     condition: ${w.hasBiomesWithStructure('end_city')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/end_city.json"
   - template: biome/biometag.json.ftl
     writer: json
     variables: "type=village_desert"
     condition: ${w.hasBiomesWithStructure('village_desert')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/village_desert.json"
   - template: biome/biometag.json.ftl
     writer: json
     variables: "type=village_plains"
     condition: ${w.hasBiomesWithStructure('village_plains')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/village_plains.json"
   - template: biome/biometag.json.ftl
     writer: json
     variables: "type=village_savanna"
     condition: ${w.hasBiomesWithStructure('village_savanna')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/village_savanna.json"
   - template: biome/biometag.json.ftl
     writer: json
     variables: "type=village_snowy"
     condition: ${w.hasBiomesWithStructure('village_snowy')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/village_snowy.json"
   - template: biome/biometag.json.ftl
     writer: json
     variables: "type=village_taiga"
     condition: ${w.hasBiomesWithStructure('village_taiga')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/village_taiga.json"
   - template: biome/biometag.json.ftl
     writer: json
     variables: "type=ocean_ruin_cold"
     condition: ${w.hasBiomesWithStructure('ocean_ruin_cold')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/ocean_ruin_cold.json"
   - template: biome/biometag.json.ftl
     writer: json
     variables: "type=ocean_ruin_warm"
     condition: ${w.hasBiomesWithStructure('ocean_ruin_warm')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/ocean_ruin_warm.json"
   - template: biome/biometag.json.ftl
     writer: json
     variables: "type=ruined_portal_standard"
     condition: ${w.hasBiomesWithStructure('ruined_portal_standard')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/ruined_portal_standard.json"
   - template: biome/biometag.json.ftl
     writer: json
     variables: "type=ruined_portal_desert"
     condition: ${w.hasBiomesWithStructure('ruined_portal_desert')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/ruined_portal_desert.json"
   - template: biome/biometag.json.ftl
     writer: json
     variables: "type=ruined_portal_jungle"
     condition: ${w.hasBiomesWithStructure('ruined_portal_jungle')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/ruined_portal_jungle.json"
   - template: biome/biometag.json.ftl
     writer: json
     variables: "type=ruined_portal_swamp"
     condition: ${w.hasBiomesWithStructure('ruined_portal_swamp')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/ruined_portal_swamp.json"
   - template: biome/biometag.json.ftl
     writer: json
     variables: "type=ruined_portal_mountain"
     condition: ${w.hasBiomesWithStructure('ruined_portal_mountain')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/ruined_portal_mountain.json"
   - template: biome/biometag.json.ftl
     writer: json
     variables: "type=ruined_portal_ocean"
     condition: ${w.hasBiomesWithStructure('ruined_portal_ocean')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/ruined_portal_ocean.json"
   - template: biome/biometag.json.ftl
     writer: json
     variables: "type=ruined_portal_nether"
     condition: ${w.hasBiomesWithStructure('ruined_portal_nether')}
-    deleteWhenConditionFalse: true
     name: "@RESROOT/data/minecraft/tags/worldgen/biome/has_structure/ruined_portal_nether.json"
 
 field_inclusions: [heightVariation, baseHeight, rainingPossibility, temperature,

--- a/src/main/java/net/mcreator/generator/Generator.java
+++ b/src/main/java/net/mcreator/generator/Generator.java
@@ -312,10 +312,9 @@ public class Generator implements IGenerator, Closeable {
 
 			if (TemplateExpressionParser.shouldSkipTemplateBasedOnCondition(this, conditionRaw,
 					workspace.getWorkspaceInfo(), operator)) {
-				if (((Map<?, ?>) template).get("deleteWhenConditionFalse") != null && performFSTasks)
-					if (workspace.getFolderManager().isFileInWorkspace(new File(name))) {
-						new File(name).delete(); // if template is skipped, we delete its potential file
-					}
+				if (workspace.getFolderManager().isFileInWorkspace(new File(name)) && performFSTasks) {
+					new File(name).delete(); // if template is skipped, we delete its potential file
+				}
 				continue;
 			}
 
@@ -412,10 +411,9 @@ public class Generator implements IGenerator, Closeable {
 
 				if (TemplateExpressionParser.shouldSkipTemplateBasedOnCondition(this, conditionRaw,
 						workspace.getWorkspaceInfo(), operator)) {
-					if (((Map<?, ?>) template).get("deleteWhenConditionFalse") != null && performFSTasks)
-						if (workspace.getFolderManager().isFileInWorkspace(new File(name))) {
-							new File(name).delete(); // if template is skipped, we delete its potential file
-						}
+					if (workspace.getFolderManager().isFileInWorkspace(new File(name)) && performFSTasks) {
+						new File(name).delete(); // if template is skipped, we delete its potential file
+					}
 					continue;
 				}
 
@@ -468,13 +466,8 @@ public class Generator implements IGenerator, Closeable {
 								.replace("@registryname", element.getRegistryName())));
 
 				if (TemplateExpressionParser.shouldSkipTemplateBasedOnCondition(this, conditionRaw, generatableElement,
-						operator)) {
-					if (((Map<?, ?>) template).get("deleteWhenConditionFalse") != null && performFSTasks)
-						if (workspace.getFolderManager().isFileInWorkspace(new File(name))) {
-							new File(name).delete(); // if template is skipped, we delete its potential file
-						}
+						operator))
 					continue;
-				}
 
 				GeneratorTemplate generatorTemplate = new GeneratorTemplate(new File(name),
 						Integer.toString(templateID) + ((Map<?, ?>) template).get("template"), (Map<?, ?>) template);


### PR DESCRIPTION
This PR removes `deleteWhenConditionFalse` generator template parameter. Mod element files now use `files` metadata tag and don't need it anymore. As for global files, their conditions are typically based on various type mod elements' usage of certain options, so these are now always deleted if their conditions fail.