### PR TITLE
Fix NBTEditorView performance

### DIFF
--- a/src/main/java/net/mcreator/ui/views/NBTEditorView.java
+++ b/src/main/java/net/mcreator/ui/views/NBTEditorView.java
@@ -75,8 +75,6 @@ public class NBTEditorView extends ViewBase {
 			addTagToNode(tag, root);
 
 			model.setRoot(root);
-
-			TreeUtils.expandAllNodes(tree, 0, tree.getRowCount());
 		} catch (IOException e) {
 			LOG.error(e.getMessage(), e);
 		}

--- a/src/main/java/net/mcreator/ui/views/NBTEditorView.java
+++ b/src/main/java/net/mcreator/ui/views/NBTEditorView.java
@@ -20,7 +20,6 @@ package net.mcreator.ui.views;
 
 import net.mcreator.ui.MCreator;
 import net.mcreator.ui.component.util.ComponentUtils;
-import net.mcreator.ui.component.util.TreeUtils;
 import net.mcreator.ui.laf.SlickTreeUI;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -75,6 +74,8 @@ public class NBTEditorView extends ViewBase {
 			addTagToNode(tag, root);
 
 			model.setRoot(root);
+
+			tree.expandRow(1);
 		} catch (IOException e) {
 			LOG.error(e.getMessage(), e);
 		}


### PR DESCRIPTION
This PR fixes the NBTEditorView performance when opening large nbt files by no longer expanding every single node by default. This leads to the program either freezing or taking over 30 seconds to open the nbt file.