### PR TITLE
Follow the user's language

### DIFF
--- a/src/main/java/net/mcreator/preferences/PreferencesData.java
+++ b/src/main/java/net/mcreator/preferences/PreferencesData.java
@@ -40,7 +40,7 @@ public class PreferencesData {
 
 	public static class UISettings {
 
-		@PreferencesEntry public Locale language = L10N.DEFAULT_LOCALE;
+		@PreferencesEntry public Locale language = Locale.getDefault();
 
 		@PreferencesEntry public Color interfaceAccentColor = MCreatorTheme.MAIN_TINT_DEFAULT;
 


### PR DESCRIPTION
public static Locale getDefault()
Gets the current value of the default locale for this instance of the Java Virtual Machine.
The Java Virtual Machine sets the default locale during startup based on the host environment. It is used by many locale-sensitive methods if no locale is explicitly specified. It can be changed using the setDefault method.
Returns:
the default locale for this instance of the Java Virtual Machine