### PR TITLE
Changes to macOS look

### DIFF
--- a/plugins/mcreator-localization/lang/texts.properties
+++ b/plugins/mcreator-localization/lang/texts.properties
@@ -1515,7 +1515,8 @@ preferences.ui.language=Interface language
 preferences.ui.language.description=WARNING: Translations are community-contributed and may be missing, inaccurate or wrong.<br>\
   You need to restart MCreator to apply changes.
 preferences.ui.usemacOSMenuBar=Use the default macOS menu bar
-preferences.ui.usemacOSMenuBar.description=On a macOS device, use the default menu bar located on the top of your screen.
+preferences.ui.usemacOSMenuBar.description=On a macOS device, use the default menu bar located on the top of your screen.<br>\
+  Requires restart of MCreator to take effect.
 preferences.ui.useNativeFileChooser=Use default system file chooser
 preferences.ui.useNativeFileChooser.description=Check to use the default system file chooser. Only works on Windows at the moment.
 preferences.ui.interfaceAccentColor=Interface accent color
@@ -1539,7 +1540,8 @@ preferences.ui.autoreloadTabs.description=Disable this option if you are having 
 preferences.ui.remindOfUnsavedChanges=Warn about unsaved changes in the mod element editor
 preferences.ui.remindOfUnsavedChanges.description=If enabled, closing the mod element editor without saving its changes will suggest to save them
 preferences.ui.discordRichPresenceEnable=Enable Discord Rich Presence
-preferences.ui.discordRichPresenceEnable.description=When this is enabled, Discord app will show that you are using MCreator
+preferences.ui.discordRichPresenceEnable.description=When this is enabled, Discord app will show that you are using MCreator.<br>\
+  NOTE: Does not work on macOS.
 preferences.backups.workspaceAutosaveInterval=Workspace autosave interval (in seconds)
 preferences.backups.workspaceAutosaveInterval.description=This parameter defines how often the workspace should be auto-saved in case there were any changes.<br>\
   Workspace is also autosaved when MCreator is closed.

--- a/src/main/java/net/mcreator/Launcher.java
+++ b/src/main/java/net/mcreator/Launcher.java
@@ -97,6 +97,7 @@ public class Launcher {
 		// if the OS is macOS, we enable javafx single thread mode to avoid some deadlocks with JFXPanel
 		if (OS.getOS() == OS.MAC) {
 			System.setProperty("javafx.embed.singleThread", "true");
+			System.setProperty("apple.awt.application.appearance", "system");
 		}
 
 		if ("true".equals(System.getProperty("javafx.embed.singleThread"))) {

--- a/src/main/java/net/mcreator/preferences/PreferencesData.java
+++ b/src/main/java/net/mcreator/preferences/PreferencesData.java
@@ -51,7 +51,7 @@ public class PreferencesData {
 
 		@PreferencesEntry(arrayData = { "on", "off", "gasp", "lcd", "lcd_hbgr", "lcd_vrgb", "lcd_vbgr" })
 		public String textAntialiasingType = "on";
-		@PreferencesEntry public boolean usemacOSMenuBar = true;
+		@PreferencesEntry public boolean usemacOSMenuBar = OS.getOS() == OS.MAC;
 		@PreferencesEntry public boolean useNativeFileChooser = OS.getOS() == OS.WINDOWS;
 		@PreferencesEntry public boolean expandSectionsByDefault = false;
 		@PreferencesEntry public boolean use2DAcceleration = false;

--- a/src/main/java/net/mcreator/ui/MCreator.java
+++ b/src/main/java/net/mcreator/ui/MCreator.java
@@ -140,8 +140,11 @@ public final class MCreator extends JFrame implements IWorkspaceProvider, IGener
 		else
 			setSize(1002, 640);
 
-		if (OS.getOS() == OS.MAC)
+		if (OS.getOS() == OS.MAC) {
 			getRootPane().putClientProperty("apple.awt.fullscreenable", true);
+			getRootPane().putClientProperty("apple.awt.transparentTitleBar", true);
+			getRootPane().putClientProperty("apple.awt.fullWindowContent", true);
+		}
 
 		if (PreferencesManager.PREFERENCES.hidden.fullScreen)
 			setExtendedState(JFrame.MAXIMIZED_BOTH);

--- a/src/main/java/net/mcreator/ui/MainMenuBar.java
+++ b/src/main/java/net/mcreator/ui/MainMenuBar.java
@@ -18,6 +18,8 @@
 
 package net.mcreator.ui;
 
+import net.mcreator.io.OS;
+import net.mcreator.preferences.PreferencesManager;
 import net.mcreator.ui.component.SocialButtons;
 import net.mcreator.ui.component.util.ComponentUtils;
 import net.mcreator.ui.ide.CodeEditorView;
@@ -47,21 +49,24 @@ public class MainMenuBar extends JMenuBar {
 
 		setBorder(BorderFactory.createMatteBorder(0, 0, 1, 0, (Color) UIManager.get("MCreatorLAF.BLACK_ACCENT")));
 
-		JMenu logo = new JMenu("  MCreator");
-		logo.setMnemonic('M');
-		logo.setIcon(new ImageIcon(ImageUtils.resizeAA(UIRES.getBuiltIn("icon").getImage(), 14, 14)));
+		if (("false".equals(Boolean.toString(PreferencesManager.PREFERENCES.ui.usemacOSMenuBar))) || (OS.getOS()
+				!= OS.MAC)) {
+			JMenu logo = new JMenu("  MCreator");
+			logo.setMnemonic('M');
+			logo.setIcon(new ImageIcon(ImageUtils.resizeAA(UIRES.getBuiltIn("icon").getImage(), 14, 14)));
 
-		logo.add(mcreator.actionRegistry.mcreatorWebsite);
-		logo.add(mcreator.actionRegistry.mcreatorCommunity);
-		SocialButtons socialButtons = new SocialButtons();
-		socialButtons.setBorder(BorderFactory.createEmptyBorder(3, 29, 7, 0));
-		logo.add(socialButtons);
-		logo.addSeparator();
-		logo.add(mcreator.actionRegistry.donate);
-		logo.addSeparator();
-		logo.add(mcreator.actionRegistry.mcreatorPublish);
+			logo.add(mcreator.actionRegistry.mcreatorWebsite);
+			logo.add(mcreator.actionRegistry.mcreatorCommunity);
+			SocialButtons socialButtons = new SocialButtons();
+			socialButtons.setBorder(BorderFactory.createEmptyBorder(3, 29, 7, 0));
+			logo.add(socialButtons);
+			logo.addSeparator();
+			logo.add(mcreator.actionRegistry.donate);
+			logo.addSeparator();
+			logo.add(mcreator.actionRegistry.mcreatorPublish);
 
-		add(logo);
+			add(logo);
+		}
 
 		JMenu file = L10N.menu("menubar.file");
 		file.setMnemonic('F');
@@ -243,6 +248,12 @@ public class MainMenuBar extends JMenuBar {
 
 		JMenu help = L10N.menu("menubar.help");
 		addHelpSearch(help);
+		if ("true".equals(System.getProperty("apple.laf.useScreenMenuBar")) && (OS.getOS() == OS.MAC)) {
+			help.add(mcreator.actionRegistry.mcreatorWebsite);
+			help.add(mcreator.actionRegistry.mcreatorCommunity);
+			help.add(mcreator.actionRegistry.mcreatorPublish);
+			help.addSeparator();
+		}
 		help.add(mcreator.actionRegistry.help);
 		help.add(mcreator.actionRegistry.support);
 		help.add(mcreator.actionRegistry.knowledgeBase);

--- a/src/main/java/net/mcreator/ui/MainToolBar.java
+++ b/src/main/java/net/mcreator/ui/MainToolBar.java
@@ -28,7 +28,7 @@ import java.awt.event.MouseEvent;
 public class MainToolBar extends JToolBar {
 
 	MainToolBar(MCreator mcreator) {
-		setBorder(BorderFactory.createMatteBorder(0, 0, 1, 0, (Color) UIManager.get("MCreatorLAF.BLACK_ACCENT")));
+		setBorder(BorderFactory.createMatteBorder(30, 0, 1, 0, (Color) UIManager.get("MCreatorLAF.DARK_ACCENT")));
 		setFloatable(false);
 
 		add(new JEmptyBox(4, 4));
@@ -97,7 +97,7 @@ public class MainToolBar extends JToolBar {
 
 	@Override public JButton add(Action action) {
 		JButton button = super.add(action);
-		button.setBorder(BorderFactory.createEmptyBorder(4, 4, 4, 4));
+		button.setBorder(BorderFactory.createEmptyBorder(8, 8, 8, 8));
 		button.addMouseListener(new MouseAdapter() {
 			@Override public void mouseEntered(MouseEvent mouseEvent) {
 				super.mouseEntered(mouseEvent);

--- a/src/main/java/net/mcreator/ui/component/util/DiscordClient.java
+++ b/src/main/java/net/mcreator/ui/component/util/DiscordClient.java
@@ -40,7 +40,8 @@ public class DiscordClient implements Closeable {
 	private final Timer timer = new Timer();
 
 	public DiscordClient() {
-		if (!PreferencesManager.PREFERENCES.ui.discordRichPresenceEnable)
+		if (!PreferencesManager.PREFERENCES.ui.discordRichPresenceEnable || System.getProperty("os.arch").toLowerCase()
+				.startsWith("aarch"))
 			return;
 
 		try {
@@ -67,7 +68,8 @@ public class DiscordClient implements Closeable {
 	}
 
 	public void updatePresence(String state, String details, String smallImage) {
-		if (!PreferencesManager.PREFERENCES.ui.discordRichPresenceEnable)
+		if (!PreferencesManager.PREFERENCES.ui.discordRichPresenceEnable || System.getProperty("os.arch").toLowerCase()
+				.startsWith("aarch"))
 			return;
 
 		new Thread(() -> {
@@ -86,7 +88,8 @@ public class DiscordClient implements Closeable {
 	}
 
 	@Override public void close() {
-		if (!PreferencesManager.PREFERENCES.ui.discordRichPresenceEnable)
+		if (!PreferencesManager.PREFERENCES.ui.discordRichPresenceEnable || System.getProperty("os.arch").toLowerCase()
+				.startsWith("aarch"))
 			return;
 
 		try {

--- a/src/main/java/net/mcreator/ui/dialogs/ProgressDialog.java
+++ b/src/main/java/net/mcreator/ui/dialogs/ProgressDialog.java
@@ -47,6 +47,7 @@ public class ProgressDialog extends MCreatorDialog {
 			mcreator = (MCreator) w;
 		}
 
+		setUndecorated(true);
 		setBackground((Color) UIManager.get("MCreatorLAF.DARK_ACCENT"));
 
 		setClosable(false);

--- a/src/main/java/net/mcreator/ui/workspace/selector/RecentWorkspacesRenderer.java
+++ b/src/main/java/net/mcreator/ui/workspace/selector/RecentWorkspacesRenderer.java
@@ -50,7 +50,7 @@ class RecentWorkspacesRenderer extends JLabel implements ListCellRenderer<Recent
 
 		setOpaque(true);
 
-		setBackground((Color) UIManager.get("MCreatorLAF.DARK_ACCENT"));
+		setBackground((Color) UIManager.get("MCreatorLAF.BLACK_ACCENT"));
 		setForeground(isSelected ?
 				(Color) UIManager.get("MCreatorLAF.MAIN_TINT") :
 				(Color) UIManager.get("MCreatorLAF.GRAY_COLOR"));

--- a/src/main/java/net/mcreator/ui/workspace/selector/WorkspaceSelector.java
+++ b/src/main/java/net/mcreator/ui/workspace/selector/WorkspaceSelector.java
@@ -91,6 +91,10 @@ public final class WorkspaceSelector extends JFrame implements DropTargetListene
 				}
 			});
 
+		getRootPane().putClientProperty("apple.awt.fullWindowContent", true);
+		getRootPane().putClientProperty("apple.awt.transparentTitleBar", true);
+		getRootPane().putClientProperty("apple.awt.windowTitleVisible", false);
+
 		JPanel actions = new JPanel(new FlowLayout(FlowLayout.LEFT, 10, 10));
 		addWorkspaceButton(L10N.t("dialog.workspace_selector.new_workspace"), UIRES.get("addwrk"), e -> {
 			NewWorkspaceDialog newWorkspaceDialog = new NewWorkspaceDialog(this);
@@ -168,8 +172,8 @@ public final class WorkspaceSelector extends JFrame implements DropTargetListene
 		logoPanel.add("Center", socialButtons);
 		logoPanel.add("South", version);
 
-		logoPanel.setBorder(BorderFactory.createEmptyBorder(45, 26 + 25, 0, 10));
-		actions.setBorder(BorderFactory.createEmptyBorder(25, 24 + 25, 2, 10));
+		logoPanel.setBorder(BorderFactory.createEmptyBorder(30, 26 + 25, 0, 10));
+		actions.setBorder(BorderFactory.createEmptyBorder(40, 24 + 25, 2, 10));
 
 		JPanel southcenter = new JPanel(new FlowLayout(FlowLayout.RIGHT));
 		southcenter.setBorder(BorderFactory.createEmptyBorder(0, 0, 26, 60 - 1));
@@ -223,8 +227,7 @@ public final class WorkspaceSelector extends JFrame implements DropTargetListene
 		add("Center",
 				PanelUtils.centerAndSouthElement(PanelUtils.northAndCenterElement(logoPanel, actions), southcenter));
 
-		recentPanel.setBorder(
-				BorderFactory.createMatteBorder(0, 0, 0, 1, (Color) UIManager.get("MCreatorLAF.LIGHT_ACCENT")));
+		recentPanel.setBorder(BorderFactory.createEmptyBorder(30, 0, 0, 0));
 		recentPanel.setPreferredSize(new Dimension(220, 10));
 
 		initWebsitePanel();
@@ -233,7 +236,7 @@ public final class WorkspaceSelector extends JFrame implements DropTargetListene
 
 		new DropTarget(this, DnDConstants.ACTION_MOVE, this, true, null);
 
-		setSize(790, 460);
+		setSize(820, 460);
 		setResizable(false);
 		setLocationRelativeTo(null);
 	}

--- a/src/main/java/net/mcreator/ui/workspace/selector/WorkspaceSelector.java
+++ b/src/main/java/net/mcreator/ui/workspace/selector/WorkspaceSelector.java
@@ -343,6 +343,8 @@ public final class WorkspaceSelector extends JFrame implements DropTargetListene
 			DefaultListModel<RecentWorkspaceEntry> defaultListModel = new DefaultListModel<>();
 			recentWorkspaces.getList().forEach(defaultListModel::addElement);
 			JList<RecentWorkspaceEntry> recentsList = new JList<>(defaultListModel);
+			recentPanel.setBackground((Color) UIManager.get("MCreatorLAF.BLACK_ACCENT"));
+			recentsList.setBackground((Color) UIManager.get("MCreatorLAF.BLACK_ACCENT"));
 			recentsList.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
 			recentsList.addMouseListener(new MouseAdapter() {
 				@Override public void mouseClicked(MouseEvent mouseEvent) {
@@ -391,10 +393,12 @@ public final class WorkspaceSelector extends JFrame implements DropTargetListene
 			scrollPane.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
 			recentPanel.add(scrollPane);
 		} else if (recentWorkspaces == null) {
+			recentPanel.setBackground((Color) UIManager.get("MCreatorLAF.BLACK_ACCENT"));
 			JLabel norecents = L10N.label("dialog.workspace_selector.no_workspaces_loaded");
 			norecents.setForeground((Color) UIManager.get("MCreatorLAF.GRAY_COLOR"));
 			recentPanel.add(PanelUtils.totalCenterInPanel(norecents));
 		} else {
+			recentPanel.setBackground((Color) UIManager.get("MCreatorLAF.BLACK_ACCENT"));
 			JLabel norecents = L10N.label("dialog.workspace_selector.no_workspaces");
 			norecents.setForeground((Color) UIManager.get("MCreatorLAF.GRAY_COLOR"));
 			recentPanel.add(PanelUtils.totalCenterInPanel(norecents));


### PR DESCRIPTION
This change affects all systems, but it generally looks better without changing anything in the UX

1. Added a few system properties that are required for native LAF. This includes the extendable title bar, etc. Some small visual changes come with this for all systems, such as dual color instead of a border for workspaceSelector.
2. Tweaked the main menu for macOS to fix issues caused by the duplicated MCreator tab, because of Apple's method of automatically displaying the application name as its separate tab.
3. Removed progressDialog's close/maximize options.

Before
<img width="902" alt="Capture d’écran 2023-04-08 à 14 32 32" src="https://user-images.githubusercontent.com/49318596/230723886-bc0ceb0a-0384-4e74-b033-4fa8db04f36a.png">

After
<img width="932" alt="Capture d’écran 2023-04-08 à 15 33 10" src="https://user-images.githubusercontent.com/49318596/230723966-6d9b195d-eb1f-4ed0-b846-866a1d9cd306.png">

Before
<img width="1710" alt="old" src="https://user-images.githubusercontent.com/49318596/230724283-b0164c16-c531-419e-b4dd-e897d02fb98b.png">

After
<img width="1710" alt="new" src="https://user-images.githubusercontent.com/49318596/230724286-80882541-d7af-4036-b54b-7ebed470ffa8.png">