### PR TITLE
Pass slot ID to procedures

### DIFF
--- a/plugins/generator-1.19.2/forge-1.19.2/templates/gui/gui_container.java.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/templates/gui/gui_container.java.ftl
@@ -112,10 +112,10 @@ public class ${name}Menu extends AbstractContainerMenu implements Supplier<Map<I
 					this.customSlots.put(${component.id}, this.addSlot(new SlotItemHandler(internal, ${component.id},
 						${(component.x - mx)?int + 1},
 						${(component.y - my)?int + 1}) {
+						private final int slot = ${component.id};
 
 						<#if hasProcedure(component.disablePickup) || component.disablePickup.getFixedValue()>
 						@Override public boolean mayPickup(Player entity) {
-							int slot = ${component.id};
 							return <@procedureOBJToConditionCode component.disablePickup false true/>;
 						}
 						</#if>
@@ -144,7 +144,6 @@ public class ${name}Menu extends AbstractContainerMenu implements Supplier<Map<I
 						<#if component.getClass().getSimpleName() == "InputSlot">
 							<#if hasProcedure(component.disablePlacement) || component.disablePlacement.getFixedValue()>
 								@Override public boolean mayPlace(ItemStack itemstack) {
-									int slot = ${component.id};
 									return <@procedureOBJToConditionCode component.disablePlacement false true/>;
 								}
 							<#elseif component.inputLimit.toString()?has_content>

--- a/plugins/generator-1.19.2/forge-1.19.2/templates/gui/gui_container.java.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/templates/gui/gui_container.java.ftl
@@ -115,6 +115,7 @@ public class ${name}Menu extends AbstractContainerMenu implements Supplier<Map<I
 
 						<#if hasProcedure(component.disablePickup) || component.disablePickup.getFixedValue()>
 						@Override public boolean mayPickup(Player entity) {
+							int slot = ${component.id};
 							return <@procedureOBJToConditionCode component.disablePickup false true/>;
 						}
 						</#if>
@@ -143,6 +144,7 @@ public class ${name}Menu extends AbstractContainerMenu implements Supplier<Map<I
 						<#if component.getClass().getSimpleName() == "InputSlot">
 							<#if hasProcedure(component.disablePlacement) || component.disablePlacement.getFixedValue()>
 								@Override public boolean mayPlace(ItemStack itemstack) {
+									int slot = ${component.id};
 									return <@procedureOBJToConditionCode component.disablePlacement false true/>;
 								}
 							<#elseif component.inputLimit.toString()?has_content>

--- a/plugins/generator-1.19.2/forge-1.19.2/templates/gui/gui_msg_slot.java.ftl
+++ b/plugins/generator-1.19.2/forge-1.19.2/templates/gui/gui_msg_slot.java.ftl
@@ -80,7 +80,7 @@ package ${package}.network;
 		context.setPacketHandled(true);
 	}
 
-	public static void handleSlotAction(Player entity, int slotID, int changeType, int meta, int x, int y, int z) {
+	public static void handleSlotAction(Player entity, int slot, int changeType, int meta, int x, int y, int z) {
 		Level world = entity.level;
 		HashMap guistate = ${name}Menu.guistate;
 
@@ -91,17 +91,17 @@ package ${package}.network;
 		<#list data.components as component>
 			<#if component.getClass().getSimpleName()?ends_with("Slot")>
 				<#if hasProcedure(component.onSlotChanged)>
-					if (slotID == ${component.id} && changeType == 0) {
+					if (slot == ${component.id} && changeType == 0) {
 						<@procedureOBJToCode component.onSlotChanged/>
 					}
 				</#if>
 				<#if hasProcedure(component.onTakenFromSlot)>
-					if (slotID == ${component.id} && changeType == 1) {
+					if (slot == ${component.id} && changeType == 1) {
 						<@procedureOBJToCode component.onTakenFromSlot/>
 					}
 				</#if>
 				<#if hasProcedure(component.onStackTransfer)>
-					if (slotID == ${component.id} && changeType == 2) {
+					if (slot == ${component.id} && changeType == 2) {
 						int amount = meta;
 						<@procedureOBJToCode component.onStackTransfer/>
 					}

--- a/plugins/generator-1.19.4/forge-1.19.4/templates/gui/gui_container.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/templates/gui/gui_container.java.ftl
@@ -112,10 +112,10 @@ public class ${name}Menu extends AbstractContainerMenu implements Supplier<Map<I
 					this.customSlots.put(${component.id}, this.addSlot(new SlotItemHandler(internal, ${component.id},
 						${(component.x - mx)?int + 1},
 						${(component.y - my)?int + 1}) {
+						private final int slot = ${component.id};
 
 						<#if hasProcedure(component.disablePickup) || component.disablePickup.getFixedValue()>
 						@Override public boolean mayPickup(Player entity) {
-							int slot = ${component.id};
 							return <@procedureOBJToConditionCode component.disablePickup false true/>;
 						}
 						</#if>
@@ -144,7 +144,6 @@ public class ${name}Menu extends AbstractContainerMenu implements Supplier<Map<I
 						<#if component.getClass().getSimpleName() == "InputSlot">
 							<#if hasProcedure(component.disablePlacement) || component.disablePlacement.getFixedValue()>
 								@Override public boolean mayPlace(ItemStack itemstack) {
-									int slot = ${component.id};
 									return <@procedureOBJToConditionCode component.disablePlacement false true/>;
 								}
 							<#elseif component.inputLimit.toString()?has_content>

--- a/plugins/generator-1.19.4/forge-1.19.4/templates/gui/gui_container.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/templates/gui/gui_container.java.ftl
@@ -115,6 +115,7 @@ public class ${name}Menu extends AbstractContainerMenu implements Supplier<Map<I
 
 						<#if hasProcedure(component.disablePickup) || component.disablePickup.getFixedValue()>
 						@Override public boolean mayPickup(Player entity) {
+							int slot = ${component.id};
 							return <@procedureOBJToConditionCode component.disablePickup false true/>;
 						}
 						</#if>
@@ -143,6 +144,7 @@ public class ${name}Menu extends AbstractContainerMenu implements Supplier<Map<I
 						<#if component.getClass().getSimpleName() == "InputSlot">
 							<#if hasProcedure(component.disablePlacement) || component.disablePlacement.getFixedValue()>
 								@Override public boolean mayPlace(ItemStack itemstack) {
+									int slot = ${component.id};
 									return <@procedureOBJToConditionCode component.disablePlacement false true/>;
 								}
 							<#elseif component.inputLimit.toString()?has_content>

--- a/plugins/generator-1.19.4/forge-1.19.4/templates/gui/gui_msg_slot.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/templates/gui/gui_msg_slot.java.ftl
@@ -80,7 +80,7 @@ package ${package}.network;
 		context.setPacketHandled(true);
 	}
 
-	public static void handleSlotAction(Player entity, int slotID, int changeType, int meta, int x, int y, int z) {
+	public static void handleSlotAction(Player entity, int slot, int changeType, int meta, int x, int y, int z) {
 		Level world = entity.level;
 		HashMap guistate = ${name}Menu.guistate;
 
@@ -91,17 +91,17 @@ package ${package}.network;
 		<#list data.components as component>
 			<#if component.getClass().getSimpleName()?ends_with("Slot")>
 				<#if hasProcedure(component.onSlotChanged)>
-					if (slotID == ${component.id} && changeType == 0) {
+					if (slot == ${component.id} && changeType == 0) {
 						<@procedureOBJToCode component.onSlotChanged/>
 					}
 				</#if>
 				<#if hasProcedure(component.onTakenFromSlot)>
-					if (slotID == ${component.id} && changeType == 1) {
+					if (slot == ${component.id} && changeType == 1) {
 						<@procedureOBJToCode component.onTakenFromSlot/>
 					}
 				</#if>
 				<#if hasProcedure(component.onStackTransfer)>
-					if (slotID == ${component.id} && changeType == 2) {
+					if (slot == ${component.id} && changeType == 2) {
 						int amount = meta;
 						<@procedureOBJToCode component.onStackTransfer/>
 					}

--- a/src/main/java/net/mcreator/ui/dialogs/wysiwyg/InputSlotDialog.java
+++ b/src/main/java/net/mcreator/ui/dialogs/wysiwyg/InputSlotDialog.java
@@ -43,7 +43,7 @@ public class InputSlotDialog extends AbstractWYSIWYGDialog<InputSlot> {
 	public InputSlotDialog(WYSIWYGEditor editor, @Nullable InputSlot slot) {
 		super(editor, slot);
 		setModal(true);
-		setSize(850, 470);
+		setSize(842, 470);
 		setLocationRelativeTo(editor.mcreator);
 
 		JPanel options = new JPanel();
@@ -120,7 +120,7 @@ public class InputSlotDialog extends AbstractWYSIWYGDialog<InputSlot> {
 				"x:number/y:number/z:number/world:world/entity:entity/guistate:map/slot:number/amount:number"));
 		eh3.refreshList();
 
-		add("Center", new JScrollPane(PanelUtils.centerInPanel(PanelUtils.gridElements(1, 3, 9, 5, eh, eh2, eh3))));
+		add("Center", new JScrollPane(PanelUtils.centerInPanel(PanelUtils.gridElements(1, 3, 5, 5, eh, eh2, eh3))));
 
 		add("North", PanelUtils.join(FlowLayout.LEFT, options));
 

--- a/src/main/java/net/mcreator/ui/dialogs/wysiwyg/InputSlotDialog.java
+++ b/src/main/java/net/mcreator/ui/dialogs/wysiwyg/InputSlotDialog.java
@@ -43,7 +43,7 @@ public class InputSlotDialog extends AbstractWYSIWYGDialog<InputSlot> {
 	public InputSlotDialog(WYSIWYGEditor editor, @Nullable InputSlot slot) {
 		super(editor, slot);
 		setModal(true);
-		setSize(850, 435);
+		setSize(850, 470);
 		setLocationRelativeTo(editor.mcreator);
 
 		JPanel options = new JPanel();
@@ -87,14 +87,14 @@ public class InputSlotDialog extends AbstractWYSIWYGDialog<InputSlot> {
 				IHelpContext.NONE.withEntry("gui/slot_pickup_condition"), editor.mcreator,
 				L10N.t("dialog.gui.disable_pickup"), ProcedureSelector.Side.BOTH, false,
 				L10N.checkbox("condition.common.disable"), 0,
-				Dependency.fromString("x:number/y:number/z:number/world:world/entity:entity/guistate:map"));
+				Dependency.fromString("x:number/y:number/z:number/world:world/entity:entity/guistate:map/slot:number"));
 		disablePickup.refreshList();
 
 		LogicProcedureSelector disablePlacement = new LogicProcedureSelector(
 				IHelpContext.NONE.withEntry("gui/slot_placement_condition"), editor.mcreator,
 				L10N.t("dialog.gui.disable_placement"), ProcedureSelector.Side.BOTH, false,
-				L10N.checkbox("condition.common.disable"), 0,
-				Dependency.fromString("x:number/y:number/z:number/world:world/itemstack:itemstack/guistate:map"));
+				L10N.checkbox("condition.common.disable"), 0, Dependency.fromString(
+				"x:number/y:number/z:number/world:world/itemstack:itemstack/guistate:map/slot:number"));
 		disablePlacement.refreshList();
 
 		options.add(PanelUtils.join(FlowLayout.LEFT, disablePickup));
@@ -104,18 +104,20 @@ public class InputSlotDialog extends AbstractWYSIWYGDialog<InputSlot> {
 
 		ProcedureSelector eh = new ProcedureSelector(IHelpContext.NONE.withEntry("gui/when_slot_changed"),
 				editor.mcreator, L10N.t("dialog.gui.slot_event_slot_content_changes"), ProcedureSelector.Side.BOTH,
-				false, Dependency.fromString("x:number/y:number/z:number/world:world/entity:entity/guistate:map"));
+				false,
+				Dependency.fromString("x:number/y:number/z:number/world:world/entity:entity/guistate:map/slot:number"));
 		eh.refreshList();
 
 		ProcedureSelector eh2 = new ProcedureSelector(IHelpContext.NONE.withEntry("gui/when_slot_item_taken"),
 				editor.mcreator, L10N.t("dialog.gui.slot_event_item_taken_from_slot"), ProcedureSelector.Side.BOTH,
-				false, Dependency.fromString("x:number/y:number/z:number/world:world/entity:entity/guistate:map"));
+				false,
+				Dependency.fromString("x:number/y:number/z:number/world:world/entity:entity/guistate:map/slot:number"));
 		eh2.refreshList();
 
 		ProcedureSelector eh3 = new ProcedureSelector(IHelpContext.NONE.withEntry("gui/when_transferred_from_slot"),
 				editor.mcreator, L10N.t("dialog.gui.slot_event_transferred_from_slot"), ProcedureSelector.Side.BOTH,
 				false, Dependency.fromString(
-				"x:number/y:number/z:number/world:world/entity:entity/guistate:map/amount:number"));
+				"x:number/y:number/z:number/world:world/entity:entity/guistate:map/slot:number/amount:number"));
 		eh3.refreshList();
 
 		add("Center", new JScrollPane(PanelUtils.centerInPanel(PanelUtils.gridElements(1, 3, 5, 5, eh, eh2, eh3))));

--- a/src/main/java/net/mcreator/ui/dialogs/wysiwyg/InputSlotDialog.java
+++ b/src/main/java/net/mcreator/ui/dialogs/wysiwyg/InputSlotDialog.java
@@ -120,7 +120,7 @@ public class InputSlotDialog extends AbstractWYSIWYGDialog<InputSlot> {
 				"x:number/y:number/z:number/world:world/entity:entity/guistate:map/slot:number/amount:number"));
 		eh3.refreshList();
 
-		add("Center", new JScrollPane(PanelUtils.centerInPanel(PanelUtils.gridElements(1, 3, 5, 5, eh, eh2, eh3))));
+		add("Center", new JScrollPane(PanelUtils.centerInPanel(PanelUtils.gridElements(1, 3, 9, 5, eh, eh2, eh3))));
 
 		add("North", PanelUtils.join(FlowLayout.LEFT, options));
 

--- a/src/main/java/net/mcreator/ui/dialogs/wysiwyg/OutputSlotDialog.java
+++ b/src/main/java/net/mcreator/ui/dialogs/wysiwyg/OutputSlotDialog.java
@@ -105,7 +105,7 @@ public class OutputSlotDialog extends AbstractWYSIWYGDialog<OutputSlot> {
 				"x:number/y:number/z:number/world:world/entity:entity/guistate:map/slot:number/amount:number"));
 		eh3.refreshList();
 
-		add("Center", new JScrollPane(PanelUtils.centerInPanel(PanelUtils.gridElements(1, 3, 5, 5, eh, eh2, eh3))));
+		add("Center", new JScrollPane(PanelUtils.centerInPanel(PanelUtils.gridElements(1, 3, 9, 5, eh, eh2, eh3))));
 
 		add("North", PanelUtils.join(FlowLayout.LEFT, options));
 

--- a/src/main/java/net/mcreator/ui/dialogs/wysiwyg/OutputSlotDialog.java
+++ b/src/main/java/net/mcreator/ui/dialogs/wysiwyg/OutputSlotDialog.java
@@ -41,7 +41,7 @@ public class OutputSlotDialog extends AbstractWYSIWYGDialog<OutputSlot> {
 	public OutputSlotDialog(WYSIWYGEditor editor, @Nullable OutputSlot slot) {
 		super(editor, slot);
 		setModal(true);
-		setSize(850, 350);
+		setSize(842, 350);
 		setLocationRelativeTo(editor.mcreator);
 
 		JPanel options = new JPanel();
@@ -105,7 +105,7 @@ public class OutputSlotDialog extends AbstractWYSIWYGDialog<OutputSlot> {
 				"x:number/y:number/z:number/world:world/entity:entity/guistate:map/slot:number/amount:number"));
 		eh3.refreshList();
 
-		add("Center", new JScrollPane(PanelUtils.centerInPanel(PanelUtils.gridElements(1, 3, 9, 5, eh, eh2, eh3))));
+		add("Center", new JScrollPane(PanelUtils.centerInPanel(PanelUtils.gridElements(1, 3, 5, 5, eh, eh2, eh3))));
 
 		add("North", PanelUtils.join(FlowLayout.LEFT, options));
 

--- a/src/main/java/net/mcreator/ui/dialogs/wysiwyg/OutputSlotDialog.java
+++ b/src/main/java/net/mcreator/ui/dialogs/wysiwyg/OutputSlotDialog.java
@@ -41,7 +41,7 @@ public class OutputSlotDialog extends AbstractWYSIWYGDialog<OutputSlot> {
 	public OutputSlotDialog(WYSIWYGEditor editor, @Nullable OutputSlot slot) {
 		super(editor, slot);
 		setModal(true);
-		setSize(850, 340);
+		setSize(850, 350);
 		setLocationRelativeTo(editor.mcreator);
 
 		JPanel options = new JPanel();
@@ -82,25 +82,27 @@ public class OutputSlotDialog extends AbstractWYSIWYGDialog<OutputSlot> {
 				IHelpContext.NONE.withEntry("gui/slot_pickup_condition"), editor.mcreator,
 				L10N.t("dialog.gui.disable_pickup"), ProcedureSelector.Side.BOTH, false,
 				L10N.checkbox("condition.common.disable"), 0,
-				Dependency.fromString("x:number/y:number/z:number/world:world/entity:entity/guistate:map"));
+				Dependency.fromString("x:number/y:number/z:number/world:world/entity:entity/guistate:map/slot:number"));
 		disablePickup.refreshList();
 
 		options.add(PanelUtils.join(FlowLayout.LEFT, disablePickup));
 
 		ProcedureSelector eh = new ProcedureSelector(IHelpContext.NONE.withEntry("gui/when_slot_changed"),
 				editor.mcreator, L10N.t("dialog.gui.slot_event_slot_content_changes"), ProcedureSelector.Side.BOTH,
-				false, Dependency.fromString("x:number/y:number/z:number/world:world/entity:entity/guistate:map"));
+				false,
+				Dependency.fromString("x:number/y:number/z:number/world:world/entity:entity/guistate:map/slot:number"));
 		eh.refreshList();
 
 		ProcedureSelector eh2 = new ProcedureSelector(IHelpContext.NONE.withEntry("gui/when_slot_item_taken"),
 				editor.mcreator, L10N.t("dialog.gui.slot_event_item_taken_from_slot"), ProcedureSelector.Side.BOTH,
-				false, Dependency.fromString("x:number/y:number/z:number/world:world/entity:entity/guistate:map"));
+				false,
+				Dependency.fromString("x:number/y:number/z:number/world:world/entity:entity/guistate:map/slot:number"));
 		eh2.refreshList();
 
 		ProcedureSelector eh3 = new ProcedureSelector(IHelpContext.NONE.withEntry("gui/when_transferred_from_slot"),
 				editor.mcreator, L10N.t("dialog.gui.slot_event_transferred_from_slot"), ProcedureSelector.Side.BOTH,
 				false, Dependency.fromString(
-				"x:number/y:number/z:number/world:world/entity:entity/guistate:map/amount:number"));
+				"x:number/y:number/z:number/world:world/entity:entity/guistate:map/slot:number/amount:number"));
 		eh3.refreshList();
 
 		add("Center", new JScrollPane(PanelUtils.centerInPanel(PanelUtils.gridElements(1, 3, 5, 5, eh, eh2, eh3))));


### PR DESCRIPTION
This PR allows slot procedures to use the dependency containing the slot ID in the GUI.
>This way, if you have a procedure thats fired, when an item is removed from the slot.
With the only difference being the slot number, you can share the same procedure for each of them