### PR TITLE
[1.19.4] Port the GUI element

### DIFF
--- a/plugins/generator-1.19.4/forge-1.19.4/gui.definition.yaml
+++ b/plugins/generator-1.19.4/forge-1.19.4/gui.definition.yaml
@@ -1,0 +1,31 @@
+templates:
+  - template: gui/gui_container.java.ftl
+    name: "@SRCROOT/@BASEPACKAGEPATH/world/inventory/@NAMEMenu.java"
+  - template: gui/gui_window.java.ftl
+    name: "@SRCROOT/@BASEPACKAGEPATH/client/gui/@NAMEScreen.java"
+  - template: gui/gui_msg_button.java.ftl
+    name: "@SRCROOT/@BASEPACKAGEPATH/network/@NAMEButtonMessage.java"
+    condition: hasButtonEvents()
+  - template: gui/gui_msg_slot.java.ftl
+    name: "@SRCROOT/@BASEPACKAGEPATH/network/@NAMESlotMessage.java"
+    condition: hasSlotEvents()
+
+global_templates:
+  - template: elementinits/menus.java.ftl
+    name: "@SRCROOT/@BASEPACKAGEPATH/init/@JavaModNameMenus.java"
+  - template: elementinits/screens.java.ftl
+    name: "@SRCROOT/@BASEPACKAGEPATH/init/@JavaModNameScreens.java"
+
+localizationkeys:
+  - fromlist: data.getFixedTextLabels()
+    key: gui.@modid.@registryname.@[getName()]
+    mapto: getRenderText()
+  - fromlist: data.getComponentsOfType('TextField')
+    key: gui.@modid.@registryname.@[getName()]
+    mapto: placeholder
+  - fromlist: data.getComponentsOfType('Button')
+    key: gui.@modid.@registryname.@[getName()]
+    mapto: text
+  - fromlist: data.getComponentsOfType('Checkbox')
+    key: gui.@modid.@registryname.@[getName()]
+    mapto: text

--- a/plugins/generator-1.19.4/forge-1.19.4/templates/elementinits/menus.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/templates/elementinits/menus.java.ftl
@@ -1,0 +1,50 @@
+<#--
+ # MCreator (https://mcreator.net/)
+ # Copyright (C) 2012-2020, Pylo
+ # Copyright (C) 2020-2022, Pylo, opensource contributors
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # Additional permission for code generator templates (*.ftl files)
+ #
+ # As a special exception, you may create a larger work that contains part or
+ # all of the MCreator code generator templates (*.ftl files) and distribute
+ # that work under terms of your choice, so long as that work isn't itself a
+ # template for code generation. Alternatively, if you modify or redistribute
+ # the template itself, you may (at your option) remove this special exception,
+ # which will cause the template and the resulting code generator output files
+ # to be licensed under the GNU General Public License without this special
+ # exception.
+-->
+
+<#-- @formatter:off -->
+
+/*
+ *	MCreator note: This file will be REGENERATED on each build.
+ */
+
+package ${package}.init;
+
+public class ${JavaModName}Menus {
+
+	public static final DeferredRegister<MenuType<?>> REGISTRY = DeferredRegister.create(ForgeRegistries.MENU_TYPES, ${JavaModName}.MODID);
+
+	<#list guis as gui>
+	public static final RegistryObject<MenuType<${gui.getModElement().getName()}Menu>> ${gui.getModElement().getRegistryNameUpper()}
+		= REGISTRY.register("${gui.getModElement().getRegistryName()}", () -> IForgeMenuType.create(${gui.getModElement().getName()}Menu::new));
+	</#list>
+
+}
+
+<#-- @formatter:on -->

--- a/plugins/generator-1.19.4/forge-1.19.4/templates/elementinits/screens.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/templates/elementinits/screens.java.ftl
@@ -1,0 +1,51 @@
+<#--
+ # MCreator (https://mcreator.net/)
+ # Copyright (C) 2012-2020, Pylo
+ # Copyright (C) 2020-2022, Pylo, opensource contributors
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # Additional permission for code generator templates (*.ftl files)
+ #
+ # As a special exception, you may create a larger work that contains part or
+ # all of the MCreator code generator templates (*.ftl files) and distribute
+ # that work under terms of your choice, so long as that work isn't itself a
+ # template for code generation. Alternatively, if you modify or redistribute
+ # the template itself, you may (at your option) remove this special exception,
+ # which will cause the template and the resulting code generator output files
+ # to be licensed under the GNU General Public License without this special
+ # exception.
+-->
+
+<#-- @formatter:off -->
+
+/*
+ *	MCreator note: This file will be REGENERATED on each build.
+ */
+
+package ${package}.init;
+
+@Mod.EventBusSubscriber(bus = Mod.EventBusSubscriber.Bus.MOD, value = Dist.CLIENT) public class ${JavaModName}Screens {
+
+	@SubscribeEvent public static void clientLoad(FMLClientSetupEvent event) {
+		event.enqueueWork(() -> {
+			<#list guis as gui>
+			MenuScreens.register(${JavaModName}Menus.${gui.getModElement().getRegistryNameUpper()}.get(), ${gui.getModElement().getName()}Screen::new);
+			</#list>
+		});
+	}
+
+}
+
+<#-- @formatter:on -->

--- a/plugins/generator-1.19.4/forge-1.19.4/templates/gui/gui_container.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/templates/gui/gui_container.java.ftl
@@ -1,0 +1,298 @@
+<#--
+ # MCreator (https://mcreator.net/)
+ # Copyright (C) 2012-2020, Pylo
+ # Copyright (C) 2020-2022, Pylo, opensource contributors
+ # 
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ # 
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ # 
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ # 
+ # Additional permission for code generator templates (*.ftl files)
+ # 
+ # As a special exception, you may create a larger work that contains part or 
+ # all of the MCreator code generator templates (*.ftl files) and distribute 
+ # that work under terms of your choice, so long as that work isn't itself a 
+ # template for code generation. Alternatively, if you modify or redistribute 
+ # the template itself, you may (at your option) remove this special exception, 
+ # which will cause the template and the resulting code generator output files 
+ # to be licensed under the GNU General Public License without this special 
+ # exception.
+-->
+
+<#-- @formatter:off -->
+<#include "../mcitems.ftl">
+<#include "../procedures.java.ftl">
+
+<#assign mx = (data.W - data.width) / 2>
+<#assign my = (data.H - data.height) / 2>
+<#assign slotnum = 0>
+
+package ${package}.world.inventory;
+
+import ${package}.${JavaModName};
+
+<#compress>
+<#if hasProcedure(data.onTick)>
+@Mod.EventBusSubscriber
+</#if>
+public class ${name}Menu extends AbstractContainerMenu implements Supplier<Map<Integer, Slot>> {
+
+	public final static HashMap<String, Object> guistate = new HashMap<>();
+
+	public final Level world;
+	public final Player entity;
+	public int x, y, z;
+
+	private IItemHandler internal;
+
+	private final Map<Integer, Slot> customSlots = new HashMap<>();
+
+	private boolean bound = false;
+
+	public ${name}Menu(int id, Inventory inv, FriendlyByteBuf extraData) {
+		super(${JavaModName}Menus.${data.getModElement().getRegistryNameUpper()}.get(), id);
+
+		this.entity = inv.player;
+		this.world = inv.player.level;
+
+		this.internal = new ItemStackHandler(${data.getMaxSlotID() + 1});
+
+		BlockPos pos = null;
+		if (extraData != null) {
+			pos = extraData.readBlockPos();
+			this.x = pos.getX();
+			this.y = pos.getY();
+			this.z = pos.getZ();
+		}
+
+		<#if data.type == 1>
+			if (pos != null) {
+				if (extraData.readableBytes() == 1) { // bound to item
+					byte hand = extraData.readByte();
+					ItemStack itemstack;
+					if(hand == 0)
+						itemstack = this.entity.getMainHandItem();
+					else
+						itemstack = this.entity.getOffhandItem();
+					itemstack.getCapability(ForgeCapabilities.ITEM_HANDLER, null).ifPresent(capability -> {
+						this.internal = capability;
+						this.bound = true;
+					});
+				} else if (extraData.readableBytes() > 1) {
+					extraData.readByte(); // drop padding
+					Entity entity = world.getEntity(extraData.readVarInt());
+					if(entity != null)
+						entity.getCapability(ForgeCapabilities.ITEM_HANDLER, null).ifPresent(capability -> {
+							this.internal = capability;
+							this.bound = true;
+						});
+				} else { // might be bound to block
+					BlockEntity ent = inv.player != null ? inv.player.level.getBlockEntity(pos) : null;
+					if (ent != null) {
+						ent.getCapability(ForgeCapabilities.ITEM_HANDLER, null).ifPresent(capability -> {
+							this.internal = capability;
+							this.bound = true;
+						});
+					}
+				}
+			}
+
+			<#list data.components as component>
+				<#if component.getClass().getSimpleName()?ends_with("Slot")>
+					<#assign slotnum += 1>
+					this.customSlots.put(${component.id}, this.addSlot(new SlotItemHandler(internal, ${component.id},
+						${(component.x - mx)?int + 1},
+						${(component.y - my)?int + 1}) {
+
+						<#if hasProcedure(component.disablePickup) || component.disablePickup.getFixedValue()>
+						@Override public boolean mayPickup(Player entity) {
+							return <@procedureOBJToConditionCode component.disablePickup false true/>;
+						}
+						</#if>
+
+						<#if hasProcedure(component.onSlotChanged)>
+						@Override public void setChanged() {
+							super.setChanged();
+							slotChanged(${component.id}, 0, 0);
+						}
+						</#if>
+
+						<#if hasProcedure(component.onTakenFromSlot)>
+						@Override public void onTake(Player entity, ItemStack stack) {
+							super.onTake(entity, stack);
+							slotChanged(${component.id}, 1, 0);
+						}
+						</#if>
+
+						<#if hasProcedure(component.onStackTransfer)>
+						@Override public void onQuickCraft(ItemStack a, ItemStack b) {
+							super.onQuickCraft(a, b);
+							slotChanged(${component.id}, 2, b.getCount() - a.getCount());
+						}
+						</#if>
+
+						<#if component.getClass().getSimpleName() == "InputSlot">
+							<#if hasProcedure(component.disablePlacement) || component.disablePlacement.getFixedValue()>
+								@Override public boolean mayPlace(ItemStack itemstack) {
+									return <@procedureOBJToConditionCode component.disablePlacement false true/>;
+								}
+							<#elseif component.inputLimit.toString()?has_content>
+								@Override public boolean mayPlace(ItemStack stack) {
+									<#if component.inputLimit.getUnmappedValue().startsWith("TAG:")>
+										<#assign tag = "\"" + component.inputLimit.getUnmappedValue().replace("TAG:", "") + "\"">
+										return stack.is(ItemTags.create(new ResourceLocation(${tag})));
+									<#else>
+										return ${mappedMCItemToItem(component.inputLimit)} == stack.getItem();
+									</#if>
+								}
+							</#if>
+						<#elseif component.getClass().getSimpleName() == "OutputSlot">
+							@Override public boolean mayPlace(ItemStack stack) {
+								return false;
+							}
+						</#if>
+					}));
+				</#if>
+			</#list>
+
+			<#assign coffx = ((data.width - 176) / 2 + data.inventoryOffsetX)?int>
+			<#assign coffy = ((data.height - 166) / 2 + data.inventoryOffsetY)?int>
+
+			for (int si = 0; si < 3; ++si)
+				for (int sj = 0; sj < 9; ++sj)
+					this.addSlot(new Slot(inv, sj + (si + 1) * 9, ${coffx} + 8 + sj * 18, ${coffy}+ 84 + si * 18));
+
+			for (int si = 0; si < 9; ++si)
+				this.addSlot(new Slot(inv, si, ${coffx} + 8 + si * 18, ${coffy} + 142));
+		</#if>
+
+		<#if hasProcedure(data.onOpen)>
+			<@procedureOBJToCode data.onOpen/>
+		</#if>
+	}
+
+	@Override public boolean stillValid(Player player) {
+		return true;
+	}
+
+	<#if data.type == 1>
+		@Override public ItemStack quickMoveStack(Player playerIn, int index) {
+			ItemStack itemstack = ItemStack.EMPTY;
+			Slot slot = (Slot) this.slots.get(index);
+
+			if (slot != null && slot.hasItem()) {
+				ItemStack itemstack1 = slot.getItem();
+				itemstack = itemstack1.copy();
+
+				if (index < ${slotnum}) {
+					if (!this.moveItemStackTo(itemstack1, ${slotnum}, this.slots.size(), true))
+						return ItemStack.EMPTY;
+					slot.onQuickCraft(itemstack1, itemstack);
+				} else if (!this.moveItemStackTo(itemstack1, 0, ${slotnum}, false)) {
+					if (index < ${slotnum} + 27) {
+						if (!this.moveItemStackTo(itemstack1, ${slotnum} + 27, this.slots.size(), true))
+							return ItemStack.EMPTY;
+					} else {
+						if (!this.moveItemStackTo(itemstack1, ${slotnum}, ${slotnum} + 27, false))
+							return ItemStack.EMPTY;
+					}
+					return ItemStack.EMPTY;
+				}
+
+				if (itemstack1.getCount() == 0)
+					slot.set(ItemStack.EMPTY);
+				else
+					slot.setChanged();
+
+				if (itemstack1.getCount() == itemstack.getCount())
+					return ItemStack.EMPTY;
+
+				slot.onTake(playerIn, itemstack1);
+			}
+			return itemstack;
+		}
+
+		<#-- #47997 -->
+		@Override ${mcc.getMethod("net.minecraft.world.inventory.AbstractContainerMenu", "moveItemStackTo", "ItemStack", "int", "int", "boolean")
+			.replace("slot.setChanged();", "slot.set(itemstack);")
+			.replace("!itemstack.isEmpty()", "slot.mayPlace(itemstack) && !itemstack.isEmpty()")}
+
+		@Override public void removed(Player playerIn) {
+			super.removed(playerIn);
+
+			<#if hasProcedure(data.onClosed)>
+				<@procedureOBJToCode data.onClosed/>
+			</#if>
+
+			if (!bound && playerIn instanceof ServerPlayer serverPlayer) {
+				if (!serverPlayer.isAlive() || serverPlayer.hasDisconnected()) {
+					for(int j = 0; j < internal.getSlots(); ++j) {
+						<#list data.components as component>
+							<#if component.getClass().getSimpleName()?ends_with("Slot") && !component.dropItemsWhenNotBound>
+								if(j == ${component.id}) continue;
+							</#if>
+						</#list>
+						playerIn.drop(internal.extractItem(j, internal.getStackInSlot(j).getCount(), false), false);
+					}
+				} else {
+					for(int i = 0; i < internal.getSlots(); ++i) {
+						<#list data.components as component>
+							<#if component.getClass().getSimpleName()?ends_with("Slot") && !component.dropItemsWhenNotBound>
+								if(i == ${component.id}) continue;
+							</#if>
+						</#list>
+						playerIn.getInventory().placeItemBackInInventory(internal.extractItem(i, internal.getStackInSlot(i).getCount(), false));
+					}
+				}
+			}
+		}
+
+		<#if data.hasSlotEvents()>
+			private void slotChanged(int slotid, int ctype, int meta) {
+				if(this.world != null && this.world.isClientSide()) {
+					${JavaModName}.PACKET_HANDLER.sendToServer(new ${name}SlotMessage(slotid, x, y, z, ctype, meta));
+					${name}SlotMessage.handleSlotAction(entity, slotid, ctype, meta, x, y, z);
+				}
+			}
+		</#if>
+	<#else>
+		@Override public ItemStack quickMoveStack(Player playerIn, int index) {
+			return ItemStack.EMPTY;
+		}
+		<#if hasProcedure(data.onClosed)>
+			@Override public void removed(Player playerIn) {
+				super.removed(playerIn);
+				<@procedureOBJToCode data.onClosed/>
+			}
+		</#if>
+	</#if>
+
+	public Map<Integer, Slot> get() {
+		return customSlots;
+	}
+
+	<#if hasProcedure(data.onTick)>
+		@SubscribeEvent public static void onPlayerTick(TickEvent.PlayerTickEvent event) {
+			Player entity = event.player;
+			if(event.phase == TickEvent.Phase.END && entity.containerMenu instanceof ${name}Menu) {
+				Level world = entity.level;
+				double x = entity.getX();
+				double y = entity.getY();
+				double z = entity.getZ();
+				<@procedureOBJToCode data.onTick/>
+			}
+		}
+	</#if>
+
+}
+</#compress>
+<#-- @formatter:on -->

--- a/plugins/generator-1.19.4/forge-1.19.4/templates/gui/gui_msg_button.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/templates/gui/gui_msg_button.java.ftl
@@ -1,0 +1,107 @@
+<#--
+ # MCreator (https://mcreator.net/)
+ # Copyright (C) 2012-2020, Pylo
+ # Copyright (C) 2020-2022, Pylo, opensource contributors
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # Additional permission for code generator templates (*.ftl files)
+ #
+ # As a special exception, you may create a larger work that contains part or
+ # all of the MCreator code generator templates (*.ftl files) and distribute
+ # that work under terms of your choice, so long as that work isn't itself a
+ # template for code generation. Alternatively, if you modify or redistribute
+ # the template itself, you may (at your option) remove this special exception,
+ # which will cause the template and the resulting code generator output files
+ # to be licensed under the GNU General Public License without this special
+ # exception.
+-->
+
+<#-- @formatter:off -->
+<#include "../procedures.java.ftl">
+
+package ${package}.network;
+
+@Mod.EventBusSubscriber(bus = Mod.EventBusSubscriber.Bus.MOD) public class ${name}ButtonMessage {
+
+	private final int buttonID, x, y, z;
+
+	public ${name}ButtonMessage(FriendlyByteBuf buffer) {
+		this.buttonID = buffer.readInt();
+		this.x = buffer.readInt();
+		this.y = buffer.readInt();
+		this.z = buffer.readInt();
+	}
+
+	public ${name}ButtonMessage(int buttonID, int x, int y, int z) {
+		this.buttonID = buttonID;
+		this.x = x;
+		this.y = y;
+		this.z = z;
+	}
+
+	public static void buffer(${name}ButtonMessage message, FriendlyByteBuf buffer) {
+		buffer.writeInt(message.buttonID);
+		buffer.writeInt(message.x);
+		buffer.writeInt(message.y);
+		buffer.writeInt(message.z);
+	}
+
+	public static void handler(${name}ButtonMessage message, Supplier<NetworkEvent.Context> contextSupplier) {
+		NetworkEvent.Context context = contextSupplier.get();
+		context.enqueueWork(() -> {
+			Player entity = context.getSender();
+			int buttonID = message.buttonID;
+			int x = message.x;
+			int y = message.y;
+			int z = message.z;
+
+			handleButtonAction(entity, buttonID, x, y, z);
+		});
+		context.setPacketHandled(true);
+	}
+
+	public static void handleButtonAction(Player entity, int buttonID, int x, int y, int z) {
+		Level world = entity.level;
+		HashMap guistate = ${name}Menu.guistate;
+
+		// security measure to prevent arbitrary chunk generation
+		if (!world.hasChunkAt(new BlockPos(x, y, z)))
+			return;
+
+		<#assign btid = 0>
+		<#list data.getComponentsOfType("Button") as component>
+				<#if hasProcedure(component.onClick)>
+					if (buttonID == ${btid}) {
+						<@procedureOBJToCode component.onClick/>
+					}
+				</#if>
+				<#assign btid +=1>
+		</#list>
+		<#list data.getComponentsOfType("ImageButton") as component>
+				<#if hasProcedure(component.onClick)>
+					if (buttonID == ${btid}) {
+						<@procedureOBJToCode component.onClick/>
+					}
+				</#if>
+				<#assign btid +=1>
+		</#list>
+	}
+
+	@SubscribeEvent public static void registerMessage(FMLCommonSetupEvent event) {
+		${JavaModName}.addNetworkMessage(${name}ButtonMessage.class, ${name}ButtonMessage::buffer, ${name}ButtonMessage::new, ${name}ButtonMessage::handler);
+	}
+
+}
+<#-- @formatter:on -->

--- a/plugins/generator-1.19.4/forge-1.19.4/templates/gui/gui_msg_slot.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/templates/gui/gui_msg_slot.java.ftl
@@ -1,0 +1,118 @@
+<#--
+ # MCreator (https://mcreator.net/)
+ # Copyright (C) 2012-2020, Pylo
+ # Copyright (C) 2020-2022, Pylo, opensource contributors
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # Additional permission for code generator templates (*.ftl files)
+ #
+ # As a special exception, you may create a larger work that contains part or
+ # all of the MCreator code generator templates (*.ftl files) and distribute
+ # that work under terms of your choice, so long as that work isn't itself a
+ # template for code generation. Alternatively, if you modify or redistribute
+ # the template itself, you may (at your option) remove this special exception,
+ # which will cause the template and the resulting code generator output files
+ # to be licensed under the GNU General Public License without this special
+ # exception.
+-->
+
+<#-- @formatter:off -->
+<#include "../procedures.java.ftl">
+
+package ${package}.network;
+
+@Mod.EventBusSubscriber(bus = Mod.EventBusSubscriber.Bus.MOD) public class ${name}SlotMessage {
+
+	private final int slotID, x, y, z, changeType, meta;
+
+	public ${name}SlotMessage(int slotID, int x, int y, int z, int changeType, int meta) {
+		this.slotID = slotID;
+		this.x = x;
+		this.y = y;
+		this.z = z;
+		this.changeType = changeType;
+		this.meta = meta;
+	}
+
+	public ${name}SlotMessage(FriendlyByteBuf buffer) {
+		this.slotID = buffer.readInt();
+		this.x = buffer.readInt();
+		this.y = buffer.readInt();
+		this.z = buffer.readInt();
+		this.changeType = buffer.readInt();
+		this.meta = buffer.readInt();
+	}
+
+	public static void buffer(${name}SlotMessage message, FriendlyByteBuf buffer) {
+		buffer.writeInt(message.slotID);
+		buffer.writeInt(message.x);
+		buffer.writeInt(message.y);
+		buffer.writeInt(message.z);
+		buffer.writeInt(message.changeType);
+		buffer.writeInt(message.meta);
+	}
+
+	public static void handler(${name}SlotMessage message, Supplier<NetworkEvent.Context> contextSupplier) {
+		NetworkEvent.Context context = contextSupplier.get();
+		context.enqueueWork(() -> {
+			Player entity = context.getSender();
+			int slotID = message.slotID;
+			int changeType = message.changeType;
+			int meta = message.meta;
+			int x = message.x;
+			int y = message.y;
+			int z = message.z;
+
+			handleSlotAction(entity, slotID, changeType, meta, x, y, z);
+		});
+		context.setPacketHandled(true);
+	}
+
+	public static void handleSlotAction(Player entity, int slotID, int changeType, int meta, int x, int y, int z) {
+		Level world = entity.level;
+		HashMap guistate = ${name}Menu.guistate;
+
+		// security measure to prevent arbitrary chunk generation
+		if (!world.hasChunkAt(new BlockPos(x, y, z)))
+			return;
+
+		<#list data.components as component>
+			<#if component.getClass().getSimpleName()?ends_with("Slot")>
+				<#if hasProcedure(component.onSlotChanged)>
+					if (slotID == ${component.id} && changeType == 0) {
+						<@procedureOBJToCode component.onSlotChanged/>
+					}
+				</#if>
+				<#if hasProcedure(component.onTakenFromSlot)>
+					if (slotID == ${component.id} && changeType == 1) {
+						<@procedureOBJToCode component.onTakenFromSlot/>
+					}
+				</#if>
+				<#if hasProcedure(component.onStackTransfer)>
+					if (slotID == ${component.id} && changeType == 2) {
+						int amount = meta;
+						<@procedureOBJToCode component.onStackTransfer/>
+					}
+				</#if>
+			</#if>
+		</#list>
+	}
+
+	@SubscribeEvent public static void registerMessage(FMLCommonSetupEvent event) {
+		${JavaModName}.addNetworkMessage(${name}SlotMessage.class, ${name}SlotMessage::buffer, ${name}SlotMessage::new, ${name}SlotMessage::handler);
+	}
+
+}
+<#-- @formatter:on -->

--- a/plugins/generator-1.19.4/forge-1.19.4/templates/gui/gui_window.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/templates/gui/gui_window.java.ftl
@@ -1,0 +1,277 @@
+<#--
+ # MCreator (https://mcreator.net/)
+ # Copyright (C) 2012-2020, Pylo
+ # Copyright (C) 2020-2022, Pylo, opensource contributors
+ # 
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ # 
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ # 
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ # 
+ # Additional permission for code generator templates (*.ftl files)
+ # 
+ # As a special exception, you may create a larger work that contains part or 
+ # all of the MCreator code generator templates (*.ftl files) and distribute 
+ # that work under terms of your choice, so long as that work isn't itself a 
+ # template for code generation. Alternatively, if you modify or redistribute 
+ # the template itself, you may (at your option) remove this special exception, 
+ # which will cause the template and the resulting code generator output files 
+ # to be licensed under the GNU General Public License without this special 
+ # exception.
+-->
+
+<#-- @formatter:off -->
+<#include "../procedures.java.ftl">
+package ${package}.client.gui;
+
+<#assign mx = data.W - data.width>
+<#assign my = data.H - data.height>
+
+public class ${name}Screen extends AbstractContainerScreen<${name}Menu> {
+
+	private final static HashMap<String, Object> guistate = ${name}Menu.guistate;
+
+	private final Level world;
+	private final int x, y, z;
+	private final Player entity;
+
+	<#list data.getComponentsOfType("TextField") as component>
+		EditBox ${component.getName()};
+	</#list>
+
+	<#list data.getComponentsOfType("Checkbox") as component>
+		Checkbox ${component.getName()};
+	</#list>
+
+	<#list data.getComponentsOfType("Button") as component>
+		Button ${component.getName()};
+	</#list>
+
+	<#list data.getComponentsOfType("ImageButton") as component>
+		ImageButton ${component.getName()};
+	</#list>
+
+	public ${name}Screen(${name}Menu container, Inventory inventory, Component text) {
+		super(container, inventory, text);
+		this.world = container.world;
+		this.x = container.x;
+		this.y = container.y;
+		this.z = container.z;
+		this.entity = container.entity;
+		this.imageWidth = ${data.width};
+		this.imageHeight = ${data.height};
+	}
+
+	<#if data.doesPauseGame>
+		@Override public boolean isPauseScreen() {
+			return true;
+		}
+	</#if>
+
+	<#if data.renderBgLayer>
+		private static final ResourceLocation texture = new ResourceLocation("${modid}:textures/screens/${registryname}.png" );
+	</#if>
+
+	@Override public void render(PoseStack ms, int mouseX, int mouseY, float partialTicks) {
+		this.renderBackground(ms);
+		if (!this.getChildAt(mouseX, mouseY).equals(Optional.empty())
+				? (this.getChildAt(mouseX, mouseY).get() instanceof Button button && button.isFocused()) || (this.getChildAt(mouseX, mouseY).get() instanceof ImageButton imageButton && imageButton.isFocused())
+						|| (this.getChildAt(mouseX, mouseY).get() instanceof Checkbox checkbox && checkbox.isFocused())
+				: false)
+			((AbstractWidget) this.getChildAt(mouseX, mouseY).get()).setFocused(false);
+		super.render(ms, mouseX, mouseY, partialTicks);
+		this.renderTooltip(ms, mouseX, mouseY);
+
+		<#list data.getComponentsOfType("TextField") as component>
+				${component.getName()}.render(ms, mouseX, mouseY, partialTicks);
+		</#list>
+
+		<#list data.getComponentsOfType("EntityModel") as component>
+			<#assign followMouse = component.followMouseMovement>
+			<#assign x = (component.x - mx/2)?int>
+			<#assign y = (component.y - my/2)?int>
+			if (<@procedureOBJToConditionCode component.entityModel/> instanceof LivingEntity livingEntity) {
+				<#if hasProcedure(component.displayCondition)>
+					if (<@procedureOBJToConditionCode component.displayCondition/>)
+				</#if>
+				InventoryScreen.renderEntityInInventoryFollowsAngle(ms, this.leftPos + ${x + 11}, this.topPos + ${y + 21}, ${component.scale},
+					${component.rotationX / 20.0}f <#if followMouse> + (float) Math.atan((this.leftPos + ${x + 11} - mouseX) / 40.0)</#if>,
+					<#if followMouse>(float) Math.atan((this.topPos + ${y + 21 - 50} - mouseY) / 40.0)<#else>0</#if>,
+					livingEntity
+				);
+			}
+		</#list>
+	}
+
+	@Override protected void renderBg(PoseStack ms, float partialTicks, int gx, int gy) {
+		RenderSystem.setShaderColor(1, 1, 1, 1);
+		RenderSystem.enableBlend();
+		RenderSystem.defaultBlendFunc();
+
+		<#if data.renderBgLayer>
+			RenderSystem.setShaderTexture(0, texture);
+			this.blit(ms, this.leftPos, this.topPos, 0, 0, this.imageWidth, this.imageHeight, this.imageWidth, this.imageHeight);
+		</#if>
+
+		<#list data.getComponentsOfType("Image") as component>
+			<#if hasProcedure(component.displayCondition)>if (<@procedureOBJToConditionCode component.displayCondition/>) {</#if>
+				RenderSystem.setShaderTexture(0, new ResourceLocation("${modid}:textures/screens/${component.image}"));
+				this.blit(ms, this.leftPos + ${(component.x - mx/2)?int}, this.topPos + ${(component.y - my/2)?int}, 0, 0,
+					${component.getWidth(w.getWorkspace())}, ${component.getHeight(w.getWorkspace())},
+					${component.getWidth(w.getWorkspace())}, ${component.getHeight(w.getWorkspace())});
+			<#if hasProcedure(component.displayCondition)>}</#if>
+		</#list>
+
+		RenderSystem.disableBlend();
+	}
+
+	@Override public boolean keyPressed(int key, int b, int c) {
+		if (key == 256) {
+			this.setFocused(false);
+			this.minecraft.player.closeContainer();
+			return true;
+		}
+
+		<#list data.getComponentsOfType("TextField") as component>
+				if(${component.getName()}.isFocused())
+					return ${component.getName()}.keyPressed(key, b, c);
+		</#list>
+
+		return super.keyPressed(key, b, c);
+	}
+
+	@Override public void containerTick() {
+		super.containerTick();
+		<#list data.getComponentsOfType("TextField") as component>
+				${component.getName()}.tick();
+		</#list>
+	}
+
+	@Override protected void renderLabels(PoseStack poseStack, int mouseX, int mouseY) {
+		<#list data.getComponentsOfType("Label") as component>
+			<#if hasProcedure(component.displayCondition)>
+				if (<@procedureOBJToConditionCode component.displayCondition/>)
+			</#if>
+			this.font.draw(poseStack,
+				<#if hasProcedure(component.text)><@procedureOBJToStringCode component.text/><#else>Component.translatable("gui.${modid}.${registryname}.${component.getName()}")</#if>,
+				${(component.x - mx / 2)?int}, ${(component.y - my / 2)?int}, ${component.color.getRGB()});
+		</#list>
+	}
+
+	@Override public void onClose() {
+		this.setFocused(false);
+		super.onClose();
+	}
+
+	@Override public void init() {
+		super.init();
+
+		<#list data.getComponentsOfType("TextField") as component>
+			${component.getName()} = new EditBox(this.font, this.leftPos + ${(component.x - mx/2)?int}, this.topPos + ${(component.y - my/2)?int},
+			${component.width}, ${component.height}, Component.translatable("gui.${modid}.${registryname}.${component.getName()}"))
+			<#if component.placeholder?has_content>
+			{
+				{
+					setSuggestion(Component.translatable("gui.${modid}.${registryname}.${component.getName()}").getString());
+				}
+
+				@Override public void insertText(String text) {
+					super.insertText(text);
+
+					if (getValue().isEmpty())
+						setSuggestion(Component.translatable("gui.${modid}.${registryname}.${component.getName()}").getString());
+					else
+						setSuggestion(null);
+				}
+
+				@Override public void moveCursorTo(int pos) {
+					super.moveCursorTo(pos);
+
+					if (getValue().isEmpty())
+						setSuggestion(Component.translatable("gui.${modid}.${registryname}.${component.getName()}").getString());
+					else
+						setSuggestion(null);
+				}
+			}
+			</#if>;
+			${component.getName()}.setMaxLength(32767);
+
+			guistate.put("text:${component.getName()}", ${component.getName()});
+			this.addWidget(this.${component.getName()});
+		</#list>
+
+		<#assign btid = 0>
+
+		<#list data.getComponentsOfType("Button") as component>
+			${component.getName()} = new Button(
+				new Button.Builder(Component.translatable("gui.${modid}.${registryname}.${component.getName()}"), <@buttonOnClick component/>)
+				.bounds(this.leftPos + ${(component.x - mx/2)?int}, this.topPos + ${(component.y - my/2)?int}, ${component.width}, ${component.height})
+			)<@buttonDisplayCondition component/>;
+
+			guistate.put("button:${component.getName()}", ${component.getName()});
+			this.addRenderableWidget(${component.getName()});
+
+			<#assign btid +=1>
+		</#list>
+
+		<#list data.getComponentsOfType("ImageButton") as component>
+		    ${component.getName()} = new ImageButton(
+				this.leftPos + ${(component.x - mx/2)?int}, this.topPos + ${(component.y - my/2)?int},
+            	${component.getWidth(w.getWorkspace())}, ${component.getHeight(w.getWorkspace())},
+				0, 0, ${component.getHeight(w.getWorkspace())},
+            	new ResourceLocation("${modid}:textures/screens/atlas/${component.getName()}.png"),
+            	${component.getWidth(w.getWorkspace())},
+				${component.getHeight(w.getWorkspace()) * 2},
+				<@buttonOnClick component/>
+			)<@buttonDisplayCondition component/>;
+
+			guistate.put("button:${component.getName()}", ${component.getName()});
+			this.addRenderableWidget(${component.getName()});
+
+			<#assign btid +=1>
+		</#list>
+
+		<#list data.getComponentsOfType("Checkbox") as component>
+			${component.getName()} = new Checkbox(this.leftPos + ${(component.x - mx/2)?int}, this.topPos + ${(component.y - my/2)?int},
+					20, 20, Component.translatable("gui.${modid}.${registryname}.${component.getName()}"), <#if hasProcedure(component.isCheckedProcedure)>
+				<@procedureOBJToConditionCode component.isCheckedProcedure/><#else>false</#if>);
+
+			guistate.put("checkbox:${component.getName()}", ${component.getName()});
+			this.addRenderableWidget(${component.getName()});
+		</#list>
+		
+		this.setInitialFocus(this.getFocused());
+	}
+
+}
+
+<#macro buttonOnClick component>
+e -> {
+    <#if hasProcedure(component.onClick)>
+	    if (<@procedureOBJToConditionCode component.displayCondition/>) {
+			${JavaModName}.PACKET_HANDLER.sendToServer(new ${name}ButtonMessage(${btid}, x, y, z));
+			${name}ButtonMessage.handleButtonAction(entity, ${btid}, x, y, z);
+		}
+	</#if>
+}
+</#macro>
+
+<#macro buttonDisplayCondition component>
+<#if hasProcedure(component.displayCondition)>
+{
+	@Override public void render(PoseStack ms, int gx, int gy, float ticks) {
+		if (<@procedureOBJToConditionCode component.displayCondition/>)
+			super.render(ms, gx, gy, ticks);
+	}
+}
+</#if>
+</#macro>
+<#-- @formatter:on -->

--- a/plugins/generator-1.19.4/forge-1.19.4/templates/modbase/mod.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/templates/modbase/mod.java.ftl
@@ -31,6 +31,7 @@ import org.apache.logging.log4j.Logger;
 		<#if w.hasSounds()>${JavaModName}Sounds.REGISTRY.register(bus);</#if>
 		<#if w.hasElementsOfBaseType("item")>${JavaModName}Items.REGISTRY.register(bus);</#if>
 		<#if w.hasElementsOfType("potioneffect")>${JavaModName}MobEffects.REGISTRY.register(bus);</#if>
+		<#if w.hasElementsOfType("gui")>${JavaModName}Menus.REGISTRY.register(bus);</#if>
 	}
 
 	private static final String PROTOCOL_VERSION = "1";


### PR DESCRIPTION
This ports the GUI element.

There are a number of changes to note in 1.19.4

-All widgets except the EditBox will get stuck focused once clicked until another widget is clicked. To prevent this, I included some code inside the render method that will automatically unfocus them.

-Regular buttons (not image buttons) now require a Button.CreateNarration as an argument. To provide that, I use the Button.Builder which uses the private field DEFAULT_NARRATION if one is not provided (which it isn't)

-In the init method, setInitialFocus is now called. (I do not know if it should be required, but the fabric changelog says I should use it)

-the field sendRepeatsToGui in KeyboardHandler has been removed along with the method setSendRepeatsToGui. I can't find any alternatives or similarly named fields/methods anywhere, but everything seems to work without it.

-Just like in overlays, renderEntityInInventoryRaw has been replaced with renderEntityInInventoryFollowsAngle. Works the same both for following and not following mouse movement.