### PR TITLE
Added new events for Java plugins

### DIFF
--- a/src/main/java/net/mcreator/plugin/events/ui/ModElementGUIEvent.java
+++ b/src/main/java/net/mcreator/plugin/events/ui/ModElementGUIEvent.java
@@ -35,7 +35,7 @@ public class ModElementGUIEvent extends TabEvent {
 	 * @param tab <p>The {@link MCreatorTabs.Tab} that is opened for the {@link ModElementGUI}.</p>
 	 * @param modElementGUI <p>The {@link ModElementGUI} that calls each event.</p>
 	 */
-	public ModElementGUIEvent(MCreator mcreator, MCreatorTabs.Tab tab, ModElementGUI<?> modElementGUI) {
+	protected ModElementGUIEvent(MCreator mcreator, MCreatorTabs.Tab tab, ModElementGUI<?> modElementGUI) {
 		super(tab);
 		this.mcreator = mcreator;
 		this.modElementGUI = modElementGUI;

--- a/src/main/java/net/mcreator/plugin/events/ui/ModElementGUIEvent.java
+++ b/src/main/java/net/mcreator/plugin/events/ui/ModElementGUIEvent.java
@@ -19,19 +19,30 @@
 
 package net.mcreator.plugin.events.ui;
 
+import net.mcreator.ui.MCreator;
 import net.mcreator.ui.MCreatorTabs;
 import net.mcreator.ui.modgui.ModElementGUI;
 
-/**
- * <p>These events are triggered at different states of a {@link ModElementGUI} loading.</p>
- */
 public class ModElementGUIEvent extends TabEvent {
 
+	private final MCreator mcreator;
 	private final ModElementGUI<?> modElementGUI;
 
-	public ModElementGUIEvent(MCreatorTabs.Tab tab, ModElementGUI<?> modElementGUI) {
+	/**
+	 * <p>These events are triggered at different states of a {@link ModElementGUI} loading.
+	 * However, this constructor is never called outside this class.</p>
+	 * @param mcreator <p>The {@link MCreator} instance where the mod element is.</p>
+	 * @param tab <p>The {@link MCreatorTabs.Tab} that is opened for the {@link ModElementGUI}.</p>
+	 * @param modElementGUI <p>The {@link ModElementGUI} that calls each event.</p>
+	 */
+	public ModElementGUIEvent(MCreator mcreator, MCreatorTabs.Tab tab, ModElementGUI<?> modElementGUI) {
 		super(tab);
+		this.mcreator = mcreator;
 		this.modElementGUI = modElementGUI;
+	}
+
+	public MCreator getMCreator() {
+		return mcreator;
 	}
 
 	public ModElementGUI<?> getModElementGUI() {
@@ -44,8 +55,8 @@ public class ModElementGUIEvent extends TabEvent {
 	 * of the mod element.
 	 */
 	public static class BeforeLoading extends ModElementGUIEvent {
-		public BeforeLoading(MCreatorTabs.Tab tab, ModElementGUI<?> modElementGUI) {
-			super(tab, modElementGUI);
+		public BeforeLoading(MCreator mcreator, MCreatorTabs.Tab tab, ModElementGUI<?> modElementGUI) {
+			super(mcreator, tab, modElementGUI);
 		}
 	}
 
@@ -55,8 +66,27 @@ public class ModElementGUIEvent extends TabEvent {
 	 * of the mod element.
 	 */
 	public static class AfterLoading extends ModElementGUIEvent {
-		public AfterLoading(MCreatorTabs.Tab tab, ModElementGUI<?> modElementGUI) {
-			super(tab, modElementGUI);
+		public AfterLoading(MCreator mcreator, MCreatorTabs.Tab tab, ModElementGUI<?> modElementGUI) {
+			super(mcreator, tab, modElementGUI);
+		}
+	}
+
+	/**
+	 * <p>When a {@link ModElementGUI} will be saved, MCreator triggers this event.
+	 * The process of saving the mod element happens just after this event is executed.</p>
+	 */
+	public static class WhenSaving extends ModElementGUIEvent {
+		/**
+		 * <p>{@code True} when the user clicks on Save only. {@code False} when the mod element is saved and then, closed.</p>
+		 */
+		private final boolean savesOnly;
+		public WhenSaving(MCreator mcreator, MCreatorTabs.Tab tab, ModElementGUI<?> modElementGUI, boolean savesOnly) {
+			super(mcreator, tab, modElementGUI);
+			this.savesOnly = savesOnly;
+		}
+
+		public boolean isSavedOnly() {
+			return savesOnly;
 		}
 	}
 }

--- a/src/main/java/net/mcreator/plugin/events/ui/PreferencesDialogEvent.java
+++ b/src/main/java/net/mcreator/plugin/events/ui/PreferencesDialogEvent.java
@@ -35,7 +35,7 @@ public class PreferencesDialogEvent extends MCREvent {
 	 *
 	 * @param preferencesDialog <p>The {@link PreferencesDialog} window that will be shown to the user.</p>
 	 */
-	public PreferencesDialogEvent(PreferencesDialog preferencesDialog) {
+	protected PreferencesDialogEvent(PreferencesDialog preferencesDialog) {
 		this.preferencesDialog = preferencesDialog;
 	}
 

--- a/src/main/java/net/mcreator/plugin/events/ui/TabEvent.java
+++ b/src/main/java/net/mcreator/plugin/events/ui/TabEvent.java
@@ -30,7 +30,7 @@ public class TabEvent extends MCREvent {
 
 	private final MCreatorTabs.Tab tab;
 
-	public TabEvent(MCreatorTabs.Tab tab) {
+	protected TabEvent(MCreatorTabs.Tab tab) {
 		this.tab = tab;
 	}
 

--- a/src/main/java/net/mcreator/plugin/events/workspace/MCreatorLoadedEvent.java
+++ b/src/main/java/net/mcreator/plugin/events/workspace/MCreatorLoadedEvent.java
@@ -17,7 +17,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package net.mcreator.plugin.events;
+package net.mcreator.plugin.events.workspace;
 
 import net.mcreator.plugin.MCREvent;
 import net.mcreator.ui.MCreator;
@@ -26,6 +26,11 @@ public class MCreatorLoadedEvent extends MCREvent {
 
 	private final MCreator mcreator;
 
+	/**
+	 * <p>An event triggered when a new {@link MCreator} window is opened, meaning a new {@link net.mcreator.workspace.Workspace} has been created or opened.</p>
+	 *
+	 * @param mcreator <p>The opened MCreator window</p>
+	 */
 	public MCreatorLoadedEvent(MCreator mcreator) {
 		this.mcreator = mcreator;
 	}

--- a/src/main/java/net/mcreator/plugin/events/workspace/WorkspaceRefactoringEvent.java
+++ b/src/main/java/net/mcreator/plugin/events/workspace/WorkspaceRefactoringEvent.java
@@ -1,0 +1,41 @@
+/*
+ * MCreator (https://mcreator.net/)
+ * Copyright (C) 2012-2020, Pylo
+ * Copyright (C) 2020-2023, Pylo, opensource contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package net.mcreator.plugin.events.workspace;
+
+import net.mcreator.plugin.MCREvent;
+import net.mcreator.ui.MCreator;
+import net.mcreator.workspace.settings.WorkspaceSettingsChange;
+
+public class WorkspaceRefactoringEvent extends MCREvent {
+	private MCreator mcreator;
+	private WorkspaceSettingsChange change;
+
+	/**
+	 * <p>An event triggered each time MCreator refactors a {@link net.mcreator.workspace.Workspace}.
+	 * This is called BEFORE MCreator starts refactoring, but when the refactor is sure to happen.</p>
+	 *
+	 * @param mcreator <p>The {@link MCreator} of the workspace</p>
+	 * @param change <p>This variable contains the new workspace settings.</p>
+	 */
+	public WorkspaceRefactoringEvent(MCreator mcreator, WorkspaceSettingsChange change) {
+		this.mcreator = mcreator;
+		this.change = change;
+	}
+}

--- a/src/main/java/net/mcreator/plugin/events/workspace/WorkspaceRefactoringEvent.java
+++ b/src/main/java/net/mcreator/plugin/events/workspace/WorkspaceRefactoringEvent.java
@@ -38,4 +38,12 @@ public class WorkspaceRefactoringEvent extends MCREvent {
 		this.mcreator = mcreator;
 		this.change = change;
 	}
+
+	public MCreator getMcreator() {
+		return mcreator;
+	}
+
+	public WorkspaceSettingsChange getChange() {
+		return change;
+	}
 }

--- a/src/main/java/net/mcreator/plugin/events/workspace/WorkspaceRefactoringEvent.java
+++ b/src/main/java/net/mcreator/plugin/events/workspace/WorkspaceRefactoringEvent.java
@@ -39,7 +39,7 @@ public class WorkspaceRefactoringEvent extends MCREvent {
 		this.change = change;
 	}
 
-	public MCreator getMcreator() {
+	public MCreator getMCreator() {
 		return mcreator;
 	}
 

--- a/src/main/java/net/mcreator/plugin/events/workspace/WorkspaceSavedEvent.java
+++ b/src/main/java/net/mcreator/plugin/events/workspace/WorkspaceSavedEvent.java
@@ -22,14 +22,16 @@ package net.mcreator.plugin.events.workspace;
 import net.mcreator.plugin.MCREvent;
 import net.mcreator.workspace.Workspace;
 
-/**
- * <p>This event class handles events when a workspace is being saved. This event is not triggered in a place of the code.
- * It only stores the sub-events and variables that can be used.</p>
- */
+
 public class WorkspaceSavedEvent extends MCREvent {
 	private final Workspace workspace;
 
-	public WorkspaceSavedEvent(Workspace workspace) {
+	/**
+	 * <p>This event is never called. It only aims to group all events inside a single class.</p>
+	 *
+	 * @param workspace <p>The {@link Workspace} that will try to be saved.</p>
+	 */
+	protected WorkspaceSavedEvent(Workspace workspace) {
 		this.workspace = workspace;
 	}
 

--- a/src/main/java/net/mcreator/plugin/events/workspace/WorkspaceSavedEvent.java
+++ b/src/main/java/net/mcreator/plugin/events/workspace/WorkspaceSavedEvent.java
@@ -1,0 +1,72 @@
+/*
+ * MCreator (https://mcreator.net/)
+ * Copyright (C) 2012-2020, Pylo
+ * Copyright (C) 2020-2023, Pylo, opensource contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package net.mcreator.plugin.events.workspace;
+
+import net.mcreator.plugin.MCREvent;
+import net.mcreator.workspace.Workspace;
+
+/**
+ * <p>This event class handles events when a workspace is being saved. This event is not triggered in a place of the code.
+ * It only stores the sub-events and variables that can be used.</p>
+ */
+public class WorkspaceSavedEvent extends MCREvent {
+	private final Workspace workspace;
+
+	public WorkspaceSavedEvent(Workspace workspace) {
+		this.workspace = workspace;
+	}
+
+	public Workspace getWorkspace() {
+		return workspace;
+	}
+
+	/**
+	 * <p>It is called every time the method to save the workspace is called. This means that even if the workspace should not and can not be saved,
+	 * this event is still triggered. When something happens during this event, the other sub-events are still called and executed,
+	 * so a behaviour can happen twice if executed in multiple events.</p>
+	 */
+	public static class CalledSavingMethod extends WorkspaceSavedEvent {
+		public CalledSavingMethod(Workspace workspace) {
+			super(workspace);
+		}
+	}
+
+	/**
+	 * <p>This event is called when MCreator started the process of saving a workspace and it detected the workspace can and should be saved.
+	 * At this point, the backup is not made yet, but MCreator is sure the workspace file is valid and not unchanged.</p>
+	 */
+	public static class BeforeSaving extends WorkspaceSavedEvent {
+
+		public BeforeSaving(Workspace workspace) {
+			super(workspace);
+		}
+	}
+
+	/**
+	 * <p>This event is called when MCreator started the process of saving a workspace and it detected the workspace can and should be saved.
+	 * At this point, the backup is not made yet, but MCreator is sure the workspace file is valid and not unchanged.</p>
+	 */
+	public static class AfterSaving extends WorkspaceSavedEvent {
+
+		public AfterSaving(Workspace workspace) {
+			super(workspace);
+		}
+	}
+}

--- a/src/main/java/net/mcreator/ui/MCreator.java
+++ b/src/main/java/net/mcreator/ui/MCreator.java
@@ -26,7 +26,7 @@ import net.mcreator.gradle.GradleTaskResult;
 import net.mcreator.io.OS;
 import net.mcreator.io.UserFolderManager;
 import net.mcreator.plugin.MCREvent;
-import net.mcreator.plugin.events.MCreatorLoadedEvent;
+import net.mcreator.plugin.events.workspace.MCreatorLoadedEvent;
 import net.mcreator.preferences.PreferencesManager;
 import net.mcreator.ui.action.ActionRegistry;
 import net.mcreator.ui.action.impl.workspace.RegenerateCodeAction;

--- a/src/main/java/net/mcreator/ui/action/impl/workspace/WorkspaceSettingsAction.java
+++ b/src/main/java/net/mcreator/ui/action/impl/workspace/WorkspaceSettingsAction.java
@@ -25,6 +25,8 @@ import net.mcreator.generator.setup.WorkspaceGeneratorSetup;
 import net.mcreator.io.FileIO;
 import net.mcreator.minecraft.StructureUtils;
 import net.mcreator.minecraft.api.ModAPIManager;
+import net.mcreator.plugin.MCREvent;
+import net.mcreator.plugin.events.workspace.WorkspaceRefactoringEvent;
 import net.mcreator.ui.MCreator;
 import net.mcreator.ui.action.ActionRegistry;
 import net.mcreator.ui.action.impl.gradle.GradleAction;
@@ -61,6 +63,9 @@ public class WorkspaceSettingsAction extends GradleAction {
 
 	public static void refactorWorkspace(MCreator mcreator, WorkspaceSettingsChange change) {
 		if (change.refactorNeeded() && change.oldSettings != null) {
+
+			MCREvent.event(new WorkspaceRefactoringEvent(mcreator, change));
+
 			if (change.generatorFlavorChanged) {
 				ShareableZIPManager.exportZIP(L10N.t("dialog.workspace.export_backup"),
 						new File(mcreator.getWorkspace().getFolderManager().getWorkspaceCacheDir(),

--- a/src/main/java/net/mcreator/ui/modgui/ModElementGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/ModElementGUI.java
@@ -21,7 +21,6 @@ package net.mcreator.ui.modgui;
 import net.mcreator.element.GeneratableElement;
 import net.mcreator.minecraft.MCItem;
 import net.mcreator.plugin.MCREvent;
-import net.mcreator.plugin.events.ModElementSavedEvent;
 import net.mcreator.plugin.events.ui.ModElementGUIEvent;
 import net.mcreator.preferences.PreferencesManager;
 import net.mcreator.ui.MCreator;

--- a/src/main/java/net/mcreator/ui/modgui/ModElementGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/ModElementGUI.java
@@ -21,6 +21,7 @@ package net.mcreator.ui.modgui;
 import net.mcreator.element.GeneratableElement;
 import net.mcreator.minecraft.MCItem;
 import net.mcreator.plugin.MCREvent;
+import net.mcreator.plugin.events.ModElementSavedEvent;
 import net.mcreator.plugin.events.ui.ModElementGUIEvent;
 import net.mcreator.preferences.PreferencesManager;
 import net.mcreator.ui.MCreator;
@@ -107,7 +108,7 @@ public abstract class ModElementGUI<GE extends GeneratableElement> extends ViewB
 	}
 
 	@Override public ViewBase showView() {
-		MCREvent.event(new ModElementGUIEvent.BeforeLoading(this.tabIn, this));
+		MCREvent.event(new ModElementGUIEvent.BeforeLoading(mcreator, this.tabIn, this));
 		this.tabIn = new MCreatorTabs.Tab(this, modElement);
 
 		// reload data lists in a background thread
@@ -131,7 +132,7 @@ public abstract class ModElementGUI<GE extends GeneratableElement> extends ViewB
 			mcreator.mcreatorTabs.addTab(this.tabIn);
 			return this;
 		}
-		MCREvent.event(new ModElementGUIEvent.AfterLoading(existing, this));
+		MCREvent.event(new ModElementGUIEvent.AfterLoading(mcreator, existing, this));
 		return (ViewBase) existing.getContent();
 	}
 
@@ -504,6 +505,7 @@ public abstract class ModElementGUI<GE extends GeneratableElement> extends ViewB
 	 * This method implements the mod element saving and generation
 	 */
 	private void finishModCreation(boolean closeTab) {
+		MCREvent.event(new ModElementGUIEvent.WhenSaving(mcreator, tabIn, this, !closeTab));
 		GE element = getElementFromGUI();
 
 		// if new element, and if we are not in the root folder, specify the folder of the mod element

--- a/src/main/java/net/mcreator/workspace/WorkspaceFileManager.java
+++ b/src/main/java/net/mcreator/workspace/WorkspaceFileManager.java
@@ -21,6 +21,8 @@ package net.mcreator.workspace;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import net.mcreator.io.FileIO;
+import net.mcreator.plugin.MCREvent;
+import net.mcreator.plugin.events.workspace.WorkspaceSavedEvent;
 import net.mcreator.preferences.PreferencesManager;
 import net.mcreator.workspace.elements.ModElement;
 import net.mcreator.workspace.elements.ModElementManager;
@@ -105,11 +107,15 @@ public class WorkspaceFileManager implements Closeable {
 	}
 
 	private void saveWorkspaceIfChanged() {
+		MCREvent.event(new WorkspaceSavedEvent.CalledSavingMethod(workspace));
+
 		if (!workspace.isDirty()) // if the workspace file was not changed, we do not perform save
 			return;
 
 		String workspacestring = gson.toJson(workspace);
 		if (workspacestring != null && !workspacestring.equals("")) {
+			MCREvent.event(new WorkspaceSavedEvent.BeforeSaving(workspace));
+
 			// first we backup workspace file
 			rotateWorkspaceFileBackup();
 
@@ -136,6 +142,8 @@ public class WorkspaceFileManager implements Closeable {
 
 			if (dataSavedListener != null)
 				dataSavedListener.dataSaved();
+
+			MCREvent.event(new WorkspaceSavedEvent.AfterSaving(workspace));
 
 			LOG.debug("Workspace stored on the FS");
 		} else {


### PR DESCRIPTION
This PR adds 3 new events for Java plugins and some java documentation to `MCreatorLoadedEvent` (and moves it to a subfolder).

- ModElementGUI.WhenSaving
- WorkspaceRefactoringEvent
- WorkspaceSavedEvent (never called/just used for sub-events)
   - CalledSavingMethod (all the time)
   - BeforeSaving (when can and should be saved)
   - AfterSaving (after the workspace is saved)