### PR TITLE
Change MCR version to 2023.1

### DIFF
--- a/src/main/resources/mcreator.conf
+++ b/src/main/resources/mcreator.conf
@@ -1,1 +1,1 @@
-mcreator=2022.4
+mcreator=2023.1


### PR DESCRIPTION
I noticed while making a personal MCreator version (to start working on Blockly panels for my Plugin Maker generator) that MCreator is still on 2022.4, instead of 2023.1. It doesn't change much for the moment, but just in case we forget.