### PR TITLE
[1.19.4] Ported remaining entity data procedures

### DIFF
--- a/plugins/generator-1.18.2/forge-1.18.2/procedures/entity_submerged_height.java.ftl
+++ b/plugins/generator-1.18.2/forge-1.18.2/procedures/entity_submerged_height.java.ftl
@@ -1,7 +1,7 @@
 (new Object() {
     public double getSubmergedHeight(Entity _entity) {
         for (TagKey<Fluid> _fldtag : Registry.FLUID.getTagNames().toList()) {
-            if (_entity.level.getFluidState(entity.blockPosition()).is(_fldtag))
+            if (_entity.level.getFluidState(_entity.blockPosition()).is(_fldtag))
                 return _entity.getFluidHeight(_fldtag);
         }
         return 0;

--- a/plugins/generator-1.19.2/forge-1.19.2/procedures/entity_submerged_height.java.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/procedures/entity_submerged_height.java.ftl
@@ -1,7 +1,7 @@
 (new Object() {
     public double getSubmergedHeight(Entity _entity) {
         for (TagKey<Fluid> _fldtag : Registry.FLUID.getTagNames().toList()) {
-            if (_entity.level.getFluidState(entity.blockPosition()).is(_fldtag))
+            if (_entity.level.getFluidState(_entity.blockPosition()).is(_fldtag))
                 return _entity.getFluidHeight(_fldtag);
         }
         return 0;

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_canusecommand.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_canusecommand.java.ftl
@@ -1,0 +1,1 @@
+(${input$entity}.hasPermissions(${opt.toInt(input$permissionlevel)}))

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_check_creature_type.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_check_creature_type.java.ftl
@@ -1,0 +1,1 @@
+(${input$entity} instanceof LivingEntity _livEnt && _livEnt.getMobType() == MobType.${field$type})

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_get_scoreboard_score.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_get_scoreboard_score.java.ftl
@@ -1,0 +1,9 @@
+/*@int*/(new Object(){
+	public int getScore(String score, Entity _ent){
+		Scoreboard _sc = _ent.getLevel().getScoreboard();
+		Objective _so = _sc.getObjective(score);
+		if (_so != null)
+			return _sc.getOrCreatePlayerScore(_ent.getScoreboardName(), _so).getScore();
+		return 0;
+	}
+}.getScore(${input$score}, ${input$entity}))

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_haspotioneffect.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_haspotioneffect.java.ftl
@@ -1,0 +1,1 @@
+(${input$entity} instanceof LivingEntity _livEnt && _livEnt.hasEffect(${generator.map(field$potion, "effects")}))

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_name.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_name.java.ftl
@@ -1,0 +1,1 @@
+(${input$entity}.getDisplayName().getString())

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_nbt_logic_get.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_nbt_logic_get.java.ftl
@@ -1,0 +1,1 @@
+(${input$entity}.getPersistentData().getBoolean(${input$tagName}))

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_nbt_num_get.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_nbt_num_get.java.ftl
@@ -1,0 +1,1 @@
+(${input$entity}.getPersistentData().getDouble(${input$tagName}))

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_nbt_text_get.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_nbt_text_get.java.ftl
@@ -1,0 +1,1 @@
+(${input$entity}.getPersistentData().getString(${input$tagName}))

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_potioneffectlevel.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_potioneffectlevel.java.ftl
@@ -1,0 +1,2 @@
+/*@int*/(${input$entity} instanceof LivingEntity _livEnt && _livEnt.hasEffect(${generator.map(field$potion, "effects")}) ?
+    _livEnt.getEffect(${generator.map(field$potion, "effects")}).getAmplifier() : 0)

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_potioneffectremaining.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_potioneffectremaining.java.ftl
@@ -1,0 +1,2 @@
+/*@int*/(${input$entity} instanceof LivingEntity _livEnt && _livEnt.hasEffect(${generator.map(field$potion, "effects")}) ?
+    _livEnt.getEffect(${generator.map(field$potion, "effects")}).getDuration() : 0)

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_registry_name.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_registry_name.java.ftl
@@ -1,0 +1,1 @@
+(ForgeRegistries.ENTITY_TYPES.getKey(${input$entity}.getType()).toString())

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_size_height.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_size_height.java.ftl
@@ -1,0 +1,1 @@
+/*@float*/(${input$entity}.getBbHeight())

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_size_width.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_size_width.java.ftl
@@ -1,0 +1,1 @@
+/*@float*/(${input$entity}.getBbWidth())

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_submerged_height.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_submerged_height.java.ftl
@@ -1,0 +1,9 @@
+(new Object() {
+    public double getSubmergedHeight(Entity _entity) {
+        for (FluidType fluidType : ForgeRegistries.FLUID_TYPES.get().getValues()) {
+            if (_entity.level.getFluidState(_entity.blockPosition()).getFluidType() == fluidType)
+                return _entity.getFluidTypeHeight(fluidType);
+        }
+        return 0;
+    }
+}.getSubmergedHeight(${input$entity}))

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/itementity_to_mcitem.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/itementity_to_mcitem.java.ftl
@@ -1,0 +1,1 @@
+/*@ItemStack*/(${input$source} instanceof ItemEntity _itemEnt ? _itemEnt.getItem() : ItemStack.EMPTY)


### PR DESCRIPTION
This PR ports the remaining entity data procedures to 1.19.4. 

Code is the same, except for the `entity_submerged_height`, which now uses FluidTypes to get the height. The PR also fixes a bug where this block could cause compilation errors in some cases