### PR TITLE
JSON mappings support and code cleanup

### DIFF
--- a/src/main/java/net/mcreator/generator/mapping/MappingLoader.java
+++ b/src/main/java/net/mcreator/generator/mapping/MappingLoader.java
@@ -19,6 +19,8 @@
 package net.mcreator.generator.mapping;
 
 import com.esotericsoftware.yamlbeans.YamlReader;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import net.mcreator.generator.GeneratorConfiguration;
 import net.mcreator.io.FileIO;
 import net.mcreator.minecraft.DataListLoader;
@@ -36,26 +38,46 @@ public class MappingLoader {
 
 	private static final Logger LOG = LogManager.getLogger("Name Mapper");
 
+	private static final Gson gson = new GsonBuilder().setLenient().create();
+
 	private final Map<String, Map<?, ?>> mappings = new ConcurrentHashMap<>();
 
 	@SuppressWarnings({ "unchecked", "rawtypes" }) public MappingLoader(GeneratorConfiguration generatorConfiguration) {
 		Set<String> fileNames = PluginLoader.INSTANCE.getResources(
-				generatorConfiguration.getGeneratorName() + ".mappings", Pattern.compile(".*\\.yaml"));
+				generatorConfiguration.getGeneratorName() + ".mappings", Pattern.compile(".*\\.(yaml|json)"));
 
 		for (String res : fileNames) {
-			String mappingName = res.split("mappings/")[1].replace(".yaml", "");
-			String mappingResource = generatorConfiguration.getGeneratorName() + "/mappings/" + mappingName + ".yaml";
+			String mappingName = res.split("mappings/")[1].replace(".yaml", "").replace(".json", "");
+			String mappingResource = generatorConfiguration.getGeneratorName() + "/mappings/" + mappingName;
 
 			try {
-				Enumeration<URL> resources = PluginLoader.INSTANCE.getResources(mappingResource);
-				Collections.list(resources).forEach(resource -> {
-					String config = FileIO.readResourceToString(resource);
+				Enumeration<URL> resources = PluginLoader.INSTANCE.getResources(mappingResource + ".yaml");
+				if (resources.hasMoreElements()) { // if yaml mappings found, process them and ignore json mappings
+					Collections.list(resources).forEach(resource -> {
+						YamlReader reader = new YamlReader(FileIO.readResourceToString(resource));
+						try {
+							Map<?, ?> mappingsFromFile = Collections.synchronizedMap(
+									new LinkedHashMap<>((Map<?, ?>) reader.read()));
+							if (mappings.get(mappingName) == null) {
+								mappings.put(mappingName, mappingsFromFile);
+							} else {
+								Map merged = Collections.synchronizedMap(new LinkedHashMap());
+								merged.putAll(mappings.get(mappingName));
+								merged.putAll(mappingsFromFile);
+								mappings.put(mappingName, merged);
+							}
+						} catch (Exception e) {
+							LOG.error("[" + mappingName + "] Error: " + e.getMessage());
+						}
+					});
+					continue;
+				}
 
-					YamlReader reader = new YamlReader(config);
-
+				Enumeration<URL> resources2 = PluginLoader.INSTANCE.getResources(mappingResource + ".json");
+				Collections.list(resources2).forEach(resource -> {
 					try {
-						Map<?, ?> mappingsFromFile = Collections.synchronizedMap(
-								new LinkedHashMap<>((Map<?, ?>) reader.read()));
+						Map<?, ?> mappingsFromFile = Collections.synchronizedMap(new LinkedHashMap<>(
+								gson.fromJson(FileIO.readResourceToString(PluginLoader.INSTANCE, res), Map.class)));
 						if (mappings.get(mappingName) == null) {
 							mappings.put(mappingName, mappingsFromFile);
 						} else {
@@ -86,5 +108,4 @@ public class MappingLoader {
 
 		return mappings.get(mappingName);
 	}
-
 }


### PR DESCRIPTION
This PR changes two classes responsible for processing data lists and mappings:
* `MappingLoader` - if YAML mappings are not found, it will try to load JSON mappings from file with the same name (so if both found, YAML have higher priority), which might be used for mapping objects that belong to the same category, but have different set of properties, e.g. custom block properties list (also JSON allows adding list objects to entries, which is not possible in YAML);
* `DataListLoader` - performed some cleanup in this one (transformed loader method to single-exit point form, removed unnecessary atomic encapsulation of `list` variable, added lots of pattern variables).