### PR TITLE
Generated code improvements

### DIFF
--- a/plugins/generator-1.18.2/forge-1.18.2/mappings/soundcategories.yaml
+++ b/plugins/generator-1.18.2/forge-1.18.2/mappings/soundcategories.yaml
@@ -1,33 +1,11 @@
-_default:
-  - NEUTRAL
-  - neutral
-neutral:
-  - NEUTRAL
-  - neutral
-master:
-  - MASTER
-  - master
-music:
-  - MUSIC
-  - music
-record:
-  - RECORDS
-  - record
-weather:
-  - WEATHER
-  - weather
-block:
-  - BLOCKS
-  - block
-hostile:
-  - HOSTILE
-  - hostile
-player:
-  - PLAYERS
-  - player
-ambient:
-  - AMBIENT
-  - ambient
-voice:
-  - VOICE
-  - voice
+_default: NEUTRAL
+neutral: NEUTRAL
+master: MASTER
+music: MUSIC
+record: RECORDS
+weather: WEATHER
+block: BLOCKS
+hostile: HOSTILE
+player: PLAYERS
+ambient: AMBIENT
+voice: VOICE

--- a/plugins/generator-1.18.2/forge-1.18.2/procedures/empty_itemstack.java.ftl
+++ b/plugins/generator-1.18.2/forge-1.18.2/procedures/empty_itemstack.java.ftl
@@ -1,1 +1,1 @@
-/*@ItemStack*/(ItemStack.EMPTY)
+/*@ItemStack*/ItemStack.EMPTY

--- a/plugins/generator-1.18.2/forge-1.18.2/templates/modbase/sounds.json.ftl
+++ b/plugins/generator-1.18.2/forge-1.18.2/templates/modbase/sounds.json.ftl
@@ -1,16 +1,13 @@
 {
 <#list sounds as sound>
 "${sound.getName()}": {
-  "category": "${generator.map(sound.getCategory(), "soundcategories", 1)}",
   <#if sound.getSubtitle()?has_content>"subtitle": "subtitles.${sound.getName()}",</#if>
   "sounds": [
     <#list sound.getFiles() as file>
     {
       "name": "${modid}:${file}",
       "stream": <#if sound.getCategory() == "record" || sound.getCategory() == "music">true<#else>false</#if>
-    }<#if file?has_next>,</#if>
-    </#list>
+    }<#sep>,</#list>
   ]
-}<#if sound?has_next>,</#if>
-</#list>
+}<#sep>,</#list>
 }

--- a/plugins/generator-1.18.2/forge-1.18.2/templates/modbase/sounds.json.ftl
+++ b/plugins/generator-1.18.2/forge-1.18.2/templates/modbase/sounds.json.ftl
@@ -7,7 +7,9 @@
     {
       "name": "${modid}:${file}",
       "stream": <#if sound.getCategory() == "record" || sound.getCategory() == "music">true<#else>false</#if>
-    }<#sep>,</#list>
+    }<#sep>,
+    </#list>
   ]
-}<#sep>,</#list>
+}<#sep>,
+</#list>
 }

--- a/plugins/generator-1.19.2/forge-1.19.2/mappings/soundcategories.yaml
+++ b/plugins/generator-1.19.2/forge-1.19.2/mappings/soundcategories.yaml
@@ -1,33 +1,11 @@
-_default:
-  - NEUTRAL
-  - neutral
-neutral:
-  - NEUTRAL
-  - neutral
-master:
-  - MASTER
-  - master
-music:
-  - MUSIC
-  - music
-record:
-  - RECORDS
-  - record
-weather:
-  - WEATHER
-  - weather
-block:
-  - BLOCKS
-  - block
-hostile:
-  - HOSTILE
-  - hostile
-player:
-  - PLAYERS
-  - player
-ambient:
-  - AMBIENT
-  - ambient
-voice:
-  - VOICE
-  - voice
+_default: NEUTRAL
+neutral: NEUTRAL
+master: MASTER
+music: MUSIC
+record: RECORDS
+weather: WEATHER
+block: BLOCKS
+hostile: HOSTILE
+player: PLAYERS
+ambient: AMBIENT
+voice: VOICE

--- a/plugins/generator-1.19.2/forge-1.19.2/procedures/empty_itemstack.java.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/procedures/empty_itemstack.java.ftl
@@ -1,1 +1,1 @@
-/*@ItemStack*/(ItemStack.EMPTY)
+/*@ItemStack*/ItemStack.EMPTY

--- a/plugins/generator-1.19.2/forge-1.19.2/templates/modbase/sounds.json.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/templates/modbase/sounds.json.ftl
@@ -1,16 +1,13 @@
 {
 <#list sounds as sound>
 "${sound.getName()}": {
-  "category": "${generator.map(sound.getCategory(), "soundcategories", 1)}",
   <#if sound.getSubtitle()?has_content>"subtitle": "subtitles.${sound.getName()}",</#if>
   "sounds": [
     <#list sound.getFiles() as file>
     {
       "name": "${modid}:${file}",
       "stream": <#if sound.getCategory() == "record" || sound.getCategory() == "music">true<#else>false</#if>
-    }<#if file?has_next>,</#if>
-    </#list>
+    }<#sep>,</#list>
   ]
-}<#if sound?has_next>,</#if>
-</#list>
+}<#sep>,</#list>
 }

--- a/plugins/generator-1.19.2/forge-1.19.2/templates/modbase/sounds.json.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/templates/modbase/sounds.json.ftl
@@ -7,7 +7,9 @@
     {
       "name": "${modid}:${file}",
       "stream": <#if sound.getCategory() == "record" || sound.getCategory() == "music">true<#else>false</#if>
-    }<#sep>,</#list>
+    }<#sep>,
+    </#list>
   ]
-}<#sep>,</#list>
+}<#sep>,
+</#list>
 }

--- a/plugins/generator-1.19.4/forge-1.19.4/mappings/soundcategories.yaml
+++ b/plugins/generator-1.19.4/forge-1.19.4/mappings/soundcategories.yaml
@@ -1,33 +1,11 @@
-_default:
-  - NEUTRAL
-  - neutral
-master:
-  - MASTER
-  - master
-music:
-  - MUSIC
-  - music
-record:
-  - RECORDS
-  - record
-weather:
-  - WEATHER
-  - weather
-block:
-  - BLOCKS
-  - block
-hostile:
-  - HOSTILE
-  - hostile
-neutral:
-  - NEUTRAL
-  - neutral
-player:
-  - PLAYERS
-  - player
-ambient:
-  - AMBIENT
-  - ambient
-voice:
-  - VOICE
-  - voice
+_default: NEUTRAL
+master: MASTER
+music: MUSIC
+record: RECORDS
+weather: WEATHER
+block: BLOCKS
+hostile: HOSTILE
+neutral: NEUTRAL
+player: PLAYERS
+ambient: AMBIENT
+voice: VOICE

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/empty_itemstack.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/empty_itemstack.java.ftl
@@ -1,1 +1,1 @@
-/*@ItemStack*/(ItemStack.EMPTY)
+/*@ItemStack*/ItemStack.EMPTY

--- a/plugins/generator-1.19.4/forge-1.19.4/templates/modbase/sounds.json.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/templates/modbase/sounds.json.ftl
@@ -1,16 +1,13 @@
 {
 <#list sounds as sound>
 "${sound.getName()}": {
-  "category": "${generator.map(sound.getCategory(), "soundcategories", 1)}",
   <#if sound.getSubtitle()?has_content>"subtitle": "subtitles.${sound.getName()}",</#if>
   "sounds": [
     <#list sound.getFiles() as file>
     {
       "name": "${modid}:${file}",
       "stream": <#if sound.getCategory() == "record" || sound.getCategory() == "music">true<#else>false</#if>
-    }<#if file?has_next>,</#if>
-    </#list>
+    }<#sep>,</#list>
   ]
-}<#if sound?has_next>,</#if>
-</#list>
+}<#sep>,</#list>
 }

--- a/plugins/generator-1.19.4/forge-1.19.4/templates/modbase/sounds.json.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/templates/modbase/sounds.json.ftl
@@ -7,7 +7,9 @@
     {
       "name": "${modid}:${file}",
       "stream": <#if sound.getCategory() == "record" || sound.getCategory() == "music">true<#else>false</#if>
-    }<#sep>,</#list>
+    }<#sep>,
+    </#list>
   ]
-}<#sep>,</#list>
+}<#sep>,
+</#list>
 }

--- a/src/main/java/net/mcreator/blockly/java/blocks/BooleanBlock.java
+++ b/src/main/java/net/mcreator/blockly/java/blocks/BooleanBlock.java
@@ -31,7 +31,6 @@ public class BooleanBlock implements IBlockGenerator {
 
 	@Override public void generateBlock(BlocklyToCode master, Element block) {
 		Element element = XMLUtil.getFirstChildrenWithName(block, "field");
-		master.append("(");
 		if (element != null) {
 			master.append(element.getTextContent().toLowerCase(Locale.ENGLISH));
 		} else {
@@ -39,7 +38,6 @@ public class BooleanBlock implements IBlockGenerator {
 			master.addCompileNote(
 					new BlocklyCompileNote(BlocklyCompileNote.Type.WARNING, L10N.t("blockly.warnings.boolean")));
 		}
-		master.append(")");
 	}
 
 	@Override public String[] getSupportedBlocks() {


### PR DESCRIPTION
- Removed the "category" field from the `sounds.json` template, as it hasn't been in use since 1.10. This also removes the second mapping set of `soundcategories`, which wasn't used anywhere else
- Removed unnecessary parentheses from the true/false and empty itemstack procedures