### PR TITLE
Add multi-threads support for the Regenerate code action

### DIFF
--- a/plugins/mcreator-localization/lang/texts.properties
+++ b/plugins/mcreator-localization/lang/texts.properties
@@ -1598,6 +1598,9 @@ preferences.gradle.offline=Run Gradle in offline mode
 preferences.gradle.offline.description=Check this if you have installed MCreator on the internet connection, but now want to develop mods without internet.<br>\
   <b>It only makes sense to use this if you don''t have internet access!<br>\
   Enabling this option can introduce several build issues, so only use if strictly necessary!</b>
+preferences.gradle.maxRegenCodeThreads=Threads to use when regenerating code
+preferences.gradle.maxRegenCodeThreads.description=Adding more threads can significantly reduce the regeneration time of big workspaces, at the cost of less available resources for other tasks.<br>\
+  The amount of time is not a linear progression with the amount of threads. The impact is less and less visible with the addition of new threads.
 preferences.bedrock.silentReload=Silently reload open Bedrock Edition app
 preferences.bedrock.silentReload.description=Keep in mind that silent reload will not save any unsaved world progress so only use this with test worlds
 preferences.notifications.openWhatsNextPage=Show "What''s Next?" page when a new workspace is setting up

--- a/src/main/java/net/mcreator/preferences/data/GradleSection.java
+++ b/src/main/java/net/mcreator/preferences/data/GradleSection.java
@@ -32,12 +32,14 @@ public class GradleSection extends PreferencesSection {
 	public static final int MAX_RAM =
 			(int) (((OperatingSystemMXBean) ManagementFactory.getOperatingSystemMXBean()).getTotalMemorySize()
 					/ 1048576) - 1024;
+	public static final int MAX_PROCESSORS = ManagementFactory.getOperatingSystemMXBean().getAvailableProcessors();
 
 	public BooleanEntry compileOnSave;
 	public BooleanEntry passLangToMinecraft;
 	public IntegerEntry xms;
 	public IntegerEntry xmx;
 	public BooleanEntry offline;
+	public IntegerEntry maxRegenCodeThreads;
 
 	GradleSection(String preferencesIdentifier) {
 		super(preferencesIdentifier);
@@ -47,6 +49,8 @@ public class GradleSection extends PreferencesSection {
 		xms = addEntry(new IntegerEntry("xms", OS.getBundledJVMBits() == OS.BIT64 ? 625 : 512, 128, MAX_RAM));
 		xmx = addEntry(new IntegerEntry("xmx", OS.getBundledJVMBits() == OS.BIT64 ? 2048 : 1500, 128, MAX_RAM));
 		offline = addEntry(new BooleanEntry("offline", false));
+		maxRegenCodeThreads= addEntry(new IntegerEntry("maxRegenCodeThreads", 2, 1, MAX_PROCESSORS));
+
 	}
 
 	@Override public String getSectionKey() {

--- a/src/main/java/net/mcreator/preferences/data/GradleSection.java
+++ b/src/main/java/net/mcreator/preferences/data/GradleSection.java
@@ -49,7 +49,7 @@ public class GradleSection extends PreferencesSection {
 		xms = addEntry(new IntegerEntry("xms", OS.getBundledJVMBits() == OS.BIT64 ? 625 : 512, 128, MAX_RAM));
 		xmx = addEntry(new IntegerEntry("xmx", OS.getBundledJVMBits() == OS.BIT64 ? 2048 : 1500, 128, MAX_RAM));
 		offline = addEntry(new BooleanEntry("offline", false));
-		maxRegenCodeThreads= addEntry(new IntegerEntry("maxRegenCodeThreads", 2, 1, MAX_PROCESSORS));
+		maxRegenCodeThreads= addEntry(new IntegerEntry("maxRegenCodeThreads", 1, 1, MAX_PROCESSORS));
 
 	}
 

--- a/src/main/java/net/mcreator/ui/action/impl/workspace/RegenerateCodeAction.java
+++ b/src/main/java/net/mcreator/ui/action/impl/workspace/RegenerateCodeAction.java
@@ -40,7 +40,6 @@ import org.apache.logging.log4j.Logger;
 import javax.annotation.Nullable;
 import javax.swing.*;
 import java.io.File;
-import java.lang.management.ManagementFactory;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
@@ -167,7 +166,6 @@ public class RegenerateCodeAction extends GradleAction {
 
 			// now we create a new thread for each list and run them at the same time
 			modElementsLists.forEach((j, modElements) -> new Thread(() -> {
-				Thread.currentThread().setPriority(Thread.MAX_PRIORITY);
 				for (ModElement mod : modElements) {
 					if (mod.isCodeLocked()) {
 						hasLockedElements.set(true);
@@ -228,15 +226,12 @@ public class RegenerateCodeAction extends GradleAction {
 					counter.i++;
 				}
 				finishedThreads.add(true);
-				Thread.currentThread().setPriority(Thread.NORM_PRIORITY);
 			}, "Regenerate#" + j).start());
 
 			// we wait all threads to finish before continuing
-			Thread.currentThread().setPriority(Thread.MIN_PRIORITY);
 			do {
 				System.out.println(); // we "print" nothing, so it can end
 			} while (finishedThreads.size() != PreferencesManager.PREFERENCES.gradle.maxRegenCodeThreads.get());
-			Thread.currentThread().setPriority(Thread.NORM_PRIORITY);
 
 			// save all updated generatable mod elements
 			generatableElementsToSave.parallelStream().forEach(mcreator.getModElementManager()::storeModElement);

--- a/src/main/java/net/mcreator/ui/action/impl/workspace/RegenerateCodeAction.java
+++ b/src/main/java/net/mcreator/ui/action/impl/workspace/RegenerateCodeAction.java
@@ -167,6 +167,7 @@ public class RegenerateCodeAction extends GradleAction {
 
 			// now we create a new thread for each list and run them at the same time
 			modElementsLists.forEach((j, modElements) -> new Thread(() -> {
+				Thread.currentThread().setPriority(Thread.MAX_PRIORITY);
 				for (ModElement mod : modElements) {
 					if (mod.isCodeLocked()) {
 						hasLockedElements.set(true);
@@ -227,12 +228,15 @@ public class RegenerateCodeAction extends GradleAction {
 					counter.i++;
 				}
 				finishedThreads.add(true);
+				Thread.currentThread().setPriority(Thread.NORM_PRIORITY);
 			}, "Regenerate#" + j).start());
 
 			// we wait all threads to finish before continuing
+			Thread.currentThread().setPriority(Thread.MIN_PRIORITY);
 			do {
 				System.out.println(); // we "print" nothing, so it can end
 			} while (finishedThreads.size() != PreferencesManager.PREFERENCES.gradle.maxRegenCodeThreads.get());
+			Thread.currentThread().setPriority(Thread.NORM_PRIORITY);
 
 			// save all updated generatable mod elements
 			generatableElementsToSave.parallelStream().forEach(mcreator.getModElementManager()::storeModElement);


### PR DESCRIPTION
Regenerating code on workspace that start to become big is always taking a long time. Computers (like laptops) that aren't powerful makes thing even worse as they can't handle things at the same speed. One major reason for this problem is that MCreator is currently using a single thread to regenerate all mod elements.

The objective of this PR is to fix that problem by allowing users to define how many threads they want to use to regenerate the code (by adding a new preference entry). The maximal number of threads is the number of threads the computer contains, so it varies on each computer. Something important to note is adding 2x more Threads won't divide by 2 the time. It's true that changing from 1 to 2 threads drastically improves performances (tests below), but the impact tends to become less and less visible the more we add threads.

# Tests
Here are the tests I ran with different setups to show the impact of this feature.
All results were calculated from the first printed `[Code Regenerate] Regenerating xxx mod element: xxx` until the last printed line.

## Test # 1
### Setup info
Workspace: 8357 mod elements - Forge 1.19.2
PC Gaming (using Intellij):
Windows 11
CPU: Intel i5-11600k @ 3.90GHz (boost @ 4.58GHz) (not overclocked) (6 cores - 12 threads)
RAM: 16GB DDR4 @ 3200MHz
MCR Prefs:
Min RAM: 8,192
Max RAM: 15,197 (max possible value)
Gradle: online
### Results
1 thread: ~1min 55 seconds
2 threads: ~58 seconds
4 threads: ~39 seconds
6 threads: ~27 seconds
8 threads: ~26 seconds
12 threads: ~25 seconds

## Test # 2
### Setup info
Workspace: 3108 mod elements - Forge 1.19.2
PC Gaming (using Intellij):
Windows 11
CPU: Intel i5-11600k @ 3.90GHz (boost @ 4.58GHz) (not overclocked) (6 cores - 12 threads)
RAM: 16GB DDR4 @ 3200MHz
MCR Prefs:
Min RAM: 8,192
Max RAM: 15,197 (max possible value)
Gradle: offline
### Results
1 thread: ~39 seconds
2 threads: ~17 seconds
4 threads: ~11 seconds
6 threads: ~10 seconds
8-12 threads: ~9 seconds

## Test # 3
### Setup info
Workspace: 3108 mod elements - Forge 1.19.2
Windows 10
CPU: Intel i5-6200U @ 2.30GHz (2 cores - 4 threads)
RAM: 8 Gb @ 2133Mhz
MCR prefs:
Min RAM: 4,096
Max RAM: 7,048 (max possible value)
Gradle: offline
## Results
1 thread: ~1min08
2 threads: ~45 seconds
4 threads: ~40 seconds

I didn't run the 8.3k workspace on my laptop because it's too big and my laptop is not powerful enough for it.