### PR TITLE
File workspace-relative path getter method

### DIFF
--- a/src/main/java/net/mcreator/generator/Generator.java
+++ b/src/main/java/net/mcreator/generator/Generator.java
@@ -267,9 +267,8 @@ public class Generator implements IGenerator, Closeable {
 			generateFiles(generatorFiles, formatAndOrganiseImports);
 
 			// store paths of generated files
-			element.getModElement().putMetadata("files", generatorFiles.stream()
-					.map(e -> getWorkspaceFolder().toPath().relativize(e.getFile().toPath()).toString()
-							.replace(File.separator, "/")).toList());
+			element.getModElement().putMetadata("files", generatorFiles.stream().map(GeneratorFile::getFile)
+					.map(e -> getFolderManager().getPathInWorkspace(e).replace(File.separator, "/")).toList());
 
 			LocalizationUtils.extractLocalizationKeys(this, element, (List<?>) map.get("localizationkeys"));
 

--- a/src/main/java/net/mcreator/ui/WindowTitleHelper.java
+++ b/src/main/java/net/mcreator/ui/WindowTitleHelper.java
@@ -30,24 +30,23 @@ public class WindowTitleHelper {
 		String appendix = "";
 		if (mcreator.mcreatorTabs.getCurrentTab() != null && mcreator.mcreatorTabs.getCurrentTab()
 				.getContent() instanceof ModElementGUI<?> modElementGUI) {
-			appendix = "- " + modElementGUI.getModElement().getName() + " (" + modElementGUI.getModElement().getType()
+			appendix = " - " + modElementGUI.getModElement().getName() + " (" + modElementGUI.getModElement().getType()
 					.getReadableName() + ")";
 		} else if (mcreator.mcreatorTabs.getCurrentTab() != null && mcreator.mcreatorTabs.getCurrentTab()
 				.getContent() instanceof CodeEditorView codeEditorView) {
 			try {
-				appendix =
-						"- " + mcreator.getWorkspaceFolder().toPath().relativize(codeEditorView.fileWorkingOn.toPath());
+				appendix = " - " + mcreator.getFolderManager().getPathInWorkspace(codeEditorView.fileWorkingOn);
 			} catch (Exception e) {
-				appendix = "- " + codeEditorView.fileWorkingOn.toPath();
+				appendix = " - " + codeEditorView.fileWorkingOn.toPath();
 			}
 		}
 		String workspaceBaseName = mcreator.getWorkspaceSettings().getModName();
 		try {
-			return (workspaceBaseName + " [" + mcreator.getWorkspaceFolder().getCanonicalPath() + "] " + appendix
-					+ " - MCreator " + Launcher.version.getMajorString());
+			return workspaceBaseName + " [" + mcreator.getWorkspaceFolder().getCanonicalPath() + "]" + appendix
+					+ " - MCreator " + Launcher.version.getMajorString();
 		} catch (IOException e) {
-			return (workspaceBaseName + " [" + mcreator.getWorkspaceFolder().getAbsolutePath() + "] " + appendix
-					+ " - MCreator " + Launcher.version.getMajorString());
+			return workspaceBaseName + " [" + mcreator.getWorkspaceFolder().getAbsolutePath() + "]" + appendix
+					+ " - MCreator " + Launcher.version.getMajorString();
 		}
 	}
 

--- a/src/main/java/net/mcreator/ui/WindowTitleHelper.java
+++ b/src/main/java/net/mcreator/ui/WindowTitleHelper.java
@@ -21,6 +21,7 @@ package net.mcreator.ui;
 import net.mcreator.Launcher;
 import net.mcreator.ui.ide.CodeEditorView;
 import net.mcreator.ui.modgui.ModElementGUI;
+import net.mcreator.ui.views.editor.image.ImageMakerView;
 
 import java.io.IOException;
 
@@ -38,6 +39,13 @@ public class WindowTitleHelper {
 				appendix = " - " + mcreator.getFolderManager().getPathInWorkspace(codeEditorView.fileWorkingOn);
 			} catch (Exception e) {
 				appendix = " - " + codeEditorView.fileWorkingOn.toPath();
+			}
+		} else if (mcreator.mcreatorTabs.getCurrentTab() != null && mcreator.mcreatorTabs.getCurrentTab()
+				.getContent() instanceof ImageMakerView imageMakerView) {
+			try {
+				appendix = " - " + mcreator.getFolderManager().getPathInWorkspace(imageMakerView.getImageFile());
+			} catch (Exception e) {
+				appendix = " - " + imageMakerView.getImageFile().toPath();
 			}
 		}
 		String workspaceBaseName = mcreator.getWorkspaceSettings().getModName();

--- a/src/main/java/net/mcreator/ui/views/editor/image/ImageMakerView.java
+++ b/src/main/java/net/mcreator/ui/views/editor/image/ImageMakerView.java
@@ -372,4 +372,9 @@ public class ImageMakerView extends ViewBase implements MouseListener, MouseMoti
 	public LayerPanel getLayerPanel() {
 		return layerPanel;
 	}
+
+	public File getImageFile() {
+		return image;
+	}
+
 }

--- a/src/main/java/net/mcreator/ui/workspace/ModElementCodeDropdown.java
+++ b/src/main/java/net/mcreator/ui/workspace/ModElementCodeDropdown.java
@@ -84,7 +84,7 @@ class ModElementCodeDropdown extends JPopupMenu {
 	private JMenuItem modElementFileMenuItem(GeneratorTemplate template) {
 		JMenuItem item = new JMenuItem(
 				"<html>" + template.getFile().getName() + "<br><small color=#666666>" + mcreator.getWorkspace()
-						.getWorkspaceFolder().toPath().relativize(template.getFile().toPath()));
+						.getFolderManager().getPathInWorkspace(template.getFile()));
 		item.setIcon(FileIcons.getIconForFile(template.getFile()));
 		item.setBackground(((Color) UIManager.get("MCreatorLAF.LIGHT_ACCENT")).darker());
 		item.setForeground((Color) UIManager.get("MCreatorLAF.BRIGHT_COLOR"));

--- a/src/main/java/net/mcreator/workspace/WorkspaceFolderManager.java
+++ b/src/main/java/net/mcreator/workspace/WorkspaceFolderManager.java
@@ -19,6 +19,7 @@
 package net.mcreator.workspace;
 
 import net.mcreator.generator.GeneratorUtils;
+import net.mcreator.io.FileIO;
 import net.mcreator.io.OS;
 import net.mcreator.ui.workspace.resources.TextureType;
 import net.mcreator.util.FilenameUtilsPatched;
@@ -29,7 +30,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.swing.*;
 import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -69,6 +69,19 @@ public class WorkspaceFolderManager {
 
 	public File getWorkspaceFolder() {
 		return workspaceFolder;
+	}
+
+	/**
+	 * Attempts to locate the provided file inside workspace folder and return its path relative to this folder.
+	 *
+	 * @param file The input file.
+	 * @return File path relative to workspace folder or its absolute path if not found in the workspace.
+	 */
+	public String getPathInWorkspace(File file) {
+		if (!isFileInWorkspace(file))
+			throw new RuntimeException(file.getAbsolutePath() + " is not in workspace path!");
+
+		return workspaceFolder.toPath().relativize(file.toPath()).toString();
 	}
 
 	/**
@@ -160,15 +173,11 @@ public class WorkspaceFolderManager {
 	}
 
 	public boolean isFileInWorkspace(File file) {
-		try {
-			boolean inworkspace = file.getCanonicalPath().startsWith(workspaceFolder.getCanonicalPath());
-			if (!inworkspace)
-				LOG.warn(file.getAbsolutePath() + " is not in workspace path!");
-			return inworkspace;
-		} catch (IOException e) {
-			LOG.error(e.getMessage(), e);
+		if (FileIO.isFileSomewhereInDirectory(file, workspaceFolder)) {
+			return true;
+		} else {
+			LOG.warn(file.getAbsolutePath() + " is not in workspace path!");
 			return false;
 		}
 	}
-
 }


### PR DESCRIPTION
* [Added](https://github.com/MCreator/MCreator/pull/3500#discussion_r1089376497) `getPathInWorkspace(File)` method to `WorkspaceFolderManager` class for easier acquirement of path of the specified file inside the workspace folder, which throws `RuntimeException`
>if used on a file outside the workspace as this is either a bug or something trying to access things it should not access
* `isFileInWorkspace()` now uses `FileIO.isFileSomewhereInDirectory(File, File)` to avoid getting `IOException`s in there;
* `WindowTitleHelper` was corrected to prevent double spaces in a row in its main method's output strings.