### PR TITLE
Blockly XML annotation

### DIFF
--- a/src/main/java/net/mcreator/blockly/data/BlocklyXML.java
+++ b/src/main/java/net/mcreator/blockly/data/BlocklyXML.java
@@ -25,5 +25,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 @Target(ElementType.FIELD) @Retention(RetentionPolicy.RUNTIME) public @interface BlocklyXML {
+
 	String value();
+
 }

--- a/src/main/java/net/mcreator/blockly/data/BlocklyXML.java
+++ b/src/main/java/net/mcreator/blockly/data/BlocklyXML.java
@@ -1,0 +1,29 @@
+/*
+ * MCreator (https://mcreator.net/)
+ * Copyright (C) 2012-2020, Pylo
+ * Copyright (C) 2020-2023, Pylo, opensource contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package net.mcreator.blockly.data;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.FIELD) @Retention(RetentionPolicy.RUNTIME) public @interface BlocklyXML {
+	String value();
+}

--- a/src/main/java/net/mcreator/element/types/Achievement.java
+++ b/src/main/java/net/mcreator/element/types/Achievement.java
@@ -58,8 +58,7 @@ import java.util.List;
 	public String achievementType;
 	public AchievementEntry parent;
 
-	@BlocklyXML("jsontriggers")
-	public String triggerxml;
+	@BlocklyXML("jsontriggers") public String triggerxml;
 
 	public Achievement(ModElement element) {
 		super(element);

--- a/src/main/java/net/mcreator/element/types/Achievement.java
+++ b/src/main/java/net/mcreator/element/types/Achievement.java
@@ -19,6 +19,7 @@
 package net.mcreator.element.types;
 
 import net.mcreator.blockly.data.BlocklyLoader;
+import net.mcreator.blockly.data.BlocklyXML;
 import net.mcreator.blockly.datapack.BlocklyToJSONTrigger;
 import net.mcreator.element.GeneratableElement;
 import net.mcreator.element.parts.AchievementEntry;
@@ -57,6 +58,7 @@ import java.util.List;
 	public String achievementType;
 	public AchievementEntry parent;
 
+	@BlocklyXML("jsontriggers")
 	public String triggerxml;
 
 	public Achievement(ModElement element) {

--- a/src/main/java/net/mcreator/element/types/Command.java
+++ b/src/main/java/net/mcreator/element/types/Command.java
@@ -19,6 +19,7 @@
 package net.mcreator.element.types;
 
 import net.mcreator.blockly.data.BlocklyLoader;
+import net.mcreator.blockly.data.BlocklyXML;
 import net.mcreator.blockly.java.BlocklyToJava;
 import net.mcreator.element.GeneratableElement;
 import net.mcreator.generator.blockly.BlocklyBlockCodeGenerator;
@@ -40,6 +41,7 @@ import java.util.Locale;
 
 	public String permissionLevel;
 
+	@BlocklyXML("cmdargs")
 	public String argsxml;
 
 	private Command() {

--- a/src/main/java/net/mcreator/element/types/Command.java
+++ b/src/main/java/net/mcreator/element/types/Command.java
@@ -41,8 +41,7 @@ import java.util.Locale;
 
 	public String permissionLevel;
 
-	@BlocklyXML("cmdargs")
-	public String argsxml;
+	@BlocklyXML("cmdargs") public String argsxml;
 
 	private Command() {
 		this(null);

--- a/src/main/java/net/mcreator/element/types/Feature.java
+++ b/src/main/java/net/mcreator/element/types/Feature.java
@@ -20,6 +20,7 @@
 package net.mcreator.element.types;
 
 import net.mcreator.blockly.data.BlocklyLoader;
+import net.mcreator.blockly.data.BlocklyXML;
 import net.mcreator.blockly.feature.BlocklyToFeature;
 import net.mcreator.element.BaseType;
 import net.mcreator.element.GeneratableElement;
@@ -47,6 +48,7 @@ import java.util.List;
 	public List<String> restrictionDimensions;
 	public List<BiomeEntry> restrictionBiomes;
 	public Procedure generateCondition;
+	@BlocklyXML("features")
 	public String featurexml;
 
 	public Feature(ModElement element) {

--- a/src/main/java/net/mcreator/element/types/Feature.java
+++ b/src/main/java/net/mcreator/element/types/Feature.java
@@ -48,8 +48,7 @@ import java.util.List;
 	public List<String> restrictionDimensions;
 	public List<BiomeEntry> restrictionBiomes;
 	public Procedure generateCondition;
-	@BlocklyXML("features")
-	public String featurexml;
+	@BlocklyXML("features") public String featurexml;
 
 	public Feature(ModElement element) {
 		super(element);

--- a/src/main/java/net/mcreator/element/types/LivingEntity.java
+++ b/src/main/java/net/mcreator/element/types/LivingEntity.java
@@ -142,8 +142,7 @@ import java.util.*;
 
 	public boolean hasAI;
 	public String aiBase;
-	@BlocklyXML("aitasks")
-	public String aixml;
+	@BlocklyXML("aitasks") public String aixml;
 
 	public boolean breedable;
 	public boolean tameable;

--- a/src/main/java/net/mcreator/element/types/LivingEntity.java
+++ b/src/main/java/net/mcreator/element/types/LivingEntity.java
@@ -19,6 +19,7 @@
 package net.mcreator.element.types;
 
 import net.mcreator.blockly.data.BlocklyLoader;
+import net.mcreator.blockly.data.BlocklyXML;
 import net.mcreator.blockly.java.BlocklyToJava;
 import net.mcreator.element.BaseType;
 import net.mcreator.element.GeneratableElement;
@@ -141,6 +142,7 @@ import java.util.*;
 
 	public boolean hasAI;
 	public String aiBase;
+	@BlocklyXML("aitasks")
 	public String aixml;
 
 	public boolean breedable;

--- a/src/main/java/net/mcreator/element/types/Procedure.java
+++ b/src/main/java/net/mcreator/element/types/Procedure.java
@@ -20,6 +20,7 @@ package net.mcreator.element.types;
 
 import com.google.common.annotations.VisibleForTesting;
 import net.mcreator.blockly.data.BlocklyLoader;
+import net.mcreator.blockly.data.BlocklyXML;
 import net.mcreator.blockly.data.Dependency;
 import net.mcreator.blockly.data.ExternalTrigger;
 import net.mcreator.blockly.java.BlocklyToProcedure;
@@ -47,6 +48,7 @@ public class Procedure extends GeneratableElement {
 
 	public static final String XML_BASE = "<xml xmlns=\"https://developers.google.com/blockly/xml\"><block type=\"event_trigger\" deletable=\"false\" x=\"40\" y=\"40\"><field name=\"trigger\">no_ext_trigger</field></block></xml>";
 
+	@BlocklyXML("procedures")
 	public String procedurexml;
 
 	private transient List<Dependency> dependencies = null;

--- a/src/main/java/net/mcreator/element/types/Procedure.java
+++ b/src/main/java/net/mcreator/element/types/Procedure.java
@@ -48,8 +48,7 @@ public class Procedure extends GeneratableElement {
 
 	public static final String XML_BASE = "<xml xmlns=\"https://developers.google.com/blockly/xml\"><block type=\"event_trigger\" deletable=\"false\" x=\"40\" y=\"40\"><field name=\"trigger\">no_ext_trigger</field></block></xml>";
 
-	@BlocklyXML("procedures")
-	public String procedurexml;
+	@BlocklyXML("procedures") public String procedurexml;
 
 	private transient List<Dependency> dependencies = null;
 

--- a/src/main/java/net/mcreator/ui/blockly/BlocklyEditorType.java
+++ b/src/main/java/net/mcreator/ui/blockly/BlocklyEditorType.java
@@ -42,4 +42,5 @@ public record BlocklyEditorType(String registryName, String extension, String st
 			throw new IllegalArgumentException("Blockly editor " + registryName + " is already registered");
 		TYPES.put(registryName, this);
 	}
+
 }

--- a/src/main/java/net/mcreator/ui/blockly/BlocklyEditorType.java
+++ b/src/main/java/net/mcreator/ui/blockly/BlocklyEditorType.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public record BlocklyEditorType(String registryName, String extension, String startBlockName) {
+
 	private static final Map<String, BlocklyEditorType> TYPES = new HashMap<>();
 
 	public static BlocklyEditorType fromName(String registryName) {

--- a/src/main/java/net/mcreator/ui/blockly/BlocklyEditorType.java
+++ b/src/main/java/net/mcreator/ui/blockly/BlocklyEditorType.java
@@ -19,7 +19,15 @@
 
 package net.mcreator.ui.blockly;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public record BlocklyEditorType(String registryName, String extension, String startBlockName) {
+	private static final Map<String, BlocklyEditorType> TYPES = new HashMap<>();
+
+	public static BlocklyEditorType fromName(String registryName) {
+		return TYPES.get(registryName);
+	}
 
 	public static final BlocklyEditorType PROCEDURE = new BlocklyEditorType("procedures", "ptpl", "event_trigger");
 	public static final BlocklyEditorType AI_TASK = new BlocklyEditorType("aitasks", "aitpl", "aitasks_container");
@@ -28,4 +36,9 @@ public record BlocklyEditorType(String registryName, String extension, String st
 	public static final BlocklyEditorType JSON_TRIGGER = new BlocklyEditorType("jsontriggers", null,
 			"advancement_trigger");
 
+	public BlocklyEditorType {
+		if (TYPES.containsKey(registryName))
+			throw new IllegalArgumentException("Blockly editor " + registryName + " is already registered");
+		TYPES.put(registryName, this);
+	}
 }


### PR DESCRIPTION
This PR adds an annotation intended to point at a field storing XML data used by a particular Blockly editor.