### PR TITLE
Add a beta status for generators

### DIFF
--- a/plugins/mcreator-localization/lang/texts.properties
+++ b/plugins/mcreator-localization/lang/texts.properties
@@ -2822,6 +2822,7 @@ dialog.generator_selector.generator_status.experimental=Experimental
 dialog.generator_selector.generator_status.legacy=Legacy
 dialog.generator_selector.generator_status.lts=Long term support
 dialog.generator_selector.generator_status.stable=Stable
+dialog.generator_selector.generator_status.beta=Beta
 dialog.generator_selector.features=Feature overview:
 dialog.generator_selector.mod_element_types=Supported mod element types:
 dialog.generator_selector.title=Generator selector

--- a/src/main/java/net/mcreator/generator/GeneratorStats.java
+++ b/src/main/java/net/mcreator/generator/GeneratorStats.java
@@ -228,7 +228,8 @@ public class GeneratorStats {
 		EXPERIMENTAL("dialog.generator_selector.generator_status.experimental"),
 		LEGACY("dialog.generator_selector.generator_status.legacy"),
 		LTS("dialog.generator_selector.generator_status.lts"),
-		STABLE("dialog.generator_selector.generator_status.stable");
+		STABLE("dialog.generator_selector.generator_status.stable"),
+		BETA("dialog.generator_selector.generator_status.beta"),;
 
 		private final String key;
 

--- a/src/main/java/net/mcreator/generator/GeneratorStats.java
+++ b/src/main/java/net/mcreator/generator/GeneratorStats.java
@@ -229,7 +229,7 @@ public class GeneratorStats {
 		LEGACY("dialog.generator_selector.generator_status.legacy"),
 		LTS("dialog.generator_selector.generator_status.lts"),
 		STABLE("dialog.generator_selector.generator_status.stable"),
-		BETA("dialog.generator_selector.generator_status.beta"),;
+		BETA("dialog.generator_selector.generator_status.beta");
 
 		private final String key;
 


### PR DESCRIPTION
This PR adds a new `beta` status for generators.

## Reasons of this PR
Currently, `dev` makes it impossible to publish to all users the generator, because MCreator makes literally impossible to switch to another generator or switch to this dev generator from ano0ther generator. `experimental` is commonly used for something that is currently at its early stage of development, and as Minecraft uses this word for the snapshots before the snapshot cycle, it will confuse users. `satble` seems to be used for a generator that is completed and has been completely updated. This means that currently if we want to publish a generator that is ready to be published (because it's stable enough), but a few features are missing, we need to mislead users on the real status of the generator (which is currently the case with the Fabric generator).

This `beta` is added, so users creating generators can have a public-friendly version of the `dev` status.