### PR TITLE
Added support for repeating fields

### DIFF
--- a/src/main/java/net/mcreator/blockly/data/ToolboxBlock.java
+++ b/src/main/java/net/mcreator/blockly/data/ToolboxBlock.java
@@ -32,6 +32,7 @@ import java.util.List;
 	public IBlockGenerator.BlockType type;
 
 	@Nullable private List<String> fields;
+	@Nullable private List<String> repeating_fields;
 	@Nullable private List<IInput> inputs;
 	@Nullable private List<StatementInput> statements;
 	@Nullable private List<IInput> repeating_inputs;
@@ -52,6 +53,10 @@ import java.util.List;
 
 	@Nullable public List<String> getFields() {
 		return fields;
+	}
+
+	@Nullable public List<String> getRepeatingFields() {
+		return repeating_fields;
 	}
 
 	public List<String> getInputs() {


### PR DESCRIPTION
This PR adds support for repeating fields, similar to #2759. To allow tests for repeating fields, the part of code that handles the different field types is moved to a separate method.

Example plugin adding a block with a repeating number input field, found in the "Math" category: [Repeating field example](https://github.com/MCreator/MCreator/files/10556617/repeating_field_example.zip)