### PR TITLE
Removed redundant function

### DIFF
--- a/plugins/generator-1.18.2/forge-1.18.2/features/block_holderset_list.java.ftl
+++ b/plugins/generator-1.18.2/forge-1.18.2/features/block_holderset_list.java.ftl
@@ -1,2 +1,2 @@
 <#include "mcitems.ftl">
-<#list field_list$block as block>${mappedBlockToBlock(toMappedMCItem(block))}<#sep>,</#list>
+<#list field_list$block as block>${mappedBlockToBlock(w.itemBlock(block))}<#sep>,</#list>

--- a/plugins/generator-1.18.2/forge-1.18.2/utils/mcitems.ftl
+++ b/plugins/generator-1.18.2/forge-1.18.2/utils/mcitems.ftl
@@ -304,7 +304,3 @@
     </#if>
     <#return '{ "Name": "minecraft:air" }'>
 </#function>
-
-<#function toMappedMCItem unmappedValue>
-    <#return generator.toMappedMItemBlock(unmappedValue)>
-</#function>

--- a/plugins/generator-1.19.2/forge-1.19.2/features/block_holderset_list.json.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/features/block_holderset_list.json.ftl
@@ -1,8 +1,8 @@
 <#include "mcitems.ftl">
 <#if field_list$block?size == 1>
-  "${mappedMCItemToIngameNameNoTags(toMappedMCItem(field_list$block?first))}"
+  "${mappedMCItemToIngameNameNoTags(w.itemBlock(field_list$block?first))}"
 <#else>
   [
-    <#list field_list$block as block>"${mappedMCItemToIngameNameNoTags(toMappedMCItem(block))}"<#sep>,</#list>
+    <#list field_list$block as block>"${mappedMCItemToIngameNameNoTags(w.itemBlock(block))}"<#sep>,</#list>
   ]
 </#if>

--- a/plugins/generator-1.19.2/forge-1.19.2/utils/mcitems.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/utils/mcitems.ftl
@@ -305,7 +305,3 @@
     </#if>
     <#return '{ "Name": "minecraft:air" }'>
 </#function>
-
-<#function toMappedMCItem unmappedValue>
-    <#return generator.toMappedMItemBlock(unmappedValue)>
-</#function>

--- a/plugins/generator-1.19.4/forge-1.19.4/utils/mcitems.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/utils/mcitems.ftl
@@ -305,7 +305,3 @@
     </#if>
     <#return '{ "Name": "minecraft:air" }'>
 </#function>
-
-<#function toMappedMCItem unmappedValue>
-    <#return generator.toMappedMItemBlock(unmappedValue)>
-</#function>

--- a/src/main/java/net/mcreator/generator/GeneratorWrapper.java
+++ b/src/main/java/net/mcreator/generator/GeneratorWrapper.java
@@ -87,10 +87,6 @@ import java.util.stream.Collectors;
 		}
 	}
 
-	public MItemBlock toMappedMItemBlock(String unmappedValue) {
-		return new MItemBlock(this.getWorkspace(), unmappedValue);
-	}
-
 	/**
 	 * Removes the "CUSTOM:" prefix and any eventual suffix (if present, it's after the last .)
 	 *


### PR DESCRIPTION
This PR removes the redundant `toMappedMCItem` function from `mcitems.ftl` (when this was first added, I didn't realize the workspace provides a method that does the same thing)