### PR TITLE
Improved unique name validator

### DIFF
--- a/src/main/java/net/mcreator/ui/dialogs/NewModElementDialog.java
+++ b/src/main/java/net/mcreator/ui/dialogs/NewModElementDialog.java
@@ -29,7 +29,7 @@ import net.mcreator.ui.validation.Validator;
 import net.mcreator.ui.validation.component.VTextField;
 import net.mcreator.ui.validation.optionpane.OptionPaneValidatior;
 import net.mcreator.ui.validation.optionpane.VOptionPane;
-import net.mcreator.ui.validation.validators.UniqueNameValidator;
+import net.mcreator.ui.validation.validators.ModElementNameValidator;
 import net.mcreator.workspace.elements.ModElement;
 
 import javax.swing.*;
@@ -53,8 +53,8 @@ public class NewModElementDialog {
 								regNameString == null || regNameString.equals("") ?
 										L10N.t("dialog.new_modelement.registry_name.empty") :
 										regNameString));
-						return UniqueNameValidator.createModElementNameValidator(mcreator.getWorkspace(),
-								(VTextField) component, L10N.t("common.mod_element_name")).validate();
+						return new ModElementNameValidator(mcreator.getWorkspace(), (VTextField) component,
+								L10N.t("common.mod_element_name")).validate();
 					}
 				}, L10N.t("dialog.new_modelement.create_new", type.getReadableName()),
 				UIManager.getString("OptionPane.cancelButtonText"), null, regName);

--- a/src/main/java/net/mcreator/ui/dialogs/tools/ArmorPackMakerTool.java
+++ b/src/main/java/net/mcreator/ui/dialogs/tools/ArmorPackMakerTool.java
@@ -37,7 +37,7 @@ import net.mcreator.ui.minecraft.MCItemHolder;
 import net.mcreator.ui.validation.Validator;
 import net.mcreator.ui.validation.component.VTextField;
 import net.mcreator.ui.validation.validators.MCItemHolderValidator;
-import net.mcreator.ui.validation.validators.UniqueNameValidator;
+import net.mcreator.ui.validation.validators.ModElementNameValidator;
 import net.mcreator.ui.views.ArmorImageMakerView;
 import net.mcreator.util.StringUtils;
 import net.mcreator.util.image.ImageUtils;
@@ -97,7 +97,7 @@ public class ArmorPackMakerTool {
 		props.add(L10N.label("dialog.tools.armor_pack_power_factor"));
 		props.add(power);
 
-		name.setValidator(UniqueNameValidator.createModElementNameValidator(mcreator.getWorkspace(), name,
+		name.setValidator(new ModElementNameValidator(mcreator.getWorkspace(), name,
 				L10N.t("dialog.tools.armor_pack_name_validator")));
 
 		dialog.add("Center", PanelUtils.centerInPanel(props));

--- a/src/main/java/net/mcreator/ui/dialogs/tools/MaterialPackMakerTool.java
+++ b/src/main/java/net/mcreator/ui/dialogs/tools/MaterialPackMakerTool.java
@@ -32,7 +32,7 @@ import net.mcreator.ui.init.L10N;
 import net.mcreator.ui.init.UIRES;
 import net.mcreator.ui.validation.Validator;
 import net.mcreator.ui.validation.component.VTextField;
-import net.mcreator.ui.validation.validators.UniqueNameValidator;
+import net.mcreator.ui.validation.validators.ModElementNameValidator;
 import net.mcreator.workspace.Workspace;
 
 import javax.swing.*;
@@ -71,7 +71,7 @@ public class MaterialPackMakerTool {
 		props.add(L10N.label("dialog.tools.material_pack_power_factor"));
 		props.add(power);
 
-		name.setValidator(UniqueNameValidator.createModElementNameValidator(mcreator.getWorkspace(), name,
+		name.setValidator(new ModElementNameValidator(mcreator.getWorkspace(), name,
 				L10N.t("dialog.tools.material_pack_name_validator")));
 
 		dialog.add("Center", PanelUtils.centerInPanel(props));

--- a/src/main/java/net/mcreator/ui/dialogs/tools/OrePackMakerTool.java
+++ b/src/main/java/net/mcreator/ui/dialogs/tools/OrePackMakerTool.java
@@ -41,7 +41,7 @@ import net.mcreator.ui.init.L10N;
 import net.mcreator.ui.init.UIRES;
 import net.mcreator.ui.validation.Validator;
 import net.mcreator.ui.validation.component.VTextField;
-import net.mcreator.ui.validation.validators.UniqueNameValidator;
+import net.mcreator.ui.validation.validators.ModElementNameValidator;
 import net.mcreator.ui.workspace.resources.TextureType;
 import net.mcreator.util.ListUtils;
 import net.mcreator.util.image.ImageUtils;
@@ -89,7 +89,7 @@ public class OrePackMakerTool {
 		props.add(L10N.label("dialog.tools.ore_pack_power_factor"));
 		props.add(power);
 
-		name.setValidator(UniqueNameValidator.createModElementNameValidator(mcreator.getWorkspace(), name,
+		name.setValidator(new ModElementNameValidator(mcreator.getWorkspace(), name,
 				L10N.t("dialog.tools.ore_pack_name_validator")));
 
 		dialog.add("Center", PanelUtils.centerInPanel(props));

--- a/src/main/java/net/mcreator/ui/dialogs/tools/ToolPackMakerTool.java
+++ b/src/main/java/net/mcreator/ui/dialogs/tools/ToolPackMakerTool.java
@@ -42,7 +42,7 @@ import net.mcreator.ui.minecraft.MCItemHolder;
 import net.mcreator.ui.validation.Validator;
 import net.mcreator.ui.validation.component.VTextField;
 import net.mcreator.ui.validation.validators.MCItemHolderValidator;
-import net.mcreator.ui.validation.validators.UniqueNameValidator;
+import net.mcreator.ui.validation.validators.ModElementNameValidator;
 import net.mcreator.ui.workspace.resources.TextureType;
 import net.mcreator.util.StringUtils;
 import net.mcreator.util.image.ImageUtils;
@@ -103,7 +103,7 @@ public class ToolPackMakerTool {
 		props.add(L10N.label("dialog.tools.tool_pack_power_factor"));
 		props.add(power);
 
-		name.setValidator(UniqueNameValidator.createModElementNameValidator(mcreator.getWorkspace(), name,
+		name.setValidator(new ModElementNameValidator(mcreator.getWorkspace(), name,
 				L10N.t("dialog.tools.tool_pack_name_validator")));
 
 		dialog.add("Center", PanelUtils.centerInPanel(props));

--- a/src/main/java/net/mcreator/ui/dialogs/tools/WoodPackMakerTool.java
+++ b/src/main/java/net/mcreator/ui/dialogs/tools/WoodPackMakerTool.java
@@ -42,7 +42,7 @@ import net.mcreator.ui.init.L10N;
 import net.mcreator.ui.init.UIRES;
 import net.mcreator.ui.validation.Validator;
 import net.mcreator.ui.validation.component.VTextField;
-import net.mcreator.ui.validation.validators.UniqueNameValidator;
+import net.mcreator.ui.validation.validators.ModElementNameValidator;
 import net.mcreator.ui.workspace.resources.TextureType;
 import net.mcreator.util.ListUtils;
 import net.mcreator.util.image.ImageUtils;
@@ -83,7 +83,7 @@ public class WoodPackMakerTool {
 		props.add(L10N.label("dialog.tools.wood_pack_power_factor"));
 		props.add(power);
 
-		name.setValidator(UniqueNameValidator.createModElementNameValidator(mcreator.getWorkspace(), name,
+		name.setValidator(new ModElementNameValidator(mcreator.getWorkspace(), name,
 				L10N.t("dialog.tools.wood_pack_name_validator")));
 
 		dialog.add("Center", PanelUtils.centerInPanel(props));

--- a/src/main/java/net/mcreator/ui/dialogs/wysiwyg/CheckboxDialog.java
+++ b/src/main/java/net/mcreator/ui/dialogs/wysiwyg/CheckboxDialog.java
@@ -51,8 +51,8 @@ public class CheckboxDialog extends AbstractWYSIWYGDialog<Checkbox> {
 
 		VTextField nameField = new VTextField(20);
 		nameField.setPreferredSize(new Dimension(200, 28));
-		UniqueNameValidator validator = new UniqueNameValidator(nameField, L10N.t("dialog.gui.checkbox_name_validator"),
-				Transliteration::transliterateString,
+		UniqueNameValidator validator = new UniqueNameValidator(L10N.t("dialog.gui.checkbox_name_validator"),
+				() -> Transliteration.transliterateString(nameField.getText()),
 				() -> editor.getComponentList().stream().map(GUIComponent::getName),
 				new JavaMemberNameValidator(nameField, false));
 		validator.setIsPresentOnList(checkbox != null);

--- a/src/main/java/net/mcreator/ui/dialogs/wysiwyg/TextFieldDialog.java
+++ b/src/main/java/net/mcreator/ui/dialogs/wysiwyg/TextFieldDialog.java
@@ -43,8 +43,8 @@ public class TextFieldDialog extends AbstractWYSIWYGDialog<TextField> {
 
 		VTextField nameField = new VTextField(20);
 		nameField.setPreferredSize(new Dimension(200, 28));
-		UniqueNameValidator validator = new UniqueNameValidator(nameField,
-				L10N.t("dialog.gui.textfield_name_validator"), Transliteration::transliterateString,
+		UniqueNameValidator validator = new UniqueNameValidator(L10N.t("dialog.gui.textfield_name_validator"),
+				() -> Transliteration.transliterateString(nameField.getText()),
 				() -> editor.getComponentList().stream().map(GUIComponent::getName),
 				new JavaMemberNameValidator(nameField, false));
 		validator.setIsPresentOnList(textField != null);

--- a/src/main/java/net/mcreator/ui/procedure/ProcedureSelector.java
+++ b/src/main/java/net/mcreator/ui/procedure/ProcedureSelector.java
@@ -36,7 +36,7 @@ import net.mcreator.ui.modgui.ModElementGUI;
 import net.mcreator.ui.validation.component.VTextField;
 import net.mcreator.ui.validation.optionpane.OptionPaneValidatior;
 import net.mcreator.ui.validation.optionpane.VOptionPane;
-import net.mcreator.ui.validation.validators.UniqueNameValidator;
+import net.mcreator.ui.validation.validators.ModElementNameValidator;
 import net.mcreator.util.StringUtils;
 import net.mcreator.workspace.elements.ModElement;
 import net.mcreator.workspace.elements.VariableType;
@@ -180,8 +180,8 @@ public class ProcedureSelector extends AbstractProcedureSelector {
 						L10N.t("action.procedure.enter_procedure_name"),
 						L10N.t("action.procedure.new_procedure_dialog_title"), null, new OptionPaneValidatior() {
 							@Override public ValidationResult validate(JComponent component) {
-								return UniqueNameValidator.createModElementNameValidator(mcreator.getWorkspace(),
-										(VTextField) component, L10N.t("common.mod_element_name")).validate();
+								return new ModElementNameValidator(mcreator.getWorkspace(), (VTextField) component,
+										L10N.t("common.mod_element_name")).validate();
 							}
 						}, L10N.t("action.procedure.create_procedure"),
 						UIManager.getString("OptionPane.cancelButtonText"), procedureNameString);

--- a/src/main/java/net/mcreator/ui/procedure/RetvalProcedureSelector.java
+++ b/src/main/java/net/mcreator/ui/procedure/RetvalProcedureSelector.java
@@ -40,7 +40,7 @@ import net.mcreator.ui.modgui.ModElementGUI;
 import net.mcreator.ui.validation.component.VTextField;
 import net.mcreator.ui.validation.optionpane.OptionPaneValidatior;
 import net.mcreator.ui.validation.optionpane.VOptionPane;
-import net.mcreator.ui.validation.validators.UniqueNameValidator;
+import net.mcreator.ui.validation.validators.ModElementNameValidator;
 import net.mcreator.util.StringUtils;
 import net.mcreator.workspace.elements.ModElement;
 import net.mcreator.workspace.elements.VariableType;
@@ -144,8 +144,8 @@ public abstract class RetvalProcedureSelector<E, T extends RetvalProcedure<E>> e
 			procedureNameString = VOptionPane.showInputDialog(mcreator, L10N.t("action.procedure.enter_procedure_name"),
 					L10N.t("action.procedure.new_procedure_dialog_title"), null, new OptionPaneValidatior() {
 						@Override public ValidationResult validate(JComponent component) {
-							return UniqueNameValidator.createModElementNameValidator(mcreator.getWorkspace(),
-									(VTextField) component, L10N.t("common.mod_element_name")).validate();
+							return new ModElementNameValidator(mcreator.getWorkspace(), (VTextField) component,
+									L10N.t("common.mod_element_name")).validate();
 						}
 					}, L10N.t("action.procedure.create_procedure"), UIManager.getString("OptionPane.cancelButtonText"),
 					procedureNameString);

--- a/src/main/java/net/mcreator/ui/validation/validators/ModElementNameValidator.java
+++ b/src/main/java/net/mcreator/ui/validation/validators/ModElementNameValidator.java
@@ -1,0 +1,38 @@
+/*
+ * MCreator (https://mcreator.net/)
+ * Copyright (C) 2020 Pylo and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package net.mcreator.ui.validation.validators;
+
+import net.mcreator.java.JavaConventions;
+import net.mcreator.ui.init.L10N;
+import net.mcreator.ui.validation.component.VTextField;
+import net.mcreator.workspace.Workspace;
+import net.mcreator.workspace.elements.ModElement;
+
+import javax.annotation.Nonnull;
+
+public class ModElementNameValidator extends UniqueNameValidator {
+
+	public ModElementNameValidator(@Nonnull Workspace workspace, VTextField textField, String name) {
+		super(name, () -> JavaConventions.convertToValidClassName(textField.getText()),
+				() -> workspace.getModElements().stream().map(ModElement::getName),
+				new JavaMemberNameValidator(textField, true));
+		setIsPresentOnList(false);
+		setIgnoreCase(true);
+	}
+}

--- a/src/main/java/net/mcreator/ui/validation/validators/UniqueNameValidator.java
+++ b/src/main/java/net/mcreator/ui/validation/validators/UniqueNameValidator.java
@@ -19,31 +19,25 @@
 
 package net.mcreator.ui.validation.validators;
 
-import net.mcreator.java.JavaConventions;
 import net.mcreator.ui.init.L10N;
 import net.mcreator.ui.validation.Validator;
-import net.mcreator.ui.validation.component.VTextField;
-import net.mcreator.workspace.Workspace;
-import net.mcreator.workspace.elements.ModElement;
 
-import javax.swing.*;
 import java.util.Collections;
 import java.util.List;
-import java.util.function.Function;
+import java.util.Objects;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 /**
- * While serving as a wrapper for the main validator of the text field instance, a unique name validator also checks
- * that the provided text field defines a non-empty name that has no duplicates in the given elements list.
+ * While serving as a wrapper for the main component validator (if specified), a unique name validator also checks
+ * if that component provides a non-empty identifier that has no duplicates in the given elements list.
  */
 public class UniqueNameValidator implements Validator {
 
 	private final String name;
-	private final JTextField holder;
+	private final Supplier<String> uniqueNameGetter;
 
-	private final Function<String, String> uniqueNameGetter;
 	private final Supplier<Stream<String>> otherNames;
 	private boolean isPresentOnList;
 	private boolean ignoreCase;
@@ -52,58 +46,32 @@ public class UniqueNameValidator implements Validator {
 	private final Validator extraValidator;
 
 	/**
-	 * @param holder         The element to add this validator to.
-	 * @param name           The text used to describe the purpose of the {@code holder}.
-	 * @param otherNames     Supplier of names of other elements in the same list. Those must all be unique names.
-	 * @param extraValidator The main validator for the {@code holder}.
-	 */
-	public UniqueNameValidator(VTextField holder, String name, Supplier<Stream<String>> otherNames,
-			Validator extraValidator) {
-		this(holder, name, e -> e, otherNames, Collections.emptyList(), extraValidator);
-	}
-
-	/**
-	 * @param holder         The element to add this validator to.
-	 * @param name           The text used to describe the purpose of the {@code holder}.
-	 * @param otherNames     Supplier of names of other elements in the same list. Those must all be unique names.
-	 * @param forbiddenNames List of strings that must not be used as a name, e.g. names of built-in properties.
-	 * @param extraValidator The main validator for the {@code holder}.
-	 */
-	public UniqueNameValidator(VTextField holder, String name, Supplier<Stream<String>> otherNames,
-			List<String> forbiddenNames, Validator extraValidator) {
-		this(holder, name, e -> e, otherNames, forbiddenNames, extraValidator);
-	}
-
-	/**
-	 * @param holder           The element to add this validator to.
-	 * @param name             The text used to describe the purpose of the {@code holder}.
-	 * @param uniqueNameGetter The function to get unique name from the {@code holder}'s text.
+	 * @param name             The text used to describe the purpose of the holder.
+	 * @param uniqueNameGetter Supplier to get unique name from the holder's text.
 	 * @param otherNames       Supplier of names of other elements in the same list. Those must all be unique names.
-	 * @param extraValidator   The main validator for the {@code holder}.
+	 * @param extraValidator   The main validator for the holder.
 	 */
-	public UniqueNameValidator(VTextField holder, String name, Function<String, String> uniqueNameGetter,
-			Supplier<Stream<String>> otherNames, Validator extraValidator) {
-		this(holder, name, uniqueNameGetter, otherNames, Collections.emptyList(), extraValidator);
+	public UniqueNameValidator(String name, Supplier<String> uniqueNameGetter, Supplier<Stream<String>> otherNames,
+			Validator extraValidator) {
+		this(name, uniqueNameGetter, otherNames, Collections.emptyList(), extraValidator);
 	}
 
 	/**
-	 * @param holder           The element to add this validator to.
-	 * @param name             The text used to describe the purpose of the {@code holder}.
-	 * @param uniqueNameGetter The function to get unique name from the {@code holder}'s text.
+	 * @param name             The text used to describe the purpose of the holder.
+	 * @param uniqueNameGetter Supplier to get unique name from the holder's text.
 	 * @param otherNames       Supplier of names of other elements in the same list. Those must all be unique names.
 	 * @param forbiddenNames   List of strings that must not be used as a name, e.g. names of built-in properties.
-	 * @param extraValidator   The main validator for the {@code holder}.
+	 * @param extraValidator   The main validator for the holder.
 	 */
-	public UniqueNameValidator(VTextField holder, String name, Function<String, String> uniqueNameGetter,
-			Supplier<Stream<String>> otherNames, List<String> forbiddenNames, Validator extraValidator) {
+	public UniqueNameValidator(String name, Supplier<String> uniqueNameGetter, Supplier<Stream<String>> otherNames,
+			List<String> forbiddenNames, Validator extraValidator) {
 		this.name = name;
-		this.holder = holder;
 		this.uniqueNameGetter = uniqueNameGetter;
 		this.otherNames = otherNames;
 		this.isPresentOnList = true;
 		this.ignoreCase = false;
 		this.forbiddenNames = forbiddenNames;
-		this.extraValidator = extraValidator != null ? extraValidator : () -> ValidationResult.PASSED;
+		this.extraValidator = Objects.requireNonNullElse(extraValidator, () -> ValidationResult.PASSED);
 	}
 
 	/**
@@ -135,28 +103,8 @@ public class UniqueNameValidator implements Validator {
 	 * @param extraValidator The new main validator for the validated element.
 	 */
 	public UniqueNameValidator wrapValidator(Validator extraValidator) {
-		return new UniqueNameValidator((VTextField) holder, name, uniqueNameGetter, otherNames, forbiddenNames,
+		return new UniqueNameValidator(name, uniqueNameGetter, otherNames, forbiddenNames,
 				extraValidator).setIsPresentOnList(isPresentOnList).setIgnoreCase(ignoreCase);
-	}
-
-	/**
-	 * Creates an instance of unique name validator to validate new mod element's name (formerly known as a
-	 * separate class called <i>{@code ModElementNameValidator}</i>).
-	 *
-	 * @param workspace The workspace to check for mod elements with the same name.
-	 * @param textField The text field to be validated.
-	 * @param name      The text used to describe the purpose of the {@code textField}.
-	 * @return An unique name validator to validate new mod element's name.
-	 */
-	public static UniqueNameValidator createModElementNameValidator(Workspace workspace, VTextField textField,
-			String name) {
-		UniqueNameValidator validator = new UniqueNameValidator(textField, name,
-				JavaConventions::convertToValidClassName,
-				() -> workspace.getModElements().stream().map(ModElement::getName),
-				new JavaMemberNameValidator(textField, true));
-		validator.setIsPresentOnList(false);
-		validator.setIgnoreCase(true);
-		return validator;
 	}
 
 	/**
@@ -173,7 +121,7 @@ public class UniqueNameValidator implements Validator {
 	}
 
 	@Override public ValidationResult validate() {
-		String uniqueName = uniqueNameGetter.apply(holder.getText());
+		String uniqueName = uniqueNameGetter.get();
 		if (uniqueName == null || uniqueName.equals(""))
 			return new ValidationResult(ValidationResultType.ERROR, L10N.t("validators.unique_name.empty", name));
 		if (otherNames.get().filter(textCheck(uniqueName)).count() > (isPresentOnList ? 1 : 0)

--- a/src/main/java/net/mcreator/ui/workspace/WorkspacePanel.java
+++ b/src/main/java/net/mcreator/ui/workspace/WorkspacePanel.java
@@ -50,7 +50,7 @@ import net.mcreator.ui.validation.Validator;
 import net.mcreator.ui.validation.component.VTextField;
 import net.mcreator.ui.validation.optionpane.OptionPaneValidatior;
 import net.mcreator.ui.validation.optionpane.VOptionPane;
-import net.mcreator.ui.validation.validators.UniqueNameValidator;
+import net.mcreator.ui.validation.validators.ModElementNameValidator;
 import net.mcreator.ui.workspace.breadcrumb.WorkspaceFolderBreadcrumb;
 import net.mcreator.ui.workspace.resources.WorkspacePanelResources;
 import net.mcreator.util.image.EmptyIcon;
@@ -1138,8 +1138,8 @@ import java.util.stream.Collectors;
 						L10N.t("workspace.elements.duplicate_element", mu.getName()), mu.getElementIcon(),
 						new OptionPaneValidatior() {
 							@Override public Validator.ValidationResult validate(JComponent component) {
-								return UniqueNameValidator.createModElementNameValidator(mcreator.getWorkspace(),
-										(VTextField) component, L10N.t("common.mod_element_name")).validate();
+								return new ModElementNameValidator(mcreator.getWorkspace(), (VTextField) component,
+										L10N.t("common.mod_element_name")).validate();
 							}
 						}, L10N.t("workspace.elements.duplicate"), UIManager.getString("OptionPane.cancelButtonText"));
 				if (modName != null && !modName.equals("")) {

--- a/src/main/java/net/mcreator/ui/workspace/WorkspacePanelVariables.java
+++ b/src/main/java/net/mcreator/ui/workspace/WorkspacePanelVariables.java
@@ -121,8 +121,8 @@ class WorkspacePanelVariables extends JPanel implements IReloadableFilterable {
 				} else if (modelColumn == 0) {
 					VTextField name = new VTextField();
 					name.enableRealtimeValidation();
-					UniqueNameValidator validator = new UniqueNameValidator(name,
-							L10N.t("workspace.variables.variable_name"), Transliteration::transliterateString,
+					UniqueNameValidator validator = new UniqueNameValidator(L10N.t("workspace.variables.variable_name"),
+							() -> Transliteration.transliterateString(name.getText()),
 							() -> TableUtil.getColumnContents(elements, 0).stream(),
 							new JavaMemberNameValidator(name, false));
 					name.setValidator(validator);
@@ -229,8 +229,9 @@ class WorkspacePanelVariables extends JPanel implements IReloadableFilterable {
 			VariableElement element = NewVariableDialog.showNewVariableDialog(workspacePanel.getMcreator(), true,
 					new OptionPaneValidatior() {
 						@Override public ValidationResult validate(JComponent component) {
-							UniqueNameValidator validator = new UniqueNameValidator((VTextField) component,
-									L10N.t("workspace.variables.variable_name"), Transliteration::transliterateString,
+							UniqueNameValidator validator = new UniqueNameValidator(
+									L10N.t("workspace.variables.variable_name"),
+									() -> Transliteration.transliterateString(((VTextField) component).getText()),
 									() -> TableUtil.getColumnContents(elements, 0).stream(),
 									new JavaMemberNameValidator((VTextField) component, false));
 							validator.setIsPresentOnList(false);


### PR DESCRIPTION
This PR resolves some confusing things related to unique name validators:
* Mod element name validator is moved from a static method back to its own class;
* Additional text converter function parameter could look confusing, so it was (together with `holder` parameter) replaced with a supplier of a unique string identifier (which should also allow validation of not only text fields but e.g. block/item or texture holders as well).