### PR TITLE
[1.19.4] Ported direction and comparison procedures

### DIFF
--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/advancement_isequalto.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/advancement_isequalto.java.ftl
@@ -1,0 +1,2 @@
+(world instanceof Level _lvl && _lvl.getServer() != null && _lvl.getServer().getAdvancements()
+    .getAdvancement(new ResourceLocation("${generator.map(field$achievement, "achievements")}" )).equals(advancement))

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/compare_blockstates.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/compare_blockstates.java.ftl
@@ -1,0 +1,2 @@
+<#include "mcitems.ftl">
+(${mappedBlockToBlockStateCode(input$a)} == ${mappedBlockToBlockStateCode(input$b)})

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/compare_dimensionids.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/compare_dimensionids.java.ftl
@@ -1,0 +1,1 @@
+(${input$a} == ${input$b})

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/compare_directions.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/compare_directions.java.ftl
@@ -1,0 +1,1 @@
+(${input$a} == ${input$b})

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/compare_entities.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/compare_entities.java.ftl
@@ -1,0 +1,1 @@
+(${input$a} == ${input$b})

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/compare_mcblocks.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/compare_mcblocks.java.ftl
@@ -1,0 +1,2 @@
+<#include "mcitems.ftl">
+(${mappedBlockToBlock(input$a)} == ${mappedBlockToBlock(input$b)})

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/compare_mcitems.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/compare_mcitems.java.ftl
@@ -1,0 +1,2 @@
+<#include "mcitems.ftl">
+(${mappedMCItemToItem(input$a)} == ${mappedMCItemToItem(input$b)})

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/direction_compare_axes.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/direction_compare_axes.java.ftl
@@ -1,0 +1,2 @@
+<#include "mcelements.ftl">
+(${toAxis(input$a)} == ${toAxis(input$b)})

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/direction_foreach.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/direction_foreach.java.ftl
@@ -1,0 +1,3 @@
+for (Direction directioniterator : Direction.values()) {
+    ${statement$foreach}
+}

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/direction_foreach_horizontal.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/direction_foreach_horizontal.java.ftl
@@ -1,0 +1,3 @@
+for (Direction directioniterator : Direction.Plane.HORIZONTAL) {
+    ${statement$foreach}
+}

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/direction_iterator.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/direction_iterator.java.ftl
@@ -1,0 +1,1 @@
+directioniterator

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/direction_offset_x.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/direction_offset_x.java.ftl
@@ -1,0 +1,1 @@
+/*@int*/(${input$direction}.getStepX())

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/direction_offset_y.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/direction_offset_y.java.ftl
@@ -1,0 +1,1 @@
+/*@int*/(${input$direction}.getStepY())

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/direction_offset_z.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/direction_offset_z.java.ftl
@@ -1,0 +1,1 @@
+/*@int*/(${input$direction}.getStepZ())

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/direction_opposite.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/direction_opposite.java.ftl
@@ -1,0 +1,1 @@
+(${input$direction}.getOpposite())

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/direction_random.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/direction_random.java.ftl
@@ -1,0 +1,1 @@
+Direction.getRandom(RandomSource.create())

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/direction_rotated_clockwise.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/direction_rotated_clockwise.java.ftl
@@ -1,0 +1,1 @@
+(${input$direction}.getClockWise(Direction.Axis.Y))

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/direction_rotated_counterclockwise.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/direction_rotated_counterclockwise.java.ftl
@@ -1,0 +1,1 @@
+(${input$direction}.getCounterClockWise(Direction.Axis.Y))

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/logic_entity_compare.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/logic_entity_compare.java.ftl
@@ -1,0 +1,1 @@
+(${input$compareTo} instanceof ${generator.map(field$entity, "entities", 0)})


### PR DESCRIPTION
This PR ports all the direction and logic procedures, with no changes from 1.19.2 (The "advancement equals" code was slightly optimized)

[Previous PR was closed due to commit issues]