### PR TITLE
Made child entities automatically scale down

### DIFF
--- a/plugins/generator-1.18.2/forge-1.18.2/livingentity.definition.yaml
+++ b/plugins/generator-1.18.2/forge-1.18.2/livingentity.definition.yaml
@@ -1,3 +1,8 @@
+global_templates:
+  - template: elementinits/breedableentities.java.ftl
+    name: "@SRCROOT/@BASEPACKAGEPATH/init/@JavaModNameBreedableEntities.java"
+    condition: hasBreedableEntities()
+
 templates:
   - template: livingentity/livingentity.java.ftl
     name: "@SRCROOT/@BASEPACKAGEPATH/entity/@NAMEEntity.java"

--- a/plugins/generator-1.18.2/forge-1.18.2/templates/elementinits/breedableentities.java.ftl
+++ b/plugins/generator-1.18.2/forge-1.18.2/templates/elementinits/breedableentities.java.ftl
@@ -1,0 +1,53 @@
+<#--
+ # MCreator (https://mcreator.net/)
+ # Copyright (C) 2012-2020, Pylo
+ # Copyright (C) 2020-2023, Pylo, opensource contributors
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # Additional permission for code generator templates (*.ftl files)
+ #
+ # As a special exception, you may create a larger work that contains part or
+ # all of the MCreator code generator templates (*.ftl files) and distribute
+ # that work under terms of your choice, so long as that work isn't itself a
+ # template for code generation. Alternatively, if you modify or redistribute
+ # the template itself, you may (at your option) remove this special exception,
+ # which will cause the template and the resulting code generator output files
+ # to be licensed under the GNU General Public License without this special
+ # exception.
+-->
+
+<#-- @formatter:off -->
+
+/*
+ *    MCreator note: This file will be REGENERATED on each build.
+ */
+
+package ${package}.init;
+
+@Mod.EventBusSubscriber
+public class ${JavaModName}BreedableEntities {
+
+    @OnlyIn(Dist.CLIENT)
+    @SubscribeEvent
+    public static void setScale(RenderLivingEvent.Pre event) {
+    <#list livingentitys as entity>
+        if (event.getEntity() instanceof ${entity.getModElement().getName()}Entity _ent && _ent.isBaby())
+            event.getPoseStack().scale(0.5f, 0.5f, 0.5f);
+    </#list>
+    }
+
+}
+
+<#-- @formatter:on -->

--- a/plugins/generator-1.19.2/forge-1.19.2/livingentity.definition.yaml
+++ b/plugins/generator-1.19.2/forge-1.19.2/livingentity.definition.yaml
@@ -1,3 +1,8 @@
+global_templates:
+  - template: elementinits/breedableentities.java.ftl
+    name: "@SRCROOT/@BASEPACKAGEPATH/init/@JavaModNameBreedableEntities.java"
+    condition: hasBreedableEntities()
+
 templates:
   - template: livingentity/livingentity.java.ftl
     name: "@SRCROOT/@BASEPACKAGEPATH/entity/@NAMEEntity.java"

--- a/plugins/generator-1.19.2/forge-1.19.2/templates/elementinits/breedableentities.java.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/templates/elementinits/breedableentities.java.ftl
@@ -1,0 +1,53 @@
+<#--
+ # MCreator (https://mcreator.net/)
+ # Copyright (C) 2012-2020, Pylo
+ # Copyright (C) 2020-2023, Pylo, opensource contributors
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # Additional permission for code generator templates (*.ftl files)
+ #
+ # As a special exception, you may create a larger work that contains part or
+ # all of the MCreator code generator templates (*.ftl files) and distribute
+ # that work under terms of your choice, so long as that work isn't itself a
+ # template for code generation. Alternatively, if you modify or redistribute
+ # the template itself, you may (at your option) remove this special exception,
+ # which will cause the template and the resulting code generator output files
+ # to be licensed under the GNU General Public License without this special
+ # exception.
+-->
+
+<#-- @formatter:off -->
+
+/*
+ *    MCreator note: This file will be REGENERATED on each build.
+ */
+
+package ${package}.init;
+
+@Mod.EventBusSubscriber
+public class ${JavaModName}BreedableEntities {
+
+    @OnlyIn(Dist.CLIENT)
+    @SubscribeEvent
+    public static void setScale(RenderLivingEvent.Pre event) {
+    <#list livingentitys as entity>
+        if (event.getEntity() instanceof ${entity.getModElement().getName()}Entity _ent && _ent.isBaby())
+            event.getPoseStack().scale(0.5f, 0.5f, 0.5f);
+    </#list>
+    }
+
+}
+
+<#-- @formatter:on -->

--- a/src/main/java/net/mcreator/ui/SplashScreen.java
+++ b/src/main/java/net/mcreator/ui/SplashScreen.java
@@ -70,7 +70,7 @@ public class SplashScreen extends JWindow {
 		if (Launcher.version != null && Launcher.version.isSnapshot()) {
 			JLabel snapshot = new JLabel("Snapshot - not for production use!");
 			snapshot.setFont(splashFont.deriveFont(14f));
-			snapshot.setForeground(new Color(255, 92, 82));
+			snapshot.setForeground(new Color(120, 239, 88));
 			snapshot.setBounds(30 + 10 - 4, 165, 500, 45);
 			imagePanel.add(snapshot);
 		}

--- a/src/main/java/net/mcreator/ui/SplashScreen.java
+++ b/src/main/java/net/mcreator/ui/SplashScreen.java
@@ -70,7 +70,7 @@ public class SplashScreen extends JWindow {
 		if (Launcher.version != null && Launcher.version.isSnapshot()) {
 			JLabel snapshot = new JLabel("Snapshot - not for production use!");
 			snapshot.setFont(splashFont.deriveFont(14f));
-			snapshot.setForeground(new Color(120, 239, 88));
+			snapshot.setForeground(new Color(255, 92, 82));
 			snapshot.setBounds(30 + 10 - 4, 165, 500, 45);
 			imagePanel.add(snapshot);
 		}

--- a/src/main/java/net/mcreator/workspace/misc/WorkspaceInfo.java
+++ b/src/main/java/net/mcreator/workspace/misc/WorkspaceInfo.java
@@ -249,6 +249,18 @@ import java.util.*;
 		return false;
 	}
 
+	public boolean hasBreedableEntities() {
+		for (ModElement element : workspace.getModElements()) {
+			if (element.getType() == ModElementType.LIVINGENTITY) {
+				if (element.getGeneratableElement() instanceof LivingEntity livingEntity) {
+					if (livingEntity.breedable)
+						return true;
+				}
+			}
+		}
+		return false;
+	}
+
 	public MItemBlock itemBlock(String itemBlock) {
 		return new MItemBlock(workspace, itemBlock);
 	}


### PR DESCRIPTION
This PR adds a new class that automatically sets the scale of entity offspring to 0.5, which is the scale Minecraft sets the bounding box to for them.