### PR TITLE
Improve broken GE detection

### DIFF
--- a/plugins/mcreator-localization/lang/texts.properties
+++ b/plugins/mcreator-localization/lang/texts.properties
@@ -612,7 +612,8 @@ workspace.elements.lock_modelement_rebuilding_workspace=Rebuilding workspace
 workspace.elements.duplicate_message=<html><font style="font-size: 13px;">Enter the name of the new mod element:</font><br><small>This mod element will be the same as {0}, but with this name.</font>
 workspace.elements.duplicate_element=Duplicate {0}
 workspace.elements.duplicate=Duplicate
-workspace.elements.edit_modelement_nosavedinstance=<html>This mod does not have saved instance. If you want to make it editable,<br>you need to remake it.<br><small>You probably see this because you have updated MCreator and your mod was made before saving was possible.
+workspace.elements.edit_modelement_nosavedinstance=<html>This mod does not have saved instance, is corrupted, or incompatible.<br>You may need to delete and remake this mod element.
+workspace.elements.edit_modelement_nosavedinstance.title=Could not load mod element
 blockly.compile_notes=Warnings and errors ({0}):
 blockly.templates.aitasks=AI templates
 blockly.templates.aitasks.export=Export AI setup

--- a/src/main/java/net/mcreator/element/GeneratableElement.java
+++ b/src/main/java/net/mcreator/element/GeneratableElement.java
@@ -134,14 +134,20 @@ public abstract class GeneratableElement {
 
 				ModElementType<?> modElementType = ModElementTypeLoader.getModElementType(newType);
 
+				JsonObject jsonObject = jsonElement.getAsJsonObject().get("definition").getAsJsonObject();
+				if (jsonObject.keySet().isEmpty()) {
+					LOG.warn("Mod element " + this.lastModElement.getName() + " (" + modElementType
+							+ ") has no definition so we can not deserialize it");
+					return null;
+				}
+
 				final GeneratableElement[] generatableElement = {
-						gson.fromJson(jsonElement.getAsJsonObject().get("definition"),
-								modElementType.getModElementStorageClass()) };
+						gson.fromJson(jsonObject, modElementType.getModElementStorageClass()) };
 
 				generatableElement[0].setModElement(this.lastModElement); // set the mod element reference
 				passWorkspaceToFields(generatableElement[0], workspace);
 
-				if (importedFormatVersion != GeneratableElement.formatVersion) {
+				if (importedFormatVersion < GeneratableElement.formatVersion) {
 					List<IConverter> converters = ConverterRegistry.getConvertersForModElementType(modElementType);
 					if (converters != null) {
 						AtomicInteger versionIncrementer = new AtomicInteger(importedFormatVersion);
@@ -158,11 +164,17 @@ public abstract class GeneratableElement {
 									versionIncrementer.set(converter.getVersionConvertingTo());
 								});
 					}
+				} else if (importedFormatVersion > GeneratableElement.formatVersion) {
+					LOG.warn(
+							"Mod element " + this.lastModElement.getName() + " (" + modElementType + ") was saved in FV"
+									+ importedFormatVersion + " but current FV is " + GeneratableElement.formatVersion
+									+ " so we can not deserialize it");
+					return null;
 				}
 
 				return generatableElement[0];
 			} catch (IllegalArgumentException e) { // we may be dealing with mod element type no longer existing
-				if (importedFormatVersion != GeneratableElement.formatVersion) {
+				if (importedFormatVersion < GeneratableElement.formatVersion) {
 					IConverter converter = ConverterRegistry.getConverterForModElementType(newType);
 					if (converter != null) {
 						try {
@@ -188,9 +200,14 @@ public abstract class GeneratableElement {
 							}
 						} catch (Exception e2) {
 							LOG.warn("Failed to convert mod element " + this.lastModElement.getName() + " of type "
-									+ newType + " to a potential alternative.", e2);
+									+ newType + " to a potential alternative." , e2);
 						}
 					}
+				} else if (importedFormatVersion > GeneratableElement.formatVersion) {
+					LOG.warn("Mod element " + this.lastModElement.getName() + " (" + newType + ") was saved in FV"
+							+ importedFormatVersion + " but current FV is " + GeneratableElement.formatVersion
+							+ " so we can not deserialize it");
+					return null;
 				}
 
 				return null;
@@ -206,9 +223,19 @@ public abstract class GeneratableElement {
 		public JsonElement serialize(GeneratableElement modElement, Type type,
 				JsonSerializationContext jsonSerializationContext) {
 			JsonObject root = new JsonObject();
-			root.add("_fv", new JsonPrimitive(GeneratableElement.formatVersion));
-			root.add("_type", gson.toJsonTree(modElement.getModElement().getType().getRegistryName()));
-			root.add("definition", gson.toJsonTree(modElement));
+			root.add("_fv" , new JsonPrimitive(GeneratableElement.formatVersion));
+			root.add("_type" , gson.toJsonTree(modElement.getModElement().getType().getRegistryName()));
+
+			JsonObject definition = gson.toJsonTree(modElement).getAsJsonObject();
+
+			if (definition.keySet().isEmpty()) {
+				LOG.warn("Mod element " + modElement.getModElement().getName() + " (" + modElement.getModElement()
+						.getType() + ") has no definition so we can't serialize it");
+				return null;
+			}
+
+			root.add("definition" , definition);
+
 			return root;
 		}
 

--- a/src/main/java/net/mcreator/element/GeneratableElement.java
+++ b/src/main/java/net/mcreator/element/GeneratableElement.java
@@ -90,6 +90,24 @@ public abstract class GeneratableElement {
 		return conversionApplied;
 	}
 
+	public final boolean performQuickValidation() {
+		for (Field field : getClass().getDeclaredFields()) {
+			if (field.isAnnotationPresent(Nonnull.class)) {
+				field.setAccessible(true);
+				try {
+					if (field.get(this) == null) {
+						LOG.warn("Field " + field.getName() + " of mod element " + this.element.getName()
+								+ " is null, but should not be. Assuming invalid generatable element.");
+						return false;
+					}
+				} catch (IllegalAccessException ignored) {
+				}
+			}
+		}
+
+		return true;
+	}
+
 	public static class GSONAdapter
 			implements JsonSerializer<GeneratableElement>, JsonDeserializer<GeneratableElement> {
 

--- a/src/main/java/net/mcreator/element/types/Block.java
+++ b/src/main/java/net/mcreator/element/types/Block.java
@@ -44,7 +44,7 @@ import java.util.List;
 import java.util.*;
 import java.util.stream.Collectors;
 
-@SuppressWarnings({ "unused" , "NotNullFieldNotInitialized" }) public class Block extends GeneratableElement
+@SuppressWarnings({ "unused", "NotNullFieldNotInitialized" }) public class Block extends GeneratableElement
 		implements IBlock, IItemWithModel, ITabContainedElement, IBlockWithBoundingBox {
 
 	public String texture;

--- a/src/main/java/net/mcreator/element/types/Block.java
+++ b/src/main/java/net/mcreator/element/types/Block.java
@@ -44,7 +44,7 @@ import java.util.List;
 import java.util.*;
 import java.util.stream.Collectors;
 
-@SuppressWarnings("unused") public class Block extends GeneratableElement
+@SuppressWarnings({ "unused" , "NotNullFieldNotInitialized" }) public class Block extends GeneratableElement
 		implements IBlock, IItemWithModel, ITabContainedElement, IBlockWithBoundingBox {
 
 	public String texture;
@@ -54,7 +54,7 @@ import java.util.stream.Collectors;
 	public String textureRight;
 	public String textureBack;
 	public int renderType;
-	public String customModelName;
+	@Nonnull public String customModelName;
 	public int rotationMode;
 	public boolean enablePitch;
 	public boolean emissiveRendering;
@@ -83,7 +83,7 @@ import java.util.stream.Collectors;
 	public boolean isWaterloggable;
 	public TabEntry creativeTab;
 
-	public String destroyTool;
+	@Nonnull public String destroyTool;
 	public MItemBlock customDrop;
 	public int dropAmount;
 	public boolean useLootTableForDrops;

--- a/src/main/java/net/mcreator/element/types/Fluid.java
+++ b/src/main/java/net/mcreator/element/types/Fluid.java
@@ -33,13 +33,14 @@ import net.mcreator.util.image.ImageUtils;
 import net.mcreator.workspace.Workspace;
 import net.mcreator.workspace.elements.ModElement;
 
+import javax.annotation.Nonnull;
 import javax.swing.*;
 import java.awt.image.BufferedImage;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-@SuppressWarnings("unused") public class Fluid extends GeneratableElement implements IBlock, ITabContainedElement {
+@SuppressWarnings({ "unused" , "NotNullFieldNotInitialized" }) public class Fluid extends GeneratableElement implements IBlock, ITabContainedElement {
 
 	public String name;
 	public String bucketName;
@@ -61,7 +62,7 @@ import java.util.List;
 	public int density;
 	public int viscosity;
 	public int temperature;
-	public String type;
+	@Nonnull public String type;
 
 	public boolean generateBucket;
 	public String textureBucket;

--- a/src/main/java/net/mcreator/element/types/Fluid.java
+++ b/src/main/java/net/mcreator/element/types/Fluid.java
@@ -40,7 +40,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-@SuppressWarnings({ "unused" , "NotNullFieldNotInitialized" }) public class Fluid extends GeneratableElement implements IBlock, ITabContainedElement {
+@SuppressWarnings({ "unused", "NotNullFieldNotInitialized" }) public class Fluid extends GeneratableElement implements IBlock, ITabContainedElement {
 
 	public String name;
 	public String bucketName;

--- a/src/main/java/net/mcreator/element/types/GameRule.java
+++ b/src/main/java/net/mcreator/element/types/GameRule.java
@@ -22,11 +22,12 @@ import net.mcreator.element.GeneratableElement;
 import net.mcreator.minecraft.MinecraftImageGenerator;
 import net.mcreator.workspace.elements.ModElement;
 
+import javax.annotation.Nonnull;
 import java.awt.image.BufferedImage;
 
-public class GameRule extends GeneratableElement {
+@SuppressWarnings("NotNullFieldNotInitialized") public class GameRule extends GeneratableElement {
 
-	public String type;
+	@Nonnull public String type;
 
 	public String displayName;
 	public String description;

--- a/src/main/java/net/mcreator/element/types/Item.java
+++ b/src/main/java/net/mcreator/element/types/Item.java
@@ -37,16 +37,17 @@ import net.mcreator.workspace.elements.ModElement;
 import net.mcreator.workspace.resources.Model;
 import net.mcreator.workspace.resources.TexturedModel;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.awt.image.BufferedImage;
 import java.util.*;
 
-@SuppressWarnings("unused") public class Item extends GeneratableElement
+@SuppressWarnings({ "unused" , "NotNullFieldNotInitialized" }) public class Item extends GeneratableElement
 		implements IItem, IItemWithModel, ITabContainedElement, IItemWithTexture {
 
 	public int renderType;
 	public String texture;
-	public String customModelName;
+	@Nonnull public String customModelName;
 
 	public Map<String, Procedure> customProperties;
 	public List<StateEntry> states;
@@ -73,7 +74,7 @@ import java.util.*;
 	public boolean hasGlow;
 	public Procedure glowCondition;
 
-	public String guiBoundTo;
+	@Nullable public String guiBoundTo;
 	public int inventorySize;
 	public int inventoryStackSize;
 

--- a/src/main/java/net/mcreator/element/types/Item.java
+++ b/src/main/java/net/mcreator/element/types/Item.java
@@ -42,7 +42,7 @@ import javax.annotation.Nullable;
 import java.awt.image.BufferedImage;
 import java.util.*;
 
-@SuppressWarnings({ "unused" , "NotNullFieldNotInitialized" }) public class Item extends GeneratableElement
+@SuppressWarnings({ "unused", "NotNullFieldNotInitialized" }) public class Item extends GeneratableElement
 		implements IItem, IItemWithModel, ITabContainedElement, IItemWithTexture {
 
 	public int renderType;

--- a/src/main/java/net/mcreator/element/types/KeyBinding.java
+++ b/src/main/java/net/mcreator/element/types/KeyBinding.java
@@ -23,11 +23,12 @@ import net.mcreator.element.parts.procedure.Procedure;
 import net.mcreator.minecraft.MinecraftImageGenerator;
 import net.mcreator.workspace.elements.ModElement;
 
+import javax.annotation.Nonnull;
 import java.awt.image.BufferedImage;
 
-@SuppressWarnings("unused") public class KeyBinding extends GeneratableElement {
+@SuppressWarnings({ "unused" , "NotNullFieldNotInitialized" }) public class KeyBinding extends GeneratableElement {
 
-	public String triggerKey;
+	@Nonnull public String triggerKey;
 	public String keyBindingName;
 	public String keyBindingCategoryKey;
 

--- a/src/main/java/net/mcreator/element/types/KeyBinding.java
+++ b/src/main/java/net/mcreator/element/types/KeyBinding.java
@@ -26,7 +26,7 @@ import net.mcreator.workspace.elements.ModElement;
 import javax.annotation.Nonnull;
 import java.awt.image.BufferedImage;
 
-@SuppressWarnings({ "unused" , "NotNullFieldNotInitialized" }) public class KeyBinding extends GeneratableElement {
+@SuppressWarnings({ "unused", "NotNullFieldNotInitialized" }) public class KeyBinding extends GeneratableElement {
 
 	@Nonnull public String triggerKey;
 	public String keyBindingName;

--- a/src/main/java/net/mcreator/element/types/LivingEntity.java
+++ b/src/main/java/net/mcreator/element/types/LivingEntity.java
@@ -53,7 +53,7 @@ import java.awt.image.BufferedImage;
 import java.util.List;
 import java.util.*;
 
-@SuppressWarnings({ "unused" , "NotNullFieldNotInitialized" }) public class LivingEntity extends GeneratableElement
+@SuppressWarnings({ "unused", "NotNullFieldNotInitialized" }) public class LivingEntity extends GeneratableElement
 		implements IEntityWithModel, ITabContainedElement, ICommonType, IMCItemProvider {
 
 	public String mobName;

--- a/src/main/java/net/mcreator/element/types/LivingEntity.java
+++ b/src/main/java/net/mcreator/element/types/LivingEntity.java
@@ -45,6 +45,7 @@ import net.mcreator.workspace.Workspace;
 import net.mcreator.workspace.elements.ModElement;
 import net.mcreator.workspace.resources.Model;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.swing.*;
 import java.awt.*;
@@ -52,13 +53,13 @@ import java.awt.image.BufferedImage;
 import java.util.List;
 import java.util.*;
 
-@SuppressWarnings("unused") public class LivingEntity extends GeneratableElement
+@SuppressWarnings({ "unused" , "NotNullFieldNotInitialized" }) public class LivingEntity extends GeneratableElement
 		implements IEntityWithModel, ITabContainedElement, ICommonType, IMCItemProvider {
 
 	public String mobName;
 	public String mobLabel;
 
-	public String mobModelName;
+	@Nonnull public String mobModelName;
 	public String mobModelTexture;
 	public String mobModelGlowTexture;
 	public Procedure transparentModelCondition;

--- a/src/main/java/net/mcreator/element/types/LootTable.java
+++ b/src/main/java/net/mcreator/element/types/LootTable.java
@@ -25,7 +25,7 @@ import net.mcreator.workspace.elements.ModElement;
 import javax.annotation.Nonnull;
 import java.util.List;
 
-@SuppressWarnings({ "unused" , "NotNullFieldNotInitialized" }) public class LootTable extends NamespacedGeneratableElement {
+@SuppressWarnings({ "unused", "NotNullFieldNotInitialized" }) public class LootTable extends NamespacedGeneratableElement {
 
 	@Nonnull public String type;
 

--- a/src/main/java/net/mcreator/element/types/LootTable.java
+++ b/src/main/java/net/mcreator/element/types/LootTable.java
@@ -22,11 +22,12 @@ import net.mcreator.element.NamespacedGeneratableElement;
 import net.mcreator.element.parts.MItemBlock;
 import net.mcreator.workspace.elements.ModElement;
 
+import javax.annotation.Nonnull;
 import java.util.List;
 
-@SuppressWarnings("unused") public class LootTable extends NamespacedGeneratableElement {
+@SuppressWarnings({ "unused" , "NotNullFieldNotInitialized" }) public class LootTable extends NamespacedGeneratableElement {
 
-	public String type;
+	@Nonnull public String type;
 
 	public List<Pool> pools;
 

--- a/src/main/java/net/mcreator/element/types/Plant.java
+++ b/src/main/java/net/mcreator/element/types/Plant.java
@@ -44,7 +44,7 @@ import java.util.stream.Collectors;
 	public int renderType;
 	public String texture;
 	public String textureBottom;
-	public String customModelName;
+	@Nonnull public String customModelName;
 
 	public String itemTexture;
 	public String particleTexture;

--- a/src/main/java/net/mcreator/element/types/RangedItem.java
+++ b/src/main/java/net/mcreator/element/types/RangedItem.java
@@ -36,7 +36,7 @@ import javax.annotation.Nonnull;
 import java.awt.image.BufferedImage;
 import java.util.*;
 
-@SuppressWarnings({ "unused" , "NotNullFieldNotInitialized" }) public class RangedItem extends GeneratableElement
+@SuppressWarnings({ "unused", "NotNullFieldNotInitialized" }) public class RangedItem extends GeneratableElement
 		implements IItem, IItemWithModel, IEntityWithModel, ITabContainedElement, IItemWithTexture {
 
 	public int renderType;

--- a/src/main/java/net/mcreator/element/types/RangedItem.java
+++ b/src/main/java/net/mcreator/element/types/RangedItem.java
@@ -32,15 +32,16 @@ import net.mcreator.workspace.elements.ModElement;
 import net.mcreator.workspace.resources.Model;
 import net.mcreator.workspace.resources.TexturedModel;
 
+import javax.annotation.Nonnull;
 import java.awt.image.BufferedImage;
 import java.util.*;
 
-@SuppressWarnings("unused") public class RangedItem extends GeneratableElement
+@SuppressWarnings({ "unused" , "NotNullFieldNotInitialized" }) public class RangedItem extends GeneratableElement
 		implements IItem, IItemWithModel, IEntityWithModel, ITabContainedElement, IItemWithTexture {
 
 	public int renderType;
 	public String texture;
-	public String customModelName;
+	@Nonnull public String customModelName;
 	public String name;
 	public List<String> specialInfo;
 	public TabEntry creativeTab;
@@ -64,7 +65,7 @@ import java.util.*;
 	public boolean bulletParticles;
 	public boolean bulletIgnitesFire;
 	public MItemBlock bulletItemTexture;
-	public String bulletModel;
+	@Nonnull public String bulletModel;
 	public String customBulletModelTexture;
 
 	public Procedure onBulletHitsBlock;

--- a/src/main/java/net/mcreator/element/types/Recipe.java
+++ b/src/main/java/net/mcreator/element/types/Recipe.java
@@ -28,7 +28,7 @@ import javax.annotation.Nonnull;
 import java.awt.image.BufferedImage;
 import java.util.Arrays;
 
-@SuppressWarnings({ "unused" , "NotNullFieldNotInitialized" }) public class Recipe extends NamespacedGeneratableElement {
+@SuppressWarnings({ "unused", "NotNullFieldNotInitialized" }) public class Recipe extends NamespacedGeneratableElement {
 
 	@Nonnull public String recipeType;
 

--- a/src/main/java/net/mcreator/element/types/Recipe.java
+++ b/src/main/java/net/mcreator/element/types/Recipe.java
@@ -24,12 +24,14 @@ import net.mcreator.minecraft.MinecraftImageGenerator;
 import net.mcreator.minecraft.RegistryNameFixer;
 import net.mcreator.workspace.elements.ModElement;
 
+import javax.annotation.Nonnull;
 import java.awt.image.BufferedImage;
 import java.util.Arrays;
 
-@SuppressWarnings("unused") public class Recipe extends NamespacedGeneratableElement {
+@SuppressWarnings({ "unused" , "NotNullFieldNotInitialized" }) public class Recipe extends NamespacedGeneratableElement {
 
-	public String recipeType;
+	@Nonnull public String recipeType;
+
 	public int recipeRetstackSize;
 	public String group;
 

--- a/src/main/java/net/mcreator/element/types/Tag.java
+++ b/src/main/java/net/mcreator/element/types/Tag.java
@@ -30,7 +30,7 @@ import java.awt.image.BufferedImage;
 import java.util.List;
 import java.util.Locale;
 
-@SuppressWarnings({ "unused" , "NotNullFieldNotInitialized" }) public class Tag extends NamespacedGeneratableElement {
+@SuppressWarnings({ "unused", "NotNullFieldNotInitialized" }) public class Tag extends NamespacedGeneratableElement {
 
 	@Nonnull public String type;
 

--- a/src/main/java/net/mcreator/element/types/Tag.java
+++ b/src/main/java/net/mcreator/element/types/Tag.java
@@ -25,13 +25,14 @@ import net.mcreator.element.parts.MItemBlock;
 import net.mcreator.minecraft.MinecraftImageGenerator;
 import net.mcreator.workspace.elements.ModElement;
 
+import javax.annotation.Nonnull;
 import java.awt.image.BufferedImage;
 import java.util.List;
 import java.util.Locale;
 
-@SuppressWarnings("unused") public class Tag extends NamespacedGeneratableElement {
+@SuppressWarnings({ "unused" , "NotNullFieldNotInitialized" }) public class Tag extends NamespacedGeneratableElement {
 
-	public String type;
+	@Nonnull public String type;
 
 	public List<MItemBlock> items;
 	public List<MItemBlock> blocks;

--- a/src/main/java/net/mcreator/element/types/Tool.java
+++ b/src/main/java/net/mcreator/element/types/Tool.java
@@ -40,7 +40,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@SuppressWarnings({ "unused" , "NotNullFieldNotInitialized" }) public class Tool extends GeneratableElement
+@SuppressWarnings({ "unused", "NotNullFieldNotInitialized" }) public class Tool extends GeneratableElement
 		implements IItem, IItemWithModel, ITabContainedElement, IItemWithTexture {
 
 	@Nonnull public String toolType;

--- a/src/main/java/net/mcreator/element/types/Tool.java
+++ b/src/main/java/net/mcreator/element/types/Tool.java
@@ -33,23 +33,25 @@ import net.mcreator.workspace.elements.ModElement;
 import net.mcreator.workspace.resources.Model;
 import net.mcreator.workspace.resources.TexturedModel;
 
+import javax.annotation.Nonnull;
 import java.awt.image.BufferedImage;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@SuppressWarnings("unused") public class Tool extends GeneratableElement
+@SuppressWarnings({ "unused" , "NotNullFieldNotInitialized" }) public class Tool extends GeneratableElement
 		implements IItem, IItemWithModel, ITabContainedElement, IItemWithTexture {
+
+	@Nonnull public String toolType;
 
 	public int renderType;
 	public String texture;
-	public String customModelName;
+	@Nonnull public String customModelName;
 
 	public String name;
 	public List<String> specialInfo;
 	public TabEntry creativeTab;
-	public String toolType;
 	public int harvestLevel;
 	public double efficiency;
 	public double attackSpeed;

--- a/src/main/java/net/mcreator/ui/action/impl/workspace/RegenerateCodeAction.java
+++ b/src/main/java/net/mcreator/ui/action/impl/workspace/RegenerateCodeAction.java
@@ -145,51 +145,48 @@ public class RegenerateCodeAction extends GradleAction {
 					hasLockedElements = true;
 				}
 
-				if (!mcreator.getModElementManager().hasModElementGeneratableElement(mod)) {
-					if (!skipAll) {
-						int opt = JOptionPane.showOptionDialog(mcreator,
-								L10N.t("dialog.workspace.regenerate_and_build.error.failed_to_import.message",
-										mod.getName(), skippedElements.size()),
-								L10N.t("dialog.workspace.regenerate_and_build.error.failed_to_import.title"),
-								JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE, null, new String[] {
-										L10N.t("dialog.workspace.regenerate_and_build.error.failed_to_import.option.skip_one"),
-										L10N.t("dialog.workspace.regenerate_and_build.error.failed_to_import.option.skip_all") },
-								0);
-						if (opt == 1)
-							skipAll = true;
-					}
-					skippedElements.add(mod);
-					continue;
-				}
-
 				try {
 					GeneratableElement generatableElement = mod.getGeneratableElement();
-
-					if (generatableElement != null) {
-						LOG.debug("Regenerating " + mod.getType().getReadableName() + " mod element: " + mod.getName());
-
-						// generate mod element code
-						List<GeneratorFile> generatedFiles = mcreator.getGenerator()
-								.generateElement(generatableElement, false);
-
-						if (!mod.isCodeLocked()) {
-							filesToReformat.addAll(
-									generatedFiles.stream().map(GeneratorFile::getFile).collect(Collectors.toSet()));
-						}
-
-						// save custom mod element picture if it has one
-						mcreator.getModElementManager().storeModElementPicture(generatableElement);
-
-						// add mod element to workspace again, so the icons get reloaded
-						mcreator.getWorkspace().addModElement(generatableElement.getModElement());
-
-						// we reinit the mod to load new icons etc.
-						generatableElement.getModElement().reinit(mcreator.getWorkspace());
-
-						generatableElementsToSave.add(generatableElement);
-					} else {
+					if (generatableElement == null) {
 						LOG.warn("Failed to regenerate: " + mod.getName() + " as it has no generatable element");
+
+						if (!skipAll) {
+							int opt = JOptionPane.showOptionDialog(mcreator,
+									L10N.t("dialog.workspace.regenerate_and_build.error.failed_to_import.message" ,
+											mod.getName(), skippedElements.size()),
+									L10N.t("dialog.workspace.regenerate_and_build.error.failed_to_import.title"),
+									JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE, null, new String[] {
+											L10N.t("dialog.workspace.regenerate_and_build.error.failed_to_import.option.skip_one"),
+											L10N.t("dialog.workspace.regenerate_and_build.error.failed_to_import.option.skip_all") },
+									0);
+							if (opt == 1)
+								skipAll = true;
+						}
+						skippedElements.add(mod);
+						continue;
 					}
+
+					LOG.debug("Regenerating " + mod.getType().getReadableName() + " mod element: " + mod.getName());
+
+					// generate mod element code
+					List<GeneratorFile> generatedFiles = mcreator.getGenerator()
+							.generateElement(generatableElement, false);
+
+					if (!mod.isCodeLocked()) {
+						filesToReformat.addAll(
+								generatedFiles.stream().map(GeneratorFile::getFile).collect(Collectors.toSet()));
+					}
+
+					// save custom mod element picture if it has one
+					mcreator.getModElementManager().storeModElementPicture(generatableElement);
+
+					// add mod element to workspace again, so the icons get reloaded
+					mcreator.getWorkspace().addModElement(generatableElement.getModElement());
+
+					// we reinit the mod to load new icons etc.
+					generatableElement.getModElement().reinit(mcreator.getWorkspace());
+
+					generatableElementsToSave.add(generatableElement);
 				} catch (Exception e) {
 					LOG.error("Failed to regenerate: " + mod.getName(), e);
 				}
@@ -210,7 +207,7 @@ public class RegenerateCodeAction extends GradleAction {
 					}
 				});
 				JOptionPane.showMessageDialog(dial,
-						L10N.t("dialog.workspace.regenerate_and_build.warning.skipped_import_of.message",
+						L10N.t("dialog.workspace.regenerate_and_build.warning.skipped_import_of.message" ,
 								skippedElements.size()),
 						L10N.t("dialog.workspace.regenerate_and_build.warning.skipped_import_of.title"),
 						JOptionPane.WARNING_MESSAGE);
@@ -272,7 +269,7 @@ public class RegenerateCodeAction extends GradleAction {
 			mcreator.getGradleConsole().markRunning(); // so console gets locked while we generate code already
 			try {
 				mcreator.getGenerator().generateBase();
-				mcreator.getGradleConsole().exec("build", taskSpecificListener);
+				mcreator.getGradleConsole().exec("build" , taskSpecificListener);
 			} catch (Exception e) { // if something fails, we still need to free the gradle console
 				LOG.error(e.getMessage(), e);
 				mcreator.getGradleConsole().markReady();
@@ -282,8 +279,7 @@ public class RegenerateCodeAction extends GradleAction {
 			dial.refreshDisplay();
 
 			dial.hideAll();
-		});
-		thread.start();
+		}); thread.start();
 		dial.setVisible(true);
 	}
 

--- a/src/main/java/net/mcreator/ui/action/impl/workspace/RegenerateCodeAction.java
+++ b/src/main/java/net/mcreator/ui/action/impl/workspace/RegenerateCodeAction.java
@@ -152,7 +152,7 @@ public class RegenerateCodeAction extends GradleAction {
 
 						if (!skipAll) {
 							int opt = JOptionPane.showOptionDialog(mcreator,
-									L10N.t("dialog.workspace.regenerate_and_build.error.failed_to_import.message" ,
+									L10N.t("dialog.workspace.regenerate_and_build.error.failed_to_import.message",
 											mod.getName(), skippedElements.size()),
 									L10N.t("dialog.workspace.regenerate_and_build.error.failed_to_import.title"),
 									JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE, null, new String[] {
@@ -207,7 +207,7 @@ public class RegenerateCodeAction extends GradleAction {
 					}
 				});
 				JOptionPane.showMessageDialog(dial,
-						L10N.t("dialog.workspace.regenerate_and_build.warning.skipped_import_of.message" ,
+						L10N.t("dialog.workspace.regenerate_and_build.warning.skipped_import_of.message",
 								skippedElements.size()),
 						L10N.t("dialog.workspace.regenerate_and_build.warning.skipped_import_of.title"),
 						JOptionPane.WARNING_MESSAGE);
@@ -269,7 +269,7 @@ public class RegenerateCodeAction extends GradleAction {
 			mcreator.getGradleConsole().markRunning(); // so console gets locked while we generate code already
 			try {
 				mcreator.getGenerator().generateBase();
-				mcreator.getGradleConsole().exec("build" , taskSpecificListener);
+				mcreator.getGradleConsole().exec("build", taskSpecificListener);
 			} catch (Exception e) { // if something fails, we still need to free the gradle console
 				LOG.error(e.getMessage(), e);
 				mcreator.getGradleConsole().markReady();
@@ -279,7 +279,8 @@ public class RegenerateCodeAction extends GradleAction {
 			dial.refreshDisplay();
 
 			dial.hideAll();
-		}); thread.start();
+		});
+		thread.start();
 		dial.setVisible(true);
 	}
 

--- a/src/main/java/net/mcreator/ui/workspace/WorkspacePanel.java
+++ b/src/main/java/net/mcreator/ui/workspace/WorkspacePanel.java
@@ -532,7 +532,7 @@ import java.util.stream.Collectors;
 		modElementsBar.add(ComponentUtils.deriveFont(elementsCount, 12));
 		modElementsBar.add(new JEmptyBox(5, 1));
 
-		se.add("East" , modElementsBar);
+		se.add("East", modElementsBar);
 
 		JPanel leftPan = new JPanel(new FlowLayout(FlowLayout.LEFT, 0, 0));
 		leftPan.setOpaque(false);
@@ -556,7 +556,7 @@ import java.util.stream.Collectors;
 		leftPan.add(new JEmptyBox(2, 2));
 		leftPan.add(sort);
 
-		se.add("West" , leftPan);
+		se.add("West", leftPan);
 
 		JScrollablePopupMenu filterPopup = new JScrollablePopupMenu();
 		filterPopup.add(new UnregisteredAction(L10N.t("workspace.elements.list.filter_all"), e -> search.setText("")));
@@ -568,7 +568,7 @@ import java.util.stream.Collectors;
 		filterPopup.addSeparator();
 		for (ModElementType<?> type : ModElementTypeLoader.REGISTRY) {
 			filterPopup.add(new UnregisteredAction(type.getReadableName(), e -> togglefilter(
-					"f:" + type.getReadableName().replace(" " , "").toLowerCase(Locale.ENGLISH))).setIcon(
+					"f:" + type.getReadableName().replace(" ", "").toLowerCase(Locale.ENGLISH))).setIcon(
 					new ImageIcon(ImageUtils.resizeAA(type.getIcon().getImage(), 16))));
 		}
 		filter.addActionListener(e -> filterPopup.show(filter, 0, 26));
@@ -632,28 +632,28 @@ import java.util.stream.Collectors;
 		slo.setOpaque(false);
 		se.setOpaque(false);
 
-		slo.add("North" , se);
+		slo.add("North", se);
 
 		mainp.setOpaque(false);
 
-		detailsbar.add("Center" , PanelUtils.gridElements(1, 6, L10N.label("workspace.elements.details.name"),
+		detailsbar.add("Center", PanelUtils.gridElements(1, 6, L10N.label("workspace.elements.details.name"),
 				L10N.label("workspace.elements.details.id"), L10N.label("workspace.elements.details.type"),
 				L10N.label("workspace.elements.details.lock"), L10N.label("workspace.elements.details.compile")));
 		detailsbar.setBorder(BorderFactory.createEmptyBorder(4, 47, 4, 8));
 		detailsbar.setBackground((Color) UIManager.get("MCreatorLAF.BLACK_ACCENT"));
 
-		modElementsPanel.add("North" , PanelUtils.northAndCenterElement(elementsBreadcrumb, detailsbar, 0, 0));
-		modElementsPanel.add("Center" , mainp);
+		modElementsPanel.add("North", PanelUtils.northAndCenterElement(elementsBreadcrumb, detailsbar, 0, 0));
+		modElementsPanel.add("Center", mainp);
 
-		slo.add("Center" , panels);
+		slo.add("Center", panels);
 
 		slo.setBorder(null);
 
 		rotatablePanel.setLayout(new BoxLayout(rotatablePanel, BoxLayout.PAGE_AXIS));
 		rotatablePanel.setBackground((Color) UIManager.get("MCreatorLAF.DARK_ACCENT"));
-		slo.add("West" , rotatablePanel);
+		slo.add("West", rotatablePanel);
 
-		add("Center" , slo);
+		add("Center", slo);
 
 		setOpaque(false);
 
@@ -749,7 +749,7 @@ import java.util.stream.Collectors;
 		};
 		toolp.setOpaque(false);
 		toolp.setBorder(BorderFactory.createEmptyBorder(3, 5, 0, 5));
-		toolp.add("North" , pne);
+		toolp.add("North", pne);
 
 		JPanel emptct = new JPanel();
 		emptct.setLayout(new BoxLayout(emptct, BoxLayout.LINE_AXIS));
@@ -762,17 +762,17 @@ import java.util.stream.Collectors;
 
 		JPanel emptbtpd = new JPanel(new BorderLayout());
 		emptbtpd.setOpaque(false);
-		emptbtpd.add("Center" , emptct);
-		emptbtpd.add("South" , new JEmptyBox(1, 40));
+		emptbtpd.add("Center", emptct);
+		emptbtpd.add("South", new JEmptyBox(1, 40));
 
-		mainp.add("ep" , PanelUtils.totalCenterInPanel(emptbtpd));
-		mainp.add("sp" , sp);
+		mainp.add("ep", PanelUtils.totalCenterInPanel(emptbtpd));
+		mainp.add("sp", sp);
 
-		addVerticalTab("mods" , L10N.t("workspace.category.mod_elements"),
+		addVerticalTab("mods", L10N.t("workspace.category.mod_elements"),
 				new WorkspacePanelMods(PanelUtils.westAndCenterElement(toolp, modElementsPanel)));
-		addVerticalTab("res" , L10N.t("workspace.category.resources"), resourcesPan);
-		addVerticalTab("locales" , L10N.t("workspace.category.variables"), new WorkspacePanelVariables(this));
-		addVerticalTab("variables" , L10N.t("workspace.category.localization"), new WorkspacePanelLocalizations(this));
+		addVerticalTab("res", L10N.t("workspace.category.resources"), resourcesPan);
+		addVerticalTab("locales", L10N.t("workspace.category.variables"), new WorkspacePanelVariables(this));
+		addVerticalTab("variables", L10N.t("workspace.category.localization"), new WorkspacePanelLocalizations(this));
 
 		verticalTabs.get(0).doClick();
 
@@ -904,7 +904,7 @@ import java.util.stream.Collectors;
 	private void togglefilter(String filter) {
 		String currentSearchText = search.getText().trim();
 		if (currentSearchText.contains(filter)) {
-			search.setText(currentSearchText.replace(filter, "").replaceAll("\\s{2,}" , " ").trim());
+			search.setText(currentSearchText.replace(filter, "").replaceAll("\\s{2,}", " ").trim());
 		} else {
 			search.setText(filter + " " + currentSearchText);
 		}
@@ -1065,8 +1065,8 @@ import java.util.stream.Collectors;
 
 			if (generatableElementOriginal != null) {
 				String modName = VOptionPane.showInputDialog(mcreator,
-						L10N.t("workspace.elements.duplicate_message" , mu.getName()),
-						L10N.t("workspace.elements.duplicate_element" , mu.getName()), mu.getElementIcon(),
+						L10N.t("workspace.elements.duplicate_message", mu.getName()),
+						L10N.t("workspace.elements.duplicate_element", mu.getName()), mu.getElementIcon(),
 						new OptionPaneValidatior() {
 							@Override public Validator.ValidationResult validate(JComponent component) {
 								return new ModElementNameValidator(mcreator.getWorkspace(), (VTextField) component,
@@ -1178,7 +1178,7 @@ import java.util.stream.Collectors;
 		if (but3.isEnabled()) {
 			if (list.getSelectedValue() != null) {
 				int n = JOptionPane.showConfirmDialog(mcreator,
-						L10N.t("workspace.elements.confirm_delete_message" , list.getSelectedValuesList().size()),
+						L10N.t("workspace.elements.confirm_delete_message", list.getSelectedValuesList().size()),
 						L10N.t("common.confirmation"), JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE, null);
 
 				if (n == 0) {
@@ -1302,11 +1302,11 @@ import java.util.stream.Collectors;
 			}
 
 			if (mcreator.getWorkspace().getModElements().isEmpty()) {
-				elementsCount.setText(L10N.t("workspace.stats.empty" , mcreator.getWorkspaceSettings().getModName(),
+				elementsCount.setText(L10N.t("workspace.stats.empty", mcreator.getWorkspaceSettings().getModName(),
 						mcreator.getGenerator().getGeneratorName()));
 			} else {
 				elementsCount.setText(
-						L10N.t("workspace.stats.current_workspace" , mcreator.getWorkspaceSettings().getModName(),
+						L10N.t("workspace.stats.current_workspace", mcreator.getWorkspaceSettings().getModName(),
 								mcreator.getGenerator().getGeneratorName(),
 								mcreator.getWorkspace().getModElements().size()));
 			}
@@ -1388,16 +1388,16 @@ import java.util.stream.Collectors;
 			while (m.find()) {
 				String pat = m.group(1);
 				if (pat.contains("f:")) {
-					pat = pat.replaceFirst("f:" , "");
+					pat = pat.replaceFirst("f:", "");
 					if (pat.equals("locked") || pat.equals("ok") || pat.equals("err"))
 						filters.add(pat);
 					for (ModElementType<?> type : ModElementTypeLoader.REGISTRY) {
-						if (pat.equals(type.getReadableName().replace(" " , "").toLowerCase(Locale.ENGLISH))) {
+						if (pat.equals(type.getReadableName().replace(" ", "").toLowerCase(Locale.ENGLISH))) {
 							metfilters.add(type);
 						}
 					}
 				} else
-					keyWords.add(pat.replace("\"" , ""));
+					keyWords.add(pat.replace("\"", ""));
 			}
 
 			boolean flattenFolders = !searchInput.isEmpty();

--- a/src/main/java/net/mcreator/ui/workspace/WorkspacePanel.java
+++ b/src/main/java/net/mcreator/ui/workspace/WorkspacePanel.java
@@ -414,7 +414,8 @@ import java.util.stream.Collectors;
 				updateElementListRenderer();
 			}
 		});
-		tilesIcons.setSelected(PreferencesManager.PREFERENCES.hidden.workspaceModElementIconSize.get() == HiddenSection.IconSize.TILES);
+		tilesIcons.setSelected(PreferencesManager.PREFERENCES.hidden.workspaceModElementIconSize.get()
+				== HiddenSection.IconSize.TILES);
 		Arrays.stream(tilesIcons.getChangeListeners()).forEach(e -> e.stateChanged(new ChangeEvent(tilesIcons)));
 		ComponentUtils.deriveFont(tilesIcons, 12);
 		tilesIcons.setBorder(BorderFactory.createEmptyBorder(3, 5, 3, 5));
@@ -465,8 +466,8 @@ import java.util.stream.Collectors;
 				updateElementListRenderer();
 			}
 		});
-		listIcons.setSelected(PreferencesManager.PREFERENCES.hidden.workspaceModElementIconSize.get()
-				== HiddenSection.IconSize.LIST);
+		listIcons.setSelected(
+				PreferencesManager.PREFERENCES.hidden.workspaceModElementIconSize.get() == HiddenSection.IconSize.LIST);
 		Arrays.stream(listIcons.getChangeListeners()).forEach(e -> e.stateChanged(new ChangeEvent(listIcons)));
 		ComponentUtils.deriveFont(listIcons, 12);
 		listIcons.setBorder(BorderFactory.createEmptyBorder(3, 5, 3, 5));
@@ -531,7 +532,7 @@ import java.util.stream.Collectors;
 		modElementsBar.add(ComponentUtils.deriveFont(elementsCount, 12));
 		modElementsBar.add(new JEmptyBox(5, 1));
 
-		se.add("East", modElementsBar);
+		se.add("East" , modElementsBar);
 
 		JPanel leftPan = new JPanel(new FlowLayout(FlowLayout.LEFT, 0, 0));
 		leftPan.setOpaque(false);
@@ -555,7 +556,7 @@ import java.util.stream.Collectors;
 		leftPan.add(new JEmptyBox(2, 2));
 		leftPan.add(sort);
 
-		se.add("West", leftPan);
+		se.add("West" , leftPan);
 
 		JScrollablePopupMenu filterPopup = new JScrollablePopupMenu();
 		filterPopup.add(new UnregisteredAction(L10N.t("workspace.elements.list.filter_all"), e -> search.setText("")));
@@ -567,7 +568,7 @@ import java.util.stream.Collectors;
 		filterPopup.addSeparator();
 		for (ModElementType<?> type : ModElementTypeLoader.REGISTRY) {
 			filterPopup.add(new UnregisteredAction(type.getReadableName(), e -> togglefilter(
-					"f:" + type.getReadableName().replace(" ", "").toLowerCase(Locale.ENGLISH))).setIcon(
+					"f:" + type.getReadableName().replace(" " , "").toLowerCase(Locale.ENGLISH))).setIcon(
 					new ImageIcon(ImageUtils.resizeAA(type.getIcon().getImage(), 16))));
 		}
 		filter.addActionListener(e -> filterPopup.show(filter, 0, 26));
@@ -622,8 +623,7 @@ import java.util.stream.Collectors;
 			sortName.setSelected(true);
 		} else if (PreferencesManager.PREFERENCES.hidden.workspaceSortType.get() == HiddenSection.SortType.TYPE) {
 			sortType.setSelected(true);
-		} else if (PreferencesManager.PREFERENCES.hidden.workspaceSortType.get()
-				== HiddenSection.SortType.LOADORDER) {
+		} else if (PreferencesManager.PREFERENCES.hidden.workspaceSortType.get() == HiddenSection.SortType.LOADORDER) {
 			sortLoadingOrder.setSelected(true);
 		} else {
 			sortDateCreated.setSelected(true);
@@ -632,28 +632,28 @@ import java.util.stream.Collectors;
 		slo.setOpaque(false);
 		se.setOpaque(false);
 
-		slo.add("North", se);
+		slo.add("North" , se);
 
 		mainp.setOpaque(false);
 
-		detailsbar.add("Center", PanelUtils.gridElements(1, 6, L10N.label("workspace.elements.details.name"),
+		detailsbar.add("Center" , PanelUtils.gridElements(1, 6, L10N.label("workspace.elements.details.name"),
 				L10N.label("workspace.elements.details.id"), L10N.label("workspace.elements.details.type"),
 				L10N.label("workspace.elements.details.lock"), L10N.label("workspace.elements.details.compile")));
 		detailsbar.setBorder(BorderFactory.createEmptyBorder(4, 47, 4, 8));
 		detailsbar.setBackground((Color) UIManager.get("MCreatorLAF.BLACK_ACCENT"));
 
-		modElementsPanel.add("North", PanelUtils.northAndCenterElement(elementsBreadcrumb, detailsbar, 0, 0));
-		modElementsPanel.add("Center", mainp);
+		modElementsPanel.add("North" , PanelUtils.northAndCenterElement(elementsBreadcrumb, detailsbar, 0, 0));
+		modElementsPanel.add("Center" , mainp);
 
-		slo.add("Center", panels);
+		slo.add("Center" , panels);
 
 		slo.setBorder(null);
 
 		rotatablePanel.setLayout(new BoxLayout(rotatablePanel, BoxLayout.PAGE_AXIS));
 		rotatablePanel.setBackground((Color) UIManager.get("MCreatorLAF.DARK_ACCENT"));
-		slo.add("West", rotatablePanel);
+		slo.add("West" , rotatablePanel);
 
-		add("Center", slo);
+		add("Center" , slo);
 
 		setOpaque(false);
 
@@ -749,7 +749,7 @@ import java.util.stream.Collectors;
 		};
 		toolp.setOpaque(false);
 		toolp.setBorder(BorderFactory.createEmptyBorder(3, 5, 0, 5));
-		toolp.add("North", pne);
+		toolp.add("North" , pne);
 
 		JPanel emptct = new JPanel();
 		emptct.setLayout(new BoxLayout(emptct, BoxLayout.LINE_AXIS));
@@ -762,17 +762,17 @@ import java.util.stream.Collectors;
 
 		JPanel emptbtpd = new JPanel(new BorderLayout());
 		emptbtpd.setOpaque(false);
-		emptbtpd.add("Center", emptct);
-		emptbtpd.add("South", new JEmptyBox(1, 40));
+		emptbtpd.add("Center" , emptct);
+		emptbtpd.add("South" , new JEmptyBox(1, 40));
 
-		mainp.add("ep", PanelUtils.totalCenterInPanel(emptbtpd));
-		mainp.add("sp", sp);
+		mainp.add("ep" , PanelUtils.totalCenterInPanel(emptbtpd));
+		mainp.add("sp" , sp);
 
-		addVerticalTab("mods", L10N.t("workspace.category.mod_elements"),
+		addVerticalTab("mods" , L10N.t("workspace.category.mod_elements"),
 				new WorkspacePanelMods(PanelUtils.westAndCenterElement(toolp, modElementsPanel)));
-		addVerticalTab("res", L10N.t("workspace.category.resources"), resourcesPan);
-		addVerticalTab("locales", L10N.t("workspace.category.variables"), new WorkspacePanelVariables(this));
-		addVerticalTab("variables", L10N.t("workspace.category.localization"), new WorkspacePanelLocalizations(this));
+		addVerticalTab("res" , L10N.t("workspace.category.resources"), resourcesPan);
+		addVerticalTab("locales" , L10N.t("workspace.category.variables"), new WorkspacePanelVariables(this));
+		addVerticalTab("variables" , L10N.t("workspace.category.localization"), new WorkspacePanelLocalizations(this));
 
 		verticalTabs.get(0).doClick();
 
@@ -848,8 +848,8 @@ import java.util.stream.Collectors;
 	 * Adds a new section to this workspace as well as a vertical tab button on the left that switches
 	 * to the section panel when clicked.
 	 *
-	 * @param id    The unique identifier of the section used for reloading/filtering contained elements.
-	 * @param name  The name of the section shown in the workspace.
+	 * @param id      The unique identifier of the section used for reloading/filtering contained elements.
+	 * @param name    The name of the section shown in the workspace.
 	 * @param section The panel representing contents of the vertical tab being added.
 	 */
 	public void addVerticalTab(String id, String name, AbstractWorkspacePanel section) {
@@ -904,7 +904,7 @@ import java.util.stream.Collectors;
 	private void togglefilter(String filter) {
 		String currentSearchText = search.getText().trim();
 		if (currentSearchText.contains(filter)) {
-			search.setText(currentSearchText.replace(filter, "").replaceAll("\\s{2,}", " ").trim());
+			search.setText(currentSearchText.replace(filter, "").replaceAll("\\s{2,}" , " ").trim());
 		} else {
 			search.setText(filter + " " + currentSearchText);
 		}
@@ -927,8 +927,7 @@ import java.util.stream.Collectors;
 	}
 
 	private void updateElementListRenderer() {
-		if (PreferencesManager.PREFERENCES.hidden.workspaceModElementIconSize.get()
-				== HiddenSection.IconSize.TILES) {
+		if (PreferencesManager.PREFERENCES.hidden.workspaceModElementIconSize.get() == HiddenSection.IconSize.TILES) {
 			list.setCellRenderer(new TilesModListRender());
 			list.setFixedCellHeight(72);
 			list.setFixedCellWidth(287);
@@ -1062,10 +1061,12 @@ import java.util.stream.Collectors;
 
 	private void duplicateCurrentlySelectedModElement() {
 		if (list.getSelectedValue() instanceof ModElement mu) {
-			if (mcreator.getModElementManager().hasModElementGeneratableElement(mu)) {
+			GeneratableElement generatableElementOriginal = mu.getGeneratableElement();
+
+			if (generatableElementOriginal != null) {
 				String modName = VOptionPane.showInputDialog(mcreator,
-						L10N.t("workspace.elements.duplicate_message", mu.getName()),
-						L10N.t("workspace.elements.duplicate_element", mu.getName()), mu.getElementIcon(),
+						L10N.t("workspace.elements.duplicate_message" , mu.getName()),
+						L10N.t("workspace.elements.duplicate_element" , mu.getName()), mu.getElementIcon(),
 						new OptionPaneValidatior() {
 							@Override public Validator.ValidationResult validate(JComponent component) {
 								return new ModElementNameValidator(mcreator.getWorkspace(), (VTextField) component,
@@ -1075,75 +1076,73 @@ import java.util.stream.Collectors;
 				if (modName != null && !modName.equals("")) {
 					modName = JavaConventions.convertToValidClassName(modName);
 
-					GeneratableElement generatableElementOriginal = mu.getGeneratableElement();
-					if (generatableElementOriginal != null) {
-						ModElement duplicateModElement = new ModElement(mcreator.getWorkspace(), mu, modName);
+					ModElement duplicateModElement = new ModElement(mcreator.getWorkspace(), mu, modName);
 
-						GeneratableElement generatableElementDuplicate = mcreator.getModElementManager()
-								.fromJSONtoGeneratableElement(mcreator.getModElementManager()
-										.generatableElementToJSON(generatableElementOriginal), duplicateModElement);
+					GeneratableElement generatableElementDuplicate = mcreator.getModElementManager()
+							.fromJSONtoGeneratableElement(mcreator.getModElementManager()
+									.generatableElementToJSON(generatableElementOriginal), duplicateModElement);
 
-						if (generatableElementDuplicate instanceof NamespacedGeneratableElement) {
-							((NamespacedGeneratableElement) generatableElementDuplicate).name = RegistryNameFixer.fromCamelCase(
-									modName);
-						}
+					if (generatableElementDuplicate instanceof NamespacedGeneratableElement) {
+						((NamespacedGeneratableElement) generatableElementDuplicate).name = RegistryNameFixer.fromCamelCase(
+								modName);
+					}
 
-						mcreator.getGenerator().generateElement(generatableElementDuplicate);
-						mcreator.getModElementManager().storeModElementPicture(generatableElementDuplicate);
-						mcreator.getModElementManager().storeModElement(generatableElementDuplicate);
+					mcreator.getGenerator().generateElement(generatableElementDuplicate);
+					mcreator.getModElementManager().storeModElementPicture(generatableElementDuplicate);
+					mcreator.getModElementManager().storeModElement(generatableElementDuplicate);
 
-						if (mu.getType() == ModElementType.CODE || mu.isCodeLocked()) {
-							List<GeneratorTemplate> originalFiles = mcreator.getGenerator()
-									.getModElementGeneratorTemplatesList(generatableElementOriginal);
-							List<GeneratorTemplate> duplicateFiles = mcreator.getGenerator()
-									.getModElementGeneratorTemplatesList(generatableElementDuplicate);
+					if (mu.getType() == ModElementType.CODE || mu.isCodeLocked()) {
+						List<GeneratorTemplate> originalFiles = mcreator.getGenerator()
+								.getModElementGeneratorTemplatesList(generatableElementOriginal);
+						List<GeneratorTemplate> duplicateFiles = mcreator.getGenerator()
+								.getModElementGeneratorTemplatesList(generatableElementDuplicate);
 
-							for (GeneratorTemplate originalTemplate : originalFiles) {
-								File originalFile = originalTemplate.getFile();
-								File duplicateFile = null;
-								for (GeneratorTemplate newCandidate : duplicateFiles) {
-									if (newCandidate.getTemplateIdentifier()
-											.equals(originalTemplate.getTemplateIdentifier())) {
-										duplicateFile = newCandidate.getFile();
-										break;
-									}
-								}
-								if (duplicateFile != null) {
-									FileIO.copyFile(originalFile, duplicateFile);
+						for (GeneratorTemplate originalTemplate : originalFiles) {
+							File originalFile = originalTemplate.getFile();
+							File duplicateFile = null;
+							for (GeneratorTemplate newCandidate : duplicateFiles) {
+								if (newCandidate.getTemplateIdentifier()
+										.equals(originalTemplate.getTemplateIdentifier())) {
+									duplicateFile = newCandidate.getFile();
+									break;
 								}
 							}
-
-							duplicateModElement.setCodeLock(true);
+							if (duplicateFile != null) {
+								FileIO.copyFile(originalFile, duplicateFile);
+							}
 						}
 
-						// if we are not in the root folder, specify the folder of the mod element
-						if (!currentFolder.equals(mcreator.getWorkspace().getFoldersRoot()))
-							duplicateModElement.setParentFolder(currentFolder);
-
-						mcreator.getWorkspace().addModElement(duplicateModElement);
-
-						updateMods();
+						duplicateModElement.setCodeLock(true);
 					}
+
+					// if we are not in the root folder, specify the folder of the mod element
+					if (!currentFolder.equals(mcreator.getWorkspace().getFoldersRoot()))
+						duplicateModElement.setParentFolder(currentFolder);
+
+					mcreator.getWorkspace().addModElement(duplicateModElement);
+
+					updateMods();
 				}
 			}
 		}
 	}
 
-	public void editCurrentlySelectedModElement(ModElement mu, JComponent component, int x, int y) {
-		if (mcreator.getModElementManager().hasModElementGeneratableElement(mu)) {
-			if (mu.isCodeLocked()) {
-				editCurrentlySelectedModElementAsCode(mu, component, x, y);
+	public void editCurrentlySelectedModElement(ModElement modElement, JComponent component, int x, int y) {
+		if (modElement.getGeneratableElement() != null) {
+			if (modElement.isCodeLocked()) {
+				editCurrentlySelectedModElementAsCode(modElement, component, x, y);
 			} else {
-				ModElementGUI<?> modeditor = mu.getType().getModElementGUI(mcreator, mu, true);
-				if (modeditor != null) {
-					modeditor.showView();
+				ModElementGUI<?> modElementGUI = modElement.getType().getModElementGUI(mcreator, modElement, true);
+				if (modElementGUI != null) {
+					modElementGUI.showView();
 				}
 			}
 		} else {
-			if (mu.isCodeLocked()) {
-				editCurrentlySelectedModElementAsCode(mu, component, x, y);
+			if (modElement.isCodeLocked()) {
+				editCurrentlySelectedModElementAsCode(modElement, component, x, y);
 			} else {
-				JOptionPane.showMessageDialog(null, L10N.t("workspace.elements.edit_modelement_nosavedinstance"));
+				JOptionPane.showMessageDialog(null, L10N.t("workspace.elements.edit_modelement_nosavedinstance"),
+						L10N.t("workspace.elements.edit_modelement_nosavedinstance.title"), JOptionPane.ERROR_MESSAGE);
 			}
 		}
 	}
@@ -1179,7 +1178,7 @@ import java.util.stream.Collectors;
 		if (but3.isEnabled()) {
 			if (list.getSelectedValue() != null) {
 				int n = JOptionPane.showConfirmDialog(mcreator,
-						L10N.t("workspace.elements.confirm_delete_message", list.getSelectedValuesList().size()),
+						L10N.t("workspace.elements.confirm_delete_message" , list.getSelectedValuesList().size()),
 						L10N.t("common.confirmation"), JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE, null);
 
 				if (n == 0) {
@@ -1303,11 +1302,11 @@ import java.util.stream.Collectors;
 			}
 
 			if (mcreator.getWorkspace().getModElements().isEmpty()) {
-				elementsCount.setText(L10N.t("workspace.stats.empty", mcreator.getWorkspaceSettings().getModName(),
+				elementsCount.setText(L10N.t("workspace.stats.empty" , mcreator.getWorkspaceSettings().getModName(),
 						mcreator.getGenerator().getGeneratorName()));
 			} else {
 				elementsCount.setText(
-						L10N.t("workspace.stats.current_workspace", mcreator.getWorkspaceSettings().getModName(),
+						L10N.t("workspace.stats.current_workspace" , mcreator.getWorkspaceSettings().getModName(),
 								mcreator.getGenerator().getGeneratorName(),
 								mcreator.getWorkspace().getModElements().size()));
 			}
@@ -1389,16 +1388,16 @@ import java.util.stream.Collectors;
 			while (m.find()) {
 				String pat = m.group(1);
 				if (pat.contains("f:")) {
-					pat = pat.replaceFirst("f:", "");
+					pat = pat.replaceFirst("f:" , "");
 					if (pat.equals("locked") || pat.equals("ok") || pat.equals("err"))
 						filters.add(pat);
 					for (ModElementType<?> type : ModElementTypeLoader.REGISTRY) {
-						if (pat.equals(type.getReadableName().replace(" ", "").toLowerCase(Locale.ENGLISH))) {
+						if (pat.equals(type.getReadableName().replace(" " , "").toLowerCase(Locale.ENGLISH))) {
 							metfilters.add(type);
 						}
 					}
 				} else
-					keyWords.add(pat.replace("\"", ""));
+					keyWords.add(pat.replace("\"" , ""));
 			}
 
 			boolean flattenFolders = !searchInput.isEmpty();

--- a/src/main/java/net/mcreator/workspace/elements/ModElementManager.java
+++ b/src/main/java/net/mcreator/workspace/elements/ModElementManager.java
@@ -71,11 +71,12 @@ public final class ModElementManager {
 		this.gson = gsonBuilder.create();
 	}
 
-	public void invalidateCache() {
-		cache.clear();
-	}
-
 	public void storeModElement(GeneratableElement element) {
+		if (element == null) {
+			LOG.warn("Attempted to store null generatable element. Something went wrong previously for this to happen!");
+			return;
+		}
+
 		cache.put(element.getModElement(), element);
 
 		FileIO.writeStringToFile(generatableElementToJSON(element),
@@ -116,9 +117,11 @@ public final class ModElementManager {
 
 		GeneratableElement generatableElement = fromJSONtoGeneratableElement(importJSON, element);
 		if (generatableElement != null && element.getType() != ModElementType.UNKNOWN) {
+			// Store the mod element in case the conversion was applied
 			if (generatableElement.wasConversionApplied())
 				storeModElement(generatableElement);
 
+			// Add it to the cache
 			cache.put(element, generatableElement);
 		}
 

--- a/src/main/java/net/mcreator/workspace/elements/ModElementManager.java
+++ b/src/main/java/net/mcreator/workspace/elements/ModElementManager.java
@@ -117,6 +117,10 @@ public final class ModElementManager {
 
 		GeneratableElement generatableElement = fromJSONtoGeneratableElement(importJSON, element);
 		if (generatableElement != null && element.getType() != ModElementType.UNKNOWN) {
+			// Make sure after conversion and importing, no Nonnull fields are null to prevent NPEs and check GE integrity
+			if (!generatableElement.performQuickValidation())
+				return null;
+
 			// Store the mod element in case the conversion was applied
 			if (generatableElement.wasConversionApplied())
 				storeModElement(generatableElement);
@@ -141,17 +145,6 @@ public final class ModElementManager {
 					+ " from JSON. This can lead to errors further down the road!", e);
 			return null;
 		}
-	}
-
-	public boolean hasModElementGeneratableElement(ModElement element) {
-		if (element == null)
-			return false;
-
-		// custom code mod element does not actually have one, but is provided by this manager
-		if (element.getType() == ModElementType.CODE)
-			return true;
-
-		return new File(workspace.getFolderManager().getModElementsDir(), element.getName() + ".mod.json").isFile();
 	}
 
 	public boolean requiresElementGradleBuild(GeneratableElement generatableElement) {

--- a/src/main/java/net/mcreator/workspace/misc/WorkspaceInfo.java
+++ b/src/main/java/net/mcreator/workspace/misc/WorkspaceInfo.java
@@ -347,4 +347,5 @@ import java.util.*;
 	public Workspace getWorkspace() {
 		return workspace;
 	}
+
 }

--- a/src/test/java/net/mcreator/integration/WorkspaceConvertersTest.java
+++ b/src/test/java/net/mcreator/integration/WorkspaceConvertersTest.java
@@ -91,8 +91,6 @@ public class WorkspaceConvertersTest {
 
 					// Check if all MEs have valid GE definition
 					for (ModElement mod : workspace.getModElements()) {
-						assertTrue(workspace.getModElementManager().hasModElementGeneratableElement(mod));
-
 						GeneratableElement ge = mod.getGeneratableElement();
 
 						assertNotNull(ge);


### PR DESCRIPTION
In the spirit of #4059 and similar issues, this PR tries to fix cases where:

* GE is broken due to manual manipulation of file by user
* GE is broken due to opening in newer MCreator and than manually editing .mcreator file to open in older again
* Manual use of Git and merge conflicts
* Antivirus preventing full write to GE files
* Bad disc sectors or file system problems (eg. abrupt PC shutdown)

break GE files and fields that are not supposed to be null become null and thus generators completely stop working due to not expecting null values. This is especially problem for global init files that fail to load for all GEs due to one or more related GEs being broken.

This PR:

* Prevents loading of broken GEs (these GEs are simply not generated, as if they were deleted)
* Prevents loading of empty GEs
* Prevents loading of GEs with FV higher than current FV of given MCreator
* Adds check that all direct GE fields marked as Nonnull are not null as simple but quite effective sanity check
* Improves handling of broken GEs in UI for more clarity for the user

We are in porting phase of Minecraft 1.20.1 but I still made this PR because this is major problem especially as more and more code is being moved to init files and they don't generate as soon as there is one broken GE that currently can't be handled.