### PR TITLE
Legacy generator switch bug fix

### DIFF
--- a/plugins/generator-1.19.4/forge-1.19.4/generator.yaml
+++ b/plugins/generator-1.19.4/forge-1.19.4/generator.yaml
@@ -1,5 +1,5 @@
 name: Minecraft Forge for @minecraft (@buildfileversion)
-status: dev
+status: stable
 buildfileversion: 45.0.39
 
 import:

--- a/src/main/java/net/mcreator/element/parts/procedure/Procedure.java
+++ b/src/main/java/net/mcreator/element/parts/procedure/Procedure.java
@@ -67,12 +67,15 @@ import java.util.List;
 	}
 
 	public String getReturnValueType(Workspace workspace) {
-		GeneratableElement generatableElement = workspace.getModElementByName(name).getGeneratableElement();
-		if (generatableElement instanceof net.mcreator.element.types.Procedure) {
-			try {
-				return ((net.mcreator.element.types.Procedure) generatableElement).getBlocklyToProcedure(
-						new HashMap<>()).getReturnType().getName();
-			} catch (Exception ignored) {
+		ModElement modElement = workspace.getModElementByName(name);
+		if (modElement != null) { // procedure ME may be removed and thus cause NPE here
+			GeneratableElement generatableElement = modElement.getGeneratableElement();
+			if (generatableElement instanceof net.mcreator.element.types.Procedure) {
+				try {
+					return ((net.mcreator.element.types.Procedure) generatableElement).getBlocklyToProcedure(
+							new HashMap<>()).getReturnType().getName();
+				} catch (Exception ignored) {
+				}
 			}
 		}
 

--- a/src/main/java/net/mcreator/generator/GeneratorTokens.java
+++ b/src/main/java/net/mcreator/generator/GeneratorTokens.java
@@ -35,17 +35,26 @@ public class GeneratorTokens {
 	}
 
 	public static String replaceTokens(Workspace workspace, WorkspaceSettings workspaceSettings, String rawname) {
-		if (rawname.contains("@SRCROOT"))
-			rawname = rawname.replace("@SRCROOT", workspace.getGenerator().getSourceRoot().getAbsolutePath());
+		return replaceTokens(workspace, workspace.getGeneratorConfiguration(), workspaceSettings, rawname);
+	}
 
-		if (rawname.contains("@RESROOT"))
-			rawname = rawname.replace("@RESROOT", workspace.getGenerator().getResourceRoot().getAbsolutePath());
+	public static String replaceTokens(Workspace workspace, GeneratorConfiguration generatorConfiguration,
+			WorkspaceSettings workspaceSettings, String rawname) {
+		if (rawname.contains("@SRCROOT")) // we need this check to prevent infinite recursion
+			rawname = rawname.replace("@SRCROOT",
+					GeneratorUtils.getSourceRoot(workspace, generatorConfiguration).getAbsolutePath());
 
-		if (rawname.contains("@MODASSETSROOT"))
-			rawname = rawname.replace("@MODASSETSROOT", workspace.getGenerator().getModAssetsRoot().getAbsolutePath());
+		if (rawname.contains("@RESROOT")) // we need this check to prevent infinite recursion
+			rawname = rawname.replace("@RESROOT",
+					GeneratorUtils.getResourceRoot(workspace, generatorConfiguration).getAbsolutePath());
 
-		if (rawname.contains("@MODDATAROOT"))
-			rawname = rawname.replace("@MODDATAROOT", workspace.getGenerator().getModDataRoot().getAbsolutePath());
+		if (rawname.contains("@MODASSETSROOT")) // we need this check to prevent infinite recursion
+			rawname = rawname.replace("@MODASSETSROOT",
+					GeneratorUtils.getModAssetsRoot(workspace, generatorConfiguration).getAbsolutePath());
+
+		if (rawname.contains("@MODDATAROOT")) // we need this check to prevent infinite recursion
+			rawname = rawname.replace("@MODDATAROOT",
+					GeneratorUtils.getModDataRoot(workspace, generatorConfiguration).getAbsolutePath());
 
 		//@formatter:off
 		return rawname

--- a/src/main/java/net/mcreator/generator/GeneratorUtils.java
+++ b/src/main/java/net/mcreator/generator/GeneratorUtils.java
@@ -25,26 +25,36 @@ import java.io.File;
 public class GeneratorUtils {
 
 	public static File getSourceRoot(Workspace workspace, GeneratorConfiguration generatorConfiguration) {
-		return new File(GeneratorTokens.replaceTokens(workspace, generatorConfiguration.getSourceRoot()));
+		return new File(
+				GeneratorTokens.replaceTokens(workspace, generatorConfiguration, workspace.getWorkspaceSettings(),
+						generatorConfiguration.getSourceRoot()));
 	}
 
 	public static File getResourceRoot(Workspace workspace, GeneratorConfiguration generatorConfiguration) {
-		return new File(GeneratorTokens.replaceTokens(workspace, generatorConfiguration.getResourceRoot()));
+		return new File(
+				GeneratorTokens.replaceTokens(workspace, generatorConfiguration, workspace.getWorkspaceSettings(),
+						generatorConfiguration.getResourceRoot()));
 	}
 
 	public static File getModAssetsRoot(Workspace workspace, GeneratorConfiguration generatorConfiguration) {
-		return new File(GeneratorTokens.replaceTokens(workspace, generatorConfiguration.getModAssetsRoot()));
+		return new File(
+				GeneratorTokens.replaceTokens(workspace, generatorConfiguration, workspace.getWorkspaceSettings(),
+						generatorConfiguration.getModAssetsRoot()));
 	}
 
 	public static File getModDataRoot(Workspace workspace, GeneratorConfiguration generatorConfiguration) {
-		return new File(GeneratorTokens.replaceTokens(workspace, generatorConfiguration.getModDataRoot()));
+		return new File(
+				GeneratorTokens.replaceTokens(workspace, generatorConfiguration, workspace.getWorkspaceSettings(),
+						generatorConfiguration.getModDataRoot()));
 	}
 
 	public static File getSpecificRoot(Workspace workspace, GeneratorConfiguration generatorConfiguration,
 			String root) {
 		String rootString = generatorConfiguration.getSpecificRoot(root);
 		if (rootString != null)
-			return new File(GeneratorTokens.replaceTokens(workspace, rootString));
+			return new File(
+					GeneratorTokens.replaceTokens(workspace, generatorConfiguration, workspace.getWorkspaceSettings(),
+							rootString));
 		else
 			return null;
 	}

--- a/src/main/java/net/mcreator/generator/setup/WorkspaceGeneratorSetup.java
+++ b/src/main/java/net/mcreator/generator/setup/WorkspaceGeneratorSetup.java
@@ -22,6 +22,7 @@ import freemarker.template.Template;
 import net.mcreator.generator.Generator;
 import net.mcreator.generator.GeneratorConfiguration;
 import net.mcreator.generator.GeneratorUtils;
+import net.mcreator.generator.setup.folders.AbstractFolderStructure;
 import net.mcreator.generator.template.base.BaseDataModelProvider;
 import net.mcreator.generator.template.base.DefaultFreemarkerConfiguration;
 import net.mcreator.io.FileIO;
@@ -46,22 +47,21 @@ public class WorkspaceGeneratorSetup {
 	private static final Logger LOG = LogManager.getLogger("Workspace Setup");
 
 	public static void cleanupGeneratorForSwitchTo(Workspace workspace, GeneratorConfiguration newGenerator) {
-		// skip if there is no generator change
-		if (workspace.getGeneratorConfiguration().getGeneratorName().equals(newGenerator.getGeneratorName()))
-			return;
+		Generator currentGenerator = workspace.getGenerator();
 
-		workspace.getGenerator().close(); // close gradle connection
+		if (currentGenerator != null) { // conversion from a generator that is present
+			// skip if there is no generator change
+			if (workspace.getGeneratorConfiguration().getGeneratorName().equals(newGenerator.getGeneratorName()))
+				return;
 
-		// delete generator base files
-		Set<String> fileNames = PluginLoader.INSTANCE.getResourcesInPackage(
-				workspace.getGenerator().getGeneratorName() + ".workspacebase");
-		for (String file : fileNames) {
-			File generatorFile = new File(workspace.getWorkspaceFolder(),
-					file.replace(workspace.getGenerator().getGeneratorName() + "/workspacebase", ""));
-			if (generatorFile.isFile())
-				generatorFile.delete();
-			else
-				FileIO.deleteDir(generatorFile);
+			LOG.info("Cleaning up generator for switch to " + newGenerator.getGeneratorName() + " from "
+					+ workspace.getGeneratorConfiguration().getGeneratorName());
+
+			// close gradle connection so no files are locked
+			currentGenerator.close();
+		} else if (workspace.getWorkspaceSettings().getCurrentGenerator() != null) {
+			LOG.warn("Cleaning up generator for switch to " + newGenerator.getGeneratorName()
+					+ " from non-existent generator " + workspace.getWorkspaceSettings().getCurrentGenerator());
 		}
 
 		// delete gradle dirs if present
@@ -75,22 +75,36 @@ public class WorkspaceGeneratorSetup {
 			FileIO.deleteDir(new File(workspace.getWorkspaceFolder(), "lib/"));
 		}
 
-		// move folders to the new locations, starting from more nested folders down
+		// delete generator base files
+		if (currentGenerator != null) { // only do it if the current generator is known/present
+			Set<String> fileNames = PluginLoader.INSTANCE.getResourcesInPackage(
+					currentGenerator.getGeneratorName() + ".workspacebase");
+			for (String file : fileNames) {
+				File generatorFile = new File(workspace.getWorkspaceFolder(),
+						file.replace(currentGenerator.getGeneratorName() + "/workspacebase", ""));
+				if (generatorFile.isFile())
+					generatorFile.delete();
+			}
+		}
 
-		moveFilesToAnotherDir(workspace.getFolderManager().getStructuresDir(),
+		AbstractFolderStructure folderStructure = AbstractFolderStructure.getFolderStructure(workspace);
+
+		LOG.info("Moving files to new locations while assuming " + folderStructure.getClass().getSimpleName() + " for the generator converting from");
+
+		// move folders to the new locations, starting from more nested folders down
+		moveFilesToAnotherDir(folderStructure.getStructuresDir(),
 				GeneratorUtils.getSpecificRoot(workspace, newGenerator, "structures_dir"));
 
-		moveFilesToAnotherDir(workspace.getFolderManager().getSoundsDir(),
+		moveFilesToAnotherDir(folderStructure.getSoundsDir(),
 				GeneratorUtils.getSpecificRoot(workspace, newGenerator, "sounds_dir"));
 
 		Arrays.stream(TextureType.values()).forEach(
-				category -> moveFilesToAnotherDir(workspace.getFolderManager().getTexturesFolder(category),
+				category -> moveFilesToAnotherDir(folderStructure.getTexturesFolder(category),
 						GeneratorUtils.getSpecificRoot(workspace, newGenerator, category.getID() + "_textures_dir")));
 
-		moveFilesToAnotherDir(workspace.getGenerator().getSourceRoot(),
-				GeneratorUtils.getSourceRoot(workspace, newGenerator));
+		moveFilesToAnotherDir(folderStructure.getSourceRoot(), GeneratorUtils.getSourceRoot(workspace, newGenerator));
 
-		moveFilesToAnotherDir(workspace.getGenerator().getResourceRoot(),
+		moveFilesToAnotherDir(folderStructure.getResourceRoot(),
 				GeneratorUtils.getResourceRoot(workspace, newGenerator));
 	}
 
@@ -98,12 +112,12 @@ public class WorkspaceGeneratorSetup {
 		if (sourceDir != null && sourceDir.isDirectory() && destinationDir != null) {
 			try {
 				if (!sourceDir.getCanonicalPath().equals(destinationDir.getCanonicalPath())) {
-					LOG.info("Moving " + sourceDir.getName() + " to a new directory");
+					LOG.info("Moving " + sourceDir.getName() + " to a new directory " + destinationDir.getName());
 					FileIO.copyDirectory(sourceDir, destinationDir);
 					FileIO.deleteDir(sourceDir);
 				}
 			} catch (IOException e) {
-				LOG.warn("Failed to determine " + sourceDir.getName() + " dirs", e);
+				LOG.warn("Failed to move " + sourceDir.getName() + " dirs", e);
 			}
 		}
 	}
@@ -160,4 +174,5 @@ public class WorkspaceGeneratorSetup {
 	public static void requestSetup(Workspace workspace) {
 		new File(workspace.getFolderManager().getWorkspaceCacheDir(), "setupInfo").delete();
 	}
+
 }

--- a/src/main/java/net/mcreator/generator/setup/folders/AbstractFolderStructure.java
+++ b/src/main/java/net/mcreator/generator/setup/folders/AbstractFolderStructure.java
@@ -17,25 +17,6 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-/*
- * MCreator (https://mcreator.net/)
- * Copyright (C) 2012-2020, Pylo
- * Copyright (C) 2020-2023, Pylo, opensource contributors
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package net.mcreator.generator.setup.folders;
 
 import net.mcreator.ui.workspace.resources.TextureType;

--- a/src/main/java/net/mcreator/generator/setup/folders/AbstractFolderStructure.java
+++ b/src/main/java/net/mcreator/generator/setup/folders/AbstractFolderStructure.java
@@ -1,0 +1,85 @@
+/*
+ * MCreator (https://mcreator.net/)
+ * Copyright (C) 2012-2020, Pylo
+ * Copyright (C) 2020-2023, Pylo, opensource contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/*
+ * MCreator (https://mcreator.net/)
+ * Copyright (C) 2012-2020, Pylo
+ * Copyright (C) 2020-2023, Pylo, opensource contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package net.mcreator.generator.setup.folders;
+
+import net.mcreator.ui.workspace.resources.TextureType;
+import net.mcreator.workspace.Workspace;
+
+import javax.annotation.Nullable;
+import java.io.File;
+import java.lang.module.ModuleDescriptor;
+
+public abstract class AbstractFolderStructure {
+
+	protected final Workspace workspace;
+
+	protected AbstractFolderStructure(Workspace workspace) {
+		this.workspace = workspace;
+	}
+
+	@Nullable public abstract File getStructuresDir();
+
+	@Nullable public abstract File getSoundsDir();
+
+	@Nullable public abstract File getTexturesFolder(TextureType section);
+
+	@Nullable public abstract File getSourceRoot();
+
+	@Nullable public abstract File getResourceRoot();
+
+	public static AbstractFolderStructure getFolderStructure(Workspace workspace) {
+		// if the current generator of the workspace is defined, we just use the current folder structure of that generator
+		if (workspace.getGenerator() != null)
+			return new CurrentFolderStructure(workspace);
+
+		String[] currentGeneratorData = workspace.getWorkspaceSettings().getCurrentGenerator().split("-");
+		//String flavor = currentGeneratorData[0];
+		String minecraftVersion = currentGeneratorData[1];
+
+		ModuleDescriptor.Version currentVersion = ModuleDescriptor.Version.parse(minecraftVersion);
+
+		if (currentVersion.compareTo(ModuleDescriptor.Version.parse("1.19.3")) < 0) {
+			return new Pre1193FolderStructure(workspace);
+		}
+
+		// if we fail to detect suitable folder structure, we just use the current folder structure
+		return new CurrentFolderStructure(workspace);
+	}
+
+}

--- a/src/main/java/net/mcreator/generator/setup/folders/CurrentFolderStructure.java
+++ b/src/main/java/net/mcreator/generator/setup/folders/CurrentFolderStructure.java
@@ -17,25 +17,6 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-/*
- * MCreator (https://mcreator.net/)
- * Copyright (C) 2012-2020, Pylo
- * Copyright (C) 2020-2023, Pylo, opensource contributors
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package net.mcreator.generator.setup.folders;
 
 import net.mcreator.generator.Generator;

--- a/src/main/java/net/mcreator/generator/setup/folders/CurrentFolderStructure.java
+++ b/src/main/java/net/mcreator/generator/setup/folders/CurrentFolderStructure.java
@@ -1,0 +1,125 @@
+/*
+ * MCreator (https://mcreator.net/)
+ * Copyright (C) 2012-2020, Pylo
+ * Copyright (C) 2020-2023, Pylo, opensource contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/*
+ * MCreator (https://mcreator.net/)
+ * Copyright (C) 2012-2020, Pylo
+ * Copyright (C) 2020-2023, Pylo, opensource contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package net.mcreator.generator.setup.folders;
+
+import net.mcreator.generator.Generator;
+import net.mcreator.generator.GeneratorConfiguration;
+import net.mcreator.generator.GeneratorFlavor;
+import net.mcreator.generator.GeneratorUtils;
+import net.mcreator.ui.workspace.resources.TextureType;
+import net.mcreator.workspace.Workspace;
+
+import javax.annotation.Nullable;
+import java.io.File;
+
+/**
+ * This version of the folder structure estimator uses folder structure of the latest supported Forge generator available.
+ * <p>
+ * If the provided workspace has generator defined, it will use that generator for the folder structure.
+ */
+class CurrentFolderStructure extends AbstractFolderStructure {
+
+	@Nullable private GeneratorConfiguration generatorConfiguration;
+
+	protected CurrentFolderStructure(Workspace workspace) {
+		super(workspace);
+
+		if (workspace.getGenerator()
+				== null) // unknown generator, we need to guess based on the latest supported Forge generator
+			generatorConfiguration = GeneratorConfiguration.getRecommendedGeneratorForFlavor(
+					Generator.GENERATOR_CACHE.values(), GeneratorFlavor.FORGE);
+	}
+
+	@Nullable @Override public File getStructuresDir() {
+		if (workspace.getGenerator() != null) { // known generator, use folder manager
+			return workspace.getFolderManager().getStructuresDir();
+		} else { // unknown generator (no definition), we need to guess (guess based on the current structure of the latest supported Forge generator)
+			if (generatorConfiguration != null)
+				return GeneratorUtils.getSpecificRoot(workspace, generatorConfiguration, "structures_dir");
+
+			return null;
+		}
+	}
+
+	@Nullable @Override public File getSoundsDir() {
+		if (workspace.getGenerator() != null) { // known generator, use folder manager
+			return workspace.getFolderManager().getSoundsDir();
+		} else { // unknown generator (no definition), we need to guess (guess based on the current structure of the latest supported Forge generator)
+			if (generatorConfiguration != null)
+				return GeneratorUtils.getSpecificRoot(workspace, generatorConfiguration, "sounds_dir");
+
+			return null;
+		}
+	}
+
+	@Nullable @Override public File getTexturesFolder(TextureType section) {
+		if (workspace.getGenerator() != null) { // known generator, use folder manager
+			return workspace.getFolderManager().getTexturesFolder(section);
+		} else { // unknown generator (no definition), we need to guess (guess based on the current structure of the latest supported Forge generator)
+			if (generatorConfiguration != null)
+				return GeneratorUtils.getSpecificRoot(workspace, generatorConfiguration,
+						section.getID() + "_textures_dir");
+
+			return null;
+		}
+	}
+
+	@Nullable @Override public File getSourceRoot() {
+		if (workspace.getGenerator() != null) { // known generator, use folder manager
+			return workspace.getGenerator().getSourceRoot();
+		} else { // unknown generator (no definition), we need to guess
+			if (generatorConfiguration != null)
+				return GeneratorUtils.getSourceRoot(workspace, generatorConfiguration);
+
+			return null;
+		}
+	}
+
+	@Nullable @Override public File getResourceRoot() {
+		if (workspace.getGenerator() != null) { // known generator, use folder manager
+			return workspace.getGenerator().getResourceRoot();
+		} else { // unknown generator (no definition), we need to guess
+			if (generatorConfiguration != null)
+				return GeneratorUtils.getResourceRoot(workspace, generatorConfiguration);
+
+			return null;
+		}
+	}
+
+}

--- a/src/main/java/net/mcreator/generator/setup/folders/Pre1193FolderStructure.java
+++ b/src/main/java/net/mcreator/generator/setup/folders/Pre1193FolderStructure.java
@@ -17,25 +17,6 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-/*
- * MCreator (https://mcreator.net/)
- * Copyright (C) 2012-2020, Pylo
- * Copyright (C) 2020-2023, Pylo, opensource contributors
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package net.mcreator.generator.setup.folders;
 
 import net.mcreator.ui.workspace.resources.TextureType;

--- a/src/main/java/net/mcreator/generator/setup/folders/Pre1193FolderStructure.java
+++ b/src/main/java/net/mcreator/generator/setup/folders/Pre1193FolderStructure.java
@@ -1,0 +1,92 @@
+/*
+ * MCreator (https://mcreator.net/)
+ * Copyright (C) 2012-2020, Pylo
+ * Copyright (C) 2020-2023, Pylo, opensource contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/*
+ * MCreator (https://mcreator.net/)
+ * Copyright (C) 2012-2020, Pylo
+ * Copyright (C) 2020-2023, Pylo, opensource contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package net.mcreator.generator.setup.folders;
+
+import net.mcreator.ui.workspace.resources.TextureType;
+import net.mcreator.workspace.Workspace;
+
+import javax.annotation.Nullable;
+import java.io.File;
+
+class Pre1193FolderStructure extends AbstractFolderStructure {
+
+	protected Pre1193FolderStructure(Workspace workspace) {
+		super(workspace);
+	}
+
+	@Nullable @Override public File getStructuresDir() {
+		return new File(getResourceRoot(), "data/" + workspace.getWorkspaceSettings().getModID() + "/structures");
+	}
+
+	@Nullable @Override public File getSoundsDir() {
+		return new File(getResourceRoot(), "assets/" + workspace.getWorkspaceSettings().getModID() + "/sounds");
+	}
+
+	@Nullable @Override public File getTexturesFolder(TextureType section) {
+		return switch (section) {
+			case BLOCK -> new File(getResourceRoot(),
+					"assets/" + workspace.getWorkspaceSettings().getModID() + "/textures/blocks");
+			case ITEM -> new File(getResourceRoot(),
+					"assets/" + workspace.getWorkspaceSettings().getModID() + "/textures/items");
+			case ARMOR -> new File(getResourceRoot(),
+					"assets/" + workspace.getWorkspaceSettings().getModID() + "/textures/models/armor");
+			case OTHER ->
+					new File(getResourceRoot(), "assets/" + workspace.getWorkspaceSettings().getModID() + "/textures");
+			// The types below may not exist on older generators with shared folder for all but block, item and armor,
+			// but this will be taken care of by converters from other texture type section
+			case ENTITY -> new File(getResourceRoot(),
+					"assets/" + workspace.getWorkspaceSettings().getModID() + "/textures/entities");
+			case EFFECT -> new File(getResourceRoot(),
+					"assets/" + workspace.getWorkspaceSettings().getModID() + "/textures/mob_effect");
+			case PARTICLE -> new File(getResourceRoot(),
+					"assets/" + workspace.getWorkspaceSettings().getModID() + "/textures/particle");
+			case SCREEN -> new File(getResourceRoot(),
+					"assets/" + workspace.getWorkspaceSettings().getModID() + "/textures/screens");
+		};
+	}
+
+	@Nullable @Override public File getSourceRoot() {
+		return new File(workspace.getWorkspaceFolder(), "src/main/java");
+	}
+
+	@Nullable @Override public File getResourceRoot() {
+		return new File(workspace.getWorkspaceFolder(), "src/main/resources");
+	}
+
+}

--- a/src/main/java/net/mcreator/workspace/Workspace.java
+++ b/src/main/java/net/mcreator/workspace/Workspace.java
@@ -46,7 +46,6 @@ import java.io.Closeable;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -416,17 +415,19 @@ public class Workspace implements Closeable, IGeneratorProvider {
 								L10N.t("dialog.workspace.unknown_generator_message", currentGenerator),
 								L10N.t("dialog.workspace.unknown_generator_title"), JOptionPane.WARNING_MESSAGE);
 						generatorConfiguration.set(GeneratorSelector.getGeneratorSelector(ui,
-								GeneratorConfiguration.getRecommendedGeneratorForFlavor(Generator.GENERATOR_CACHE.values(),
-										currentFlavor), currentFlavor, false));
+								GeneratorConfiguration.getRecommendedGeneratorForFlavor(
+										Generator.GENERATOR_CACHE.values(), currentFlavor), currentFlavor, false));
 					});
 					if (generatorConfiguration.get() != null) {
-						retval.getWorkspaceSettings().setCurrentGenerator(generatorConfiguration.get().getGeneratorName());
+						// Call generator cleanup for switch before new generator is set for the workspace
+						WorkspaceGeneratorSetup.cleanupGeneratorForSwitchTo(retval,
+								Generator.GENERATOR_CACHE.get(generatorConfiguration.get().getGeneratorName()));
+
+						retval.getWorkspaceSettings()
+								.setCurrentGenerator(generatorConfiguration.get().getGeneratorName());
 
 						retval.generator = new Generator(retval);
 						retval.regenerateRequired = true;
-
-						WorkspaceGeneratorSetup.cleanupGeneratorForSwitchTo(retval,
-								Generator.GENERATOR_CACHE.get(retval.workspaceSettings.getCurrentGenerator()));
 
 						WorkspaceGeneratorSetup.requestSetup(retval);
 					} else {
@@ -482,13 +483,14 @@ public class Workspace implements Closeable, IGeneratorProvider {
 
 		if (Generator.GENERATOR_CACHE.get(retval.getWorkspaceSettings().getCurrentGenerator())
 				!= generatorConfiguration) {
+			// Call generator cleanup for switch before new generator is set for the workspace
+			WorkspaceGeneratorSetup.cleanupGeneratorForSwitchTo(retval,
+					Generator.GENERATOR_CACHE.get(generatorConfiguration.getGeneratorName()));
+
 			retval.getWorkspaceSettings().setCurrentGenerator(generatorConfiguration.getGeneratorName());
 
 			retval.generator = new Generator(retval);
 			retval.regenerateRequired = true;
-
-			WorkspaceGeneratorSetup.cleanupGeneratorForSwitchTo(retval,
-					Generator.GENERATOR_CACHE.get(retval.workspaceSettings.getCurrentGenerator()));
 
 			WorkspaceGeneratorSetup.requestSetup(retval);
 		} else {


### PR DESCRIPTION
When switching generators, files are not moved properly to new directories when the workspace uses a generator that no longer exists as we don't know the source folder location.

This is fixed by a new folder structure system added to the workspace/generator setup sub-system.

After this is merged, 1.19.4 port is more or less complete