### PR TITLE
[1.19.4] Port more feature blocks

### DIFF
--- a/plugins/generator-1.19.4/forge-1.19.4/features/height_provider_biased_to_bottom.json.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/features/height_provider_biased_to_bottom.json.ftl
@@ -1,0 +1,6 @@
+{
+  "type": "minecraft:biased_to_bottom",
+  "min_inclusive": ${input$min},
+  "max_inclusive": ${input$max}
+  <#if field$inner != "1">, "inner": ${field$inner}</#if>
+}

--- a/plugins/generator-1.19.4/forge-1.19.4/features/height_provider_constant.json.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/features/height_provider_constant.json.ftl
@@ -1,0 +1,4 @@
+{
+  "type": "minecraft:constant",
+  "value": ${input$value}
+}

--- a/plugins/generator-1.19.4/forge-1.19.4/features/height_provider_trapezoid.json.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/features/height_provider_trapezoid.json.ftl
@@ -1,0 +1,6 @@
+{
+  "type": "minecraft:trapezoid",
+  "min_inclusive": ${input$min},
+  "max_inclusive": ${input$max}
+  <#if field$plateau != "0">, "plateau": ${field$plateau}</#if>
+}

--- a/plugins/generator-1.19.4/forge-1.19.4/features/height_provider_very_biased_to_bottom.json.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/features/height_provider_very_biased_to_bottom.json.ftl
@@ -1,0 +1,6 @@
+{
+  "type": "minecraft:very_biased_to_bottom",
+  "min_inclusive": ${input$min},
+  "max_inclusive": ${input$max}
+  <#if field$inner != "1">, "inner": ${field$inner}</#if>
+}

--- a/plugins/generator-1.19.4/forge-1.19.4/features/int_provider_biased_to_bottom.json.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/features/int_provider_biased_to_bottom.json.ftl
@@ -1,0 +1,7 @@
+{
+  "type": "biased_to_bottom",
+  "value": {
+    "min_inclusive": ${field$min},
+    "max_inclusive": ${field$max}
+  }
+}

--- a/plugins/generator-1.19.4/forge-1.19.4/features/int_provider_clamped.json.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/features/int_provider_clamped.json.ftl
@@ -1,0 +1,8 @@
+{
+  "type": "clamped",
+  "value": {
+    "min_inclusive": ${field$min},
+    "max_inclusive": ${field$max},
+    "source": ${input$toClamp}
+  }
+}

--- a/plugins/generator-1.19.4/forge-1.19.4/features/int_provider_clamped_normal.json.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/features/int_provider_clamped_normal.json.ftl
@@ -1,0 +1,9 @@
+{
+  "type": "clamped_normal",
+  "value": {
+    "mean": ${field$mean},
+    "deviation": ${field$deviation},
+    "min_inclusive": ${field$min},
+    "max_inclusive": ${field$max}
+  }
+}

--- a/plugins/generator-1.19.4/forge-1.19.4/features/int_provider_constant.json.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/features/int_provider_constant.json.ftl
@@ -1,0 +1,1 @@
+${field$value}

--- a/plugins/generator-1.19.4/forge-1.19.4/features/int_provider_uniform.json.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/features/int_provider_uniform.json.ftl
@@ -1,0 +1,7 @@
+{
+  "type": "uniform",
+  "value": {
+    "min_inclusive": ${field$min},
+    "max_inclusive": ${field$max}
+  }
+}

--- a/plugins/generator-1.19.4/forge-1.19.4/features/placement_count.json.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/features/placement_count.json.ftl
@@ -1,0 +1,4 @@
+{
+  "type": "minecraft:count",
+  "count": ${input$count}
+},

--- a/plugins/generator-1.19.4/forge-1.19.4/features/placement_count_on_every_layer.json.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/features/placement_count_on_every_layer.json.ftl
@@ -1,0 +1,4 @@
+{
+  "type": "minecraft:count_on_every_layer",
+  "count": ${input$count}
+},

--- a/plugins/generator-1.19.4/forge-1.19.4/features/placement_height_range.json.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/features/placement_height_range.json.ftl
@@ -1,0 +1,4 @@
+{
+  "type": "minecraft:height_range",
+  "height": ${input$height}
+},

--- a/plugins/generator-1.19.4/forge-1.19.4/features/placement_height_triangular.json.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/features/placement_height_triangular.json.ftl
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:height_range",
+  "height": {
+    "type": "minecraft:trapezoid",
+    "min_inclusive": ${input$min},
+    "max_inclusive": ${input$max}
+  }
+},

--- a/plugins/generator-1.19.4/forge-1.19.4/features/placement_height_uniform.json.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/features/placement_height_uniform.json.ftl
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:height_range",
+  "height": {
+    "type": "minecraft:uniform",
+    "min_inclusive": ${input$min},
+    "max_inclusive": ${input$max}
+  }
+},

--- a/plugins/generator-1.19.4/forge-1.19.4/features/placement_noise_based_count.json.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/features/placement_noise_based_count.json.ftl
@@ -1,0 +1,6 @@
+{
+  "type": "minecraft:noise_based_count",
+  "noise_to_count_ratio": ${field$ratio},
+  "noise_factor": ${field$factor}
+  <#if field$offset != "0">, "noise_offset": ${field$offset}</#if>
+},

--- a/plugins/generator-1.19.4/forge-1.19.4/features/placement_noise_threshold_count.json.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/features/placement_noise_threshold_count.json.ftl
@@ -1,0 +1,6 @@
+{
+  "type": "minecraft:noise_threshold_count",
+  "noise_level": ${field$threshold},
+  "below_noise": ${field$belowNoise},
+  "above_noise": ${field$aboveNoise}
+},

--- a/plugins/generator-1.19.4/forge-1.19.4/features/placement_offset.json.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/features/placement_offset.json.ftl
@@ -1,0 +1,5 @@
+{
+  "type": "minecraft:random_offset",
+  "xz_spread": ${input$xz},
+  "y_spread": ${input$y}
+},

--- a/plugins/generator-1.19.4/forge-1.19.4/features/vertical_anchor_above_bottom.json.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/features/vertical_anchor_above_bottom.json.ftl
@@ -1,0 +1,3 @@
+{
+  "above_bottom": ${field$value}
+}

--- a/plugins/generator-1.19.4/forge-1.19.4/features/vertical_anchor_absolute.json.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/features/vertical_anchor_absolute.json.ftl
@@ -1,0 +1,3 @@
+{
+  "absolute": ${field$value}
+}

--- a/plugins/generator-1.19.4/forge-1.19.4/features/vertical_anchor_below_top.json.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/features/vertical_anchor_below_top.json.ftl
@@ -1,0 +1,3 @@
+{
+  "below_top": ${field$value}
+}


### PR DESCRIPTION
This PR ports the int/height providers, vertical anchors, and the remaining placement blocks. Again no changes from 1.19.2