### PR TITLE
Apostrophes are now properly displayed in translations

### DIFF
--- a/src/main/java/net/mcreator/ui/init/L10N.java
+++ b/src/main/java/net/mcreator/ui/init/L10N.java
@@ -142,7 +142,7 @@ public class L10N {
 			return null;
 
 		if (rb.containsKey(key))
-			return MessageFormat.format(rb.getString(key), parameters);
+			return MessageFormat.format(rb.getString(key).replace("'", "''"), parameters);
 		else if (key.startsWith("blockly.") && (key.endsWith(".tooltip") || key.endsWith(".tip") || key.endsWith(
 				".description")))
 			return null;


### PR DESCRIPTION
Since translations exist in MCreator, apostrophes (`'`) were always removed from translations inside MCreator. In English, it's not a problem, but in some other languages like French, it's quite a problem because we use them a lot (and it's almost as essential as spaces) and texts never have them. This PR simply adds a second `'` every time a translation contains one, in order to fix the problem.

Here's an example with French:
Before the fix:
![image](https://github.com/MCreator/MCreator/assets/38427877/6243b1b6-0452-4a20-8db3-9871b940755f)


After the fix:
![image](https://github.com/MCreator/MCreator/assets/38427877/bd51d238-5211-4a42-9641-e97b4c421da9)


Edit: The fix was found on [this ](https://stackoverflow.com/questions/4449639/apostrophe-doesnt-get-translated-properly-when-placed-in-a-resource-bundle)topic


Note: Some translations will contain multiple apostrophes, but this is normal. Some translations on Crowdin got the fix, so they will simply need to be changed to have 1 apostrophe.
