### PR TITLE
Ternary operator refactoring

### DIFF
--- a/plugins/generator-1.18.2/forge-1.18.2/procedures/_logic_ternary.java.ftl
+++ b/plugins/generator-1.18.2/forge-1.18.2/procedures/_logic_ternary.java.ftl
@@ -1,0 +1,8 @@
+<#include "mcitems.ftl">
+${outputMarker}(${condition} ?
+<#if outputMarker == "/*@ItemStack*/">${mappedMCItemToItemStackCode(ifTrue, 1)}
+<#elseif outputMarker == "/*@BlockState*/">${mappedBlockToBlockStateCode(ifTrue)}
+<#else>${ifTrue}</#if> :
+<#if outputMarker == "/*@ItemStack*/">${mappedMCItemToItemStackCode(ifFalse, 1)}
+<#elseif outputMarker == "/*@BlockState*/">${mappedBlockToBlockStateCode(ifFalse)}
+<#else>${ifFalse}</#if>)

--- a/plugins/generator-1.18.2/forge-1.18.2/utils/mcitems.ftl
+++ b/plugins/generator-1.18.2/forge-1.18.2/utils/mcitems.ftl
@@ -1,10 +1,6 @@
 <#function mappedBlockToBlockStateCode mappedBlock>
     <#if mappedBlock?starts_with("/*@BlockState*/")>
         <#return mappedBlock?replace("/*@BlockState*/","")>
-    <#elseif mappedBlock?contains("/*@?*/")>
-        <#assign outputs = mappedBlock?keep_after("/*@?*/")?keep_before_last(")")>
-        <#return mappedBlock?keep_before("/*@?*/") + "?" + mappedBlockToBlockStateCode(outputs?keep_before("/*@:*/"))
-            + ":" + mappedBlockToBlockStateCode(outputs?keep_after("/*@:*/")) + ")">
     <#else>
         <#return mappedBlockToBlock(mappedBlock) + ".defaultBlockState()">
     </#if>
@@ -13,10 +9,6 @@
 <#function mappedBlockToBlock mappedBlock>
     <#if mappedBlock?starts_with("/*@BlockState*/")>
         <#return mappedBlock?replace("/*@BlockState*/","") + ".getBlock()">
-    <#elseif mappedBlock?contains("/*@?*/")>
-        <#assign outputs = mappedBlock?keep_after("/*@?*/")?keep_before_last(")")>
-        <#return mappedBlock?keep_before("/*@?*/") + "?" + mappedBlockToBlock(outputs?keep_before("/*@:*/"))
-            + ":" + mappedBlockToBlock(outputs?keep_after("/*@:*/")) + ")">
     <#elseif mappedBlock?starts_with("CUSTOM:")>
         <#return mappedElementToRegistryEntry(mappedBlock)>
     <#else>
@@ -27,10 +19,6 @@
 <#function mappedMCItemToItemStackCode mappedBlock amount=1>
     <#if mappedBlock?starts_with("/*@ItemStack*/")>
         <#return mappedBlock?replace("/*@ItemStack*/", "")>
-    <#elseif mappedBlock?contains("/*@?*/")>
-        <#assign outputs = mappedBlock?keep_after("/*@?*/")?keep_before_last(")")>
-        <#return mappedBlock?keep_before("/*@?*/") + "?" + mappedMCItemToItemStackCode(outputs?keep_before("/*@:*/"), amount)
-            + ":" + mappedMCItemToItemStackCode(outputs?keep_after("/*@:*/"), amount) + ")">
     <#elseif mappedBlock?starts_with("CUSTOM:")>
         <#return toItemStack(mappedElementToRegistryEntry(mappedBlock), amount)>
     <#else>
@@ -49,10 +37,6 @@
 <#function mappedMCItemToItem mappedBlock>
     <#if mappedBlock?starts_with("/*@ItemStack*/")>
         <#return mappedBlock?replace("/*@ItemStack*/", "") + ".getItem()">
-    <#elseif mappedBlock?contains("/*@?*/")>
-        <#assign outputs = mappedBlock?keep_after("/*@?*/")?keep_before_last(")")>
-        <#return mappedBlock?keep_before("/*@?*/") + "?" + mappedMCItemToItem(outputs?keep_before("/*@:*/"))
-            + ":" + mappedMCItemToItem(outputs?keep_after("/*@:*/")) + ")">
     <#elseif mappedBlock?starts_with("CUSTOM:")>
         <#return mappedElementToRegistryEntry(mappedBlock) + generator.isBlock(mappedBlock)?then(".asItem()", "")>
     <#else>

--- a/plugins/generator-1.19.2/forge-1.19.2/procedures/_logic_ternary.java.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/procedures/_logic_ternary.java.ftl
@@ -1,0 +1,8 @@
+<#include "mcitems.ftl">
+${outputMarker}(${condition} ?
+<#if outputMarker == "/*@ItemStack*/">${mappedMCItemToItemStackCode(ifTrue, 1)}
+<#elseif outputMarker == "/*@BlockState*/">${mappedBlockToBlockStateCode(ifTrue)}
+<#else>${ifTrue}</#if> :
+<#if outputMarker == "/*@ItemStack*/">${mappedMCItemToItemStackCode(ifFalse, 1)}
+<#elseif outputMarker == "/*@BlockState*/">${mappedBlockToBlockStateCode(ifFalse)}
+<#else>${ifFalse}</#if>)

--- a/plugins/generator-1.19.2/forge-1.19.2/utils/mcitems.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/utils/mcitems.ftl
@@ -1,10 +1,6 @@
 <#function mappedBlockToBlockStateCode mappedBlock>
     <#if mappedBlock?starts_with("/*@BlockState*/")>
         <#return mappedBlock?replace("/*@BlockState*/","")>
-    <#elseif mappedBlock?contains("/*@?*/")>
-        <#assign outputs = mappedBlock?keep_after("/*@?*/")?keep_before_last(")")>
-        <#return mappedBlock?keep_before("/*@?*/") + "?" + mappedBlockToBlockStateCode(outputs?keep_before("/*@:*/"))
-            + ":" + mappedBlockToBlockStateCode(outputs?keep_after("/*@:*/")) + ")">
     <#else>
         <#return mappedBlockToBlock(mappedBlock) + ".defaultBlockState()">
     </#if>
@@ -13,10 +9,6 @@
 <#function mappedBlockToBlock mappedBlock>
     <#if mappedBlock?starts_with("/*@BlockState*/")>
         <#return mappedBlock?replace("/*@BlockState*/","") + ".getBlock()">
-    <#elseif mappedBlock?contains("/*@?*/")>
-        <#assign outputs = mappedBlock?keep_after("/*@?*/")?keep_before_last(")")>
-        <#return mappedBlock?keep_before("/*@?*/") + "?" + mappedBlockToBlock(outputs?keep_before("/*@:*/"))
-            + ":" + mappedBlockToBlock(outputs?keep_after("/*@:*/")) + ")">
     <#elseif mappedBlock?starts_with("CUSTOM:")>
         <#return mappedElementToRegistryEntry(mappedBlock)>
     <#else>
@@ -27,10 +19,6 @@
 <#function mappedMCItemToItemStackCode mappedBlock amount=1>
     <#if mappedBlock?starts_with("/*@ItemStack*/")>
         <#return mappedBlock?replace("/*@ItemStack*/", "")>
-    <#elseif mappedBlock?contains("/*@?*/")>
-        <#assign outputs = mappedBlock?keep_after("/*@?*/")?keep_before_last(")")>
-        <#return mappedBlock?keep_before("/*@?*/") + "?" + mappedMCItemToItemStackCode(outputs?keep_before("/*@:*/"), amount)
-            + ":" + mappedMCItemToItemStackCode(outputs?keep_after("/*@:*/"), amount) + ")">
     <#elseif mappedBlock?starts_with("CUSTOM:")>
         <#return toItemStack(mappedElementToRegistryEntry(mappedBlock), amount)>
     <#else>
@@ -49,10 +37,6 @@
 <#function mappedMCItemToItem mappedBlock>
     <#if mappedBlock?starts_with("/*@ItemStack*/")>
         <#return mappedBlock?replace("/*@ItemStack*/", "") + ".getItem()">
-    <#elseif mappedBlock?contains("/*@?*/")>
-        <#assign outputs = mappedBlock?keep_after("/*@?*/")?keep_before_last(")")>
-        <#return mappedBlock?keep_before("/*@?*/") + "?" + mappedMCItemToItem(outputs?keep_before("/*@:*/"))
-            + ":" + mappedMCItemToItem(outputs?keep_after("/*@:*/")) + ")">
     <#elseif mappedBlock?starts_with("CUSTOM:")>
         <#return mappedElementToRegistryEntry(mappedBlock) + generator.isBlock(mappedBlock)?then(".asItem()", "")>
     <#else>

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/_logic_ternary.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/_logic_ternary.java.ftl
@@ -1,0 +1,8 @@
+<#include "mcitems.ftl">
+${outputMarker}(${condition} ?
+<#if outputMarker == "/*@ItemStack*/">${mappedMCItemToItemStackCode(ifTrue, 1)}
+<#elseif outputMarker == "/*@BlockState*/">${mappedBlockToBlockStateCode(ifTrue)}
+<#else>${ifTrue}</#if> :
+<#if outputMarker == "/*@ItemStack*/">${mappedMCItemToItemStackCode(ifFalse, 1)}
+<#elseif outputMarker == "/*@BlockState*/">${mappedBlockToBlockStateCode(ifFalse)}
+<#else>${ifFalse}</#if>)

--- a/plugins/generator-1.19.4/forge-1.19.4/utils/mcitems.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/utils/mcitems.ftl
@@ -1,10 +1,6 @@
 <#function mappedBlockToBlockStateCode mappedBlock>
     <#if mappedBlock?starts_with("/*@BlockState*/")>
         <#return mappedBlock?replace("/*@BlockState*/","")>
-    <#elseif mappedBlock?contains("/*@?*/")>
-        <#assign outputs = mappedBlock?keep_after("/*@?*/")?keep_before_last(")")>
-        <#return mappedBlock?keep_before("/*@?*/") + "?" + mappedBlockToBlockStateCode(outputs?keep_before("/*@:*/"))
-            + ":" + mappedBlockToBlockStateCode(outputs?keep_after("/*@:*/")) + ")">
     <#else>
         <#return mappedBlockToBlock(mappedBlock) + ".defaultBlockState()">
     </#if>
@@ -13,10 +9,6 @@
 <#function mappedBlockToBlock mappedBlock>
     <#if mappedBlock?starts_with("/*@BlockState*/")>
         <#return mappedBlock?replace("/*@BlockState*/","") + ".getBlock()">
-    <#elseif mappedBlock?contains("/*@?*/")>
-        <#assign outputs = mappedBlock?keep_after("/*@?*/")?keep_before_last(")")>
-        <#return mappedBlock?keep_before("/*@?*/") + "?" + mappedBlockToBlock(outputs?keep_before("/*@:*/"))
-            + ":" + mappedBlockToBlock(outputs?keep_after("/*@:*/")) + ")">
     <#elseif mappedBlock?starts_with("CUSTOM:")>
         <#return mappedElementToRegistryEntry(mappedBlock)>
     <#else>
@@ -27,10 +19,6 @@
 <#function mappedMCItemToItemStackCode mappedBlock amount=1>
     <#if mappedBlock?starts_with("/*@ItemStack*/")>
         <#return mappedBlock?replace("/*@ItemStack*/", "")>
-    <#elseif mappedBlock?contains("/*@?*/")>
-        <#assign outputs = mappedBlock?keep_after("/*@?*/")?keep_before_last(")")>
-        <#return mappedBlock?keep_before("/*@?*/") + "?" + mappedMCItemToItemStackCode(outputs?keep_before("/*@:*/"), amount)
-            + ":" + mappedMCItemToItemStackCode(outputs?keep_after("/*@:*/"), amount) + ")">
     <#elseif mappedBlock?starts_with("CUSTOM:")>
         <#return toItemStack(mappedElementToRegistryEntry(mappedBlock), amount)>
     <#else>
@@ -49,10 +37,6 @@
 <#function mappedMCItemToItem mappedBlock>
     <#if mappedBlock?starts_with("/*@ItemStack*/")>
         <#return mappedBlock?replace("/*@ItemStack*/", "") + ".getItem()">
-    <#elseif mappedBlock?contains("/*@?*/")>
-        <#assign outputs = mappedBlock?keep_after("/*@?*/")?keep_before_last(")")>
-        <#return mappedBlock?keep_before("/*@?*/") + "?" + mappedMCItemToItem(outputs?keep_before("/*@:*/"))
-            + ":" + mappedMCItemToItem(outputs?keep_after("/*@:*/")) + ")">
     <#elseif mappedBlock?starts_with("CUSTOM:")>
         <#return mappedElementToRegistryEntry(mappedBlock) + generator.isBlock(mappedBlock)?then(".asItem()", "")>
     <#else>

--- a/plugins/mcreator-core/blockly/js/mcreator_blocks.js
+++ b/plugins/mcreator-core/blockly/js/mcreator_blocks.js
@@ -238,8 +238,8 @@ Blockly.Blocks['logic_ternary_op'] = {
         this.setInputsInline(true);
         this.setOutput(true);
         this.setColour('#888888');
-        Blockly.Extensions.apply('logic_ternary', this, false);
-        Blockly.Extensions.apply('mark_attached_to_block_item', this, true);
+        Blockly.Extensions.apply('logic_ternary_onchange_mixin', this, false);
+        Blockly.Extensions.apply('mark_attachment_requires_mapping', this, true);
     }
 };
 

--- a/plugins/mcreator-localization/lang/texts.properties
+++ b/plugins/mcreator-localization/lang/texts.properties
@@ -3215,7 +3215,6 @@ blockly.errors.variables.improperly_defined=One of the {0} variable blocks is im
 blockly.errors.time_to_formatted_string=Time as formatted text block can not be empty.
 blockly.errors.unsupported={0} procedure block is not supported in this editor!
 blockly.errors.remove_block=Remove this block!
-blockly.errors.ternary_operator.nesting=Ternary operator block cannot be nested in output values.
 blockly.errors.ternary_operator.no_output=Found ternary operator block without output value.
 blockly.errors.empty_mcitem=Empty Minecraft element block. You need to define the element.
 blockly.errors.exception_compiling=Exception while compiling blocks: {0}

--- a/src/main/java/net/mcreator/blockly/java/JavaKeywordsMap.java
+++ b/src/main/java/net/mcreator/blockly/java/JavaKeywordsMap.java
@@ -85,4 +85,8 @@ public final class JavaKeywordsMap {
 		put("NAN", "Double.NaN");
 	}};
 
+	public static final HashMap<String, String> MARKER_TYPES = new HashMap<>() {{
+		put("MCItem", "/*@ItemStack*/");
+		put("MCItemBlock", "/*@BlockState*/");
+	}};
 }

--- a/src/main/java/net/mcreator/blockly/java/ProcedureCodeOptimizer.java
+++ b/src/main/java/net/mcreator/blockly/java/ProcedureCodeOptimizer.java
@@ -159,6 +159,16 @@ public class ProcedureCodeOptimizer {
 	}
 
 	/**
+	 * This method maps the passed string to a marker comment for proper mapping of adjacent value by the generator
+	 *
+	 * @param marker The string to map
+	 * @return The proper marker comment
+	 */
+	public static String mapMarker(String marker) {
+		return JavaKeywordsMap.MARKER_TYPES.getOrDefault(marker, "");
+	}
+
+	/**
 	 * This method removes blockstate/itemstack/int markers from the given code
 	 *
 	 * @param code The code to optimize

--- a/src/main/java/net/mcreator/generator/blockly/BlocklyBlockCodeGenerator.java
+++ b/src/main/java/net/mcreator/generator/blockly/BlocklyBlockCodeGenerator.java
@@ -22,6 +22,7 @@ import net.mcreator.blockly.BlocklyCompileNote;
 import net.mcreator.blockly.BlocklyToCode;
 import net.mcreator.blockly.IBlockGenerator;
 import net.mcreator.blockly.data.*;
+import net.mcreator.blockly.java.ProcedureCodeOptimizer;
 import net.mcreator.generator.template.TemplateGenerator;
 import net.mcreator.generator.template.TemplateGeneratorException;
 import net.mcreator.ui.init.L10N;
@@ -105,6 +106,7 @@ public class BlocklyBlockCodeGenerator {
 
 		// we get the list of all elements present in the actual xml
 		List<Element> elements = XMLUtil.getDirectChildren(block);
+		Element mutation = XMLUtil.getFirstChildrenWithName(block, "mutation");
 
 		// check for all fields if they exist, if they do, add them to data model
 		if (toolboxBlock.getFields() != null) {
@@ -229,7 +231,6 @@ public class BlocklyBlockCodeGenerator {
 						.filter(e -> e.getNodeName().equals("field") && e.getAttribute("name")
 								.matches(fieldName + "\\d+"))
 						.collect(Collectors.toMap(e -> e.getAttribute("name"), e -> e));
-				Element mutation = XMLUtil.getFirstChildrenWithName(block, "mutation");
 				Map<Integer, String> processedElements = new HashMap<>();
 				for (int i = 0; mutation != null && mutation.hasAttribute("inputs") ?
 						i < Integer.parseInt(mutation.getAttribute("inputs")) :
@@ -261,7 +262,6 @@ public class BlocklyBlockCodeGenerator {
 						.filter(e -> e.getNodeName().equals("value") && e.getAttribute("name")
 								.matches(inputName + "\\d+"))
 						.collect(Collectors.toMap(e -> e.getAttribute("name"), e -> e));
-				Element mutation = XMLUtil.getFirstChildrenWithName(block, "mutation");
 				Map<Integer, String> processedElements = new HashMap<>();
 				for (int i = 0; mutation != null && mutation.hasAttribute("inputs") ?
 						i < Integer.parseInt(mutation.getAttribute("inputs")) :
@@ -292,7 +292,6 @@ public class BlocklyBlockCodeGenerator {
 						.filter(e -> e.getNodeName().equals("value") && e.getAttribute("name")
 								.matches(advancedInput.name() + "\\d+"))
 						.collect(Collectors.toMap(e -> e.getAttribute("name"), e -> e));
-				Element mutation = XMLUtil.getFirstChildrenWithName(block, "mutation");
 				Map<Integer, String> processedElements = new HashMap<>();
 				for (int i = 0; mutation != null && mutation.hasAttribute("inputs") ?
 						i < Integer.parseInt(mutation.getAttribute("inputs")) :
@@ -339,7 +338,6 @@ public class BlocklyBlockCodeGenerator {
 						.filter(e -> e.getNodeName().equals("statement") && e.getAttribute("name")
 								.matches(statementInput.name() + "\\d+"))
 						.collect(Collectors.toMap(e -> e.getAttribute("name"), e -> e));
-				Element mutation = XMLUtil.getFirstChildrenWithName(block, "mutation");
 				Map<Integer, String> processedElements = new HashMap<>();
 				for (int i = 0; mutation != null && mutation.hasAttribute("inputs") ?
 						i < Integer.parseInt(mutation.getAttribute("inputs")) :
@@ -395,6 +393,8 @@ public class BlocklyBlockCodeGenerator {
 
 		if (templateGenerator != null) {
 			dataModel.put("customBlockIndex", customBlockIndex);
+			if (mutation != null && mutation.hasAttribute("marker"))
+				dataModel.put("outputMarker", ProcedureCodeOptimizer.mapMarker(mutation.getAttribute("marker")));
 
 			if (additionalData != null) {
 				dataModel.putAll(additionalData);

--- a/src/main/java/net/mcreator/ui/blockly/BlocklyJavascriptBridge.java
+++ b/src/main/java/net/mcreator/ui/blockly/BlocklyJavascriptBridge.java
@@ -22,6 +22,7 @@ package net.mcreator.ui.blockly;
 import com.google.gson.Gson;
 import net.mcreator.blockly.data.ExternalTrigger;
 import net.mcreator.blockly.java.BlocklyVariables;
+import net.mcreator.blockly.java.JavaKeywordsMap;
 import net.mcreator.element.ModElementType;
 import net.mcreator.io.OS;
 import net.mcreator.minecraft.*;
@@ -264,6 +265,10 @@ public class BlocklyJavascriptBridge {
 
 	@SuppressWarnings("unused") public String getGlobalTriggers() {
 		return new Gson().toJson(ext_triggers, Map.class);
+	}
+
+	@SuppressWarnings("unused") public String[] getMarkerRequiringTypes() {
+		return JavaKeywordsMap.MARKER_TYPES.keySet().toArray(String[]::new);
 	}
 
 	@SuppressWarnings("unused") public String[] getListOf(String type) {

--- a/src/main/resources/blockly/js/mcreator_blockly.js
+++ b/src/main/resources/blockly/js/mcreator_blockly.js
@@ -90,6 +90,20 @@ function jsonToBlocklyDropDownArray(json) {
     return retval;
 }
 
+function setMarkerStatus(container, block) {
+    var parentConnection = block.outputConnection && block.outputConnection.targetConnection;
+    if (parentConnection && parentConnection.getCheck()) {
+        var types = parentConnection.getCheck();
+        for (const mark of javabridge.getMarkerRequiringTypes()) {
+            if (types.indexOf('' + mark) != -1) { // add empty string to "convert" Java strings to JS strings
+                container.setAttribute('marker', mark);
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 // Helper function to use in Blockly extensions that append a dropdown
 function appendDropDown(listType, fieldName) {
     return function () {


### PR DESCRIPTION
Looking at how the `return_*` procedure block is designed to be generated, I thought of applying the same approach to the `logic_ternary_op` block so that we don't need massive hackery in `mcitems.ftl` that started becoming a problem as of https://github.com/MCreator/MCreator/pull/3660#issuecomment-1480066261, and this is what the PR is focused on.
* `mark_attached_to_block_item` extension was renamed to more generic `mark_attachment_requires_mapping`, and the mutation node it creates now stores `marker` string representing the type of values the parent input accepts instead of simply boolean `mark` property;
* `logic_ternary` extension used by the block for validation of output values (`THEN`/`ELSE`) was replaced with a custom one (`logic_ternary_onchange_mixin`) that does not barely disconnects mismatching blocks but instead updates types of values accepted by specified inputs (this removes another limitation of the operator block, allowing to nest it in output values).