### PR TITLE
Blockly panel holder

### DIFF
--- a/src/main/java/net/mcreator/ui/blockly/BlocklyPanel.java
+++ b/src/main/java/net/mcreator/ui/blockly/BlocklyPanel.java
@@ -69,6 +69,7 @@ public class BlocklyPanel extends JFXPanel {
 	private String currentXML = "";
 
 	private final MCreator mcreator;
+	private final BlocklyEditorType type;
 
 	private static final String MINIMAL_XML = "<xml xmlns=\"https://developers.google.com/blockly/xml\"></xml>";
 
@@ -76,6 +77,7 @@ public class BlocklyPanel extends JFXPanel {
 		setOpaque(false);
 
 		this.mcreator = mcreator;
+		this.type = type;
 
 		bridge = new BlocklyJavascriptBridge(mcreator, () -> {
 			String newXml = (String) executeJavaScriptSynchronously("workspaceToXML();");
@@ -287,6 +289,10 @@ public class BlocklyPanel extends JFXPanel {
 
 	public MCreator getMCreator() {
 		return mcreator;
+	}
+
+	public BlocklyEditorType getType() {
+		return type;
 	}
 
 	private String cleanupXML(String xml) {

--- a/src/main/java/net/mcreator/ui/modgui/AchievementGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/AchievementGUI.java
@@ -66,7 +66,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-public class AchievementGUI extends ModElementGUI<Achievement> {
+public class AchievementGUI extends ModElementGUI<Achievement> implements IBlocklyPanelHolder {
 
 	private final VTextField achievementName = new VTextField(20);
 	private final VTextField achievementDescription = new VTextField(20);
@@ -216,7 +216,7 @@ public class AchievementGUI extends ModElementGUI<Achievement> {
 			BlocklyLoader.INSTANCE.getBlockLoader(BlocklyEditorType.JSON_TRIGGER)
 					.loadBlocksAndCategoriesInPanel(blocklyPanel, ToolboxType.EMPTY);
 			blocklyPanel.getJSBridge()
-					.setJavaScriptEventListener(() -> new Thread(AchievementGUI.this::regenerateTrigger).start());
+					.setJavaScriptEventListener(() -> new Thread(AchievementGUI.this::regenerateBlocklyXML).start());
 			if (!isEditingMode()) {
 				blocklyPanel.setXML(
 						"<xml><block type=\"advancement_trigger\" deletable=\"false\" x=\"40\" y=\"80\"/></xml>");
@@ -245,7 +245,7 @@ public class AchievementGUI extends ModElementGUI<Achievement> {
 		}
 	}
 
-	private synchronized void regenerateTrigger() {
+	@Override public synchronized void regenerateBlocklyXML() {
 		BlocklyBlockCodeGenerator blocklyBlockCodeGenerator = new BlocklyBlockCodeGenerator(externalBlocks,
 				mcreator.getGeneratorStats().getBlocklyBlocks(BlocklyEditorType.JSON_TRIGGER));
 
@@ -321,7 +321,7 @@ public class AchievementGUI extends ModElementGUI<Achievement> {
 			blocklyPanel.clearWorkspace();
 			blocklyPanel.setXML(achievement.triggerxml);
 
-			regenerateTrigger();
+			regenerateBlocklyXML();
 		});
 	}
 
@@ -349,6 +349,10 @@ public class AchievementGUI extends ModElementGUI<Achievement> {
 
 	@Override public @Nullable URI contextURL() throws URISyntaxException {
 		return new URI(MCreatorApplication.SERVER_DOMAIN + "/wiki/how-make-achievement");
+	}
+
+	@Override public List<BlocklyPanel> getBlocklyPanels() {
+		return List.of(blocklyPanel);
 	}
 
 }

--- a/src/main/java/net/mcreator/ui/modgui/AchievementGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/AchievementGUI.java
@@ -216,7 +216,7 @@ public class AchievementGUI extends ModElementGUI<Achievement> implements IBlock
 			BlocklyLoader.INSTANCE.getBlockLoader(BlocklyEditorType.JSON_TRIGGER)
 					.loadBlocksAndCategoriesInPanel(blocklyPanel, ToolboxType.EMPTY);
 			blocklyPanel.getJSBridge()
-					.setJavaScriptEventListener(() -> new Thread(AchievementGUI.this::regenerateBlocklyXML).start());
+					.setJavaScriptEventListener(() -> new Thread(AchievementGUI.this::regenerateTrigger).start());
 			if (!isEditingMode()) {
 				blocklyPanel.setXML(
 						"<xml><block type=\"advancement_trigger\" deletable=\"false\" x=\"40\" y=\"80\"/></xml>");
@@ -245,7 +245,7 @@ public class AchievementGUI extends ModElementGUI<Achievement> implements IBlock
 		}
 	}
 
-	@Override public synchronized void regenerateBlocklyXML() {
+	private synchronized void regenerateTrigger() {
 		BlocklyBlockCodeGenerator blocklyBlockCodeGenerator = new BlocklyBlockCodeGenerator(externalBlocks,
 				mcreator.getGeneratorStats().getBlocklyBlocks(BlocklyEditorType.JSON_TRIGGER));
 
@@ -321,7 +321,7 @@ public class AchievementGUI extends ModElementGUI<Achievement> implements IBlock
 			blocklyPanel.clearWorkspace();
 			blocklyPanel.setXML(achievement.triggerxml);
 
-			regenerateBlocklyXML();
+			regenerateTrigger();
 		});
 	}
 

--- a/src/main/java/net/mcreator/ui/modgui/CommandGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/CommandGUI.java
@@ -93,7 +93,7 @@ public class CommandGUI extends ModElementGUI<Command> implements IBlocklyPanelH
 			BlocklyLoader.INSTANCE.getBlockLoader(BlocklyEditorType.COMMAND_ARG)
 					.loadBlocksAndCategoriesInPanel(blocklyPanel, ToolboxType.COMMAND);
 			blocklyPanel.getJSBridge()
-					.setJavaScriptEventListener(() -> new Thread(CommandGUI.this::regenerateBlocklyXML).start());
+					.setJavaScriptEventListener(() -> new Thread(CommandGUI.this::regenerateArgs).start());
 			if (!isEditingMode()) {
 				blocklyPanel.setXML(Command.XML_BASE);
 			}
@@ -124,7 +124,7 @@ public class CommandGUI extends ModElementGUI<Command> implements IBlocklyPanelH
 		}
 	}
 
-	@Override public synchronized void regenerateBlocklyXML() {
+	private synchronized void regenerateArgs() {
 		BlocklyToJava blocklyToJava;
 		try {
 			blocklyToJava = new BlocklyToJava(mcreator.getWorkspace(), this.modElement, BlocklyEditorType.COMMAND_ARG,
@@ -160,7 +160,7 @@ public class CommandGUI extends ModElementGUI<Command> implements IBlocklyPanelH
 		blocklyPanel.addTaskToRunAfterLoaded(() -> {
 			blocklyPanel.clearWorkspace();
 			blocklyPanel.setXML(command.argsxml);
-			regenerateBlocklyXML();
+			regenerateArgs();
 		});
 	}
 

--- a/src/main/java/net/mcreator/ui/modgui/CommandGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/CommandGUI.java
@@ -54,7 +54,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-public class CommandGUI extends ModElementGUI<Command> {
+public class CommandGUI extends ModElementGUI<Command> implements IBlocklyPanelHolder {
 
 	private final VTextField commandName = new VTextField(25);
 	private final JComboBox<String> permissionLevel = new JComboBox<>(
@@ -93,7 +93,7 @@ public class CommandGUI extends ModElementGUI<Command> {
 			BlocklyLoader.INSTANCE.getBlockLoader(BlocklyEditorType.COMMAND_ARG)
 					.loadBlocksAndCategoriesInPanel(blocklyPanel, ToolboxType.COMMAND);
 			blocklyPanel.getJSBridge()
-					.setJavaScriptEventListener(() -> new Thread(CommandGUI.this::regenerateArgs).start());
+					.setJavaScriptEventListener(() -> new Thread(CommandGUI.this::regenerateBlocklyXML).start());
 			if (!isEditingMode()) {
 				blocklyPanel.setXML(Command.XML_BASE);
 			}
@@ -124,7 +124,7 @@ public class CommandGUI extends ModElementGUI<Command> {
 		}
 	}
 
-	private synchronized void regenerateArgs() {
+	@Override public synchronized void regenerateBlocklyXML() {
 		BlocklyToJava blocklyToJava;
 		try {
 			blocklyToJava = new BlocklyToJava(mcreator.getWorkspace(), this.modElement, BlocklyEditorType.COMMAND_ARG,
@@ -160,7 +160,7 @@ public class CommandGUI extends ModElementGUI<Command> {
 		blocklyPanel.addTaskToRunAfterLoaded(() -> {
 			blocklyPanel.clearWorkspace();
 			blocklyPanel.setXML(command.argsxml);
-			regenerateArgs();
+			regenerateBlocklyXML();
 		});
 	}
 
@@ -174,6 +174,10 @@ public class CommandGUI extends ModElementGUI<Command> {
 
 	@Override public @Nullable URI contextURL() throws URISyntaxException {
 		return new URI(MCreatorApplication.SERVER_DOMAIN + "/wiki/making-command");
+	}
+
+	@Override public List<BlocklyPanel> getBlocklyPanels() {
+		return List.of(blocklyPanel);
 	}
 
 }

--- a/src/main/java/net/mcreator/ui/modgui/FeatureGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/FeatureGUI.java
@@ -57,7 +57,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-public class FeatureGUI extends ModElementGUI<Feature> {
+public class FeatureGUI extends ModElementGUI<Feature> implements IBlocklyPanelHolder {
+
 	private ProcedureSelector generateCondition;
 	private BiomeListField restrictionBiomes;
 	private DimensionListField restrictionDimensions;
@@ -114,7 +115,7 @@ public class FeatureGUI extends ModElementGUI<Feature> {
 			BlocklyLoader.INSTANCE.getBlockLoader(BlocklyEditorType.FEATURE)
 					.loadBlocksAndCategoriesInPanel(blocklyPanel, ToolboxType.FEATURE);
 			blocklyPanel.getJSBridge()
-					.setJavaScriptEventListener(() -> new Thread(FeatureGUI.this::regenerateFeature).start());
+					.setJavaScriptEventListener(() -> new Thread(FeatureGUI.this::regenerateBlocklyXML).start());
 			if (!isEditingMode()) {
 				blocklyPanel.setXML(Feature.XML_BASE);
 			}
@@ -142,7 +143,7 @@ public class FeatureGUI extends ModElementGUI<Feature> {
 		addPage(page1);
 	}
 
-	private synchronized void regenerateFeature() {
+	@Override public synchronized void regenerateBlocklyXML() {
 		BlocklyBlockCodeGenerator blocklyBlockCodeGenerator = new BlocklyBlockCodeGenerator(externalBlocks,
 				mcreator.getGeneratorStats().getBlocklyBlocks(BlocklyEditorType.FEATURE));
 
@@ -194,7 +195,7 @@ public class FeatureGUI extends ModElementGUI<Feature> {
 		blocklyPanel.addTaskToRunAfterLoaded(() -> {
 			blocklyPanel.clearWorkspace();
 			blocklyPanel.setXML(feature.featurexml);
-			regenerateFeature();
+			regenerateBlocklyXML();
 		});
 	}
 
@@ -209,4 +210,9 @@ public class FeatureGUI extends ModElementGUI<Feature> {
 
 		return feature;
 	}
+
+	@Override public List<BlocklyPanel> getBlocklyPanels() {
+		return List.of(blocklyPanel);
+	}
+
 }

--- a/src/main/java/net/mcreator/ui/modgui/FeatureGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/FeatureGUI.java
@@ -115,7 +115,7 @@ public class FeatureGUI extends ModElementGUI<Feature> implements IBlocklyPanelH
 			BlocklyLoader.INSTANCE.getBlockLoader(BlocklyEditorType.FEATURE)
 					.loadBlocksAndCategoriesInPanel(blocklyPanel, ToolboxType.FEATURE);
 			blocklyPanel.getJSBridge()
-					.setJavaScriptEventListener(() -> new Thread(FeatureGUI.this::regenerateBlocklyXML).start());
+					.setJavaScriptEventListener(() -> new Thread(FeatureGUI.this::regenerateFeature).start());
 			if (!isEditingMode()) {
 				blocklyPanel.setXML(Feature.XML_BASE);
 			}
@@ -143,7 +143,7 @@ public class FeatureGUI extends ModElementGUI<Feature> implements IBlocklyPanelH
 		addPage(page1);
 	}
 
-	@Override public synchronized void regenerateBlocklyXML() {
+	private synchronized void regenerateFeature() {
 		BlocklyBlockCodeGenerator blocklyBlockCodeGenerator = new BlocklyBlockCodeGenerator(externalBlocks,
 				mcreator.getGeneratorStats().getBlocklyBlocks(BlocklyEditorType.FEATURE));
 
@@ -195,7 +195,7 @@ public class FeatureGUI extends ModElementGUI<Feature> implements IBlocklyPanelH
 		blocklyPanel.addTaskToRunAfterLoaded(() -> {
 			blocklyPanel.clearWorkspace();
 			blocklyPanel.setXML(feature.featurexml);
-			regenerateBlocklyXML();
+			regenerateFeature();
 		});
 	}
 

--- a/src/main/java/net/mcreator/ui/modgui/IBlocklyPanelHolder.java
+++ b/src/main/java/net/mcreator/ui/modgui/IBlocklyPanelHolder.java
@@ -36,10 +36,4 @@ public interface IBlocklyPanelHolder {
 		return null;
 	}
 
-	/**
-	 * @implNote The method should be declared as {@code synchronized} to ensure its thread-safety.
-	 */
-	default void regenerateBlocklyXML() {
-	}
-
 }

--- a/src/main/java/net/mcreator/ui/modgui/IBlocklyPanelHolder.java
+++ b/src/main/java/net/mcreator/ui/modgui/IBlocklyPanelHolder.java
@@ -1,0 +1,45 @@
+/*
+ * MCreator (https://mcreator.net/)
+ * Copyright (C) 2012-2020, Pylo
+ * Copyright (C) 2020-2023, Pylo, opensource contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package net.mcreator.ui.modgui;
+
+import net.mcreator.ui.blockly.BlocklyEditorType;
+import net.mcreator.ui.blockly.BlocklyPanel;
+
+import java.util.List;
+
+public interface IBlocklyPanelHolder {
+
+	List<BlocklyPanel> getBlocklyPanels();
+
+	default BlocklyPanel getSpecificBlocklyPanel(BlocklyEditorType type) {
+		for (BlocklyPanel panel : getBlocklyPanels()) {
+			if (panel.getType() == type)
+				return panel;
+		}
+		return null;
+	}
+
+	/**
+	 * @implNote The method should be declared as {@code synchronized} to ensure its thread-safety.
+	 */
+	default void regenerateBlocklyXML() {
+	}
+
+}

--- a/src/main/java/net/mcreator/ui/modgui/LivingEntityGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/LivingEntityGUI.java
@@ -265,7 +265,7 @@ public class LivingEntityGUI extends ModElementGUI<LivingEntity> implements IBlo
 				</block></next></block></next></block></next></block></next></block></xml>""");
 	}
 
-	@Override public synchronized void regenerateBlocklyXML() {
+	private synchronized void regenerateAITasks() {
 		BlocklyBlockCodeGenerator blocklyBlockCodeGenerator = new BlocklyBlockCodeGenerator(externalBlocks,
 				mcreator.getGeneratorStats().getBlocklyBlocks(BlocklyEditorType.AI_TASK));
 
@@ -685,7 +685,7 @@ public class LivingEntityGUI extends ModElementGUI<LivingEntity> implements IBlo
 		aiBase.setPreferredSize(new Dimension(250, 32));
 		aiBase.addActionListener(e -> {
 			if (editorReady)
-				regenerateBlocklyXML();
+				regenerateAITasks();
 		});
 
 		JPanel aitopoveral = new JPanel(new BorderLayout(5, 0));
@@ -721,7 +721,7 @@ public class LivingEntityGUI extends ModElementGUI<LivingEntity> implements IBlo
 			BlocklyLoader.INSTANCE.getBlockLoader(BlocklyEditorType.AI_TASK)
 					.loadBlocksAndCategoriesInPanel(blocklyPanel, ToolboxType.AI_BUILDER);
 			blocklyPanel.getJSBridge()
-					.setJavaScriptEventListener(() -> new Thread(LivingEntityGUI.this::regenerateBlocklyXML).start());
+					.setJavaScriptEventListener(() -> new Thread(LivingEntityGUI.this::regenerateAITasks).start());
 			if (!isEditingMode()) {
 				setDefaultAISet();
 			}
@@ -1052,7 +1052,7 @@ public class LivingEntityGUI extends ModElementGUI<LivingEntity> implements IBlo
 		blocklyPanel.addTaskToRunAfterLoaded(() -> {
 			blocklyPanel.clearWorkspace();
 			blocklyPanel.setXML(livingEntity.aixml);
-			regenerateBlocklyXML();
+			regenerateAITasks();
 		});
 
 		if (breedable.isSelected()) {

--- a/src/main/java/net/mcreator/ui/modgui/LivingEntityGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/LivingEntityGUI.java
@@ -81,7 +81,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-public class LivingEntityGUI extends ModElementGUI<LivingEntity> {
+public class LivingEntityGUI extends ModElementGUI<LivingEntity> implements IBlocklyPanelHolder {
 
 	private ProcedureSelector onStruckByLightning;
 	private ProcedureSelector whenMobFalls;
@@ -265,7 +265,7 @@ public class LivingEntityGUI extends ModElementGUI<LivingEntity> {
 				</block></next></block></next></block></next></block></next></block></xml>""");
 	}
 
-	private synchronized void regenerateAITasks() {
+	@Override public synchronized void regenerateBlocklyXML() {
 		BlocklyBlockCodeGenerator blocklyBlockCodeGenerator = new BlocklyBlockCodeGenerator(externalBlocks,
 				mcreator.getGeneratorStats().getBlocklyBlocks(BlocklyEditorType.AI_TASK));
 
@@ -685,7 +685,7 @@ public class LivingEntityGUI extends ModElementGUI<LivingEntity> {
 		aiBase.setPreferredSize(new Dimension(250, 32));
 		aiBase.addActionListener(e -> {
 			if (editorReady)
-				regenerateAITasks();
+				regenerateBlocklyXML();
 		});
 
 		JPanel aitopoveral = new JPanel(new BorderLayout(5, 0));
@@ -721,7 +721,7 @@ public class LivingEntityGUI extends ModElementGUI<LivingEntity> {
 			BlocklyLoader.INSTANCE.getBlockLoader(BlocklyEditorType.AI_TASK)
 					.loadBlocksAndCategoriesInPanel(blocklyPanel, ToolboxType.AI_BUILDER);
 			blocklyPanel.getJSBridge()
-					.setJavaScriptEventListener(() -> new Thread(LivingEntityGUI.this::regenerateAITasks).start());
+					.setJavaScriptEventListener(() -> new Thread(LivingEntityGUI.this::regenerateBlocklyXML).start());
 			if (!isEditingMode()) {
 				setDefaultAISet();
 			}
@@ -1052,7 +1052,7 @@ public class LivingEntityGUI extends ModElementGUI<LivingEntity> {
 		blocklyPanel.addTaskToRunAfterLoaded(() -> {
 			blocklyPanel.clearWorkspace();
 			blocklyPanel.setXML(livingEntity.aixml);
-			regenerateAITasks();
+			regenerateBlocklyXML();
 		});
 
 		if (breedable.isSelected()) {
@@ -1175,6 +1175,10 @@ public class LivingEntityGUI extends ModElementGUI<LivingEntity> {
 
 	@Override public @Nullable URI contextURL() throws URISyntaxException {
 		return new URI(MCreatorApplication.SERVER_DOMAIN + "/wiki/how-make-mob");
+	}
+
+	@Override public List<BlocklyPanel> getBlocklyPanels() {
+		return List.of(blocklyPanel);
 	}
 
 }

--- a/src/main/java/net/mcreator/ui/modgui/ProcedureGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/ProcedureGUI.java
@@ -103,7 +103,7 @@ public class ProcedureGUI extends ModElementGUI<net.mcreator.element.types.Proce
 		super.finalizeGUI(false);
 	}
 
-	@Override public synchronized void regenerateBlocklyXML() {
+	private synchronized void regenerateProcedure() {
 		BlocklyBlockCodeGenerator blocklyBlockCodeGenerator = new BlocklyBlockCodeGenerator(externalBlocks,
 				mcreator.getGeneratorStats().getBlocklyBlocks(BlocklyEditorType.PROCEDURE));
 		BlocklyToProcedure blocklyToJava;
@@ -574,7 +574,7 @@ public class ProcedureGUI extends ModElementGUI<net.mcreator.element.types.Proce
 			for (VariableElement variable : mcreator.getWorkspace().getVariableElements()) {
 				blocklyPanel.addGlobalVariable(variable.getName(), variable.getType().getBlocklyVariableType());
 			}
-			blocklyPanel.getJSBridge().setJavaScriptEventListener(() -> new Thread(this::regenerateBlocklyXML).start());
+			blocklyPanel.getJSBridge().setJavaScriptEventListener(() -> new Thread(this::regenerateProcedure).start());
 			if (!isEditingMode()) {
 				blocklyPanel.setXML(net.mcreator.element.types.Procedure.XML_BASE);
 			}
@@ -660,7 +660,7 @@ public class ProcedureGUI extends ModElementGUI<net.mcreator.element.types.Proce
 			blocklyPanel.setXML(procedure.procedurexml);
 			localVars.removeAllElements();
 			blocklyPanel.getLocalVariablesList().forEach(localVars::addElement);
-			regenerateBlocklyXML();
+			regenerateProcedure();
 		});
 	}
 

--- a/src/main/java/net/mcreator/ui/modgui/ProcedureGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/ProcedureGUI.java
@@ -60,7 +60,7 @@ import java.util.List;
 import java.util.*;
 import java.util.stream.Collectors;
 
-public class ProcedureGUI extends ModElementGUI<net.mcreator.element.types.Procedure> {
+public class ProcedureGUI extends ModElementGUI<net.mcreator.element.types.Procedure> implements IBlocklyPanelHolder {
 
 	private final JPanel pane5 = new JPanel(new BorderLayout(0, 0));
 
@@ -103,7 +103,7 @@ public class ProcedureGUI extends ModElementGUI<net.mcreator.element.types.Proce
 		super.finalizeGUI(false);
 	}
 
-	private synchronized void regenerateProcedure() {
+	@Override public synchronized void regenerateBlocklyXML() {
 		BlocklyBlockCodeGenerator blocklyBlockCodeGenerator = new BlocklyBlockCodeGenerator(externalBlocks,
 				mcreator.getGeneratorStats().getBlocklyBlocks(BlocklyEditorType.PROCEDURE));
 		BlocklyToProcedure blocklyToJava;
@@ -574,7 +574,7 @@ public class ProcedureGUI extends ModElementGUI<net.mcreator.element.types.Proce
 			for (VariableElement variable : mcreator.getWorkspace().getVariableElements()) {
 				blocklyPanel.addGlobalVariable(variable.getName(), variable.getType().getBlocklyVariableType());
 			}
-			blocklyPanel.getJSBridge().setJavaScriptEventListener(() -> new Thread(this::regenerateProcedure).start());
+			blocklyPanel.getJSBridge().setJavaScriptEventListener(() -> new Thread(this::regenerateBlocklyXML).start());
 			if (!isEditingMode()) {
 				blocklyPanel.setXML(net.mcreator.element.types.Procedure.XML_BASE);
 			}
@@ -660,7 +660,7 @@ public class ProcedureGUI extends ModElementGUI<net.mcreator.element.types.Proce
 			blocklyPanel.setXML(procedure.procedurexml);
 			localVars.removeAllElements();
 			blocklyPanel.getLocalVariablesList().forEach(localVars::addElement);
-			regenerateProcedure();
+			regenerateBlocklyXML();
 		});
 	}
 
@@ -668,6 +668,10 @@ public class ProcedureGUI extends ModElementGUI<net.mcreator.element.types.Proce
 		net.mcreator.element.types.Procedure procedure = new net.mcreator.element.types.Procedure(modElement);
 		procedure.procedurexml = blocklyPanel.getXML();
 		return procedure;
+	}
+
+	@Override public List<BlocklyPanel> getBlocklyPanels() {
+		return List.of(blocklyPanel);
 	}
 
 }


### PR DESCRIPTION
This PR adds an interface for `ModElementGUI` subclasses that offers "official" support for interaction with their `BlocklyPanel`s. These are the new methods:
* `List<BlocklyPanel> getBlocklyPanels()` - returns the list of all `BlocklyPanel` instances used to define MEs of certain type;
* `BlocklyPanel getSpecificBlocklyPanel(BlocklyEditorType type)` - returns a `BlocklyPanel` of the specified editor type if defined by the `ModElementGUI` (could be used e.g. by plugins to listen for when certain blocks are present and enable some parts of UI depending on that);