### PR TITLE
Maker tool recipe fixes

### DIFF
--- a/src/main/java/net/mcreator/ui/dialogs/tools/ArmorPackMakerTool.java
+++ b/src/main/java/net/mcreator/ui/dialogs/tools/ArmorPackMakerTool.java
@@ -165,6 +165,7 @@ public class ArmorPackMakerTool {
 		Recipe armorHelmetRecipe = (Recipe) ModElementType.RECIPE.getModElementGUI(mcreator,
 						new ModElement(workspace, name + "ArmorHelmetRecipe", ModElementType.RECIPE), false)
 				.getElementFromGUI();
+		armorHelmetRecipe.craftingBookCategory = "EQUIPMENT";
 		armorHelmetRecipe.recipeSlots[0] = base;
 		armorHelmetRecipe.recipeSlots[1] = base;
 		armorHelmetRecipe.recipeSlots[2] = base;
@@ -179,7 +180,9 @@ public class ArmorPackMakerTool {
 		mcreator.getModElementManager().storeModElement(armorHelmetRecipe);
 
 		Recipe armorBodyRecipe = (Recipe) ModElementType.RECIPE.getModElementGUI(mcreator,
-				new ModElement(workspace, name + "ArmorBodyRecipe", ModElementType.RECIPE), false).getElementFromGUI();
+						new ModElement(workspace, name + "ArmorChestplateRecipe", ModElementType.RECIPE), false)
+				.getElementFromGUI();
+		armorBodyRecipe.craftingBookCategory = "EQUIPMENT";
 		armorBodyRecipe.recipeSlots[0] = base;
 		armorBodyRecipe.recipeSlots[2] = base;
 		armorBodyRecipe.recipeSlots[3] = base;
@@ -199,6 +202,7 @@ public class ArmorPackMakerTool {
 		Recipe armorLeggingsRecipe = (Recipe) ModElementType.RECIPE.getModElementGUI(mcreator,
 						new ModElement(workspace, name + "ArmorLeggingsRecipe", ModElementType.RECIPE), false)
 				.getElementFromGUI();
+		armorLeggingsRecipe.craftingBookCategory = "EQUIPMENT";
 		armorLeggingsRecipe.recipeSlots[0] = base;
 		armorLeggingsRecipe.recipeSlots[1] = base;
 		armorLeggingsRecipe.recipeSlots[2] = base;
@@ -216,6 +220,7 @@ public class ArmorPackMakerTool {
 
 		Recipe armorBootsRecipe = (Recipe) ModElementType.RECIPE.getModElementGUI(mcreator,
 				new ModElement(workspace, name + "ArmorBootsRecipe", ModElementType.RECIPE), false).getElementFromGUI();
+		armorBootsRecipe.craftingBookCategory = "EQUIPMENT";
 		armorBootsRecipe.recipeSlots[3] = base;
 		armorBootsRecipe.recipeSlots[5] = base;
 		armorBootsRecipe.recipeSlots[6] = base;

--- a/src/main/java/net/mcreator/ui/dialogs/tools/OrePackMakerTool.java
+++ b/src/main/java/net/mcreator/ui/dialogs/tools/OrePackMakerTool.java
@@ -236,6 +236,7 @@ public class OrePackMakerTool {
 
 		Recipe itemToBlockRecipe = (Recipe) ModElementType.RECIPE.getModElementGUI(mcreator,
 				new ModElement(workspace, name + "OreBlockRecipe", ModElementType.RECIPE), false).getElementFromGUI();
+		itemToBlockRecipe.craftingBookCategory = "BUILDING";
 		itemToBlockRecipe.recipeSlots[0] = new MItemBlock(workspace, "CUSTOM:" + oreItemName);
 		itemToBlockRecipe.recipeSlots[1] = new MItemBlock(workspace, "CUSTOM:" + oreItemName);
 		itemToBlockRecipe.recipeSlots[2] = new MItemBlock(workspace, "CUSTOM:" + oreItemName);

--- a/src/main/java/net/mcreator/ui/dialogs/tools/ToolPackMakerTool.java
+++ b/src/main/java/net/mcreator/ui/dialogs/tools/ToolPackMakerTool.java
@@ -233,6 +233,7 @@ public class ToolPackMakerTool {
 
 		Recipe pickaxeRecipe = (Recipe) ModElementType.RECIPE.getModElementGUI(mcreator,
 				new ModElement(workspace, name + "PickaxeRecipe", ModElementType.RECIPE), false).getElementFromGUI();
+		pickaxeRecipe.craftingBookCategory = "EQUIPMENT";
 		pickaxeRecipe.recipeSlots[0] = base;
 		pickaxeRecipe.recipeSlots[1] = base;
 		pickaxeRecipe.recipeSlots[2] = base;
@@ -248,6 +249,7 @@ public class ToolPackMakerTool {
 
 		Recipe axeRecipe = (Recipe) ModElementType.RECIPE.getModElementGUI(mcreator,
 				new ModElement(workspace, name + "AxeRecipe", ModElementType.RECIPE), false).getElementFromGUI();
+		axeRecipe.craftingBookCategory = "EQUIPMENT";
 		axeRecipe.recipeSlots[0] = base;
 		axeRecipe.recipeSlots[1] = base;
 		axeRecipe.recipeSlots[3] = base;
@@ -263,6 +265,7 @@ public class ToolPackMakerTool {
 
 		Recipe swordRecipe = (Recipe) ModElementType.RECIPE.getModElementGUI(mcreator,
 				new ModElement(workspace, name + "SwordRecipe", ModElementType.RECIPE), false).getElementFromGUI();
+		swordRecipe.craftingBookCategory = "EQUIPMENT";
 		swordRecipe.recipeSlots[1] = base;
 		swordRecipe.recipeSlots[4] = base;
 		swordRecipe.recipeSlots[7] = new MItemBlock(workspace, "Items.STICK");
@@ -276,6 +279,7 @@ public class ToolPackMakerTool {
 
 		Recipe shovelRecipe = (Recipe) ModElementType.RECIPE.getModElementGUI(mcreator,
 				new ModElement(workspace, name + "ShovelRecipe", ModElementType.RECIPE), false).getElementFromGUI();
+		shovelRecipe.craftingBookCategory = "EQUIPMENT";
 		shovelRecipe.recipeSlots[1] = base;
 		shovelRecipe.recipeSlots[4] = new MItemBlock(workspace, "Items.STICK");
 		shovelRecipe.recipeSlots[7] = new MItemBlock(workspace, "Items.STICK");
@@ -289,6 +293,7 @@ public class ToolPackMakerTool {
 
 		Recipe hoeRecipe = (Recipe) ModElementType.RECIPE.getModElementGUI(mcreator,
 				new ModElement(workspace, name + "HoeRecipe", ModElementType.RECIPE), false).getElementFromGUI();
+		hoeRecipe.craftingBookCategory = "EQUIPMENT";
 		hoeRecipe.recipeSlots[0] = base;
 		hoeRecipe.recipeSlots[1] = base;
 		hoeRecipe.recipeSlots[4] = new MItemBlock(workspace, "Items.STICK");

--- a/src/main/java/net/mcreator/ui/dialogs/tools/WoodPackMakerTool.java
+++ b/src/main/java/net/mcreator/ui/dialogs/tools/WoodPackMakerTool.java
@@ -387,6 +387,7 @@ public class WoodPackMakerTool {
 		//Recipes
 		Recipe woodRecipe = (Recipe) ModElementType.RECIPE.getModElementGUI(mcreator,
 				new ModElement(workspace, name + "WoodRecipe", ModElementType.RECIPE), false).getElementFromGUI();
+		woodRecipe.craftingBookCategory = "BUILDING";
 		woodRecipe.recipeSlots[0] = new MItemBlock(workspace, "CUSTOM:" + logBlock.getModElement().getName());
 		woodRecipe.recipeSlots[1] = new MItemBlock(workspace, "CUSTOM:" + logBlock.getModElement().getName());
 		woodRecipe.recipeSlots[3] = new MItemBlock(workspace, "CUSTOM:" + logBlock.getModElement().getName());
@@ -402,6 +403,7 @@ public class WoodPackMakerTool {
 
 		Recipe planksRecipe = (Recipe) ModElementType.RECIPE.getModElementGUI(mcreator,
 				new ModElement(workspace, name + "PlanksRecipe", ModElementType.RECIPE), false).getElementFromGUI();
+		planksRecipe.craftingBookCategory = "BUILDING";
 		planksRecipe.recipeSlots[4] = new MItemBlock(workspace,
 				"TAG:" + woodItemTag.namespace + ":" + woodItemTag.name);
 		planksRecipe.recipeReturnStack = new MItemBlock(workspace, "CUSTOM:" + name + "Planks");
@@ -416,6 +418,7 @@ public class WoodPackMakerTool {
 
 		Recipe stairsRecipe = (Recipe) ModElementType.RECIPE.getModElementGUI(mcreator,
 				new ModElement(workspace, name + "StairsRecipe", ModElementType.RECIPE), false).getElementFromGUI();
+		stairsRecipe.craftingBookCategory = "BUILDING";
 		stairsRecipe.recipeSlots[0] = new MItemBlock(workspace, "CUSTOM:" + planksBlock.getModElement().getName());
 		stairsRecipe.recipeSlots[3] = new MItemBlock(workspace, "CUSTOM:" + planksBlock.getModElement().getName());
 		stairsRecipe.recipeSlots[4] = new MItemBlock(workspace, "CUSTOM:" + planksBlock.getModElement().getName());
@@ -433,6 +436,7 @@ public class WoodPackMakerTool {
 
 		Recipe slabRecipe = (Recipe) ModElementType.RECIPE.getModElementGUI(mcreator,
 				new ModElement(workspace, name + "SlabRecipe", ModElementType.RECIPE), false).getElementFromGUI();
+		slabRecipe.craftingBookCategory = "BUILDING";
 		slabRecipe.recipeSlots[6] = new MItemBlock(workspace, "CUSTOM:" + planksBlock.getModElement().getName());
 		slabRecipe.recipeSlots[7] = new MItemBlock(workspace, "CUSTOM:" + planksBlock.getModElement().getName());
 		slabRecipe.recipeSlots[8] = new MItemBlock(workspace, "CUSTOM:" + planksBlock.getModElement().getName());
@@ -464,6 +468,7 @@ public class WoodPackMakerTool {
 
 		Recipe fenceGateRecipe = (Recipe) ModElementType.RECIPE.getModElementGUI(mcreator,
 				new ModElement(workspace, name + "FenceGateRecipe", ModElementType.RECIPE), false).getElementFromGUI();
+		fenceGateRecipe.craftingBookCategory = "REDSTONE";
 		fenceGateRecipe.recipeSlots[3] = new MItemBlock(workspace, "Items.STICK");
 		fenceGateRecipe.recipeSlots[4] = new MItemBlock(workspace, "CUSTOM:" + planksBlock.getModElement().getName());
 		fenceGateRecipe.recipeSlots[5] = new MItemBlock(workspace, "Items.STICK");
@@ -482,6 +487,7 @@ public class WoodPackMakerTool {
 		Recipe pressurePlateRecipe = (Recipe) ModElementType.RECIPE.getModElementGUI(mcreator,
 						new ModElement(workspace, name + "PressurePlateRecipe", ModElementType.RECIPE), false)
 				.getElementFromGUI();
+		pressurePlateRecipe.craftingBookCategory = "REDSTONE";
 		pressurePlateRecipe.recipeSlots[6] = new MItemBlock(workspace,
 				"CUSTOM:" + planksBlock.getModElement().getName());
 		pressurePlateRecipe.recipeSlots[7] = new MItemBlock(workspace,
@@ -497,6 +503,7 @@ public class WoodPackMakerTool {
 
 		Recipe buttonRecipe = (Recipe) ModElementType.RECIPE.getModElementGUI(mcreator,
 				new ModElement(workspace, name + "ButtonRecipe", ModElementType.RECIPE), false).getElementFromGUI();
+		buttonRecipe.craftingBookCategory = "REDSTONE";
 		buttonRecipe.recipeSlots[4] = new MItemBlock(workspace, "CUSTOM:" + planksBlock.getModElement().getName());
 		buttonRecipe.recipeShapeless = true;
 		buttonRecipe.recipeReturnStack = new MItemBlock(workspace, "CUSTOM:" + name + "Button");

--- a/src/main/java/net/mcreator/ui/dialogs/tools/WoodPackMakerTool.java
+++ b/src/main/java/net/mcreator/ui/dialogs/tools/WoodPackMakerTool.java
@@ -388,6 +388,7 @@ public class WoodPackMakerTool {
 		Recipe woodRecipe = (Recipe) ModElementType.RECIPE.getModElementGUI(mcreator,
 				new ModElement(workspace, name + "WoodRecipe", ModElementType.RECIPE), false).getElementFromGUI();
 		woodRecipe.craftingBookCategory = "BUILDING";
+		woodRecipe.group = "bark";
 		woodRecipe.recipeSlots[0] = new MItemBlock(workspace, "CUSTOM:" + logBlock.getModElement().getName());
 		woodRecipe.recipeSlots[1] = new MItemBlock(workspace, "CUSTOM:" + logBlock.getModElement().getName());
 		woodRecipe.recipeSlots[3] = new MItemBlock(workspace, "CUSTOM:" + logBlock.getModElement().getName());
@@ -404,6 +405,7 @@ public class WoodPackMakerTool {
 		Recipe planksRecipe = (Recipe) ModElementType.RECIPE.getModElementGUI(mcreator,
 				new ModElement(workspace, name + "PlanksRecipe", ModElementType.RECIPE), false).getElementFromGUI();
 		planksRecipe.craftingBookCategory = "BUILDING";
+		planksRecipe.group = "planks";
 		planksRecipe.recipeSlots[4] = new MItemBlock(workspace,
 				"TAG:" + woodItemTag.namespace + ":" + woodItemTag.name);
 		planksRecipe.recipeReturnStack = new MItemBlock(workspace, "CUSTOM:" + name + "Planks");
@@ -419,6 +421,7 @@ public class WoodPackMakerTool {
 		Recipe stairsRecipe = (Recipe) ModElementType.RECIPE.getModElementGUI(mcreator,
 				new ModElement(workspace, name + "StairsRecipe", ModElementType.RECIPE), false).getElementFromGUI();
 		stairsRecipe.craftingBookCategory = "BUILDING";
+		stairsRecipe.group = "wooden_stairs";
 		stairsRecipe.recipeSlots[0] = new MItemBlock(workspace, "CUSTOM:" + planksBlock.getModElement().getName());
 		stairsRecipe.recipeSlots[3] = new MItemBlock(workspace, "CUSTOM:" + planksBlock.getModElement().getName());
 		stairsRecipe.recipeSlots[4] = new MItemBlock(workspace, "CUSTOM:" + planksBlock.getModElement().getName());
@@ -437,6 +440,7 @@ public class WoodPackMakerTool {
 		Recipe slabRecipe = (Recipe) ModElementType.RECIPE.getModElementGUI(mcreator,
 				new ModElement(workspace, name + "SlabRecipe", ModElementType.RECIPE), false).getElementFromGUI();
 		slabRecipe.craftingBookCategory = "BUILDING";
+		slabRecipe.group = "wooden_slab";
 		slabRecipe.recipeSlots[6] = new MItemBlock(workspace, "CUSTOM:" + planksBlock.getModElement().getName());
 		slabRecipe.recipeSlots[7] = new MItemBlock(workspace, "CUSTOM:" + planksBlock.getModElement().getName());
 		slabRecipe.recipeSlots[8] = new MItemBlock(workspace, "CUSTOM:" + planksBlock.getModElement().getName());
@@ -451,6 +455,7 @@ public class WoodPackMakerTool {
 
 		Recipe fenceRecipe = (Recipe) ModElementType.RECIPE.getModElementGUI(mcreator,
 				new ModElement(workspace, name + "FenceRecipe", ModElementType.RECIPE), false).getElementFromGUI();
+		fenceRecipe.group = "wooden_fence";
 		fenceRecipe.recipeSlots[3] = new MItemBlock(workspace, "CUSTOM:" + planksBlock.getModElement().getName());
 		fenceRecipe.recipeSlots[4] = new MItemBlock(workspace, "Items.STICK");
 		fenceRecipe.recipeSlots[5] = new MItemBlock(workspace, "CUSTOM:" + planksBlock.getModElement().getName());
@@ -469,6 +474,7 @@ public class WoodPackMakerTool {
 		Recipe fenceGateRecipe = (Recipe) ModElementType.RECIPE.getModElementGUI(mcreator,
 				new ModElement(workspace, name + "FenceGateRecipe", ModElementType.RECIPE), false).getElementFromGUI();
 		fenceGateRecipe.craftingBookCategory = "REDSTONE";
+		fenceGateRecipe.group = "wooden_fence_gate";
 		fenceGateRecipe.recipeSlots[3] = new MItemBlock(workspace, "Items.STICK");
 		fenceGateRecipe.recipeSlots[4] = new MItemBlock(workspace, "CUSTOM:" + planksBlock.getModElement().getName());
 		fenceGateRecipe.recipeSlots[5] = new MItemBlock(workspace, "Items.STICK");
@@ -488,6 +494,7 @@ public class WoodPackMakerTool {
 						new ModElement(workspace, name + "PressurePlateRecipe", ModElementType.RECIPE), false)
 				.getElementFromGUI();
 		pressurePlateRecipe.craftingBookCategory = "REDSTONE";
+		pressurePlateRecipe.group = "wooden_pressure_plate";
 		pressurePlateRecipe.recipeSlots[6] = new MItemBlock(workspace,
 				"CUSTOM:" + planksBlock.getModElement().getName());
 		pressurePlateRecipe.recipeSlots[7] = new MItemBlock(workspace,
@@ -504,6 +511,7 @@ public class WoodPackMakerTool {
 		Recipe buttonRecipe = (Recipe) ModElementType.RECIPE.getModElementGUI(mcreator,
 				new ModElement(workspace, name + "ButtonRecipe", ModElementType.RECIPE), false).getElementFromGUI();
 		buttonRecipe.craftingBookCategory = "REDSTONE";
+		buttonRecipe.group = "wooden_button";
 		buttonRecipe.recipeSlots[4] = new MItemBlock(workspace, "CUSTOM:" + planksBlock.getModElement().getName());
 		buttonRecipe.recipeShapeless = true;
 		buttonRecipe.recipeReturnStack = new MItemBlock(workspace, "CUSTOM:" + name + "Button");
@@ -517,6 +525,7 @@ public class WoodPackMakerTool {
 
 		Recipe stickRecipe = (Recipe) ModElementType.RECIPE.getModElementGUI(mcreator,
 				new ModElement(workspace, name + "StickRecipe", ModElementType.RECIPE), false).getElementFromGUI();
+		stickRecipe.group = "sticks";
 		stickRecipe.recipeSlots[0] = new MItemBlock(workspace, "CUSTOM:" + planksBlock.getModElement().getName());
 		stickRecipe.recipeSlots[3] = new MItemBlock(workspace, "CUSTOM:" + planksBlock.getModElement().getName());
 		stickRecipe.recipeReturnStack = new MItemBlock(workspace, "Items.STICK");


### PR DESCRIPTION
This PR fixes some bugs related to maker tool recipes:
- Recipes are now in the correct recipe book category
- Renamed armor chestplate recipe to match #3849
- Wood pack recipes are now grouped together with the other wood recipes