### PR TITLE
Inlined variant variable for some block/plant states files

### DIFF
--- a/plugins/generator-1.18.2/forge-1.18.2/block.definition.yaml
+++ b/plugins/generator-1.18.2/forge-1.18.2/block.definition.yaml
@@ -21,7 +21,6 @@ templates:
   # Normal block templates
   - template: json/block_states.json.ftl
     writer: json
-    variables: "variant= "
     name: "@MODASSETSROOT/blockstates/@registryname.json"
   - template: json/block_all_fixed.json.ftl
     condition: "renderType() #= 10"
@@ -203,7 +202,6 @@ templates:
   - template: json/block_states.json.ftl
     condition: "blockBase %= Leaves"
     writer: json
-    variables: "variant= "
     name: "@MODASSETSROOT/blockstates/@registryname.json"
   - template: json/block.json.ftl
     condition:

--- a/plugins/generator-1.18.2/forge-1.18.2/plant.definition.yaml
+++ b/plugins/generator-1.18.2/forge-1.18.2/plant.definition.yaml
@@ -53,12 +53,10 @@ templates:
   - template: json/block_states.json.ftl
     writer: json
     condition: "plantType %= normal"
-    variables: "variant= "
     name: "@MODASSETSROOT/blockstates/@registryname.json"
   - template: json/block_states.json.ftl
     writer: json
     condition: "plantType %= growapable"
-    variables: "variant= "
     name: "@MODASSETSROOT/blockstates/@registryname.json"
   - template: json/block_states_dplant.json.ftl
     writer: json

--- a/plugins/generator-1.18.2/forge-1.18.2/templates/json/block_states.json.ftl
+++ b/plugins/generator-1.18.2/forge-1.18.2/templates/json/block_states.json.ftl
@@ -126,7 +126,7 @@
 <#else>
 {
   "variants": {
-    "${var_variant}": {
+    "": {
       "model": "${modid}:block/${registryname}"
     }
   }

--- a/plugins/generator-1.19.2/forge-1.19.2/block.definition.yaml
+++ b/plugins/generator-1.19.2/forge-1.19.2/block.definition.yaml
@@ -28,7 +28,6 @@ templates:
   # Normal block templates
   - template: json/block_states.json.ftl
     writer: json
-    variables: "variant= "
     name: "@MODASSETSROOT/blockstates/@registryname.json"
   - template: json/block_all_fixed.json.ftl
     condition: "renderType() #= 10"
@@ -210,7 +209,6 @@ templates:
   - template: json/block_states.json.ftl
     condition: "blockBase %= Leaves"
     writer: json
-    variables: "variant= "
     name: "@MODASSETSROOT/blockstates/@registryname.json"
   - template: json/block.json.ftl
     condition:

--- a/plugins/generator-1.19.2/forge-1.19.2/plant.definition.yaml
+++ b/plugins/generator-1.19.2/forge-1.19.2/plant.definition.yaml
@@ -53,12 +53,10 @@ templates:
   - template: json/block_states.json.ftl
     writer: json
     condition: "plantType %= normal"
-    variables: "variant= "
     name: "@MODASSETSROOT/blockstates/@registryname.json"
   - template: json/block_states.json.ftl
     writer: json
     condition: "plantType %= growapable"
-    variables: "variant= "
     name: "@MODASSETSROOT/blockstates/@registryname.json"
   - template: json/block_states_double_plant.json.ftl
     writer: json

--- a/plugins/generator-1.19.2/forge-1.19.2/templates/json/block_states.json.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/templates/json/block_states.json.ftl
@@ -126,7 +126,7 @@
 <#else>
 {
   "variants": {
-    "${var_variant}": {
+    "": {
       "model": "${modid}:block/${registryname}"
     }
   }


### PR DESCRIPTION
This PR inlines `variables` parameter for some use cases of `json/block_states.json.ftl` template when it was only setting `variant` variable to the same value `" "`.