### PR TITLE
Fixes to texture flipping on X axis

### DIFF
--- a/src/main/java/net/mcreator/ui/minecraft/TextureHolder.java
+++ b/src/main/java/net/mcreator/ui/minecraft/TextureHolder.java
@@ -115,8 +115,9 @@ public class TextureHolder extends VButton {
 		return id;
 	}
 
-	public TextureHolder flipOnX() {
-		this.xFlip = true;
+	public TextureHolder setFlipOnX(boolean xFlip) {
+		this.xFlip = xFlip;
+		repaint();
 		return this;
 	}
 
@@ -139,11 +140,10 @@ public class TextureHolder extends VButton {
 	}
 
 	@Override public void setIcon(Icon icon) {
-		if (!xFlip || icon == null) {
-			super.setIcon(icon);
+		if (icon == null) {
+			super.setIcon(null);
 		} else {
 			super.setIcon(new Icon() {
-
 				@Override public int getIconHeight() {
 					return icon.getIconHeight();
 				}
@@ -154,8 +154,10 @@ public class TextureHolder extends VButton {
 
 				@Override public synchronized void paintIcon(Component c, Graphics g, int x, int y) {
 					Graphics2D g2 = (Graphics2D) g.create();
-					g2.translate(0, icon.getIconHeight());
-					g2.scale(1, -1);
+					if (xFlip) {
+						g2.translate(0, icon.getIconHeight());
+						g2.scale(1, -1);
+					}
 					icon.paintIcon(c, g2, x, y);
 				}
 			});

--- a/src/main/java/net/mcreator/ui/minecraft/TextureHolder.java
+++ b/src/main/java/net/mcreator/ui/minecraft/TextureHolder.java
@@ -39,7 +39,7 @@ public class TextureHolder extends VButton {
 
 	private boolean removeButtonHover;
 
-	private boolean xFlip;
+	private boolean uvFlip;
 
 	public TextureHolder(TypedTextureSelectorDialog td) {
 		this(td, 70);
@@ -115,12 +115,6 @@ public class TextureHolder extends VButton {
 		return id;
 	}
 
-	public TextureHolder setFlipOnX(boolean xFlip) {
-		this.xFlip = xFlip;
-		repaint();
-		return this;
-	}
-
 	public void setTextureFromTextureName(String texture) {
 		if (texture != null && !texture.equals("")) {
 			id = texture;
@@ -139,6 +133,12 @@ public class TextureHolder extends VButton {
 		this.actionListener = actionListener;
 	}
 
+	public TextureHolder setFlipUV(boolean uvFlip) {
+		this.uvFlip = uvFlip;
+		repaint();
+		return this;
+	}
+
 	@Override public void setIcon(Icon icon) {
 		if (icon == null) {
 			super.setIcon(null);
@@ -154,11 +154,12 @@ public class TextureHolder extends VButton {
 
 				@Override public synchronized void paintIcon(Component c, Graphics g, int x, int y) {
 					Graphics2D g2 = (Graphics2D) g.create();
-					if (xFlip) {
-						g2.translate(0, icon.getIconHeight());
-						g2.scale(1, -1);
+					if (uvFlip) {
+						g2.translate(icon.getIconWidth(), icon.getIconHeight());
+						g2.scale(-1, -1);
 					}
 					icon.paintIcon(c, g2, x, y);
+					g2.dispose();
 				}
 			});
 		}

--- a/src/main/java/net/mcreator/ui/modgui/BlockGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/BlockGUI.java
@@ -433,8 +433,8 @@ public class BlockGUI extends ModElementGUI<Block> {
 		JPanel destal = new JPanel(new GridLayout(3, 4));
 		destal.setOpaque(false);
 
-		texture = new TextureHolder(new TypedTextureSelectorDialog(mcreator, TextureType.BLOCK)).setFlipOnX(true);
-		textureTop = new TextureHolder(new TypedTextureSelectorDialog(mcreator, TextureType.BLOCK)).setFlipOnX(true);
+		texture = new TextureHolder(new TypedTextureSelectorDialog(mcreator, TextureType.BLOCK)).setFlipUV(true);
+		textureTop = new TextureHolder(new TypedTextureSelectorDialog(mcreator, TextureType.BLOCK)).setFlipUV(true);
 
 		textureLeft = new TextureHolder(new TypedTextureSelectorDialog(mcreator, TextureType.BLOCK));
 		textureFront = new TextureHolder(new TypedTextureSelectorDialog(mcreator, TextureType.BLOCK));
@@ -1248,38 +1248,31 @@ public class BlockGUI extends ModElementGUI<Block> {
 	}
 
 	private void updateTextureOptions() {
-		texture.setVisible(false);
-		texture.setFlipOnX(false);
+		texture.setFlipUV(false);
+		textureTop.setFlipUV(false);
 		textureTop.setVisible(false);
-		textureTop.setFlipOnX(false);
 		textureLeft.setVisible(false);
 		textureFront.setVisible(false);
 		textureRight.setVisible(false);
 		textureBack.setVisible(false);
 
 		if (normal.equals(renderType.getSelectedItem())) {
-			texture.setVisible(true);
-			texture.setFlipOnX(true);
+			texture.setFlipUV(true);
+			textureTop.setFlipUV(true);
 			textureTop.setVisible(true);
-			textureTop.setFlipOnX(true);
 			textureLeft.setVisible(true);
 			textureFront.setVisible(true);
 			textureRight.setVisible(true);
 			textureBack.setVisible(true);
 		} else if (grassBlock.equals(renderType.getSelectedItem())) {
-			texture.setVisible(true);
 			textureTop.setVisible(true);
 			textureLeft.setVisible(true);
 			textureFront.setVisible(true);
 		} else if ("Pane".equals(blockBase.getSelectedItem()) || "Door".equals(blockBase.getSelectedItem())) {
 			textureTop.setVisible(true);
-			texture.setVisible(true);
 		} else if ("Stairs".equals(blockBase.getSelectedItem()) || "Slab".equals(blockBase.getSelectedItem())) {
 			textureTop.setVisible(true);
 			textureFront.setVisible(true);
-			texture.setVisible(true);
-		} else {
-			texture.setVisible(true);
 		}
 	}
 

--- a/src/main/java/net/mcreator/ui/modgui/BlockGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/BlockGUI.java
@@ -433,8 +433,8 @@ public class BlockGUI extends ModElementGUI<Block> {
 		JPanel destal = new JPanel(new GridLayout(3, 4));
 		destal.setOpaque(false);
 
-		texture = new TextureHolder(new TypedTextureSelectorDialog(mcreator, TextureType.BLOCK)).flipOnX();
-		textureTop = new TextureHolder(new TypedTextureSelectorDialog(mcreator, TextureType.BLOCK)).flipOnX();
+		texture = new TextureHolder(new TypedTextureSelectorDialog(mcreator, TextureType.BLOCK)).setFlipOnX(true);
+		textureTop = new TextureHolder(new TypedTextureSelectorDialog(mcreator, TextureType.BLOCK)).setFlipOnX(true);
 
 		textureLeft = new TextureHolder(new TypedTextureSelectorDialog(mcreator, TextureType.BLOCK));
 		textureFront = new TextureHolder(new TypedTextureSelectorDialog(mcreator, TextureType.BLOCK));
@@ -1249,7 +1249,9 @@ public class BlockGUI extends ModElementGUI<Block> {
 
 	private void updateTextureOptions() {
 		texture.setVisible(false);
+		texture.setFlipOnX(false);
 		textureTop.setVisible(false);
+		textureTop.setFlipOnX(false);
 		textureLeft.setVisible(false);
 		textureFront.setVisible(false);
 		textureRight.setVisible(false);
@@ -1257,7 +1259,9 @@ public class BlockGUI extends ModElementGUI<Block> {
 
 		if (normal.equals(renderType.getSelectedItem())) {
 			texture.setVisible(true);
+			texture.setFlipOnX(true);
 			textureTop.setVisible(true);
+			textureTop.setFlipOnX(true);
 			textureLeft.setVisible(true);
 			textureFront.setVisible(true);
 			textureRight.setVisible(true);


### PR DESCRIPTION
This PR replaces `flipOnX()` method on `TextureHolder` class with `setFlipOnX(boolean)`, allowing to specify when exactly the selected texture should be flipped (e.g. resolves an issue with `BlockGUI` when it flips bottom and top textures even if they are used for a built-in model different from `normal`).