### PR TITLE
Entry selection events

### DIFF
--- a/plugins/mcreator-core/blockly/js/field_ai_condition_selector.js
+++ b/plugins/mcreator-core/blockly/js/field_ai_condition_selector.js
@@ -74,9 +74,15 @@ class FieldAiConditionSelector extends Blockly.FieldLabelSerializable {
         this.setValue(fieldElement.textContent);
     }
 
-    setValue(newEntry) {
+    setValue(newValue) {
+        let newCondition = newValue || 'null,null';
+        if (this.getValidator()) {
+            newCondition = this.getValidator().call(this, newCondition);
+            if (!newCondition)
+                return;
+        }
         const oldCondition = this.condition;
-        this.condition = newEntry || 'null,null';
+        this.condition = newCondition;
         if (this.condition.split(',').length === 2) {
             this.doValueUpdate_('Conditions: ' +
                 (this.condition.split(',')[0] !== 'null' ? 'X' : 'O') +

--- a/plugins/mcreator-core/blockly/js/field_ai_condition_selector.js
+++ b/plugins/mcreator-core/blockly/js/field_ai_condition_selector.js
@@ -56,7 +56,7 @@ class FieldAiConditionSelector extends Blockly.FieldLabelSerializable {
                 let thisField = this;
                 javabridge.openAIConditionEditor(this.condition, {
                     'callback': function (data) {
-                        thisField.setEntry(data);
+                        thisField.setValue(data);
                     }
                 });
             } else {
@@ -71,11 +71,11 @@ class FieldAiConditionSelector extends Blockly.FieldLabelSerializable {
     }
 
     fromXml(fieldElement) {
-        this.setEntry(fieldElement.textContent);
+        this.setValue(fieldElement.textContent);
     }
 
-    setEntry(newEntry) {
-        const oldEntry = this.condition;
+    setValue(newEntry) {
+        const oldCondition = this.condition;
         this.condition = newEntry || 'null,null';
         if (this.condition.split(',').length === 2) {
             this.doValueUpdate_('Conditions: ' +
@@ -86,7 +86,8 @@ class FieldAiConditionSelector extends Blockly.FieldLabelSerializable {
             this.doValueUpdate_('Conditions: OO');
         }
         this.forceRerender();
-        Blockly.Events.fire(new EntryChange(this.sourceBlock_, this.name, oldEntry, newEntry));
+        Blockly.Events.fire(new Blockly.Events.BlockChange(this.sourceBlock_,
+            'field', this.name, oldCondition, this.condition));
     }
 }
 

--- a/plugins/mcreator-core/blockly/js/field_ai_condition_selector.js
+++ b/plugins/mcreator-core/blockly/js/field_ai_condition_selector.js
@@ -56,13 +56,7 @@ class FieldAiConditionSelector extends Blockly.FieldLabelSerializable {
                 let thisField = this;
                 javabridge.openAIConditionEditor(this.condition, {
                     'callback': function (data) {
-                        if (data) {
-                            thisField.condition = data;
-                        } else {
-                            thisField.condition = 'null,null';
-                        }
-
-                        thisField.updateDisplay();
+                        thisField.setEntry(data);
                     }
                 });
             } else {
@@ -77,19 +71,22 @@ class FieldAiConditionSelector extends Blockly.FieldLabelSerializable {
     }
 
     fromXml(fieldElement) {
-        this.condition = fieldElement.textContent || 'null,null';
-        this.updateDisplay();
+        this.setEntry(fieldElement.textContent);
     }
 
-    updateDisplay() {
+    setEntry(newEntry) {
+        const oldEntry = this.condition;
+        this.condition = newEntry || 'null,null';
         if (this.condition.split(',').length === 2) {
-            this.setValue('Conditions: ' +
+            this.doValueUpdate_('Conditions: ' +
                 (this.condition.split(',')[0] !== 'null' ? 'X' : 'O') +
                 (this.condition.split(',')[1] !== 'null' ? 'X' : 'O')
             );
         } else {
-            this.setValue('Conditions: OO');
+            this.doValueUpdate_('Conditions: OO');
         }
+        this.forceRerender();
+        Blockly.Events.fire(new EntryChange(this.sourceBlock_, this.name, oldEntry, newEntry));
     }
 }
 

--- a/plugins/mcreator-core/blockly/js/field_data_list_selector.js
+++ b/plugins/mcreator-core/blockly/js/field_data_list_selector.js
@@ -77,7 +77,7 @@ class FieldDataListSelector extends Blockly.FieldLabelSerializable {
                 let thisField = this; // reference to this field, to use in the callback function
                 javabridge.openEntrySelector(this.type, this.typeFilter, this.customEntryProviders, {
                     'callback': function (data) {
-                        thisField.setEntry(data);
+                        thisField.setValue(data);
                         javabridge.triggerEvent();
                     }
                 });
@@ -99,9 +99,9 @@ class FieldDataListSelector extends Blockly.FieldLabelSerializable {
             let readableName = javabridge.getReadableNameOf(fieldElement.textContent, this.type);
             if (!readableName) // The readable name is an empty string because it couldn't be found
                 readableName = fieldElement.textContent; // In this case, we use the actual value
-            this.setEntry(fieldElement.textContent + ',' + readableName);
+            this.setValue(fieldElement.textContent + ',' + readableName);
         } else {
-            this.setEntry(FieldDataListSelector.getDefaultEntry());
+            this.setValue(FieldDataListSelector.getDefaultEntry());
         }
     };
 
@@ -121,7 +121,7 @@ class FieldDataListSelector extends Blockly.FieldLabelSerializable {
         return '';
     }
 
-    setEntry(newEntry) {
+    setValue(newEntry) {
         const oldEntry = this.entry;
         this.entry = newEntry || FieldDataListSelector.getDefaultEntry();
         if (this.entry.split(',').length === 2) {
@@ -131,7 +131,8 @@ class FieldDataListSelector extends Blockly.FieldLabelSerializable {
         }
         this.setTooltip(this.getText_()); // Update the field tooltip
         this.forceRerender(); // Update the selected text and shape
-        Blockly.Events.fire(new EntryChange(this.sourceBlock_, this.name, oldEntry, newEntry));
+        Blockly.Events.fire(new Blockly.Events.BlockChange(this.sourceBlock_,
+            'field', this.name, oldEntry, this.entry));
     };
 }
 

--- a/plugins/mcreator-core/blockly/js/field_data_list_selector.js
+++ b/plugins/mcreator-core/blockly/js/field_data_list_selector.js
@@ -77,14 +77,8 @@ class FieldDataListSelector extends Blockly.FieldLabelSerializable {
                 let thisField = this; // reference to this field, to use in the callback function
                 javabridge.openEntrySelector(this.type, this.typeFilter, this.customEntryProviders, {
                     'callback': function (data) {
-                        if (data !== undefined) {
-                            thisField.entry = data;
-                        } else {
-                            thisField.entry = FieldDataListSelector.getDefaultEntry();
-                        }
-
+                        thisField.setEntry(data);
                         javabridge.triggerEvent();
-                        thisField.updateDisplay();
                     }
                 });
             } else {
@@ -105,10 +99,10 @@ class FieldDataListSelector extends Blockly.FieldLabelSerializable {
             let readableName = javabridge.getReadableNameOf(fieldElement.textContent, this.type);
             if (!readableName) // The readable name is an empty string because it couldn't be found
                 readableName = fieldElement.textContent; // In this case, we use the actual value
-            this.entry = fieldElement.textContent + ',' + readableName;
-        } else
-            this.entry = FieldDataListSelector.getDefaultEntry();
-        this.updateDisplay();
+            this.setEntry(fieldElement.textContent + ',' + readableName);
+        } else {
+            this.setEntry(FieldDataListSelector.getDefaultEntry());
+        }
     };
 
     // Returns the readable text
@@ -127,14 +121,17 @@ class FieldDataListSelector extends Blockly.FieldLabelSerializable {
         return '';
     }
 
-    updateDisplay() {
+    setEntry(newEntry) {
+        const oldEntry = this.entry;
+        this.entry = newEntry || FieldDataListSelector.getDefaultEntry();
         if (this.entry.split(',').length === 2) {
-            this.setValue(this.entry.split(',')[0]);
+            this.doValueUpdate_(this.entry.split(',')[0]);
         } else {
-            this.setValue('');
+            this.doValueUpdate_('');
         }
         this.setTooltip(this.getText_()); // Update the field tooltip
         this.forceRerender(); // Update the selected text and shape
+        Blockly.Events.fire(new EntryChange(this.sourceBlock_, this.name, oldEntry, newEntry));
     };
 }
 

--- a/plugins/mcreator-core/blockly/js/field_data_list_selector.js
+++ b/plugins/mcreator-core/blockly/js/field_data_list_selector.js
@@ -121,9 +121,15 @@ class FieldDataListSelector extends Blockly.FieldLabelSerializable {
         return '';
     }
 
-    setValue(newEntry) {
+    setValue(newValue) {
+        let newEntry = newValue || FieldDataListSelector.getDefaultEntry();
+        if (this.getValidator()) {
+            newEntry = this.getValidator().call(this, newEntry);
+            if (!newEntry)
+                return;
+        }
         const oldEntry = this.entry;
-        this.entry = newEntry || FieldDataListSelector.getDefaultEntry();
+        this.entry = newEntry;
         if (this.entry.split(',').length === 2) {
             this.doValueUpdate_(this.entry.split(',')[0]);
         } else {

--- a/plugins/mcreator-core/blockly/js/field_mcitem_selector.js
+++ b/plugins/mcreator-core/blockly/js/field_mcitem_selector.js
@@ -44,7 +44,7 @@ class FieldMCItemSelector extends Blockly.FieldImage {
                 let thisField = this; // reference to this field, to use in the callback function
                 javabridge.openMCItemSelector(this.supported_mcitems, {
                     'callback': function (selected) {
-                        thisField.setValue(selected);
+                        thisField.setEntry(selected);
                         javabridge.triggerEvent();
                     }
                 });
@@ -60,11 +60,17 @@ class FieldMCItemSelector extends Blockly.FieldImage {
     };
 
     setValue(new_mcitem) {
-        this.src_ = javabridge.getMCItemURI(new_mcitem);
+        this.setEntry(new_mcitem);
+    };
+
+    setEntry(newEntry) {
+        this.src_ = javabridge.getMCItemURI(newEntry);
         if (this.imageElement_) {
             this.imageElement_.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', this.src_ || '');
         }
-        this.mcitem = new_mcitem;
+        const oldEntry = this.mcitem;
+        this.mcitem = newEntry;
+        Blockly.Events.fire(new EntryChange(this.sourceBlock_, this.name, oldEntry, newEntry));
     };
 }
 

--- a/plugins/mcreator-core/blockly/js/field_mcitem_selector.js
+++ b/plugins/mcreator-core/blockly/js/field_mcitem_selector.js
@@ -59,7 +59,13 @@ class FieldMCItemSelector extends Blockly.FieldImage {
         return this.mcitem;
     };
 
-    setValue(new_mcitem) {
+    setValue(newValue) {
+        let new_mcitem = newValue;
+        if (this.getValidator()) {
+            new_mcitem = this.getValidator().call(this, new_mcitem);
+            if (!new_mcitem)
+                return;
+        }
         this.src_ = javabridge.getMCItemURI(new_mcitem);
         if (this.imageElement_) {
             this.imageElement_.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', this.src_ || '');

--- a/plugins/mcreator-core/blockly/js/field_mcitem_selector.js
+++ b/plugins/mcreator-core/blockly/js/field_mcitem_selector.js
@@ -44,7 +44,7 @@ class FieldMCItemSelector extends Blockly.FieldImage {
                 let thisField = this; // reference to this field, to use in the callback function
                 javabridge.openMCItemSelector(this.supported_mcitems, {
                     'callback': function (selected) {
-                        thisField.setEntry(selected);
+                        thisField.setValue(selected);
                         javabridge.triggerEvent();
                     }
                 });
@@ -60,17 +60,14 @@ class FieldMCItemSelector extends Blockly.FieldImage {
     };
 
     setValue(new_mcitem) {
-        this.setEntry(new_mcitem);
-    };
-
-    setEntry(newEntry) {
-        this.src_ = javabridge.getMCItemURI(newEntry);
+        this.src_ = javabridge.getMCItemURI(new_mcitem);
         if (this.imageElement_) {
             this.imageElement_.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', this.src_ || '');
         }
-        const oldEntry = this.mcitem;
-        this.mcitem = newEntry;
-        Blockly.Events.fire(new EntryChange(this.sourceBlock_, this.name, oldEntry, newEntry));
+        const old_mcitem = this.mcitem;
+        this.mcitem = new_mcitem;
+        Blockly.Events.fire(new Blockly.Events.BlockChange(this.sourceBlock_,
+            'field', this.name, old_mcitem, this.mcitem));
     };
 }
 

--- a/src/main/resources/blockly/js/mcreator_blockly.js
+++ b/src/main/resources/blockly/js/mcreator_blockly.js
@@ -125,15 +125,3 @@ function workspaceToXML() {
 
     return Blockly.Xml.domToText(treeXml);
 }
-
-class EntryChange extends Blockly.Events.BlockChange {
-    constructor(block, name, oldValue, newValue) {
-        super(block, 'field', name, oldValue, newValue);
-    }
-
-    run(forward) {
-        const block = this.blockId && this.getEventWorkspace_().getBlockById(this.blockId);
-        if (block && block.getField(this.name).setEntry)
-            block.getField(this.name).setEntry(forward ? this.newValue : this.oldValue);
-    }
-}

--- a/src/main/resources/blockly/js/mcreator_blockly.js
+++ b/src/main/resources/blockly/js/mcreator_blockly.js
@@ -125,3 +125,15 @@ function workspaceToXML() {
 
     return Blockly.Xml.domToText(treeXml);
 }
+
+class EntryChange extends Blockly.Events.BlockChange {
+    constructor(block, name, oldValue, newValue) {
+        super(block, 'field', name, oldValue, newValue);
+    }
+
+    run(forward) {
+        const block = this.blockId && this.getEventWorkspace_().getBlockById(this.blockId);
+        if (block && block.getField(this.name).setEntry)
+            block.getField(this.name).setEntry(forward ? this.newValue : this.oldValue);
+    }
+}


### PR DESCRIPTION
This PR changes entry selector fields we have so far to allow their interaction with event system (proper undoing/redoing).
On its own, this is a cosmetic change, but it will be needed later (e.g. by #3503 to update parent block properties basing on the field value).