### PR TITLE
Templates generation fixes

### DIFF
--- a/.idea/inspectionProfiles/MCreator.xml
+++ b/.idea/inspectionProfiles/MCreator.xml
@@ -22,9 +22,6 @@
       <option name="m_reportAllNonLibraryCalls" value="false" />
       <option name="callCheckString" value="java.io.File,.*,java.io.InputStream,read|skip|available|markSupported,java.io.Reader,read|skip|ready|markSupported,java.lang.Boolean,.*,java.lang.Byte,.*,java.lang.Character,.*,java.lang.Double,.*,java.lang.Float,.*,java.lang.Integer,.*,java.lang.Long,.*,java.lang.Math,.*,java.lang.Object,equals|hashCode|toString,java.lang.Short,.*,java.lang.StrictMath,.*,java.lang.String,.*,java.math.BigInteger,.*,java.math.BigDecimal,.*,java.net.InetAddress,.*,java.net.URI,.*,java.util.UUID,.*,java.util.regex.Matcher,pattern|toMatchResult|start|end|group|groupCount|matches|find|lookingAt|quoteReplacement|replaceAll|replaceFirst|regionStart|regionEnd|hasTransparantBounds|hasAnchoringBounds|hitEnd|requireEnd,java.util.regex.Pattern,.*" />
     </inspection_tool>
-    <inspection_tool class="Java9CollectionFactory" enabled="true" level="WEAK WARNING" enabled_by_default="true">
-      <option name="IGNORE_NON_CONSTANT" value="true" />
-    </inspection_tool>
     <inspection_tool class="JavaDoc" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="TOP_LEVEL_CLASS_OPTIONS">
         <value>

--- a/.idea/inspectionProfiles/MCreator.xml
+++ b/.idea/inspectionProfiles/MCreator.xml
@@ -22,6 +22,9 @@
       <option name="m_reportAllNonLibraryCalls" value="false" />
       <option name="callCheckString" value="java.io.File,.*,java.io.InputStream,read|skip|available|markSupported,java.io.Reader,read|skip|ready|markSupported,java.lang.Boolean,.*,java.lang.Byte,.*,java.lang.Character,.*,java.lang.Double,.*,java.lang.Float,.*,java.lang.Integer,.*,java.lang.Long,.*,java.lang.Math,.*,java.lang.Object,equals|hashCode|toString,java.lang.Short,.*,java.lang.StrictMath,.*,java.lang.String,.*,java.math.BigInteger,.*,java.math.BigDecimal,.*,java.net.InetAddress,.*,java.net.URI,.*,java.util.UUID,.*,java.util.regex.Matcher,pattern|toMatchResult|start|end|group|groupCount|matches|find|lookingAt|quoteReplacement|replaceAll|replaceFirst|regionStart|regionEnd|hasTransparantBounds|hasAnchoringBounds|hitEnd|requireEnd,java.util.regex.Pattern,.*" />
     </inspection_tool>
+    <inspection_tool class="Java9CollectionFactory" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <option name="IGNORE_NON_CONSTANT" value="true" />
+    </inspection_tool>
     <inspection_tool class="JavaDoc" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="TOP_LEVEL_CLASS_OPTIONS">
         <value>

--- a/src/main/java/net/mcreator/generator/Generator.java
+++ b/src/main/java/net/mcreator/generator/Generator.java
@@ -215,7 +215,7 @@ public class Generator implements IGenerator, Closeable {
 		if (element.getModElement().isCodeLocked()) {
 			LOG.debug("Skipping code generation for mod element: " + element.getModElement().getName()
 					+ " - the code of this element is locked");
-			return Collections.emptyList();
+			return new ArrayList<>();
 		}
 
 		Map<?, ?> map = generatorConfiguration.getDefinitionsProvider()
@@ -223,7 +223,7 @@ public class Generator implements IGenerator, Closeable {
 		if (map == null) {
 			LOG.warn("Failed to load element definition for mod element type " + element.getModElement().getType()
 					.getRegistryName());
-			return Collections.emptyList();
+			return new ArrayList<>();
 		}
 
 		Set<GeneratorFile> generatorFiles = new HashSet<>();

--- a/src/main/java/net/mcreator/generator/Generator.java
+++ b/src/main/java/net/mcreator/generator/Generator.java
@@ -229,7 +229,7 @@ public class Generator implements IGenerator, Closeable {
 		Set<GeneratorFile> generatorFiles = new HashSet<>();
 
 		// generate all source files
-		List<GeneratorTemplate> generatorTemplateList = getModElementGeneratorTemplatesList(element, performFSTasks);
+		List<GeneratorTemplate> generatorTemplateList = getModElementGeneratorTemplatesList(element);
 		for (GeneratorTemplate generatorTemplate : generatorTemplateList) {
 			String templateFileName = (String) generatorTemplate.getTemplateDefinition().get("template");
 
@@ -290,7 +290,7 @@ public class Generator implements IGenerator, Closeable {
 			return;
 		}
 
-		for (GeneratorTemplate template : getModElementGeneratorTemplatesList(generatableElement, true)) {
+		for (GeneratorTemplate template : getModElementGeneratorTemplatesList(generatableElement)) {
 			if (workspace.getFolderManager().isFileInWorkspace(template.getFile()))
 				template.getFile().delete();
 		}
@@ -417,11 +417,6 @@ public class Generator implements IGenerator, Closeable {
 	}
 
 	public List<GeneratorTemplate> getModElementGeneratorTemplatesList(GeneratableElement generatableElement) {
-		return getModElementGeneratorTemplatesList(generatableElement, false);
-	}
-
-	private List<GeneratorTemplate> getModElementGeneratorTemplatesList(GeneratableElement generatableElement,
-			boolean performFSTasks) {
 		if (generatableElement == null)
 			throw new RuntimeException("GeneratableElement is null");
 
@@ -462,18 +457,12 @@ public class Generator implements IGenerator, Closeable {
 		}
 
 		// we add all list templates (if any) for given element to the list
-		getModElementListTemplates(generatableElement, performFSTasks).forEach(
-				e -> e.forEachTemplate(files::add, null));
+		getModElementListTemplates(generatableElement).forEach(e -> e.forEachTemplate(files::add, null));
 
 		return new ArrayList<>(files);
 	}
 
 	public List<GeneratorTemplatesList> getModElementListTemplates(GeneratableElement generatableElement) {
-		return getModElementListTemplates(generatableElement, false);
-	}
-
-	private List<GeneratorTemplatesList> getModElementListTemplates(GeneratableElement generatableElement,
-			boolean performFSTasks) {
 		if (generatableElement == null)
 			throw new RuntimeException("GeneratableElement is null");
 

--- a/src/main/java/net/mcreator/generator/Generator.java
+++ b/src/main/java/net/mcreator/generator/Generator.java
@@ -499,8 +499,10 @@ public class Generator implements IGenerator, Closeable {
 				// we check type of list data collection and convert it to a list if needed
 				List<?> items;
 				if (listData instanceof Map<?, ?> listMap)
+					//noinspection Java9CollectionFactory
 					items = Collections.unmodifiableList(new ArrayList<>(listMap.entrySet()));
 				else if (listData instanceof Collection<?> collection)
+					//noinspection Java9CollectionFactory
 					items = Collections.unmodifiableList(new ArrayList<>(collection));
 				else if (listData instanceof Iterable<?> iterable) // fallback for the worst case
 					items = StreamSupport.stream(iterable.spliterator(), false).toList();

--- a/src/main/java/net/mcreator/generator/Generator.java
+++ b/src/main/java/net/mcreator/generator/Generator.java
@@ -229,7 +229,7 @@ public class Generator implements IGenerator, Closeable {
 		Set<GeneratorFile> generatorFiles = new HashSet<>();
 
 		// generate all source files
-		List<GeneratorTemplate> generatorTemplateList = getModElementGeneratorTemplatesList(element);
+		List<GeneratorTemplate> generatorTemplateList = getModElementGeneratorTemplatesList(element, performFSTasks);
 		for (GeneratorTemplate generatorTemplate : generatorTemplateList) {
 			String templateFileName = (String) generatorTemplate.getTemplateDefinition().get("template");
 
@@ -290,7 +290,7 @@ public class Generator implements IGenerator, Closeable {
 			return;
 		}
 
-		for (GeneratorTemplate template : getModElementGeneratorTemplatesList(generatableElement)) {
+		for (GeneratorTemplate template : getModElementGeneratorTemplatesList(generatableElement, true)) {
 			if (workspace.getFolderManager().isFileInWorkspace(template.getFile()))
 				template.getFile().delete();
 		}
@@ -417,6 +417,11 @@ public class Generator implements IGenerator, Closeable {
 	}
 
 	public List<GeneratorTemplate> getModElementGeneratorTemplatesList(GeneratableElement generatableElement) {
+		return getModElementGeneratorTemplatesList(generatableElement, false);
+	}
+
+	private List<GeneratorTemplate> getModElementGeneratorTemplatesList(GeneratableElement generatableElement,
+			boolean performFSTasks) {
 		if (generatableElement == null)
 			throw new RuntimeException("GeneratableElement is null");
 
@@ -457,12 +462,18 @@ public class Generator implements IGenerator, Closeable {
 		}
 
 		// we add all list templates (if any) for given element to the list
-		getModElementListTemplates(generatableElement).forEach(e -> e.forEachTemplate(files::add, null));
+		getModElementListTemplates(generatableElement, performFSTasks).forEach(
+				e -> e.forEachTemplate(files::add, null));
 
 		return new ArrayList<>(files);
 	}
 
 	public List<GeneratorTemplatesList> getModElementListTemplates(GeneratableElement generatableElement) {
+		return getModElementListTemplates(generatableElement, false);
+	}
+
+	private List<GeneratorTemplatesList> getModElementListTemplates(GeneratableElement generatableElement,
+			boolean performFSTasks) {
 		if (generatableElement == null)
 			throw new RuntimeException("GeneratableElement is null");
 

--- a/src/main/java/net/mcreator/generator/Generator.java
+++ b/src/main/java/net/mcreator/generator/Generator.java
@@ -488,11 +488,9 @@ public class Generator implements IGenerator, Closeable {
 				// we check type of list data collection and convert it to a list if needed
 				List<?> items;
 				if (listData instanceof Map<?, ?> listMap)
-					//noinspection Java9CollectionFactory
-					items = Collections.unmodifiableList(new ArrayList<>(listMap.entrySet()));
+					items = List.copyOf(listMap.entrySet());
 				else if (listData instanceof Collection<?> collection)
-					//noinspection Java9CollectionFactory
-					items = Collections.unmodifiableList(new ArrayList<>(collection));
+					items = List.copyOf(collection);
 				else if (listData instanceof Iterable<?> iterable) // fallback for the worst case
 					items = StreamSupport.stream(iterable.spliterator(), false).toList();
 				else


### PR DESCRIPTION
Some kind of continuation of #3426 that fixes even more bugs found in `Generator` after its refactoring.
* Replaced some of `Collections.emptyList()` calls with new list constructor to avoid `UnsupportedOperationException`s;
* Future list data of a `GeneratorTemplatesList` is now unmodifiable from the very moment it's acquired;
* Removed `performFSTasks` argument from methods getting regular and list templates as these don't use it anymore (pushed as a separate commit to revert in case of being future-proof).