### PR TITLE
Relaxed the placement requirement for features

### DIFF
--- a/plugins/mcreator-localization/lang/texts.properties
+++ b/plugins/mcreator-localization/lang/texts.properties
@@ -3204,6 +3204,7 @@ blockly.warnings.empty_text_trim_block=Skipped empty text trim block. Using defa
 blockly.warnings.block_not_supported=Block {0} is not supported by the selected generator. It will be skipped.
 blockly.warnings.unmodifiable_ai_bases=The selected AI base does not support custom AI task goals. They will not be generated.
 blockly.warnings.statement_input_empty=Statement input {0} on block {1} is empty.
+blockly.warnings.features.missing_placement=Missing placement. The feature might not generate in the intended position
 blockly.errors.disabled_block_type.remove=Disabled block type {0}. Remove this block!
 blockly.errors.unknown_block_type.remove=Unknown block type {0}. Remove this block!
 blockly.errors.cancel_event.null=Failed to load selected external trigger.
@@ -3253,7 +3254,6 @@ blockly.errors.duplicate_dependencies_provided.statement=Statement input {0} pro
 blockly.errors.api_required="{0}" API required by block {1} is either disabled in workspace settings or not supported by the current generator.
 blockly.errors.call_procedure_missing_deps=The procedure you are calling ({0}) requires the following dependencies that are not provided: {1}
 blockly.errors.features.missing_feature=Missing feature
-blockly.errors.features.missing_placement=Missing placement
 blockly.block.cancel_event=Cancel event
 dialog.bedrock.enable_addons=<html>Your Add-On was not added to your Minecraft Bedrock Edition before.<br><br>\
   Make sure you <b>enable your addon</b> and <b>enable it for selected world</b>.<br>In order for the addon to work, \

--- a/src/main/java/net/mcreator/blockly/feature/BlocklyToFeature.java
+++ b/src/main/java/net/mcreator/blockly/feature/BlocklyToFeature.java
@@ -71,8 +71,8 @@ public class BlocklyToFeature extends BlocklyToJava {
 
 	@Override protected void postBlocksPlacement(Document doc, Element startBlock, List<Element> baseBlocks) {
 		if (baseBlocks.isEmpty())
-			addCompileNote(new BlocklyCompileNote(BlocklyCompileNote.Type.ERROR,
-					L10N.t("blockly.errors.features.missing_placement")));
+			addCompileNote(new BlocklyCompileNote(BlocklyCompileNote.Type.WARNING,
+					L10N.t("blockly.warnings.features.missing_placement")));
 	}
 
 	public final String getFeatureConfigurationCode() {

--- a/src/test/java/net/mcreator/integration/generator/GTFeatureBlocks.java
+++ b/src/test/java/net/mcreator/integration/generator/GTFeatureBlocks.java
@@ -99,11 +99,10 @@ public class GTFeatureBlocks {
 						</block></value><next>%s</next></block></xml>""".formatted(testXML);
 			} else {
 				switch (featureBlock.getOutputType()) {
-				// Features are tested with the "In square" placement
 				case "Feature" -> feature.featurexml = """
 						<xml xmlns="https://developers.google.com/blockly/xml">
 						<block type="feature_container" deletable="false" x="40" y="40">
-						<value name="feature">%s</value><next><block type="placement_in_square"></block></next></block></xml>
+						<value name="feature">%s</value></block></xml>
 						""".formatted(testXML);
 				// Placed features are tested with the "Random patch" feature
 				case "PlacedFeature" -> feature.featurexml = """
@@ -112,7 +111,7 @@ public class GTFeatureBlocks {
 						<value name="feature"><block type="feature_random_patch">
 							<value name="feature">%s</value>
 							<field name="tries">128</field><field name="xzSpread">7</field><field name="ySpread">3</field>
-						</block></value><next><block type="placement_in_square"></block></next></block></xml>
+						</block></value></block></xml>
 						""".formatted(testXML);
 				// Vertical anchors are tested with the "Height: At constant height" placement
 				case "VerticalAnchor" -> feature.featurexml = """
@@ -145,7 +144,7 @@ public class GTFeatureBlocks {
 								<value name="target">%s</value>
 								<value name="state"><block type="mcitem_allblocks"><field name="value">Blocks.STONE</field></block></value>
 							</block></value>
-						</block></value><next><block type="placement_in_square"></block></next></block></xml>
+						</block></value></block></xml>
 						""".formatted(testXML);
 				// The "Ore target" block is also tested with the "Replace single block" feature
 				case "OreTarget" -> feature.featurexml = """
@@ -154,7 +153,7 @@ public class GTFeatureBlocks {
 						<value name="feature"><block type="feature_replace_single_block">
 							<mutation inputs="1"></mutation>
 							<value name="target0">%s</value>
-						</block></value><next><block type="placement_in_square"></block></next></block></xml>
+						</block></value></block></xml>
 						""".formatted(testXML);
 				// Blockstate providers are tested with the simple block feature
 				case "BlockStateProvider" -> feature.featurexml = """
@@ -162,7 +161,7 @@ public class GTFeatureBlocks {
 						<block type="feature_container" deletable="false" x="40" y="40">
 						<value name="feature"><block type="feature_simple_block">
 							<value name="block">%s</value>
-						</block></value><next><block type="placement_in_square"></block></next></block></xml>
+						</block></value></block></xml>
 						""".formatted(testXML);
 				// Other output types (Height provider, block predicate, etc.) are tested with an appropriate placement block
 				case "HeightProvider" -> feature.featurexml = getXMLFor("placement_height_range", "height", testXML);


### PR DESCRIPTION
This PR relaxes the placement requirement for the feature mod element, so that it's just a warning and not a full error. Minecraft doesn't require the placement list to be non-empty.

This is mostly intended for cases where a user needs to refer to a placed feature with no extra placements, or if a custom-defined feature type already handles placement.