### PR TITLE
Missing block models

### DIFF
--- a/plugins/mcreator-localization/help/default/block/model.md
+++ b/plugins/mcreator-localization/help/default/block/model.md
@@ -4,6 +4,8 @@ bounding box of the block.
 * **Normal** - Normal block with textures on each side
 * **Single texture** - Block with same texture on all sides
 * **Cross** - Model used by plants
+* **Crop** - Model used by crop plants
+* **Grass block** - Model used by grass blocks (top and side textures will be tinted)
 * Custom - you can define custom JSON and OBJ models too
 
 When making custom models, JSON is recommended due to vanilla support for this model type.


### PR DESCRIPTION
Populates `block/model` help tip with missing **Crop** and **Grass block** model descriptions.