### PR TITLE
Minor changes

### DIFF
--- a/src/main/java/net/mcreator/generator/template/base/DefaultFreemarkerConfiguration.java
+++ b/src/main/java/net/mcreator/generator/template/base/DefaultFreemarkerConfiguration.java
@@ -39,7 +39,7 @@ public class DefaultFreemarkerConfiguration extends Configuration {
 		setAutoEscapingPolicy(Configuration.DISABLE_AUTO_ESCAPING_POLICY);
 		setDefaultEncoding("UTF-8");
 		setTemplateExceptionHandler(TemplateExceptionHandler.RETHROW_HANDLER);
-		setNumberFormat("0.#####");
+		setNumberFormat("0.##########");
 		setBooleanFormat("c");
 		setCFormat(JSONCFormat.INSTANCE);
 		setTemplateUpdateDelayMilliseconds(Integer.MAX_VALUE);

--- a/src/main/java/net/mcreator/generator/template/base/DefaultFreemarkerConfiguration.java
+++ b/src/main/java/net/mcreator/generator/template/base/DefaultFreemarkerConfiguration.java
@@ -39,7 +39,7 @@ public class DefaultFreemarkerConfiguration extends Configuration {
 		setAutoEscapingPolicy(Configuration.DISABLE_AUTO_ESCAPING_POLICY);
 		setDefaultEncoding("UTF-8");
 		setTemplateExceptionHandler(TemplateExceptionHandler.RETHROW_HANDLER);
-		setNumberFormat("computer");
+		setNumberFormat("0.#####");
 		setBooleanFormat("c");
 		setCFormat(JSONCFormat.INSTANCE);
 		setTemplateUpdateDelayMilliseconds(Integer.MAX_VALUE);

--- a/src/main/java/net/mcreator/ui/modgui/RecipeGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/RecipeGUI.java
@@ -25,7 +25,6 @@ import net.mcreator.minecraft.ElementUtil;
 import net.mcreator.minecraft.RegistryNameFixer;
 import net.mcreator.ui.MCreator;
 import net.mcreator.ui.MCreatorApplication;
-import net.mcreator.ui.component.JEmptyBox;
 import net.mcreator.ui.component.util.AdaptiveGridLayout;
 import net.mcreator.ui.component.util.ComponentUtils;
 import net.mcreator.ui.component.util.PanelUtils;
@@ -47,7 +46,6 @@ import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
-import java.util.Objects;
 
 public class RecipeGUI extends ModElementGUI<Recipe> {
 
@@ -62,7 +60,7 @@ public class RecipeGUI extends ModElementGUI<Recipe> {
 
 	private final JCheckBox recipeShapeless = L10N.checkbox("elementgui.common.enable");
 
-	private final JSpinner xpReward = new JSpinner(new SpinnerNumberModel(1.0, 0, 256, 1));
+	private final JSpinner xpReward = new JSpinner(new SpinnerNumberModel(1.0, 0, 256, 0.1));
 	private final JSpinner cookingTime = new JSpinner(new SpinnerNumberModel(200, 0, 1000000, 1));
 
 	private final JComboBox<String> namespace = new JComboBox<>(new String[] { "mod", "minecraft" });


### PR DESCRIPTION
- Removed unused imports from `RecipeGUI.java`
- Allow decimal XP reward values for recipes (this is already used for example by glass smelting recipe)
- Changed the Freemarker default number formatting to have at most 5 decimal digits. This prevents extremely long numbers in the generated code due to floating point errors:
![digits](https://github.com/MCreator/MCreator/assets/64546452/384cb595-5e83-44b9-ba95-f4b177fc60ed)
