### PR TITLE
Fix feature's basetype on Fabric

### DIFF
--- a/src/main/java/net/mcreator/element/types/Feature.java
+++ b/src/main/java/net/mcreator/element/types/Feature.java
@@ -88,7 +88,7 @@ import java.util.List;
 		if (getModElement().getGenerator().getGeneratorConfiguration().getGeneratorFlavor() == GeneratorFlavor.FABRIC)
 			return List.of(BaseType.FEATURE); // Fabric needs to be handled differently than Forge
 		else if (hasGenerationConditions())
-				return List.of(BaseType.FEATURE);
+			return List.of(BaseType.FEATURE);
 		else
 			return Collections.emptyList();
 	}

--- a/src/main/java/net/mcreator/element/types/Feature.java
+++ b/src/main/java/net/mcreator/element/types/Feature.java
@@ -27,6 +27,7 @@ import net.mcreator.element.GeneratableElement;
 import net.mcreator.element.parts.BiomeEntry;
 import net.mcreator.element.parts.procedure.Procedure;
 import net.mcreator.element.types.interfaces.ICommonType;
+import net.mcreator.generator.GeneratorFlavor;
 import net.mcreator.generator.blockly.BlocklyBlockCodeGenerator;
 import net.mcreator.generator.blockly.OutputBlockCodeGenerator;
 import net.mcreator.generator.blockly.ProceduralBlockCodeGenerator;
@@ -84,9 +85,11 @@ import java.util.List;
 	}
 
 	@Override public Collection<BaseType> getBaseTypesProvided() {
-		if (hasGenerationConditions()) {
-			return List.of(BaseType.FEATURE);
-		}
-		return Collections.emptyList();
+		if (getModElement().getGenerator().getGeneratorConfiguration().getGeneratorFlavor() == GeneratorFlavor.FABRIC)
+			return List.of(BaseType.FEATURE); // Fabric needs to be handled differently than Forge
+		else if (hasGenerationConditions())
+				return List.of(BaseType.FEATURE);
+		else
+			return Collections.emptyList();
 	}
 }


### PR DESCRIPTION
The feature mod element conditions were made for Fabric, but Fabric is completely different when it comes to the world generation, so this PR adds a condition to check if the current generator is a Fabric generator, so the feature mod element is always added to the feature base type, making possible to generate all features inside the common.features.yaml file, no matter if the generation condition are true or, because it is required to properly generate on Fabric, no matter the condition.

In summary:
This adds a condition to check if it's Fabric or not, if it's Fabric, BaseType.Feature is always added, if no, the previous behaviour.