### PR TITLE
Fixed procedure selectors' enabling/disabling

### DIFF
--- a/src/main/java/net/mcreator/ui/procedure/RetvalProcedureSelector.java
+++ b/src/main/java/net/mcreator/ui/procedure/RetvalProcedureSelector.java
@@ -214,12 +214,13 @@ public abstract class RetvalProcedureSelector<E, T extends RetvalProcedure<E>> e
 		edit.setEnabled(selected != null && !selected.string.equals(defaultName));
 
 		if (fixedValue != null)
-			fixedValue.setEnabled(!edit.isEnabled());
+			fixedValue.setEnabled(isEnabled() && !edit.isEnabled());
 
 		return selected;
 	}
 
 	@Override public void setEnabled(boolean enabled) {
+		super.setEnabled(enabled);
 		if (fixedValue != null)
 			fixedValue.setEnabled(enabled);
 


### PR DESCRIPTION
This PR fixes return value procedure selectors not properly enabling or disabling their `fixedValue` component when updating their own state.
Closes #3846 where this was reported.