### PR TITLE
Pattern match fix

### DIFF
--- a/plugins/generator-1.19.2/forge-1.19.2/procedures/entity_has_achievement.java.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/procedures/entity_has_achievement.java.ftl
@@ -1,2 +1,3 @@
-(${input$entity} instanceof ServerPlayer _plr && _plr.level instanceof ServerLevel && _plr.getAdvancements()
-        .getOrStartProgress(_plr.server.getAdvancements().getAdvancement(new ResourceLocation("${generator.map(field$achievement, "achievements")}"))).isDone())
+<#assign plr = "_plr" + customBlockIndex>
+(${input$entity} instanceof ServerPlayer ${plr} && ${plr}.level instanceof ServerLevel && ${plr}.getAdvancements()
+        .getOrStartProgress(${plr}.server.getAdvancements().getAdvancement(new ResourceLocation("${generator.map(field$achievement, "achievements")}"))).isDone())

--- a/plugins/generator-1.19.2/forge-1.19.2/procedures/world_data_isday.java.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/procedures/world_data_isday.java.ftl
@@ -1,1 +1,1 @@
-(world instanceof Level _lvl && _lvl.isDay())
+(world instanceof Level _lvl${customBlockIndex} && _lvl${customBlockIndex}.isDay())

--- a/plugins/generator-1.19.2/forge-1.19.2/procedures/world_data_israided.java.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/procedures/world_data_israided.java.ftl
@@ -1,2 +1,2 @@
 <#include "mcelements.ftl">
-(world instanceof ServerLevel _level && _level.isRaided(${toBlockPos(input$x,input$y,input$z)}))
+(world instanceof ServerLevel _level${customBlockIndex} && _level${customBlockIndex}.isRaided(${toBlockPos(input$x,input$y,input$z)}))

--- a/plugins/generator-1.19.2/forge-1.19.2/procedures/world_data_isvillage.java.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/procedures/world_data_isvillage.java.ftl
@@ -1,2 +1,2 @@
 <#include "mcelements.ftl">
-(world instanceof ServerLevel _level && _level.isVillage(${toBlockPos(input$x,input$y,input$z)}))
+(world instanceof ServerLevel _level${customBlockIndex} && _level${customBlockIndex}.isVillage(${toBlockPos(input$x,input$y,input$z)}))

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/advancement_isequalto.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/advancement_isequalto.java.ftl
@@ -1,2 +1,2 @@
-(world instanceof Level _lvl && _lvl.getServer() != null && _lvl.getServer().getAdvancements()
+(world instanceof Level _lvl${customBlockIndex} && _lvl${customBlockIndex}.getServer() != null && _lvl${customBlockIndex}.getServer().getAdvancements()
     .getAdvancement(new ResourceLocation("${generator.map(field$achievement, "achievements")}" )).equals(advancement))

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/blockat_plant_type.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/blockat_plant_type.java.ftl
@@ -1,3 +1,3 @@
 <#include "mcelements.ftl">
-(world.getBlockState(${toBlockPos(input$x,input$y,input$z)}).getBlock() instanceof IPlantable _plant &&
-	_plant.getPlantType(world, ${toBlockPos(input$x,input$y,input$z)}) == PlantType.${generator.map(field$planttype, "planttypes")})
+(world.getBlockState(${toBlockPos(input$x,input$y,input$z)}).getBlock() instanceof IPlantable _plant${customBlockIndex} &&
+	_plant${customBlockIndex}.getPlantType(world, ${toBlockPos(input$x,input$y,input$z)}) == PlantType.${generator.map(field$planttype, "planttypes")})

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_check_creature_type.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_check_creature_type.java.ftl
@@ -1,1 +1,1 @@
-(${input$entity} instanceof LivingEntity _livEnt && _livEnt.getMobType() == MobType.${field$type})
+(${input$entity} instanceof LivingEntity _livEnt${customBlockIndex} && _livEnt${customBlockIndex}.getMobType() == MobType.${field$type})

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_has_achievement.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_has_achievement.java.ftl
@@ -1,2 +1,3 @@
-(${input$entity} instanceof ServerPlayer _plr && _plr.level instanceof ServerLevel && _plr.getAdvancements()
-        .getOrStartProgress(_plr.server.getAdvancements().getAdvancement(new ResourceLocation("${generator.map(field$achievement, "achievements")}"))).isDone())
+<#assign plr = "_plr" + customBlockIndex>
+(${input$entity} instanceof ServerPlayer ${plr} && ${plr}.level instanceof ServerLevel && ${plr}.getAdvancements()
+        .getOrStartProgress(${plr}.server.getAdvancements().getAdvancement(new ResourceLocation("${generator.map(field$achievement, "achievements")}"))).isDone())

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_has_screen_open.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_has_screen_open.java.ftl
@@ -1,1 +1,1 @@
-(${input$entity} instanceof Player _plr && _plr.containerMenu instanceof ${field$guiname}Menu)
+(${input$entity} instanceof Player _plr${customBlockIndex} && _plr${customBlockIndex}.containerMenu instanceof ${field$guiname}Menu)

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_haspotioneffect.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/entity_haspotioneffect.java.ftl
@@ -1,1 +1,1 @@
-(${input$entity} instanceof LivingEntity _livEnt && _livEnt.hasEffect(${generator.map(field$potion, "effects")}))
+(${input$entity} instanceof LivingEntity _livEnt${customBlockIndex} && _livEnt${customBlockIndex}.hasEffect(${generator.map(field$potion, "effects")}))

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/item_can_smelt.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/item_can_smelt.java.ftl
@@ -1,2 +1,2 @@
 <#include "mcitems.ftl">
-(world instanceof Level _lvlCanSmelt && _lvlCanSmelt.getRecipeManager().getRecipeFor(RecipeType.SMELTING, new SimpleContainer(${mappedMCItemToItemStackCode(input$item, 1)}), _lvlCanSmelt).isPresent())
+(world instanceof Level _level${customBlockIndex} && _level${customBlockIndex}.getRecipeManager().getRecipeFor(RecipeType.SMELTING, new SimpleContainer(${mappedMCItemToItemStackCode(input$item, 1)}), _level${customBlockIndex}).isPresent())

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/world_data_is_block_powered.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/world_data_is_block_powered.java.ftl
@@ -1,2 +1,2 @@
 <#include "mcelements.ftl">
-(world instanceof Level _lvl_isPow && _lvl_isPow.hasNeighborSignal(${toBlockPos(input$x,input$y,input$z)}))
+(world instanceof Level _level${customBlockIndex} && _level${customBlockIndex}.hasNeighborSignal(${toBlockPos(input$x,input$y,input$z)}))

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/world_data_isday.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/world_data_isday.java.ftl
@@ -1,1 +1,1 @@
-(world instanceof Level _lvl && _lvl.isDay())
+(world instanceof Level _lvl${customBlockIndex} && _lvl${customBlockIndex}.isDay())

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/world_data_israided.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/world_data_israided.java.ftl
@@ -1,2 +1,2 @@
 <#include "mcelements.ftl">
-(world instanceof ServerLevel _level && _level.isRaided(${toBlockPos(input$x,input$y,input$z)}))
+(world instanceof ServerLevel _level${customBlockIndex} && _level${customBlockIndex}.isRaided(${toBlockPos(input$x,input$y,input$z)}))

--- a/plugins/generator-1.19.4/forge-1.19.4/procedures/world_data_isvillage.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/procedures/world_data_isvillage.java.ftl
@@ -1,2 +1,2 @@
 <#include "mcelements.ftl">
-(world instanceof ServerLevel _level && _level.isVillage(${toBlockPos(input$x,input$y,input$z)}))
+(world instanceof ServerLevel _level${customBlockIndex} && _level${customBlockIndex}.isVillage(${toBlockPos(input$x,input$y,input$z)}))


### PR DESCRIPTION
This PR fixes #3859 by using the custom block index to ensure that the pattern variables are all distinct. Turns out the issue wasn't caused by the procedure optimizer, and so the possible fixes were either this one, or going back to unnecessary ternary operators