### PR TITLE
[1.19.4] Port the advancement mod element + JSON triggers

### DIFF
--- a/plugins/generator-1.19.4/datapack-1.19.4/achievement.definition.yaml
+++ b/plugins/generator-1.19.4/datapack-1.19.4/achievement.definition.yaml
@@ -1,0 +1,4 @@
+templates:
+  - template: advancement.json.ftl
+    writer: json
+    name: "@MODDATAROOT/advancements/@registryname.json"

--- a/plugins/generator-1.19.4/datapack-1.19.4/jsontriggers/_mcitemblock.json.ftl
+++ b/plugins/generator-1.19.4/datapack-1.19.4/jsontriggers/_mcitemblock.json.ftl
@@ -1,0 +1,2 @@
+<#include "mcitems.ftl">
+${mappedMCItemToIngameNameNoTags(block)}

--- a/plugins/generator-1.19.4/datapack-1.19.4/jsontriggers/biome_entered.json.ftl
+++ b/plugins/generator-1.19.4/datapack-1.19.4/jsontriggers/biome_entered.json.ftl
@@ -1,0 +1,16 @@
+{
+  "trigger": "minecraft:location",
+  "conditions": {
+    "player": [
+        {
+            "condition": "minecraft:entity_properties",
+            "entity": "this",
+            "predicate": {
+              "location": {
+                "biome": "${generator.map(field$biome, "biomes")}"
+              }
+            }
+        }
+    ]
+  }
+}

--- a/plugins/generator-1.19.4/datapack-1.19.4/jsontriggers/block_placed.json.ftl
+++ b/plugins/generator-1.19.4/datapack-1.19.4/jsontriggers/block_placed.json.ftl
@@ -1,0 +1,6 @@
+{
+  "trigger": "minecraft:placed_block",
+  "conditions": {
+    "block": "${input$block}"
+  }
+}

--- a/plugins/generator-1.19.4/datapack-1.19.4/jsontriggers/custom_trigger.json.ftl
+++ b/plugins/generator-1.19.4/datapack-1.19.4/jsontriggers/custom_trigger.json.ftl
@@ -1,0 +1,3 @@
+{
+    "trigger": "minecraft:impossible"
+}

--- a/plugins/generator-1.19.4/datapack-1.19.4/jsontriggers/dimension_entered.json.ftl
+++ b/plugins/generator-1.19.4/datapack-1.19.4/jsontriggers/dimension_entered.json.ftl
@@ -1,0 +1,14 @@
+{
+  "trigger": "minecraft:changed_dimension",
+  "conditions": {
+    <#if field$dimension == "Surface">
+    "to": "minecraft:overworld"
+    <#elseif field$dimension == "Nether">
+    "to": "minecraft:the_nether"
+    <#elseif field$dimension == "End">
+    "to": "minecraft:the_end"
+    <#else>
+    "to": "${generator.getResourceLocationForModElement(field$dimension.toString().replace("CUSTOM:", ""))}"
+    </#if>
+  }
+}

--- a/plugins/generator-1.19.4/datapack-1.19.4/jsontriggers/dimension_left.json.ftl
+++ b/plugins/generator-1.19.4/datapack-1.19.4/jsontriggers/dimension_left.json.ftl
@@ -1,0 +1,14 @@
+{
+  "trigger": "minecraft:changed_dimension",
+  "conditions": {
+    <#if field$dimension == "Surface">
+    "from": "minecraft:overworld"
+    <#elseif field$dimension == "Nether">
+    "from": "minecraft:the_nether"
+    <#elseif field$dimension == "End">
+    "from": "minecraft:the_end"
+    <#else>
+    "from": "${generator.getResourceLocationForModElement(field$dimension.toString().replace("CUSTOM:", ""))}"
+    </#if>
+  }
+}

--- a/plugins/generator-1.19.4/datapack-1.19.4/jsontriggers/item_consumed.json.ftl
+++ b/plugins/generator-1.19.4/datapack-1.19.4/jsontriggers/item_consumed.json.ftl
@@ -1,0 +1,10 @@
+{
+  "trigger": "minecraft:consume_item",
+  "conditions": {
+    "item": {
+        "items": [
+            "${input$item}"
+  		]
+    }
+  }
+}

--- a/plugins/generator-1.19.4/datapack-1.19.4/jsontriggers/item_consumed.json.ftl
+++ b/plugins/generator-1.19.4/datapack-1.19.4/jsontriggers/item_consumed.json.ftl
@@ -4,7 +4,7 @@
     "item": {
         "items": [
             "${input$item}"
-  		]
+        ]
     }
   }
 }

--- a/plugins/generator-1.19.4/datapack-1.19.4/jsontriggers/item_damaged.json.ftl
+++ b/plugins/generator-1.19.4/datapack-1.19.4/jsontriggers/item_damaged.json.ftl
@@ -1,0 +1,14 @@
+{
+  "trigger": "minecraft:item_durability_changed",
+  "conditions": {
+    "item": {
+        "items": [
+            "${input$item}"
+        ],
+        "durability": {
+          "min": ${input$amount_l},
+          "max": ${input$amount_h}
+        }
+      }
+  }
+}

--- a/plugins/generator-1.19.4/datapack-1.19.4/jsontriggers/item_in_inventory.json.ftl
+++ b/plugins/generator-1.19.4/datapack-1.19.4/jsontriggers/item_in_inventory.json.ftl
@@ -1,0 +1,16 @@
+{
+  "trigger": "minecraft:inventory_changed",
+  "conditions": {
+    "items": [
+      {
+        "items": [
+            "${input$item}"
+        ],
+        "count": {
+          "min": ${input$amount_l},
+          "max": ${input$amount_h}
+        }
+      }
+    ]
+  }
+}

--- a/plugins/generator-1.19.4/datapack-1.19.4/jsontriggers/tick.json.ftl
+++ b/plugins/generator-1.19.4/datapack-1.19.4/jsontriggers/tick.json.ftl
@@ -1,0 +1,3 @@
+{
+    "trigger": "minecraft:tick"
+}

--- a/plugins/generator-1.19.4/datapack-1.19.4/templates/advancement.json.ftl
+++ b/plugins/generator-1.19.4/datapack-1.19.4/templates/advancement.json.ftl
@@ -1,0 +1,56 @@
+<#-- @formatter:off -->
+<#include "mcitems.ftl">
+{
+    <#if !data.disableDisplay>
+        "display": {
+          <#if data.parent == "none" && !data.parent.toString().contains("@")>
+              <#if !data.background?has_content || data.background == "Default">
+                  "background": "minecraft:textures/block/stone.png",
+              <#else>
+                  "background": "${modid}:textures/screens/${data.background}",
+              </#if>
+          </#if>
+          "icon": {
+            ${mappedMCItemToIngameItemName(data.achievementIcon)}
+          },
+          "title": "${data.achievementName}",
+          "description": "${data.achievementDescription}",
+          "frame": "${data.achievementType}",
+          "show_toast": ${data.showPopup},
+          "announce_to_chat": ${data.announceToChat},
+          "hidden": ${data.hideIfNotCompleted}
+        },
+    </#if>
+    "criteria": {
+      "${registryname}": ${triggercode}
+    }
+    <#if data.hasRewards()>,
+    "rewards": {
+        "experience": ${data.rewardXP}
+
+        <#if data.rewardFunction?has_content && data.rewardFunction != "No function">,
+        "function": "${generator.getResourceLocationForModElement(data.rewardFunction)}"
+        </#if>
+
+        <#if data.rewardLoot?has_content>,
+        "loot": [
+            <#list data.rewardLoot as value>
+                "${generator.getResourceLocationForModElement(value)}"<#sep>,
+            </#list>
+        ]
+        </#if>
+
+        <#if data.rewardRecipes?has_content>,
+        "recipes": [
+            <#list data.rewardRecipes as value>
+                "${generator.getResourceLocationForModElement(value)}"<#sep>,
+            </#list>
+        ]
+        </#if>
+    }
+    </#if>
+    <#if data.parent != "none" && !data.parent.toString().contains("@")>
+    ,"parent": "${data.parent}"
+    </#if>
+}
+<#-- @formatter:on -->

--- a/plugins/generator-1.19.4/forge-1.19.4/achievement.definition.yaml
+++ b/plugins/generator-1.19.4/forge-1.19.4/achievement.definition.yaml
@@ -1,0 +1,10 @@
+templates:
+  - template: json/advancement.json.ftl
+    writer: json
+    name: "@MODDATAROOT/advancements/@registryname.json"
+
+localizationkeys:
+  - key: advancements.@registryname.title
+    mapto: achievementName
+  - key: advancements.@registryname.descr
+    mapto: achievementDescription

--- a/plugins/generator-1.19.4/forge-1.19.4/templates/json/advancement.json.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/templates/json/advancement.json.ftl
@@ -1,0 +1,65 @@
+<#-- @formatter:off -->
+<#include "../mcitems.ftl">
+{
+    <#if !data.disableDisplay>
+        "display": {
+          <#if data.parent == "none" && !data.parent.toString().contains("@")>
+              <#if !data.background?has_content || data.background == "Default">
+                  "background": "minecraft:textures/block/stone.png",
+              <#else>
+                  "background": "${modid}:textures/screens/${data.background}",
+              </#if>
+          </#if>
+          "icon": {
+            ${mappedMCItemToIngameItemName(data.achievementIcon)}
+          },
+          "title": {
+            "translate": "advancements.${registryname}.title"
+          },
+          "description": {
+            "translate": "advancements.${registryname}.descr"
+          },
+          "frame": "${data.achievementType}",
+          "show_toast": ${data.showPopup},
+          "announce_to_chat": ${data.announceToChat},
+          "hidden": ${data.hideIfNotCompleted}
+        },
+    </#if>
+    "criteria": {
+      "${registryname}": ${triggercode}
+    },
+    "requirements": [
+      [
+        "${registryname}"
+      ]
+    ]
+    <#if data.hasRewards()>,
+    "rewards": {
+        "experience": ${data.rewardXP}
+
+        <#if data.rewardFunction?has_content && data.rewardFunction != "No function">,
+        "function": "${generator.getResourceLocationForModElement(data.rewardFunction)}"
+        </#if>
+
+        <#if data.rewardLoot?has_content>,
+        "loot": [
+            <#list data.rewardLoot as value>
+                "${generator.getResourceLocationForModElement(value)}"<#sep>,
+            </#list>
+        ]
+        </#if>
+
+        <#if data.rewardRecipes?has_content>,
+        "recipes": [
+            <#list data.rewardRecipes as value>
+                "${generator.getResourceLocationForModElement(value)}"<#sep>,
+            </#list>
+        ]
+        </#if>
+    }
+    </#if>
+    <#if data.parent?has_content && data.parent != "none" && !data.parent.toString().contains("@")>,
+    "parent": "${data.parent}"
+    </#if>
+}
+<#-- @formatter:on -->

--- a/plugins/generator-1.19.4/forge-1.19.4/templates/json/advancement.json.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/templates/json/advancement.json.ftl
@@ -27,12 +27,7 @@
     </#if>
     "criteria": {
       "${registryname}": ${triggercode}
-    },
-    "requirements": [
-      [
-        "${registryname}"
-      ]
-    ]
+    }
     <#if data.hasRewards()>,
     "rewards": {
         "experience": ${data.rewardXP}


### PR DESCRIPTION
This PR ports the advancement mod element as well as the JSON triggers.

Only 1 trigger had changes, the `placed_block` trigger, where the structure `"block": "<...>"` is now used instead of `"item": { "items": [ "<...>" ] }`, but other than that everything is the same.