### PR TITLE
[1.19.4] Ported some more procedure blocks

### DIFF
--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_add_achievement.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_add_achievement.java.ftl
@@ -1,0 +1,8 @@
+if(${input$entity} instanceof ServerPlayer _player) {
+	Advancement _adv = _player.server.getAdvancements().getAdvancement(new ResourceLocation("${generator.map(field$achievement, "achievements")}"));
+	AdvancementProgress _ap = _player.getAdvancements().getOrStartProgress(_adv);
+	if (!_ap.isDone()) {
+		for (String criteria : _ap.getRemainingCriteria())
+			_player.getAdvancements().award(_adv, criteria);
+	}
+}

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_add_exhaustion.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_add_exhaustion.java.ftl
@@ -1,0 +1,1 @@
+if (${input$entity} instanceof Player _player) _player.causeFoodExhaustion(${opt.toFloat(input$amount)});

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_add_xp.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_add_xp.java.ftl
@@ -1,0 +1,1 @@
+if (${input$entity} instanceof Player _player) _player.giveExperiencePoints(${opt.toInt(input$xpamount)});

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_add_xp_level.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_add_xp_level.java.ftl
@@ -1,0 +1,1 @@
+if (${input$entity} instanceof Player _player) _player.giveExperienceLevels(${opt.toInt(input$xpamount)});

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_checkgamemode.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_checkgamemode.java.ftl
@@ -1,0 +1,11 @@
+(new Object(){
+	public boolean checkGamemode(Entity _ent){
+		if(_ent instanceof ServerPlayer _serverPlayer) {
+			return _serverPlayer.gameMode.getGameModeForPlayer() == GameType.${generator.map(field$gamemode, "gamemodes")};
+		} else if(_ent.level.isClientSide() && _ent instanceof Player _player) {
+			return Minecraft.getInstance().getConnection().getPlayerInfo(_player.getGameProfile().getId()) != null
+				&& Minecraft.getInstance().getConnection().getPlayerInfo(_player.getGameProfile().getId()).getGameMode() == GameType.${generator.map(field$gamemode, "gamemodes")};
+		}
+		return false;
+	}
+}.checkGamemode(${input$entity}))

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_has_achievement.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_has_achievement.java.ftl
@@ -1,0 +1,2 @@
+(${input$entity} instanceof ServerPlayer _plr && _plr.level instanceof ServerLevel && _plr.getAdvancements()
+        .getOrStartProgress(_plr.server.getAdvancements().getAdvancement(new ResourceLocation("${generator.map(field$achievement, "achievements")}"))).isDone())

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_has_screen_open.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_has_screen_open.java.ftl
@@ -1,0 +1,1 @@
+(${input$entity} instanceof Player _plr && _plr.containerMenu instanceof ${field$guiname}Menu)

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_remove_xp.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_remove_xp.java.ftl
@@ -1,0 +1,1 @@
+if (${input$entity} instanceof Player _player) _player.giveExperiencePoints(-(${opt.toInt(input$amount)}));

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_remove_xp_level.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_remove_xp_level.java.ftl
@@ -1,0 +1,1 @@
+if (${input$entity} instanceof Player _player) _player.giveExperienceLevels(-(${opt.toInt(input$xpamount)}));

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_set_foodlevel.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_set_foodlevel.java.ftl
@@ -1,0 +1,1 @@
+if (${input$entity} instanceof Player _player) _player.getFoodData().setFoodLevel(${opt.toInt(input$foodlevel)});

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_set_gamemode.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_set_gamemode.java.ftl
@@ -1,0 +1,1 @@
+if (${input$entity} instanceof ServerPlayer _player) _player.setGameMode(GameType.${generator.map(field$gamemode, "gamemodes")});

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_set_saturation.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_set_saturation.java.ftl
@@ -1,0 +1,1 @@
+if (${input$entity} instanceof Player _player) _player.getFoodData().setSaturation(${opt.toFloat(input$amount)});

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_xp_until_next_level.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_xp_until_next_level.java.ftl
@@ -1,0 +1,1 @@
+/*@int*/(${input$entity} instanceof Player _plr ? _plr.getXpNeededForNextLevel() : 0)

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_xplevel.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_xplevel.java.ftl
@@ -1,0 +1,1 @@
+/*@int*/(${input$entity} instanceof Player _plr ? _plr.experienceLevel : 0)

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/get_dimensionid.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/get_dimensionid.java.ftl
@@ -1,0 +1,9 @@
+<#if field$dimension=="Surface">
+	(Level.OVERWORLD)
+<#elseif field$dimension=="Nether">
+	(Level.NETHER)
+<#elseif field$dimension=="End">
+	(Level.END)
+<#else>
+	(ResourceKey.create(Registries.DIMENSION, new ResourceLocation("${generator.getResourceLocationForModElement(field$dimension.replace("CUSTOM:", ""))}")))
+</#if>

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/wait.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/wait.java.ftl
@@ -1,0 +1,5 @@
+<#-- @formatter:off -->
+${JavaModName}.queueServerWork(${opt.toInt(input$ticks)}, () -> {
+	${statement$do}
+});
+<#-- @formatter:on -->


### PR DESCRIPTION
This PR ports the wait, dimension id, all the remaining player data, and some player management procedures. Code is mostly the same, except for the "get_dimensionid" and minor improvements to the "Grant advancement" procedure