### PR TITLE
BugFix - Modded block as POI crashes game

### DIFF
--- a/plugins/generator-1.19.2/forge-1.19.2/templates/elementinits/villagerprofessions.java.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/templates/elementinits/villagerprofessions.java.ftl
@@ -49,22 +49,24 @@ public class ${JavaModName}VillagerProfessions {
 		public static final RegistryObject<VillagerProfession> ${villagerprofession.getModElement().getRegistryNameUpper()} =
 			registerProfession(
 					"${villagerprofession.getModElement().getRegistryName()}",
-					${mappedBlockToBlock(villagerprofession.pointOfInterest)},
+					() -> ${mappedBlockToBlock(villagerprofession.pointOfInterest)},
 					ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("${villagerprofession.actionSound}"))
 			);
 	</#list>
 
-	private static RegistryObject<VillagerProfession> registerProfession(String name, Block block, SoundEvent soundEvent) {
-		Optional<Holder<PoiType>> existingCheck = PoiTypes.forState(block.defaultBlockState());
+	private static RegistryObject<VillagerProfession> registerProfession(String name, Supplier<Block> block, SoundEvent soundEvent) {
+		return PROFESSIONS.register(name, () -> {
+			Optional<Holder<PoiType>> existingCheck = PoiTypes.forState(block.get().defaultBlockState());
 
-		if (existingCheck.isPresent()) {
-			${JavaModName}.LOGGER.error("Skipping villager profession " + name + " that uses POI block " + block + " that is already in use by " + existingCheck);
-			return null;
-		}
+			if (existingCheck.isPresent()) {
+				${JavaModName}.LOGGER.error("Skipping villager profession " + name + " that uses POI block " + block.get() + " that is already in use by " + existingCheck);
+				return null;
+			}
 
-		Supplier<PoiType> poi = POI.register(name, () -> new PoiType(ImmutableSet.copyOf(block.getStateDefinition().getPossibleStates()), 1, 1));
-		Predicate<Holder<PoiType>> poiPredicate = poiTypeHolder -> poiTypeHolder.get() == poi.get();
-		return PROFESSIONS.register(name, () -> new VillagerProfession(${JavaModName}.MODID + ":" + name, poiPredicate, poiPredicate, ImmutableSet.of(), ImmutableSet.of(), soundEvent));
+			Supplier<PoiType> poi = POI.register(name, () -> new PoiType(ImmutableSet.copyOf(block.get().getStateDefinition().getPossibleStates()), 1, 1));
+			Predicate<Holder<PoiType>> poiPredicate = poiTypeHolder -> poiTypeHolder.get() == poi.get();
+			return new VillagerProfession(${JavaModName}.MODID + ":" + name, poiPredicate, poiPredicate, ImmutableSet.of(), ImmutableSet.of(), soundEvent);
+		});
 	}
 
 }

--- a/plugins/generator-1.19.4/forge-1.19.4/templates/elementinits/villagerprofessions.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/templates/elementinits/villagerprofessions.java.ftl
@@ -49,22 +49,24 @@ public class ${JavaModName}VillagerProfessions {
 		public static final RegistryObject<VillagerProfession> ${villagerprofession.getModElement().getRegistryNameUpper()} =
 			registerProfession(
 					"${villagerprofession.getModElement().getRegistryName()}",
-					${mappedBlockToBlock(villagerprofession.pointOfInterest)},
+					() -> ${mappedBlockToBlock(villagerprofession.pointOfInterest)},
 					ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("${villagerprofession.actionSound}"))
 			);
 	</#list>
 
-	private static RegistryObject<VillagerProfession> registerProfession(String name, Block block, SoundEvent soundEvent) {
-		Optional<Holder<PoiType>> existingCheck = PoiTypes.forState(block.defaultBlockState());
+	private static RegistryObject<VillagerProfession> registerProfession(String name, Supplier<Block> block, SoundEvent soundEvent) {
+		return PROFESSIONS.register(name, () -> {
+			Optional<Holder<PoiType>> existingCheck = PoiTypes.forState(block.get().defaultBlockState());
 
-		if (existingCheck.isPresent()) {
-			${JavaModName}.LOGGER.error("Skipping villager profession " + name + " that uses POI block " + block + " that is already in use by " + existingCheck);
-			return null;
-		}
+			if (existingCheck.isPresent()) {
+				${JavaModName}.LOGGER.error("Skipping villager profession " + name + " that uses POI block " + block.get() + " that is already in use by " + existingCheck);
+				return null;
+			}
 
-		Supplier<PoiType> poi = POI.register(name, () -> new PoiType(ImmutableSet.copyOf(block.getStateDefinition().getPossibleStates()), 1, 1));
-		Predicate<Holder<PoiType>> poiPredicate = poiTypeHolder -> poiTypeHolder.get() == poi.get();
-		return PROFESSIONS.register(name, () -> new VillagerProfession(${JavaModName}.MODID + ":" + name, poiPredicate, poiPredicate, ImmutableSet.of(), ImmutableSet.of(), soundEvent));
+			Supplier<PoiType> poi = POI.register(name, () -> new PoiType(ImmutableSet.copyOf(block.get().getStateDefinition().getPossibleStates()), 1, 1));
+			Predicate<Holder<PoiType>> poiPredicate = poiTypeHolder -> poiTypeHolder.get() == poi.get();
+			return new VillagerProfession(${JavaModName}.MODID + ":" + name, poiPredicate, poiPredicate, ImmutableSet.of(), ImmutableSet.of(), soundEvent);
+		});
 	}
 
 }


### PR DESCRIPTION
This PR closes #3886 as it fixes a bug where, if villager POI is a custom block (instead of vanilla) it would crash the game.
The fix is simple : it wraps the new Villager profession into a supplier.