### PR TITLE
[1.19.4] Ported the entities data list

### DIFF
--- a/plugins/generator-1.19.4/datapack-1.19.4/mappings/entities.yaml
+++ b/plugins/generator-1.19.4/datapack-1.19.4/mappings/entities.yaml
@@ -7,12 +7,511 @@ _mcreator_map_template:
   - "@NAMEEntity"
   - "@JavaModNameEntities.@REGISTRYNAME.get()"
   - "@modid:@registryname"
-EntityZombie:
-  - Zombie
-  - EntityType.ZOMBIE
-  - zombie
+EntityAgeable: AgeableMob
+EntityAmbientCreature: AmbientCreature
+EntityAnimal: Animal
+EntityCreature: PathfinderMob
+EntityFlying: FlyingMob
+EntityGolem: AbstractGolem
+EntityHanging: HangingEntity
+EntityLiving: LivingEntity
+EntityMinecartContainer: AbstractMinecartContainer
+EntityMob: Mob
+EntityMonster: Monster
+EntityShoulderRiding: ShoulderRidingEntity
+EntitySpellcasterIllager: SpellcasterIllager
+EntityTameable: TamableAnimal
+EntityThrowable: ThrowableProjectile
+EntityWaterMob: WaterAnimal
+EntityAllay:
+  - Allay
+  - EntityType.ALLAY
+  - allay
+EntityAreaEffectCloud:
+  - AreaEffectCloud
+  - EntityType.AREA_EFFECT_CLOUD
+  - area_effect_cloud
+EntityArmorStand:
+  - ArmorStand
+  - EntityType.ARMOR_STAND
+  - armor_stand
+EntityArrow:
+  - Arrow
+  - EntityType.ARROW
+  - arrow
+EntityAxolotl:
+  - Axolotl
+  - EntityType.AXOLOTL
+  - axolotl
+EntityBat:
+  - Bat
+  - EntityType.BAT
+  - bat
 EntityBee:
   - Bee
   - EntityType.BEE
   - bee
-# just some copied from 1.19.2 for test use, replace with proper mappings
+EntityBlaze:
+  - Blaze
+  - EntityType.BLAZE
+  - blaze
+EntityBlockDisplay:
+  - Display.BlockDisplay
+  - EntityType.BLOCK_DISPLAY
+  - block_display
+EntityBoat:
+  - Boat
+  - EntityType.BOAT
+  - boat
+EntityCat:
+  - Cat
+  - EntityType.CAT
+  - cat
+EntityCaveSpider:
+  - CaveSpider
+  - EntityType.CAVE_SPIDER
+  - cave_spider
+EntityChestBoat:
+  - ChestBoat
+  - EntityType.CHEST_BOAT
+  - chest_boat
+EntityMinecartChest:
+  - MinecartChest
+  - EntityType.CHEST_MINECART
+  - chest_minecart
+EntityChicken:
+  - Chicken
+  - EntityType.CHICKEN
+  - chicken
+EntityCod:
+  - Cod
+  - EntityType.COD
+  - cod
+EntityMinecartCommandBlock:
+  - MinecartCommandBlock
+  - EntityType.COMMAND_BLOCK_MINECART
+  - command_block_minecart
+EntityCow:
+  - Cow
+  - EntityType.COW
+  - cow
+EntityCreeper:
+  - Creeper
+  - EntityType.CREEPER
+  - creeper
+EntityDonkey:
+  - Donkey
+  - EntityType.DONKEY
+  - donkey
+EntityDolphin:
+  - Dolphin
+  - EntityType.DOLPHIN
+  - dolphin
+EntityDragonFireball:
+  - DragonFireball
+  - EntityType.DRAGON_FIREBALL
+  - dragon_fireball
+EntityDrowned:
+  - Drowned
+  - EntityType.DROWNED
+  - drowned
+EntityEgg:
+  - ThrownEgg
+  - EntityType.EGG
+  - egg
+EntityElderGuardian:
+  - ElderGuardian
+  - EntityType.ELDER_GUARDIAN
+  - elder_guardian
+EntityEnderCrystal:
+  - EndCrystal
+  - EntityType.END_CRYSTAL
+  - end_crystal
+EntityDragon:
+  - EnderDragon
+  - EntityType.ENDER_DRAGON
+  - ender_dragon
+EntityEnderPearl:
+  - ThrownEnderpearl
+  - EntityType.ENDER_PEARL
+  - ender_pearl
+EntityEnderman:
+  - EnderMan
+  - EntityType.ENDERMAN
+  - enderman
+EntityEndermite:
+  - Endermite
+  - EntityType.ENDERMITE
+  - endermite
+EntityEvoker:
+  - Evoker
+  - EntityType.EVOKER
+  - evoker
+EntityEvokerFangs:
+  - EvokerFangs
+  - EntityType.EVOKER_FANGS
+  - evoker_fangs
+EntityExpBottle:
+  - ThrownExperienceBottle
+  - EntityType.EXPERIENCE_BOTTLE
+  - experience_bottle
+EntityXPOrb:
+  - ExperienceOrb
+  - EntityType.EXPERIENCE_ORB
+  - experience_orb
+EntityEnderEye:
+  - EyeOfEnder
+  - EntityType.EYE_OF_ENDER
+  - eye_of_ender
+EntityFallingBlock:
+  - FallingBlockEntity
+  - EntityType.FALLING_BLOCK
+  - falling_block
+EntityFireworkRocket:
+  - FireworkRocketEntity
+  - EntityType.FIREWORK_ROCKET
+  - firework_rocket
+EntityFox:
+  - Fox
+  - EntityType.FOX
+  - fox
+EntityFrog:
+  - Frog
+  - EntityType.FROG
+  - frog
+EntityMinecartFurnace:
+  - MinecartFurnace
+  - EntityType.FURNACE_MINECART
+  - furnace_minecart
+EntityGhast:
+  - Ghast
+  - EntityType.GHAST
+  - ghast
+EntityGiantZombie:
+  - Giant
+  - EntityType.GIANT
+  - giant
+EntityGlowItemFrame:
+  - GlowItemFrame
+  - EntityType.GLOW_ITEM_FRAME
+  - glow_item_frame
+EntityGlowSquid:
+  - GlowSquid
+  - EntityType.GLOW_SQUID
+  - glow_squid
+EntityGoat:
+  - Goat
+  - EntityType.GOAT
+  - goat
+EntityGuardian:
+  - Guardian
+  - EntityType.GUARDIAN
+  - guardian
+EntityHoglin:
+  - Hoglin
+  - EntityType.HOGLIN
+  - hoglin
+EntityMinecartHopper:
+  - MinecartHopper
+  - EntityType.HOPPER_MINECART
+  - hopper_minecart
+EntityHorse:
+  - Horse
+  - EntityType.HORSE
+  - horse
+EntityHusk:
+  - Husk
+  - EntityType.HUSK
+  - husk
+EntityIllusionIllager:
+  - Illusioner
+  - EntityType.ILLUSIONER
+  - illusioner
+EntityInteraction:
+  - Interaction
+  - EntityType.INTERACTION
+  - interaction
+EntityIronGolem:
+  - IronGolem
+  - EntityType.IRON_GOLEM
+  - iron_golem
+EntityItem:
+  - ItemEntity
+  - EntityType.ITEM
+  - item
+EntityItemDisplay:
+  - Display.ItemDisplay
+  - EntityType.ITEM_DISPLAY
+  - item_display
+EntityItemFrame:
+  - ItemFrame
+  - EntityType.ITEM_FRAME
+  - item_frame
+EntityFireball:
+  - LargeFireball
+  - EntityType.FIREBALL
+  - fireball
+EntityLeashKnot:
+  - LeashFenceKnotEntity
+  - EntityType.LEASH_KNOT
+  - leash_knot
+EntityLightningBolt:
+  - LightningBolt
+  - EntityType.LIGHTNING_BOLT
+  - lightning_bolt
+EntityLlama:
+  - Llama
+  - EntityType.LLAMA
+  - llama
+EntityLlamaSpit:
+  - LlamaSpit
+  - EntityType.LLAMA_SPIT
+  - llama_spit
+EntityMagmaCube:
+  - MagmaCube
+  - EntityType.MAGMA_CUBE
+  - magma_cube
+EntityMarker:
+  - Marker
+  - EntityType.MARKER
+  - marker
+EntityMinecart:
+  - Minecart
+  - EntityType.MINECART
+  - minecart
+EntityMooshroom:
+  - MushroomCow
+  - EntityType.MOOSHROOM
+  - mooshroom
+EntityMule:
+  - Mule
+  - EntityType.MULE
+  - mule
+EntityOcelot:
+  - Ocelot
+  - EntityType.OCELOT
+  - ocelot
+EntityPainting:
+  - Painting
+  - EntityType.PAINTING
+  - painting
+EntityPanda:
+  - Panda
+  - EntityType.PANDA
+  - panda
+EntityParrot:
+  - Parrot
+  - EntityType.PARROT
+  - parrot
+EntityPhantom:
+  - Phantom
+  - EntityType.PHANTOM
+  - phantom
+EntityPig:
+  - Pig
+  - EntityType.PIG
+  - pig
+EntityPiglin:
+  - Piglin
+  - EntityType.PIGLIN
+  - piglin
+EntityPiglinBrute:
+  - PiglinBrute
+  - EntityType.PIGLIN_BRUTE
+  - piglin_brute
+EntityPillager:
+  - Pillager
+  - EntityType.PILLAGER
+  - pillager
+EntityPolarBear:
+  - PolarBear
+  - EntityType.POLAR_BEAR
+  - polar_bear
+EntityPotion:
+  - ThrownPotion
+  - EntityType.POTION
+  - potion
+EntityPufferfish:
+  - Pufferfish
+  - EntityType.PUFFERFISH
+  - pufferfish
+EntityRabbit:
+  - Rabbit
+  - EntityType.RABBIT
+  - rabbit
+EntityRavager:
+  - Ravager
+  - EntityType.RAVAGER
+  - ravager
+EntitySalmon:
+  - Salmon
+  - EntityType.SALMON
+  - salmon
+EntitySheep:
+  - Sheep
+  - EntityType.SHEEP
+  - sheep
+EntityShulker:
+  - Shulker
+  - EntityType.SHULKER
+  - shulker
+EntityShulkerBullet:
+  - ShulkerBullet
+  - EntityType.SHULKER_BULLET
+  - shulker_bullet
+EntitySilverfish:
+  - Silverfish
+  - EntityType.SILVERFISH
+  - silverfish
+EntitySkeleton:
+  - Skeleton
+  - EntityType.SKELETON
+  - skeleton
+EntitySkeletonHorse:
+  - SkeletonHorse
+  - EntityType.SKELETON_HORSE
+  - skeleton_horse
+EntitySlime:
+  - Slime
+  - EntityType.SLIME
+  - slime
+EntitySmallFireball:
+  - SmallFireball
+  - EntityType.SMALL_FIREBALL
+  - small_fireball
+EntitySnowman:
+  - SnowGolem
+  - EntityType.SNOW_GOLEM
+  - snow_golem
+EntitySnowball:
+  - Snowball
+  - EntityType.SNOWBALL
+  - snowball
+EntityMinecartMobSpawner:
+  - MinecartSpawner
+  - EntityType.SPAWNER_MINECART
+  - spawner_minecart
+EntitySpectralArrow:
+  - SpectralArrow
+  - EntityType.SPECTRAL_ARROW
+  - spectral_arrow
+EntitySpider:
+  - Spider
+  - EntityType.SPIDER
+  - spider
+EntitySquid:
+  - Squid
+  - EntityType.SQUID
+  - squid
+EntityStray:
+  - Stray
+  - EntityType.STRAY
+  - stray
+EntityStrider:
+  - Strider
+  - EntityType.STRIDER
+  - strider
+EntityTadpole:
+  - Tadpole
+  - EntityType.TADPOLE
+  - tadpole
+EntityTextDisplay:
+  - Display.TextDisplay
+  - EntityType.TEXT_DISPLAY
+  - text_display
+EntityTNTPrimed:
+  - PrimedTnt
+  - EntityType.TNT
+  - tnt
+EntityMinecartTNT:
+  - MinecartTNT
+  - EntityType.TNT_MINECART
+  - tnt_minecart
+EntityTraderLlama:
+  - TraderLlama
+  - EntityType.TRADER_LLAMA
+  - trader_llama
+EntityTrident:
+  - ThrownTrident
+  - EntityType.TRIDENT
+  - trident
+EntityTropicalFish:
+  - TropicalFish
+  - EntityType.TROPICAL_FISH
+  - tropical_fish
+EntityTurtle:
+  - Turtle
+  - EntityType.TURTLE
+  - turtle
+EntityVex:
+  - Vex
+  - EntityType.VEX
+  - vex
+EntityVillager:
+  - Villager
+  - EntityType.VILLAGER
+  - villager
+EntityVindicator:
+  - Vindicator
+  - EntityType.VINDICATOR
+  - vindicator
+EntityWanderingTrader:
+  - WanderingTrader
+  - EntityType.WANDERING_TRADER
+  - wandering_trader
+EntityWarden:
+  - Warden
+  - EntityType.WARDEN
+  - warden
+EntityWitch:
+  - Witch
+  - EntityType.WITCH
+  - witch
+EntityWither:
+  - WitherBoss
+  - EntityType.WITHER
+  - wither
+EntityWitherSkeleton:
+  - WitherSkeleton
+  - EntityType.WITHER_SKELETON
+  - wither_skeleton
+EntityWitherSkull:
+  - WitherSkull
+  - EntityType.WITHER_SKULL
+  - wither_skull
+EntityWolf:
+  - Wolf
+  - EntityType.WOLF
+  - wolf
+EntityZoglin:
+  - Zoglin
+  - EntityType.ZOGLIN
+  - zoglin
+EntityZombie:
+  - Zombie
+  - EntityType.ZOMBIE
+  - zombie
+EntityZombieHorse:
+  - ZombieHorse
+  - EntityType.ZOMBIE_HORSE
+  - zombie_horse
+EntityZombieVillager:
+  - ZombieVillager
+  - EntityType.ZOMBIE_VILLAGER
+  - zombie_villager
+EntityPigZombie:
+  - ZombifiedPiglin
+  - EntityType.ZOMBIFIED_PIGLIN
+  - zombified_piglin
+EntityPlayer:
+  - Player
+  - EntityType.PLAYER
+  - player
+EntityPlayerMP:
+  - ServerPlayer
+  - EntityType.PLAYER
+  - player
+EntityFishHook:
+  - FishingHook
+  - EntityType.FISHING_BOBBER
+  - fishing_bobber

--- a/plugins/mcreator-core/datalists/entities.yaml
+++ b/plugins/mcreator-core/datalists/entities.yaml
@@ -384,3 +384,15 @@
 - EntityWarden:
   readable_name: "Warden"
   type: spawnable
+- EntityBlockDisplay:
+  readable_name: "Block display"
+  type: spawnable
+- EntityInteraction:
+  readable_name: "Interaction"
+  type: spawnable
+- EntityItemDisplay:
+  readable_name: "Item display"
+  type: spawnable
+- EntityTextDisplay:
+  readable_name: "Text display"
+  type: spawnable


### PR DESCRIPTION
This PR ports the entities data list to 1.19.4, including the display and interaction entities. The mappings file is also rearranged, with abstract types at the top, and the proper types matching the order in `EntityType.java`