### PR TITLE
Limit the patch feature xz spread

### DIFF
--- a/plugins/mcreator-core/features/feature_random_patch_simple.json
+++ b/plugins/mcreator-core/features/feature_random_patch_simple.json
@@ -12,6 +12,7 @@
       "name": "xzSpread",
       "value": 7,
       "min": 0,
+      "max": 16,
       "precision": 1
     },
     {


### PR DESCRIPTION
This PR fixes #3639 by limiting the xz spread to 16 (This also prevents the "Detected setBlock in a far chunk" error spam in log — features are meant to edit only the chunk they generate in, and the 8 neighboring chunks)

To span multiple chunks, the placement should make the feature more common instead