### PR TITLE
Blockly panel holder type is now visible from JS

### DIFF
--- a/src/main/java/net/mcreator/ui/blockly/BlocklyPanel.java
+++ b/src/main/java/net/mcreator/ui/blockly/BlocklyPanel.java
@@ -71,7 +71,7 @@ public class BlocklyPanel extends JFXPanel {
 
 	private static final String MINIMAL_XML = "<xml xmlns=\"https://developers.google.com/blockly/xml\"></xml>";
 
-	public BlocklyPanel(MCreator mcreator) {
+	public BlocklyPanel(MCreator mcreator, BlocklyEditorType type) {
 		setOpaque(false);
 
 		this.mcreator = mcreator;
@@ -175,6 +175,8 @@ public class BlocklyPanel extends JFXPanel {
 					// register JS bridge
 					JSObject window = (JSObject) webEngine.executeScript("window");
 					window.setMember("javabridge", bridge);
+					if (type != null)
+						window.setMember("editorType", type.registryName());
 
 					loaded = true;
 					runAfterLoaded.forEach(ThreadUtil::runOnFxThread);

--- a/src/main/java/net/mcreator/ui/blockly/BlocklyPanel.java
+++ b/src/main/java/net/mcreator/ui/blockly/BlocklyPanel.java
@@ -44,6 +44,7 @@ import org.apache.logging.log4j.Logger;
 import org.w3c.dom.Element;
 import org.w3c.dom.Text;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.swing.*;
 import java.lang.reflect.Method;
@@ -71,7 +72,7 @@ public class BlocklyPanel extends JFXPanel {
 
 	private static final String MINIMAL_XML = "<xml xmlns=\"https://developers.google.com/blockly/xml\"></xml>";
 
-	public BlocklyPanel(MCreator mcreator, BlocklyEditorType type) {
+	public BlocklyPanel(MCreator mcreator, @Nonnull BlocklyEditorType type) {
 		setOpaque(false);
 
 		this.mcreator = mcreator;
@@ -175,8 +176,7 @@ public class BlocklyPanel extends JFXPanel {
 					// register JS bridge
 					JSObject window = (JSObject) webEngine.executeScript("window");
 					window.setMember("javabridge", bridge);
-					if (type != null)
-						window.setMember("editorType", type.registryName());
+					window.setMember("editorType", type.registryName());
 
 					loaded = true;
 					runAfterLoaded.forEach(ThreadUtil::runOnFxThread);

--- a/src/main/java/net/mcreator/ui/modgui/AchievementGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/AchievementGUI.java
@@ -211,7 +211,7 @@ public class AchievementGUI extends ModElementGUI<Achievement> {
 		page1group.addValidationElement(achievementDescription);
 
 		externalBlocks = BlocklyLoader.INSTANCE.getBlockLoader(BlocklyEditorType.JSON_TRIGGER).getDefinedBlocks();
-		blocklyPanel = new BlocklyPanel(mcreator);
+		blocklyPanel = new BlocklyPanel(mcreator, BlocklyEditorType.JSON_TRIGGER);
 		blocklyPanel.addTaskToRunAfterLoaded(() -> {
 			BlocklyLoader.INSTANCE.getBlockLoader(BlocklyEditorType.JSON_TRIGGER)
 					.loadBlocksAndCategoriesInPanel(blocklyPanel, ToolboxType.EMPTY);

--- a/src/main/java/net/mcreator/ui/modgui/CommandGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/CommandGUI.java
@@ -88,7 +88,7 @@ public class CommandGUI extends ModElementGUI<Command> {
 
 		externalBlocks = BlocklyLoader.INSTANCE.getBlockLoader(BlocklyEditorType.COMMAND_ARG).getDefinedBlocks();
 
-		blocklyPanel = new BlocklyPanel(mcreator);
+		blocklyPanel = new BlocklyPanel(mcreator, BlocklyEditorType.COMMAND_ARG);
 		blocklyPanel.addTaskToRunAfterLoaded(() -> {
 			BlocklyLoader.INSTANCE.getBlockLoader(BlocklyEditorType.COMMAND_ARG)
 					.loadBlocksAndCategoriesInPanel(blocklyPanel, ToolboxType.COMMAND);

--- a/src/main/java/net/mcreator/ui/modgui/FeatureGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/FeatureGUI.java
@@ -109,7 +109,7 @@ public class FeatureGUI extends ModElementGUI<Feature> {
 		propertiesAndCondition.setOpaque(false);
 
 		externalBlocks = BlocklyLoader.INSTANCE.getBlockLoader(BlocklyEditorType.FEATURE).getDefinedBlocks();
-		blocklyPanel = new BlocklyPanel(mcreator);
+		blocklyPanel = new BlocklyPanel(mcreator, BlocklyEditorType.FEATURE);
 		blocklyPanel.addTaskToRunAfterLoaded(() -> {
 			BlocklyLoader.INSTANCE.getBlockLoader(BlocklyEditorType.FEATURE)
 					.loadBlocksAndCategoriesInPanel(blocklyPanel, ToolboxType.FEATURE);

--- a/src/main/java/net/mcreator/ui/modgui/LivingEntityGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/LivingEntityGUI.java
@@ -701,7 +701,7 @@ public class LivingEntityGUI extends ModElementGUI<LivingEntity> {
 
 		externalBlocks = BlocklyLoader.INSTANCE.getBlockLoader(BlocklyEditorType.AI_TASK).getDefinedBlocks();
 
-		blocklyPanel = new BlocklyPanel(mcreator);
+		blocklyPanel = new BlocklyPanel(mcreator, BlocklyEditorType.AI_TASK);
 		blocklyPanel.addTaskToRunAfterLoaded(() -> {
 			BlocklyLoader.INSTANCE.getBlockLoader(BlocklyEditorType.AI_TASK)
 					.loadBlocksAndCategoriesInPanel(blocklyPanel, ToolboxType.AI_BUILDER);

--- a/src/main/java/net/mcreator/ui/modgui/ProcedureGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/ProcedureGUI.java
@@ -564,7 +564,7 @@ public class ProcedureGUI extends ModElementGUI<net.mcreator.element.types.Proce
 
 		externalBlocks = BlocklyLoader.INSTANCE.getBlockLoader(BlocklyEditorType.PROCEDURE).getDefinedBlocks();
 
-		blocklyPanel = new BlocklyPanel(mcreator);
+		blocklyPanel = new BlocklyPanel(mcreator, BlocklyEditorType.PROCEDURE);
 		blocklyPanel.addTaskToRunAfterLoaded(() -> {
 			BlocklyLoader.INSTANCE.getBlockLoader(BlocklyEditorType.PROCEDURE)
 					.loadBlocksAndCategoriesInPanel(blocklyPanel, ToolboxType.PROCEDURE);


### PR DESCRIPTION
`BlocklyPanel`'s holder type can now be determined directly in JS files using the new `editorType` constant acquired from the `BlocklyEditorType` passed to the panel's constructor.
Could be used by #3503 to avoid obsolete converter.