### PR TITLE
[1.19.4] Port some entity related procedure blocks

### DIFF
--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_despawn.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_despawn.java.ftl
@@ -1,0 +1,1 @@
+if(!${input$entity}.level.isClientSide()) ${input$entity}.discard();

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_dimension_id.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_dimension_id.java.ftl
@@ -1,0 +1,1 @@
+(${input$entity}.level.dimension())

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_direction.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_direction.java.ftl
@@ -1,0 +1,1 @@
+/*@float*/(${input$entity}.getYRot())

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_direction_value.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_direction_value.java.ftl
@@ -1,0 +1,1 @@
+(${input$entity}.getDirection())

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_disable_damage.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_disable_damage.java.ftl
@@ -1,0 +1,4 @@
+if(${input$entity} instanceof Player _player) {
+    _player.getAbilities().invulnerable = ${input$condition};
+    _player.onUpdateAbilities();
+}

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_execute_command.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_execute_command.java.ftl
@@ -1,0 +1,10 @@
+{
+	Entity _ent = ${input$entity};
+	if(!_ent.level.isClientSide() && _ent.getServer() != null) {
+		_ent.getServer().getCommands().performPrefixedCommand(new CommandSourceStack(
+			CommandSource.NULL, _ent.position(), _ent.getRotationVector(),
+			_ent.level instanceof ServerLevel ? (ServerLevel) _ent.level : null, 4,
+			_ent.getName().getString(), _ent.getDisplayName(), _ent.level.getServer(), _ent
+		), ${input$command});
+	}
+}

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_extinguish.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_extinguish.java.ftl
@@ -1,0 +1,1 @@
+${input$entity}.clearFire();

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_foodlevel.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_foodlevel.java.ftl
@@ -1,0 +1,1 @@
+/*@int*/(${input$entity} instanceof Player _plr ? _plr.getFoodData().getFoodLevel():0)

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_get_absorption.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_get_absorption.java.ftl
@@ -1,0 +1,1 @@
+/*@float*/(${input$entity} instanceof Player _plr ? _plr.getAbsorptionAmount() : 0)

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_get_armor_slot_item.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_get_armor_slot_item.java.ftl
@@ -1,0 +1,2 @@
+<#include "mcelements.ftl">
+/*@ItemStack*/(${input$entity} instanceof LivingEntity _entGetArmor ? _entGetArmor.getItemBySlot(${toArmorSlot(input$slotid)}):ItemStack.EMPTY)

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_get_controlling_passenger.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_get_controlling_passenger.java.ftl
@@ -1,0 +1,1 @@
+(${input$entity}.getControllingPassenger())

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_get_fire_ticks.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_get_fire_ticks.java.ftl
@@ -1,0 +1,1 @@
+/*@int*/(${input$entity}.getRemainingFireTicks())

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_get_first_passenger.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_get_first_passenger.java.ftl
@@ -1,0 +1,1 @@
+(${input$entity}.getFirstPassenger())

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_get_fly_speed.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_get_fly_speed.java.ftl
@@ -1,0 +1,1 @@
+/*@float*/(${input$entity} instanceof Player _plr ? _plr.getAbilities().getFlyingSpeed():0)

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_get_oxygen.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_get_oxygen.java.ftl
@@ -1,0 +1,1 @@
+/*@int*/(${input$entity}.getAirSupply())

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_get_saturation.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_get_saturation.java.ftl
@@ -1,0 +1,1 @@
+(${input$entity} instanceof Player _plr ? _plr.getFoodData().getSaturationLevel():0)

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_get_shootpower.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_get_shootpower.java.ftl
@@ -1,0 +1,1 @@
+(${input$projectile_entity} instanceof Projectile _projEnt? _projEnt.getDeltaMovement().length():0)

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_get_slot.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_get_slot.java.ftl
@@ -1,0 +1,10 @@
+<#include "mcitems.ftl">
+/*@ItemStack*/(new Object(){
+	public ItemStack getItemStack(int sltid, Entity entity) {
+		AtomicReference<ItemStack> _retval = new AtomicReference<>(ItemStack.EMPTY);
+		entity.getCapability(ForgeCapabilities.ITEM_HANDLER, null).ifPresent(capability -> {
+			_retval.set(capability.getStackInSlot(sltid).copy());
+		});
+		return _retval.get();
+	}
+}.getItemStack(${opt.toInt(input$slotid)}, ${input$entity}))

--- a/plugins/generator-1.19.4/forge-1.19.4/utils/mcelements.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/utils/mcelements.ftl
@@ -1,0 +1,37 @@
+<#function toResourceLocation string>
+    <#if string?matches('"[^+]*"')>
+        <#return "new ResourceLocation(" + string?lower_case + ")">
+    <#else>
+        <#return "new ResourceLocation((" + string + ").toLowerCase(java.util.Locale.ENGLISH))">
+    </#if>
+</#function>
+
+<#function toArmorSlot slot>
+    <#if slot == "/*@int*/0">
+        <#return "EquipmentSlot.FEET">
+    <#elseif slot == "/*@int*/1">
+        <#return "EquipmentSlot.LEGS">
+    <#elseif slot == "/*@int*/2">
+        <#return "EquipmentSlot.CHEST">
+    <#elseif slot == "/*@int*/3">
+        <#return "EquipmentSlot.HEAD">
+    <#else>
+        <#return "EquipmentSlot.byTypeAndIndex(EquipmentSlot.Type.ARMOR, ${opt.toInt(slot)})">
+    </#if>
+</#function>
+
+<#function toAxis direction>
+    <#if (direction == "Direction.EAST") || (direction == "Direction.WEST")>
+        <#return "Direction.Axis.X">
+    <#elseif (direction == "Direction.UP") || (direction == "Direction.DOWN")>
+        <#return "Direction.Axis.Y">
+    <#elseif (direction == "Direction.NORTH") || (direction == "Direction.SOUTH")>
+        <#return "Direction.Axis.Z">
+    <#else>
+        <#return direction + ".getAxis()">
+    </#if>
+</#function>
+
+<#function toBlockPos x y z>
+    <#return "new BlockPos(" + opt.removeParentheses(x) + "," + opt.removeParentheses(y) + "," + opt.removeParentheses(z) +")">
+</#function>


### PR DESCRIPTION
This PR ports some entity-related procedure blocks to 1.19.4. All blocks are exactly the same as in 1.19.2.
It also includes `mcelements.ftl`, but nothing changed in this file too.