### PR TITLE
Escape apostrophes in Blockly categories

### DIFF
--- a/src/main/java/net/mcreator/blockly/data/ExternalBlockLoader.java
+++ b/src/main/java/net/mcreator/blockly/data/ExternalBlockLoader.java
@@ -161,10 +161,10 @@ public class ExternalBlockLoader {
 		// Handle other and API categories
 		for (ToolboxCategory category : toolboxCategories) {
 			StringBuilder categoryBuilder = new StringBuilder();
-			categoryBuilder.append("<category name=\"").append(category.getName()).append("\" colour=\"")
-					.append(category.color).append("\">");
+			categoryBuilder.append("<category name=\"").append(category.getName().replace("'", "\\'"))
+					.append("\" colour=\"").append(category.color).append("\">");
 			if (category.getDescription() != null) {
-				categoryBuilder.append("<label text=\"").append(category.getDescription())
+				categoryBuilder.append("<label text=\"").append(category.getDescription().replace("'", "\\'"))
 						.append("\" web-class=\"whlab\"/>");
 			}
 			for (ToolboxBlock toolboxBlock : toolboxBlocksList) {


### PR DESCRIPTION
This PR modifies `ExternalBlockLoader` to escape apostrophes in Blockly category names/descriptions. Other parts seem to not cause problems with toolbox XML parsing. Closes #3941.