### PR TITLE
[1.19.4] Ported remaining block data procedures, added missing int markers

### DIFF
--- a/plugins/generator-1.18.2/forge-1.18.2/procedures/blockat_harvestlevel.java.ftl
+++ b/plugins/generator-1.18.2/forge-1.18.2/procedures/blockat_harvestlevel.java.ftl
@@ -1,5 +1,5 @@
 <#include "mcelements.ftl">
-(new Object(){
+/*@int*/(new Object(){
 	public int getHarvestLevel(Block _bl) {
 		return TierSortingRegistry.getSortedTiers().stream().filter(t -> t.getTag() != null && _bl.defaultBlockState().is(t.getTag()))
                     .map(Tier::getLevel).findFirst().orElse(0);

--- a/plugins/generator-1.19.2/forge-1.19.2/procedures/blockat_harvestlevel.java.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/procedures/blockat_harvestlevel.java.ftl
@@ -1,5 +1,5 @@
 <#include "mcelements.ftl">
-(new Object(){
+/*@int*/(new Object(){
 	public int getHarvestLevel(BlockState _bs) {
 		return TierSortingRegistry.getSortedTiers().stream().filter(t -> t.getTag() != null && _bs.is(t.getTag()))
 					.map(Tier::getLevel).findFirst().orElse(0);

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/block_random_from_tag.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/block_random_from_tag.java.ftl
@@ -1,0 +1,2 @@
+<#include "mcelements.ftl">
+(ForgeRegistries.BLOCKS.tags().getTag(BlockTags.create(${toResourceLocation(input$tag)})).getRandomElement(RandomSource.create()).orElseGet(() -> Blocks.AIR))

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/block_registry_name.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/block_registry_name.java.ftl
@@ -1,0 +1,2 @@
+<#include "mcitems.ftl">
+(ForgeRegistries.BLOCKS.getKey(${mappedBlockToBlock(input$block)}).toString())

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/blockat_enchant_power_bonus.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/blockat_enchant_power_bonus.java.ftl
@@ -1,0 +1,2 @@
+<#include "mcelements.ftl">
+/*@float*/(world.getBlockState(${toBlockPos(input$x,input$y,input$z)}).getEnchantPowerBonus(world, ${toBlockPos(input$x,input$y,input$z)}))

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/blockat_hardness.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/blockat_hardness.java.ftl
@@ -1,0 +1,2 @@
+<#include "mcelements.ftl">
+/*@float*/(world.getBlockState(${toBlockPos(input$x,input$y,input$z)}).getDestroySpeed(world, ${toBlockPos(input$x,input$y,input$z)}))

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/blockat_harvestlevel.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/blockat_harvestlevel.java.ftl
@@ -1,3 +1,7 @@
 <#include "mcelements.ftl">
-/*@int*/(TierSortingRegistry.getSortedTiers().stream().filter(t -> t.getTag() != null &&
-	world.getBlockState(${toBlockPos(input$x,input$y,input$z)}).is(t.getTag())).map(Tier::getLevel).findFirst().orElse(0))
+/*@int*/(new Object(){
+	public int getHarvestLevel(BlockState _bs) {
+		return TierSortingRegistry.getSortedTiers().stream().filter(t -> t.getTag() != null && _bs.is(t.getTag()))
+				.map(Tier::getLevel).findFirst().orElse(0);
+	}
+}.getHarvestLevel(world.getBlockState(${toBlockPos(input$x,input$y,input$z)})))

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/blockat_harvestlevel.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/blockat_harvestlevel.java.ftl
@@ -1,0 +1,3 @@
+<#include "mcelements.ftl">
+/*@int*/(TierSortingRegistry.getSortedTiers().stream().filter(t -> t.getTag() != null &&
+	world.getBlockState(${toBlockPos(input$x,input$y,input$z)}).is(t.getTag())).map(Tier::getLevel).findFirst().orElse(0))

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/blockat_is_side_solid.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/blockat_is_side_solid.java.ftl
@@ -1,0 +1,2 @@
+<#include "mcelements.ftl">
+(world.getBlockState(${toBlockPos(input$x,input$y,input$z)}).isFaceSturdy(world, ${toBlockPos(input$x,input$y,input$z)}, ${input$direction}))

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/blockat_is_solid.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/blockat_is_solid.java.ftl
@@ -1,0 +1,2 @@
+<#include "mcelements.ftl">
+(world.getBlockState(${toBlockPos(input$x,input$y,input$z)}).canOcclude())

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/blockat_lightlevel.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/blockat_lightlevel.java.ftl
@@ -1,0 +1,2 @@
+<#include "mcelements.ftl">
+/*@int*/(world.getBlockState(${toBlockPos(input$x,input$y,input$z)}).getLightEmission(world, ${toBlockPos(input$x,input$y,input$z)}))

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/blockat_opacity.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/blockat_opacity.java.ftl
@@ -1,0 +1,2 @@
+<#include "mcelements.ftl">
+/*@int*/(world.getBlockState(${toBlockPos(input$x,input$y,input$z)}).getLightBlock(world,${toBlockPos(input$x,input$y,input$z)}))

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/blockat_plant_type.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/blockat_plant_type.java.ftl
@@ -1,0 +1,3 @@
+<#include "mcelements.ftl">
+(world.getBlockState(${toBlockPos(input$x,input$y,input$z)}).getBlock() instanceof IPlantable _plant &&
+	_plant.getPlantType(world, ${toBlockPos(input$x,input$y,input$z)}) == PlantType.${generator.map(field$planttype, "planttypes")})

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/compare_mcblock_material.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/compare_mcblock_material.java.ftl
@@ -1,0 +1,2 @@
+<#include "mcitems.ftl">
+(${mappedBlockToBlockStateCode(input$a)}.getMaterial() == net.minecraft.world.level.material.Material.${generator.map(field$material, "materials")})

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/item_bucket_to_fluid.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/item_bucket_to_fluid.java.ftl
@@ -1,0 +1,2 @@
+<#include "mcitems.ftl">
+/*@BlockState*/(${mappedMCItemToItem(input$source)} instanceof BucketItem _bucket ? _bucket.getFluid().defaultFluidState().createLegacyBlock() : Blocks.AIR.defaultBlockState())

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/mcitem_to_block.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/mcitem_to_block.java.ftl
@@ -1,0 +1,2 @@
+<#include "mcitems.ftl">
+/*@BlockState*/(${mappedMCItemToItem(input$source)} instanceof BlockItem _bi ? _bi.getBlock().defaultBlockState() : Blocks.AIR.defaultBlockState())

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/registryname_to_mcitemblock.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/registryname_to_mcitemblock.java.ftl
@@ -1,0 +1,2 @@
+<#include "mcelements.ftl">
+ForgeRegistries.BLOCKS.getValue(${toResourceLocation(input$registryname)})


### PR DESCRIPTION
This PR ports the remaining block data procedures, with almost no changes from 1.19.2. The "Get block harvest level" procedure was missing the int markers