### PR TITLE
Fixed 1.19.4 ore generation ignoring dimension/generation condition

### DIFF
--- a/plugins/generator-1.19.4/forge-1.19.4/templates/block/configured_oregen.json.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/templates/block/configured_oregen.json.ftl
@@ -1,21 +1,21 @@
 <#include "../mcitems.ftl">
 {
-    "type": "minecraft:ore",
+    "type": "${modid}:${registryname}",
     "config": {
-		"size": ${data.frequencyOnChunk},
-		"discard_chance_on_air_exposure": 0,
-		"targets": [
-			<#list data.blocksToReplace as replacementBlock>
-			{
-				"target": {
-					"predicate_type": "blockstate_match",
-					"block_state": ${mappedMCItemToBlockStateJSON(replacementBlock)}
-				},
-				"state": {
-                  "Name": "${modid}:${registryname}"
+        "size": ${data.frequencyOnChunk},
+        "discard_chance_on_air_exposure": 0,
+        "targets": [
+            <#list data.blocksToReplace as replacementBlock>
+            {
+                "target": {
+                    "predicate_type": "blockstate_match",
+                    "block_state": ${mappedMCItemToBlockStateJSON(replacementBlock)}
+                },
+                "state": {
+                    "Name": "${modid}:${registryname}"
                 }
-			}<#sep>,
-			</#list>
-		]
-	}
+            }<#sep>,
+            </#list>
+        ]
+    }
 }


### PR DESCRIPTION
In 1.19.4, block configured feature would call `minecraft:ore` instead of the custom feature, so the restriction dimension and additional generation conditions were ignored. This PR also changes the template indentation to be more consistent