### PR TITLE
Recent plugin changes

### DIFF
--- a/plugins/mcreator-localization/lang/texts.properties
+++ b/plugins/mcreator-localization/lang/texts.properties
@@ -516,6 +516,7 @@ dialog.plugin_update_notify.update=Update plugin
 dialog.plugin_update_notify.close=Close this window
 dialog.plugin_update_notify.update_title=Plugin updates
 dialog.plugin_update_notify.version_message=<html><b>{0}</b><br>Currently installed version: <b>{1}</b>, new version: <b>{2}</b>
+dialog.plugin_update_notify.changes_message=Changes in the latest version:
 dialog.setup_workspace.title=Workspace setup for selected generator
 dialog.reload_gradle_project.title=Reloading Gradle project
 dialog.setup_workspace.progress.reloading_gradle_project=Reloading Gradle project

--- a/src/main/java/net/mcreator/plugin/PluginLoader.java
+++ b/src/main/java/net/mcreator/plugin/PluginLoader.java
@@ -19,6 +19,8 @@
 package net.mcreator.plugin;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import net.mcreator.io.FileIO;
 import net.mcreator.io.UserFolderManager;
@@ -276,15 +278,19 @@ public class PluginLoader extends URLClassLoader {
 
 	private void checkForPluginUpdates() {
 		if (MCreatorApplication.isInternet) {
-			pluginUpdates.addAll(plugins.stream().parallel().map(plugin -> {
+			pluginUpdates.addAll(plugins.parallelStream().map(plugin -> {
 				if (plugin.getInfo().getUpdateJSONURL() != null) {
 					if (!plugin.getInfo().getVersion().equals(PluginInfo.VERSION_NOT_SPECIFIED)) {
 						try {
 							String updateJSON = WebIO.readURLToString(plugin.getInfo().getUpdateJSONURL());
-							String version = JsonParser.parseString(updateJSON).getAsJsonObject().get(plugin.getID())
-									.getAsJsonObject().get("latest").getAsString();
+							JsonObject updateData = JsonParser.parseString(updateJSON).getAsJsonObject()
+									.get(plugin.getID()).getAsJsonObject();
+							String version = updateData.get("latest").getAsString();
 							if (!version.equals(plugin.getPluginVersion())) {
-								return new PluginUpdateInfo(plugin, version);
+								return new PluginUpdateInfo(plugin, version, updateData.has("changes") ?
+										updateData.get("changes").getAsJsonArray().asList().stream()
+												.map(JsonElement::getAsString).toList() :
+										null);
 							}
 						} catch (Exception e) {
 							LOG.warn("Failed to parse update info for plugin: " + plugin.getID(), e);

--- a/src/main/java/net/mcreator/plugin/PluginUpdateInfo.java
+++ b/src/main/java/net/mcreator/plugin/PluginUpdateInfo.java
@@ -19,9 +19,10 @@
 
 package net.mcreator.plugin;
 
+import javax.annotation.Nullable;
 import java.util.List;
 
 /**
  * <p>This record is used to save the plugin and the new version/changes of the detected update.</p>
  */
-public record PluginUpdateInfo(Plugin plugin, String newVersion, List<String> recentChanges) {}
+public record PluginUpdateInfo(Plugin plugin, String newVersion, @Nullable List<String> recentChanges) {}

--- a/src/main/java/net/mcreator/plugin/PluginUpdateInfo.java
+++ b/src/main/java/net/mcreator/plugin/PluginUpdateInfo.java
@@ -19,7 +19,9 @@
 
 package net.mcreator.plugin;
 
+import java.util.List;
+
 /**
- * <p>This record is used to save the plugin and the new version of the detected update.</p>
+ * <p>This record is used to save the plugin and the new version/changes of the detected update.</p>
  */
-public record PluginUpdateInfo(Plugin plugin, String newVersion) {}
+public record PluginUpdateInfo(Plugin plugin, String newVersion, List<String> recentChanges) {}

--- a/src/main/java/net/mcreator/ui/dialogs/UpdatePluginDialog.java
+++ b/src/main/java/net/mcreator/ui/dialogs/UpdatePluginDialog.java
@@ -62,16 +62,17 @@ public class UpdatePluginDialog {
 				plugins.add(PanelUtils.westAndEastElement(label, PanelUtils.join(update)));
 			}
 
-			MCreatorDialog window = new MCreatorDialog(null, L10N.t("dialog.plugin_update_notify.update_title"));
-			window.setSize(720, 300);
-			window.setLocationRelativeTo(parent);
-			window.setModal(true);
+			MCreatorDialog dialog = new MCreatorDialog(JOptionPane.getRootFrame(),
+					L10N.t("dialog.plugin_update_notify.update_title"));
+			dialog.setSize(700, 300);
+			dialog.setLocationRelativeTo(parent);
+			dialog.setModal(true);
 
 			JButton close = L10N.button("dialog.plugin_update_notify.close");
-			close.addActionListener(e -> window.setVisible(false));
+			close.addActionListener(e -> dialog.setVisible(false));
 
-			window.getContentPane().add("Center", PanelUtils.centerAndSouthElement(pan, PanelUtils.join(close)));
-			window.setVisible(true);
+			dialog.add("Center", PanelUtils.centerAndSouthElement(pan, PanelUtils.join(close)));
+			dialog.setVisible(true);
 		}
 	}
 }

--- a/src/main/java/net/mcreator/ui/dialogs/UpdatePluginDialog.java
+++ b/src/main/java/net/mcreator/ui/dialogs/UpdatePluginDialog.java
@@ -44,16 +44,21 @@ public class UpdatePluginDialog {
 			pan.setPreferredSize(new Dimension(560, 250));
 
 			for (PluginUpdateInfo pluginUpdateInfo : PluginLoader.INSTANCE.getPluginUpdates()) {
-				JLabel label = L10N.label("dialog.plugin_update_notify.version_message",
+				StringBuilder usb = new StringBuilder(L10N.t("dialog.plugin_update_notify.version_message",
 						pluginUpdateInfo.plugin().getInfo().getName(), pluginUpdateInfo.plugin().getInfo().getVersion(),
-						pluginUpdateInfo.newVersion());
+						pluginUpdateInfo.newVersion()));
+				if (pluginUpdateInfo.recentChanges() != null) {
+					usb.append("<br>").append(L10N.t("dialog.plugin_update_notify.changes_message")).append("<ul>");
+					for (String change : pluginUpdateInfo.recentChanges())
+						usb.append("<li>").append(change).append("</li>");
+				}
 
+				JLabel label = new JLabel(usb.toString());
 				JButton update = L10N.button("dialog.plugin_update_notify.update");
 				update.addActionListener(e -> DesktopUtils.browseSafe(
 						MCreatorApplication.SERVER_DOMAIN + "/node/" + pluginUpdateInfo.plugin().getInfo()
 								.getPluginPageID()));
-
-				plugins.add(PanelUtils.westAndEastElement(label, update));
+				plugins.add(PanelUtils.westAndEastElement(label, PanelUtils.join(update)));
 			}
 
 			JOptionPane.showOptionDialog(parent, pan, L10N.t("dialog.plugin_update_notify.update_title"),

--- a/src/main/java/net/mcreator/ui/dialogs/UpdatePluginDialog.java
+++ b/src/main/java/net/mcreator/ui/dialogs/UpdatePluginDialog.java
@@ -41,6 +41,7 @@ public class UpdatePluginDialog {
 
 			pan.add("North", L10N.label("dialog.plugin_update_notify.message"));
 			pan.add("Center", new JScrollPane(PanelUtils.pullElementUp(plugins)));
+			pan.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
 			pan.setPreferredSize(new Dimension(560, 250));
 
 			for (PluginUpdateInfo pluginUpdateInfo : PluginLoader.INSTANCE.getPluginUpdates()) {
@@ -61,9 +62,16 @@ public class UpdatePluginDialog {
 				plugins.add(PanelUtils.westAndEastElement(label, PanelUtils.join(update)));
 			}
 
-			JOptionPane.showOptionDialog(parent, pan, L10N.t("dialog.plugin_update_notify.update_title"),
-					JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE, null,
-					new Object[] { L10N.t("dialog.plugin_update_notify.close") }, "");
+			MCreatorDialog window = new MCreatorDialog(null, L10N.t("dialog.plugin_update_notify.update_title"));
+			window.setSize(720, 300);
+			window.setLocationRelativeTo(parent);
+			window.setModal(true);
+
+			JButton close = L10N.button("dialog.plugin_update_notify.close");
+			close.addActionListener(e -> window.setVisible(false));
+
+			window.getContentPane().add("Center", PanelUtils.centerAndSouthElement(pan, PanelUtils.join(close)));
+			window.setVisible(true);
 		}
 	}
 }


### PR DESCRIPTION
This PR adds support for plugin update data files to include a short summary of changes in the latest version using the list of strings called `changes` which is looked up on the same level as the `latest` parameter.