### PR TITLE
Keep only one MCreator Process

### DIFF
--- a/src/main/java/net/mcreator/ui/MCreatorApplication.java
+++ b/src/main/java/net/mcreator/ui/MCreatorApplication.java
@@ -100,13 +100,17 @@ public final class MCreatorApplication {
 					+ " process and exit the new process, current port:"+rmiPort);
 			var client =  RMIHandler.launchClient(rmiPort);
 
-			new Thread(()->{
-				try {
-					client.openWorkspace(launchArguments.get(launchArguments.size() - 1));
-				} catch (RemoteException ignored) {}
-			}).start();
-			//wait :(
-			Thread.sleep(3000L);
+			if (launchArguments.size() != 0) {
+				new Thread(() -> {
+					try {
+						client.openWorkspace(launchArguments.get(launchArguments.size() - 1));
+					} catch (RemoteException ignored) {
+					}
+				}).start();
+
+				//wait :(
+				Thread.sleep(3000L);
+			}
 
 			System.exit(0);
 		} catch (MalformedURLException | NotBoundException | RemoteException ignored) {

--- a/src/main/java/net/mcreator/ui/workspace/selector/WorkspaceSelector.java
+++ b/src/main/java/net/mcreator/ui/workspace/selector/WorkspaceSelector.java
@@ -45,6 +45,7 @@ import net.mcreator.util.ListUtils;
 import net.mcreator.util.StringUtils;
 import net.mcreator.util.image.EmptyIcon;
 import net.mcreator.util.image.ImageUtils;
+import net.mcreator.util.rmi.MCreatorRMIWorkspaceOpenListener;
 import net.mcreator.workspace.ShareableZIPManager;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -60,6 +61,7 @@ import java.awt.dnd.*;
 import java.awt.event.*;
 import java.awt.image.BufferedImage;
 import java.io.File;
+import java.rmi.RemoteException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -83,6 +85,12 @@ public final class WorkspaceSelector extends JFrame implements DropTargetListene
 	public WorkspaceSelector(@Nullable MCreatorApplication application, WorkspaceOpenListener workspaceOpenListener) {
 		this.workspaceOpenListener = workspaceOpenListener;
 		this.application = application;
+
+		try {
+			MCreatorRMIWorkspaceOpenListener.getInstance().setWorkspaceOpenListener(workspaceOpenListener);
+		} catch (RemoteException e) {
+			e.printStackTrace();
+		}
 
 		setTitle("MCreator " + Launcher.version.getMajorString());
 		setIconImage(UIRES.getAppIcon().getImage());

--- a/src/main/java/net/mcreator/util/rmi/IRMIWorkspaceOpener.java
+++ b/src/main/java/net/mcreator/util/rmi/IRMIWorkspaceOpener.java
@@ -1,0 +1,27 @@
+/*
+ * MCreator (https://mcreator.net/)
+ * Copyright (C) 2012-2020, Pylo
+ * Copyright (C) 2020-2023, Pylo, opensource contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package net.mcreator.util.rmi;
+
+import java.rmi.Remote;
+import java.rmi.RemoteException;
+
+public interface IRMIWorkspaceOpener extends Remote {
+	void openWorkspace(String workspaceFile) throws RemoteException;
+}

--- a/src/main/java/net/mcreator/util/rmi/MCreatorRMIWorkspaceOpenListener.java
+++ b/src/main/java/net/mcreator/util/rmi/MCreatorRMIWorkspaceOpenListener.java
@@ -1,0 +1,83 @@
+/*
+ * MCreator (https://mcreator.net/)
+ * Copyright (C) 2012-2020, Pylo
+ * Copyright (C) 2020-2023, Pylo, opensource contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package net.mcreator.util.rmi;
+
+import net.mcreator.ui.workspace.selector.WorkspaceOpenListener;
+import org.apache.commons.io.FilenameUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import javax.annotation.Nonnull;
+import java.io.File;
+import java.rmi.RemoteException;
+import java.rmi.server.UnicastRemoteObject;
+
+public class MCreatorRMIWorkspaceOpenListener extends UnicastRemoteObject implements IRMIWorkspaceOpener {
+
+	private static final Logger LOG = LogManager.getLogger("MCreatorRMIServer");
+
+	private static final Object lock = new Object();
+
+	private static MCreatorRMIWorkspaceOpenListener instance;
+	public static  MCreatorRMIWorkspaceOpenListener getInstance() throws RemoteException {
+		if (instance == null) instance = new MCreatorRMIWorkspaceOpenListener();
+		return instance;
+	}
+
+	private WorkspaceOpenListener workspaceOpenListener;
+
+	protected MCreatorRMIWorkspaceOpenListener() throws RemoteException {
+	}
+
+	public void setWorkspaceOpenListener(@Nonnull WorkspaceOpenListener workspaceOpenListener){
+		synchronized (lock){
+			lock.notifyAll();
+		}
+		this.workspaceOpenListener = workspaceOpenListener;
+	}
+
+	@Override public void openWorkspace(@Nonnull String workspaceFile) throws RemoteException {
+		File fl;
+		if (workspaceFile.startsWith("\"")&&workspaceFile.endsWith("\"")){
+			fl = new File(workspaceFile.substring(1,workspaceFile.length()-1));
+		} else {
+			fl = new File(workspaceFile);
+		}
+
+		//exclude invalidate
+		if (!FilenameUtils.isExtension(fl.getPath(),"mcreator")){
+			return;
+		}
+
+		synchronized (lock) {
+			if (workspaceOpenListener == null) {
+				try {
+					lock.wait(10000);
+				} catch (InterruptedException e) {
+					e.printStackTrace();
+				}
+			}
+
+			LOG.info("starting to open workspace"+fl);
+
+			workspaceOpenListener.workspaceOpened(fl);
+		}
+	}
+}

--- a/src/main/java/net/mcreator/util/rmi/RMIHandler.java
+++ b/src/main/java/net/mcreator/util/rmi/RMIHandler.java
@@ -1,0 +1,41 @@
+/*
+ * MCreator (https://mcreator.net/)
+ * Copyright (C) 2012-2020, Pylo
+ * Copyright (C) 2020-2023, Pylo, opensource contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package net.mcreator.util.rmi;
+
+import java.net.MalformedURLException;
+import java.rmi.AlreadyBoundException;
+import java.rmi.Naming;
+import java.rmi.NotBoundException;
+import java.rmi.RemoteException;
+import java.rmi.registry.LocateRegistry;
+
+public class RMIHandler {
+	public static IRMIWorkspaceOpener launchClient(int port)
+			throws MalformedURLException, NotBoundException, RemoteException {
+		return (IRMIWorkspaceOpener) Naming.lookup(
+				"rmi://localhost:" + port + "/mcreator");
+	}
+
+	public static void launchServer(int port) throws RemoteException, AlreadyBoundException, MalformedURLException {
+		LocateRegistry.createRegistry(port);
+		Naming.bind("rmi://localhost:" + port + "/mcreator",
+				MCreatorRMIWorkspaceOpenListener.getInstance());
+	}
+}


### PR DESCRIPTION
I HAVE PASSED THE FINAL EXAM IN CHINA,I HAVE THE FREE TIME TO MAKE THE PR

The pr do these:

1.  avoid making new mcreator process to waste resource
2.  Enable mcreator to handle project startup events in one process

The pr has passed some test(A MCreator process exists)

1.  open the  new project (commandline: "mcreator.exe "C:\Users\Admin\\.mcreator\MCreatorWorkspace\test\test.mcreator"")
2.  open the new process (commandline: "mcreator.exe")
3.  open the wrong file (commandline: "mcreator.exe "C:\helloworld.cpp"")

these test has return result:

1.  Because a process already exists, the project has been entrusted to the original process
2.  Exited
3.  Exited 

The test jar file

[mcreator.zip](https://github.com/MCreator/MCreator/files/12461471/mcreator.zip)
