### PR TITLE
[1.19.4] Port some world procedure blocks

### DIFF
--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/world_data_block_direction_at.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/world_data_block_direction_at.java.ftl
@@ -1,0 +1,13 @@
+<#include "mcelements.ftl">
+(new Object() {
+	public Direction getDirection(BlockPos pos){
+		BlockState _bs = world.getBlockState(pos);
+		Property<?> property = _bs.getBlock().getStateDefinition().getProperty("facing");
+		if (property != null && _bs.getValue(property) instanceof Direction _dir)
+			return _dir;
+		else if (_bs.hasProperty(BlockStateProperties.AXIS))
+			return Direction.fromAxisAndDirection(_bs.getValue(BlockStateProperties.AXIS), Direction.AxisDirection.POSITIVE);
+		else if (_bs.hasProperty(BlockStateProperties.HORIZONTAL_AXIS))
+			return Direction.fromAxisAndDirection(_bs.getValue(BlockStateProperties.HORIZONTAL_AXIS), Direction.AxisDirection.POSITIVE);
+		return Direction.NORTH;
+}}.getDirection(${toBlockPos(input$x,input$y,input$z)}))

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/world_data_blockat.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/world_data_blockat.java.ftl
@@ -1,0 +1,2 @@
+<#include "mcelements.ftl">
+/*@BlockState*/(world.getBlockState(${toBlockPos(input$x,input$y,input$z)}))

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/world_data_canseesky.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/world_data_canseesky.java.ftl
@@ -1,0 +1,2 @@
+<#include "mcelements.ftl">
+(world.canSeeSkyFromBelowWater(${toBlockPos(input$x,input$y,input$z)}))

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/world_data_checkdifficulty.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/world_data_checkdifficulty.java.ftl
@@ -1,0 +1,1 @@
+(world.getDifficulty()==Difficulty.${field$difficulty})

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/world_data_current_time.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/world_data_current_time.java.ftl
@@ -1,0 +1,1 @@
+/*@float*/(world.dayTime())

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/world_data_dimensionid.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/world_data_dimensionid.java.ftl
@@ -1,0 +1,1 @@
+(world instanceof Level _lvl ? _lvl.dimension() : Level.OVERWORLD)

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/world_data_fluidat.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/world_data_fluidat.java.ftl
@@ -1,0 +1,2 @@
+<#include "mcelements.ftl">
+/*@BlockState*/(world.getFluidState(${toBlockPos(input$x,input$y,input$z)}).createLegacyBlock())

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/world_data_get_indirect_power.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/world_data_get_indirect_power.java.ftl
@@ -1,0 +1,2 @@
+<#include "mcelements.ftl">
+/*@int*/(world instanceof Level _lvl_getIndPow ? _lvl_getIndPow.getBestNeighborSignal(${toBlockPos(input$x,input$y,input$z)}):0)

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/world_data_get_redstone_power.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/world_data_get_redstone_power.java.ftl
@@ -1,0 +1,2 @@
+<#include "mcelements.ftl">
+/*@int*/(world instanceof Level _lvl_getRedPow ? _lvl_getRedPow.getSignal(${toBlockPos(input$x,input$y,input$z)}, ${input$direction}):0)

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/world_data_heightat.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/world_data_heightat.java.ftl
@@ -1,0 +1,1 @@
+/*@int*/(world.getHeight(Heightmap.Types.${field$heightType}, ${opt.toInt(input$x)}, ${opt.toInt(input$z)}))

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/world_data_is_block_powered.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/world_data_is_block_powered.java.ftl
@@ -1,0 +1,2 @@
+<#include "mcelements.ftl">
+(world instanceof Level _lvl_isPow && _lvl_isPow.hasNeighborSignal(${toBlockPos(input$x,input$y,input$z)}))

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/world_data_isair.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/world_data_isair.java.ftl
@@ -1,0 +1,2 @@
+<#include "mcelements.ftl">
+(world.isEmptyBlock(${toBlockPos(input$x,input$y,input$z)}))

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/world_data_isday.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/world_data_isday.java.ftl
@@ -1,0 +1,1 @@
+(world instanceof Level _lvl && _lvl.isDay())

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/world_data_israining.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/world_data_israining.java.ftl
@@ -1,0 +1,1 @@
+(world.getLevelData().isRaining())

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/world_data_isremote.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/world_data_isremote.java.ftl
@@ -1,0 +1,1 @@
+(world.isClientSide())

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/world_data_isthundering.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/world_data_isthundering.java.ftl
@@ -1,0 +1,1 @@
+(world.getLevelData().isThundering())

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/world_data_light_level.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/world_data_light_level.java.ftl
@@ -1,0 +1,2 @@
+<#include "mcelements.ftl">
+/*@int*/(world.getMaxLocalRawBrightness(${toBlockPos(input$x,input$y,input$z)}))

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/world_data_moon_phase.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/world_data_moon_phase.java.ftl
@@ -1,0 +1,1 @@
+/*@int*/(world.dimensionType().moonPhase(world.dayTime()))

--- a/plugins/generator-1.19.4/forge-1.19.4/utils/mcelements.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/utils/mcelements.ftl
@@ -33,5 +33,5 @@
 </#function>
 
 <#function toBlockPos x y z>
-    <#return "new BlockPos(" + opt.removeParentheses(x) + "," + opt.removeParentheses(y) + "," + opt.removeParentheses(z) +")">
+	<#return "BlockPos.containing(" + opt.removeParentheses(x) + "," + opt.removeParentheses(y) + "," + opt.removeParentheses(z) +")">
 </#function>

--- a/plugins/generator-1.19.4/forge-1.19.4/utils/mcelements.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/utils/mcelements.ftl
@@ -1,37 +1,41 @@
 <#function toResourceLocation string>
-    <#if string?matches('"[^+]*"')>
-        <#return "new ResourceLocation(" + string?lower_case + ")">
-    <#else>
-        <#return "new ResourceLocation((" + string + ").toLowerCase(java.util.Locale.ENGLISH))">
-    </#if>
+	<#if string?matches('"[^+]*"')>
+		<#return "new ResourceLocation(" + string?lower_case + ")">
+	<#else>
+		<#return "new ResourceLocation((" + string + ").toLowerCase(java.util.Locale.ENGLISH))">
+	</#if>
 </#function>
 
 <#function toArmorSlot slot>
-    <#if slot == "/*@int*/0">
-        <#return "EquipmentSlot.FEET">
-    <#elseif slot == "/*@int*/1">
-        <#return "EquipmentSlot.LEGS">
-    <#elseif slot == "/*@int*/2">
-        <#return "EquipmentSlot.CHEST">
-    <#elseif slot == "/*@int*/3">
-        <#return "EquipmentSlot.HEAD">
-    <#else>
-        <#return "EquipmentSlot.byTypeAndIndex(EquipmentSlot.Type.ARMOR, ${opt.toInt(slot)})">
-    </#if>
+	<#if slot == "/*@int*/0">
+		<#return "EquipmentSlot.FEET">
+	<#elseif slot == "/*@int*/1">
+		<#return "EquipmentSlot.LEGS">
+	<#elseif slot == "/*@int*/2">
+		<#return "EquipmentSlot.CHEST">
+	<#elseif slot == "/*@int*/3">
+		<#return "EquipmentSlot.HEAD">
+	<#else>
+		<#return "EquipmentSlot.byTypeAndIndex(EquipmentSlot.Type.ARMOR, ${opt.toInt(slot)})">
+	</#if>
 </#function>
 
 <#function toAxis direction>
-    <#if (direction == "Direction.EAST") || (direction == "Direction.WEST")>
-        <#return "Direction.Axis.X">
-    <#elseif (direction == "Direction.UP") || (direction == "Direction.DOWN")>
-        <#return "Direction.Axis.Y">
-    <#elseif (direction == "Direction.NORTH") || (direction == "Direction.SOUTH")>
-        <#return "Direction.Axis.Z">
-    <#else>
-        <#return direction + ".getAxis()">
-    </#if>
+	<#if (direction == "Direction.EAST") || (direction == "Direction.WEST")>
+		<#return "Direction.Axis.X">
+	<#elseif (direction == "Direction.UP") || (direction == "Direction.DOWN")>
+		<#return "Direction.Axis.Y">
+	<#elseif (direction == "Direction.NORTH") || (direction == "Direction.SOUTH")>
+		<#return "Direction.Axis.Z">
+	<#else>
+		<#return direction + ".getAxis()">
+	</#if>
 </#function>
 
 <#function toBlockPos x y z>
-	<#return "BlockPos.containing(" + opt.removeParentheses(x) + "," + opt.removeParentheses(y) + "," + opt.removeParentheses(z) +")">
+	<#if x?starts_with("/*@int*/") && y?starts_with("/*@int*/") && z?starts_with("/*@int*/")>
+		<#return "new BlockPos(" + opt.removeParentheses(x) + "," + opt.removeParentheses(y) + "," + opt.removeParentheses(z) +")">
+	<#else>
+		<#return "BlockPos.containing(" + opt.removeParentheses(x) + "," + opt.removeParentheses(y) + "," + opt.removeParentheses(z) +")">
+	</#if>
 </#function>


### PR DESCRIPTION
This PR ports some world procedure blocks as well as porting the `toBlockPos` function inside `mcelements.ftl` (BlockPos got several changes and the constructor no longer support double).

Almost everything is like in 1.19.2, except the `world_data_block_direction_at` that required some changes for the axis part.