### PR TITLE
Added helper method to get localization keys list from mod element

### DIFF
--- a/src/main/java/net/mcreator/generator/Generator.java
+++ b/src/main/java/net/mcreator/generator/Generator.java
@@ -280,6 +280,18 @@ public class Generator implements IGenerator, Closeable {
 		return new ArrayList<>(generatorFiles);
 	}
 
+	public List<String> getElementLocalizationKeys(GeneratableElement element) {
+		Map<?, ?> map = generatorConfiguration.getDefinitionsProvider()
+				.getModElementDefinition(element.getModElement().getType()); // config map
+		if (map == null) {
+			LOG.warn("Failed to load element definition for mod element type " + element.getModElement().getType()
+					.getRegistryName());
+			return new ArrayList<>();
+		}
+
+		return LocalizationUtils.getLocalizationKeys(this, element, (List<?>) map.get("localizationkeys"));
+	}
+
 	public void removeElementFilesAndLangKeys(GeneratableElement generatableElement) {
 		Map<?, ?> map = generatorConfiguration.getDefinitionsProvider()
 				.getModElementDefinition(generatableElement.getModElement().getType());

--- a/src/main/java/net/mcreator/generator/Generator.java
+++ b/src/main/java/net/mcreator/generator/Generator.java
@@ -271,7 +271,7 @@ public class Generator implements IGenerator, Closeable {
 					.map(e -> getWorkspaceFolder().toPath().relativize(e.getFile().toPath()).toString()
 							.replace(File.separator, "/")).toList());
 
-			LocalizationUtils.extractLocalizationKeys(this, element, (List<?>) map.get("localizationkeys"));
+			LocalizationUtils.generateLocalizationKeys(this, element, (List<?>) map.get("localizationkeys"));
 
 			// do additional tasks if mod element has them
 			element.finalizeModElementGeneration();

--- a/src/main/java/net/mcreator/generator/Generator.java
+++ b/src/main/java/net/mcreator/generator/Generator.java
@@ -289,7 +289,8 @@ public class Generator implements IGenerator, Closeable {
 			return new ArrayList<>();
 		}
 
-		return LocalizationUtils.getLocalizationKeys(this, element, (List<?>) map.get("localizationkeys"));
+		return new ArrayList<>(LocalizationUtils.processDefinitionToLocalizationKeys(this, element,
+				(List<?>) map.get("localizationkeys")).keySet());
 	}
 
 	public void removeElementFilesAndLangKeys(GeneratableElement generatableElement) {

--- a/src/main/java/net/mcreator/generator/LocalizationUtils.java
+++ b/src/main/java/net/mcreator/generator/LocalizationUtils.java
@@ -101,14 +101,14 @@ public class LocalizationUtils {
 										keytpl.replace("@NAME", element.getModElement().getName()).replace("@modid",
 														generator.getWorkspace().getWorkspaceSettings().getModID())
 												.replace("@registryname", element.getModElement().getRegistryName())));
-						addLocalizationEntry(generator, template, entry, key);
+						keysToEntries.put(key, entry);
 					}
 				} else {
 					String key = GeneratorTokens.replaceTokens(generator.getWorkspace(),
 							keytpl.replace("@NAME", element.getModElement().getName())
 									.replace("@modid", generator.getWorkspace().getWorkspaceSettings().getModID())
 									.replace("@registryname", element.getModElement().getRegistryName()));
-					addLocalizationEntry(generator, template, element, key);
+					keysToEntries.put(key, element);
 				}
 			}
 		}

--- a/src/main/java/net/mcreator/generator/LocalizationUtils.java
+++ b/src/main/java/net/mcreator/generator/LocalizationUtils.java
@@ -78,18 +78,13 @@ public class LocalizationUtils {
 		}
 	}
 
-	public static List<String> getLocalizationKeys(Generator generator, GeneratableElement element,
-			@Nullable List<?> localizationkeys) {
-		return new ArrayList<>(processDefinitionToLocalizationKeys(generator, element, localizationkeys).keySet());
-	}
-
 	public static void extractLocalizationKeys(Generator generator, GeneratableElement element,
 			@Nullable List<?> localizationkeys) {
 		processDefinitionToLocalizationKeys(generator, element, localizationkeys)
 				.forEach((k, v) -> addLocalizationEntry(generator, localizationkeys, v, k));
 	}
 
-	private static Map<String, Object> processDefinitionToLocalizationKeys(Generator generator,
+	static Map<String, Object> processDefinitionToLocalizationKeys(Generator generator,
 			GeneratableElement element, @Nullable List<?> localizationkeys) {
 		HashMap<String, Object> keysToEntries = new HashMap<>();
 

--- a/src/main/java/net/mcreator/generator/LocalizationUtils.java
+++ b/src/main/java/net/mcreator/generator/LocalizationUtils.java
@@ -26,10 +26,7 @@ import net.mcreator.workspace.Workspace;
 
 import javax.annotation.Nullable;
 import java.io.File;
-import java.util.Collection;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class LocalizationUtils {
@@ -81,8 +78,21 @@ public class LocalizationUtils {
 		}
 	}
 
+	public static List<String> getLocalizationKeys(Generator generator, GeneratableElement element,
+			@Nullable List<?> localizationkeys) {
+		return new ArrayList<>(processDefinitionToLocalizationKeys(generator, element, localizationkeys).keySet());
+	}
+
 	public static void extractLocalizationKeys(Generator generator, GeneratableElement element,
 			@Nullable List<?> localizationkeys) {
+		processDefinitionToLocalizationKeys(generator, element, localizationkeys)
+				.forEach((k, v) -> addLocalizationEntry(generator, localizationkeys, v, k));
+	}
+
+	private static Map<String, Object> processDefinitionToLocalizationKeys(Generator generator,
+			GeneratableElement element, @Nullable List<?> localizationkeys) {
+		HashMap<String, Object> keysToEntries = new HashMap<>();
+
 		if (localizationkeys != null) {
 			for (Object template : localizationkeys) {
 				String keytpl = (String) ((Map<?, ?>) template).get("key");
@@ -107,6 +117,8 @@ public class LocalizationUtils {
 				}
 			}
 		}
+
+		return keysToEntries;
 	}
 
 	private static void addLocalizationEntry(Generator generator, Object template, Object entry, String key) {


### PR DESCRIPTION
This PR adds a helper method to `LocalizationUtils` that gets localization keys list from the provided mod element, reorganizing code of neighboring methods to make that possible.