### PR TITLE
[1.19.4] Ported projectile procedures and data list

### DIFF
--- a/plugins/generator-1.19.4/forge-1.19.4/mappings/projectiles.yaml
+++ b/plugins/generator-1.19.4/forge-1.19.4/mappings/projectiles.yaml
@@ -1,0 +1,40 @@
+_default:
+  - Snowball
+  - EntityType.SNOWBALL
+_mcreator_prefix: "CUSTOM:"
+_mcreator_map_template:
+  - "@NAMEEntity"
+  - "@JavaModNameEntities.@REGISTRYNAME.get()"
+Arrow:
+  - Arrow
+  - EntityType.ARROW
+DragonFireball:
+  - DragonFireball
+  - EntityType.DRAGON_FIREBALL
+Egg:
+  - ThrownEgg
+  - EntityType.EGG
+EnderPearl:
+  - ThrownEnderpearl
+  - EntityType.ENDER_PEARL
+ExperienceBottle:
+  - ThrownExperienceBottle
+  - EntityType.EXPERIENCE_BOTTLE
+LargeFireball:
+  - LargeFireball
+  - EntityType.FIREBALL
+LlamaSpit:
+  - LlamaSpit
+  - EntityType.LLAMA_SPIT
+SmallFireball:
+  - SmallFireball
+  - EntityType.SMALL_FIREBALL
+Snowball:
+  - Snowball
+  - EntityType.SNOWBALL
+SpectralArrow:
+  - SpectralArrow
+  - EntityType.SPECTRAL_ARROW
+WitherSkull:
+  - WitherSkull
+  - EntityType.WITHER_SKULL

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/projectile_shoot_from_entity.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/projectile_shoot_from_entity.java.ftl
@@ -1,0 +1,10 @@
+{
+	Entity _shootFrom = ${input$entity};
+	Level projectileLevel = _shootFrom.level;
+	if (!projectileLevel.isClientSide()) {
+		Projectile _entityToSpawn = ${input$projectile};
+		_entityToSpawn.setPos(_shootFrom.getX(), _shootFrom.getEyeY() - 0.1, _shootFrom.getZ());
+		_entityToSpawn.shoot(_shootFrom.getLookAngle().x, _shootFrom.getLookAngle().y, _shootFrom.getLookAngle().z, ${opt.toFloat(input$speed)}, ${opt.toFloat(input$inaccuracy)});
+		projectileLevel.addFreshEntity(_entityToSpawn);
+	}
+}

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/projectile_shoot_from_pos.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/projectile_shoot_from_pos.java.ftl
@@ -1,0 +1,6 @@
+if(world instanceof ServerLevel projectileLevel) {
+	Projectile _entityToSpawn = ${input$projectile};
+	_entityToSpawn.setPos(${input$x}, ${input$y}, ${input$z});
+	_entityToSpawn.shoot(${input$dx}, ${input$dy}, ${input$dz}, ${opt.toFloat(input$speed)}, ${opt.toFloat(input$inaccuracy)});
+	projectileLevel.addFreshEntity(_entityToSpawn);
+}

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/projectiles_arrow.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/projectiles_arrow.java.ftl
@@ -1,0 +1,16 @@
+<#assign projectile = generator.map(field$projectile, "projectiles", 1)>
+<#assign hasShooter = (input$shooter != "null")>
+<#assign isPiercing = (input$piercing != "/*@int*/0")>
+new Object() {
+	public Projectile getArrow(Level level<#if hasShooter>, Entity shooter</#if>, float damage, int knockback<#if isPiercing>, byte piercing</#if>) {
+		AbstractArrow entityToSpawn = new ${generator.map(field$projectile, "projectiles", 0)}(${projectile}, level);
+		<#if hasShooter>entityToSpawn.setOwner(shooter);</#if>
+		entityToSpawn.setBaseDamage(damage);
+		entityToSpawn.setKnockback(knockback);
+		<#if field$projectile?starts_with("CUSTOM:")>entityToSpawn.setSilent(true);</#if>
+		<#if isPiercing>entityToSpawn.setPierceLevel(piercing);</#if>
+		<#if field$fire == "TRUE">entityToSpawn.setSecondsOnFire(100);</#if>
+		<#if field$particles == "TRUE">entityToSpawn.setCritArrow(true);</#if>
+		<#if field$pickup != "DISALLOWED">entityToSpawn.pickup = AbstractArrow.Pickup.${field$pickup};</#if>
+		return entityToSpawn;
+}}.getArrow(projectileLevel<#if hasShooter>, ${input$shooter}</#if>, ${opt.toFloat(input$damage)}, ${opt.toInt(input$knockback)}<#if isPiercing>, (byte) ${input$piercing}</#if>)

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/projectiles_fireball.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/projectiles_fireball.java.ftl
@@ -1,0 +1,17 @@
+<#assign hasShooter = (input$shooter != "null")>
+<#assign hasAcceleration = (input$ax != "/*@int*/0") || (input$ay != "/*@int*/0") || (input$az != "/*@int*/0")>
+<#if (!hasShooter) && (!hasAcceleration)>
+new ${generator.map(field$projectile, "projectiles", 0)}(${generator.map(field$projectile, "projectiles", 1)}, projectileLevel)
+<#else>
+new Object() {
+	public Projectile getFireball(Level level<#if hasShooter>, Entity shooter</#if><#if hasAcceleration>, double ax, double ay, double az</#if>) {
+		AbstractHurtingProjectile entityToSpawn = new ${generator.map(field$projectile, "projectiles", 0)}(${generator.map(field$projectile, "projectiles", 1)}, level);
+		<#if hasShooter>entityToSpawn.setOwner(shooter);</#if>
+		<#if hasAcceleration>
+		entityToSpawn.xPower = ax;
+		entityToSpawn.yPower = ay;
+		entityToSpawn.zPower = az;
+		</#if>
+		return entityToSpawn;
+}}.getFireball(projectileLevel<#if hasShooter>, ${input$shooter}</#if><#if hasAcceleration>, ${input$ax}, ${input$ay}, ${input$az}</#if>)
+</#if>

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/projectiles_throwable.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/projectiles_throwable.java.ftl
@@ -1,0 +1,10 @@
+<#if input$shooter == "null">
+new ${generator.map(field$projectile, "projectiles", 0)}(${generator.map(field$projectile, "projectiles", 1)}, projectileLevel)
+<#else>
+new Object() {
+	public Projectile getProjectile(Level level, Entity shooter) {
+		Projectile entityToSpawn = new ${generator.map(field$projectile, "projectiles", 0)}(${generator.map(field$projectile, "projectiles", 1)}, level);
+		entityToSpawn.setOwner(shooter);
+		return entityToSpawn;
+}}.getProjectile(projectileLevel, ${input$shooter})
+</#if>


### PR DESCRIPTION
This PR ports the projectile procedures and data list, with no changes from 1.19.2. The mappings are ordered to match `EntityType.java`