### PR TITLE
Localizable dependency tooltip

### DIFF
--- a/plugins/mcreator-localization/lang/texts.properties
+++ b/plugins/mcreator-localization/lang/texts.properties
@@ -3100,6 +3100,7 @@ common.add=Add
 common.close=Close
 common.cancel=Cancel
 common.confirmation=Confirmation
+common.dependency={0}, type: {1}
 common.mod_element_name=Mod element name
 common.not_applicable=N/A
 common.name_already_exists=This name already exists

--- a/src/main/java/net/mcreator/blockly/data/Dependency.java
+++ b/src/main/java/net/mcreator/blockly/data/Dependency.java
@@ -19,6 +19,7 @@
 package net.mcreator.blockly.data;
 
 import net.mcreator.generator.mapping.NameMapper;
+import net.mcreator.ui.init.L10N;
 import net.mcreator.workspace.Workspace;
 import net.mcreator.workspace.elements.VariableTypeLoader;
 
@@ -48,6 +49,10 @@ public class Dependency implements Comparable<Dependency> {
 
 	@Override public int hashCode() {
 		return name.hashCode();
+	}
+
+	@Override public String toString() {
+		return L10N.t("common.dependency", name, type);
 	}
 
 	public String getType(Workspace workspace) {

--- a/src/main/java/net/mcreator/ui/modgui/ProcedureGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/ProcedureGUI.java
@@ -274,7 +274,7 @@ public class ProcedureGUI extends ModElementGUI<net.mcreator.element.types.Proce
 			setForeground(isSelected ? (Color) UIManager.get("MCreatorLAF.BRIGHT_COLOR") : col.brighter());
 			ComponentUtils.deriveFont(this, 14);
 			setText(value.getName());
-			setToolTipText(value.getName() + ", type: " + value.getRawType());
+			setToolTipText(value.toString());
 			return this;
 		}
 	}


### PR DESCRIPTION
This tiny PR allows dependency description to be translated using `Dependency#toString()` method.