### PR TITLE
Register secondary font

### DIFF
--- a/src/main/java/net/mcreator/ui/laf/MCreatorTheme.java
+++ b/src/main/java/net/mcreator/ui/laf/MCreatorTheme.java
@@ -86,6 +86,7 @@ public class MCreatorTheme extends OceanTheme {
 							PluginLoader.INSTANCE.getResourceAsStream("themes/default_dark/fonts/secondary_font.ttf"));
 					LOG.info("Main font from default_dark will be used.");
 				}
+				GraphicsEnvironment.getLocalGraphicsEnvironment().registerFont(secondary_font);
 			}
 
 			InputStream consoleFontStream = PluginLoader.INSTANCE.getResourceAsStream(


### PR DESCRIPTION
Adds a single line to register `secondary_font` to allow using it in HTML-based text components (e.g. `new JLabel("<html>...")`).