### PR TITLE
Allow JMods in project browser's external libraries list

### DIFF
--- a/src/main/java/net/mcreator/io/zip/ZipIO.java
+++ b/src/main/java/net/mcreator/io/zip/ZipIO.java
@@ -173,7 +173,7 @@ public class ZipIO {
 
 	public static boolean checkIfZip(File zipfile) {
 		try (RandomAccessFile raf = new RandomAccessFile(zipfile, "r")) {
-			return raf.readInt() == 0x504B0304;
+			return Arrays.asList(0x504B0304, 0x4a4d0100).contains(raf.readInt());
 		} catch (IOException e) {
 			return false;
 		}

--- a/src/main/java/net/mcreator/io/zip/ZipIO.java
+++ b/src/main/java/net/mcreator/io/zip/ZipIO.java
@@ -173,10 +173,17 @@ public class ZipIO {
 
 	public static boolean checkIfZip(File zipfile) {
 		try (RandomAccessFile raf = new RandomAccessFile(zipfile, "r")) {
-			return Arrays.asList(0x504B0304, 0x4a4d0100).contains(raf.readInt());
+			return raf.readInt() == 0x504B0304;
 		} catch (IOException e) {
 			return false;
 		}
 	}
 
+	public static boolean checkIfJMod(File zipfile) {
+		try (RandomAccessFile raf = new RandomAccessFile(zipfile, "r")) {
+			return raf.readInt() == 0x4a4d0100;
+		} catch (IOException e) {
+			return false;
+		}
+	}
 }

--- a/src/main/java/net/mcreator/ui/browser/WorkspaceFileBrowser.java
+++ b/src/main/java/net/mcreator/ui/browser/WorkspaceFileBrowser.java
@@ -220,7 +220,7 @@ public class WorkspaceFileBrowser extends JPanel {
 	/**
 	 * Reloads all the project files.
 	 */
-	public void reloadTree() {
+	public synchronized void reloadTree() {
 		if (jtf1.getText().isEmpty()) {
 			List<DefaultMutableTreeNode> state = TreeUtils.getExpansionState(tree);
 
@@ -396,7 +396,8 @@ public class WorkspaceFileBrowser extends JPanel {
 				File libraryFile = new File(libraryInfo.getLocationAsString());
 				if (libraryFile.isFile() && (ZipIO.checkIfZip(libraryFile) || ZipIO.checkIfJMod(libraryFile))) {
 					String libName = FilenameUtilsPatched.removeExtension(libraryFile.getName());
-					if (libName.equals("rt") || libraryFile.getName().endsWith(".jmod"))
+
+					if (libName.equals("rt") || libName.equals("java.base"))
 						libName = "Java " + System.getProperty("java.version") + " SDK";
 					else
 						libName = "Gradle: " + libName;

--- a/src/main/java/net/mcreator/ui/browser/WorkspaceFileBrowser.java
+++ b/src/main/java/net/mcreator/ui/browser/WorkspaceFileBrowser.java
@@ -393,10 +393,10 @@ public class WorkspaceFileBrowser extends JPanel {
 		if (mcreator.getGenerator().getProjectJarManager() != null) {
 			List<LibraryInfo> libraryInfos = mcreator.getGenerator().getProjectJarManager().getClassFileSources();
 			for (LibraryInfo libraryInfo : libraryInfos) {
-				File libraryFile = new File(libraryInfo.getLocationAsString());
-				if (libraryFile.isFile() && ZipIO.checkIfZip(libraryFile)) {
-					String libName = FilenameUtilsPatched.removeExtension(libraryFile.getName());
-					if (libName.equals("rt"))
+				File libFile = new File(libraryInfo.getLocationAsString());
+				if (libFile.isFile() && (ZipIO.checkIfZip(libFile) || libFile.getName().endsWith(".jmod"))) {
+					String libName = FilenameUtilsPatched.removeExtension(libFile.getName());
+					if (libName.equals("rt") || libFile.getName().endsWith(".jmod"))
 						libName = "Java " + System.getProperty("java.version") + " SDK";
 					else
 						libName = "Gradle: " + libName;
@@ -406,8 +406,8 @@ public class WorkspaceFileBrowser extends JPanel {
 						ZipIO.iterateZip(sourceFile, entry -> libsrc.addElement(entry.getName()), true);
 						addFileNodeToFilterTreeNode(extDeps, libsrc.root);
 					} else {
-						FileTree lib = new FileTree(new FileNode(libName, libraryFile.getAbsolutePath() + ":%:"));
-						ZipIO.iterateZip(libraryFile, entry -> lib.addElement(entry.getName()), true);
+						FileTree lib = new FileTree(new FileNode(libName, libFile.getAbsolutePath() + ":%:"));
+						ZipIO.iterateZip(libFile, entry -> lib.addElement(entry.getName()), true);
 						addFileNodeToFilterTreeNode(extDeps, lib.root);
 					}
 				}

--- a/src/main/java/net/mcreator/ui/browser/WorkspaceFileBrowser.java
+++ b/src/main/java/net/mcreator/ui/browser/WorkspaceFileBrowser.java
@@ -394,7 +394,7 @@ public class WorkspaceFileBrowser extends JPanel {
 			List<LibraryInfo> libraryInfos = mcreator.getGenerator().getProjectJarManager().getClassFileSources();
 			for (LibraryInfo libraryInfo : libraryInfos) {
 				File libraryFile = new File(libraryInfo.getLocationAsString());
-				if (libraryFile.isFile() && ZipIO.checkIfZip(libraryFile)) {
+				if (libraryFile.isFile() && (ZipIO.checkIfZip(libraryFile) || ZipIO.checkIfJMod(libraryFile))) {
 					String libName = FilenameUtilsPatched.removeExtension(libraryFile.getName());
 					if (libName.equals("rt") || libraryFile.getName().endsWith(".jmod"))
 						libName = "Java " + System.getProperty("java.version") + " SDK";

--- a/src/main/java/net/mcreator/ui/browser/WorkspaceFileBrowser.java
+++ b/src/main/java/net/mcreator/ui/browser/WorkspaceFileBrowser.java
@@ -393,10 +393,10 @@ public class WorkspaceFileBrowser extends JPanel {
 		if (mcreator.getGenerator().getProjectJarManager() != null) {
 			List<LibraryInfo> libraryInfos = mcreator.getGenerator().getProjectJarManager().getClassFileSources();
 			for (LibraryInfo libraryInfo : libraryInfos) {
-				File libFile = new File(libraryInfo.getLocationAsString());
-				if (libFile.isFile() && (ZipIO.checkIfZip(libFile) || libFile.getName().endsWith(".jmod"))) {
-					String libName = FilenameUtilsPatched.removeExtension(libFile.getName());
-					if (libName.equals("rt") || libFile.getName().endsWith(".jmod"))
+				File libraryFile = new File(libraryInfo.getLocationAsString());
+				if (libraryFile.isFile() && ZipIO.checkIfZip(libraryFile)) {
+					String libName = FilenameUtilsPatched.removeExtension(libraryFile.getName());
+					if (libName.equals("rt") || libraryFile.getName().endsWith(".jmod"))
 						libName = "Java " + System.getProperty("java.version") + " SDK";
 					else
 						libName = "Gradle: " + libName;
@@ -406,8 +406,8 @@ public class WorkspaceFileBrowser extends JPanel {
 						ZipIO.iterateZip(sourceFile, entry -> libsrc.addElement(entry.getName()), true);
 						addFileNodeToFilterTreeNode(extDeps, libsrc.root);
 					} else {
-						FileTree lib = new FileTree(new FileNode(libName, libFile.getAbsolutePath() + ":%:"));
-						ZipIO.iterateZip(libFile, entry -> lib.addElement(entry.getName()), true);
+						FileTree lib = new FileTree(new FileNode(libName, libraryFile.getAbsolutePath() + ":%:"));
+						ZipIO.iterateZip(libraryFile, entry -> lib.addElement(entry.getName()), true);
 						addFileNodeToFilterTreeNode(extDeps, lib.root);
 					}
 				}


### PR DESCRIPTION
Not sure how wise and necessary this change is from maintainers' point of view, but personally, I was a bit confused not seeing source code of Java on newer MCreator versions. Does it look smelly and should I instead check the integer value at the beginning of such files (like it's currently done in `ZipIO.checkIfZip()`)?