### PR TITLE
Fix generator stats problem with plugins

### DIFF
--- a/src/main/java/net/mcreator/ui/dialogs/workspace/GeneratorSelector.java
+++ b/src/main/java/net/mcreator/ui/dialogs/workspace/GeneratorSelector.java
@@ -43,7 +43,7 @@ import java.util.Map;
 
 public class GeneratorSelector {
 
-	private static final String covpfx = "dialog.generator_selector.coverage.";
+	public static final String covpfx = "dialog.generator_selector.coverage.";
 
 	private static final List<GeneratorFlavor> compatible1 = List.of(GeneratorFlavor.FORGE, GeneratorFlavor.FABRIC,
 			GeneratorFlavor.NEOFORGE, GeneratorFlavor.QUILT);
@@ -129,7 +129,11 @@ public class GeneratorSelector {
 
 			JPanel supportedElements = new JPanel(new GridLayout(-1, 6, 7, 3));
 			DataListLoader.getCache().entrySet().stream().filter(e -> !e.getValue().isEmpty()).map(Map.Entry::getKey)
-					.sorted().forEach(e -> addStatsBar(L10N.t(covpfx + e), e, supportedElements, stats));
+					.sorted().forEach(e -> {
+						String name = L10N.t(covpfx + e);
+						if (name != null)
+							addStatsBar(name, e, supportedElements, stats);
+					});
 
 			genStats.add(PanelUtils.northAndCenterElement(L10N.label("dialog.generator_selector.element_coverage"),
 					supportedElements, 10, 10));
@@ -138,8 +142,11 @@ public class GeneratorSelector {
 
 			JPanel supportedProcedures = new JPanel(new GridLayout(-1, 4, 7, 3));
 
-			stats.getGeneratorBlocklyBlocks()
-					.forEach((key, value) -> addStatsBar(L10N.t(covpfx + key), key, supportedProcedures, stats));
+			stats.getGeneratorBlocklyBlocks().forEach((key, value) -> {
+				String name = L10N.t(covpfx + key);
+				if (name != null)
+					addStatsBar(name, key, supportedProcedures, stats);
+			});
 
 			addStatsBar(L10N.t(covpfx + "triggers"), "triggers", supportedProcedures, stats);
 

--- a/src/main/java/net/mcreator/ui/init/L10N.java
+++ b/src/main/java/net/mcreator/ui/init/L10N.java
@@ -21,6 +21,7 @@ package net.mcreator.ui.init;
 import net.mcreator.plugin.PluginLoader;
 import net.mcreator.preferences.PreferencesManager;
 import net.mcreator.ui.component.TechnicalButton;
+import net.mcreator.ui.dialogs.workspace.GeneratorSelector;
 import net.mcreator.ui.help.HelpLoader;
 import net.mcreator.util.FilenameUtilsPatched;
 import net.mcreator.util.locale.LocaleRegistration;
@@ -138,34 +139,25 @@ public class L10N {
 	}
 
 	public static String t(String key, Object... parameters) {
-		if (key == null)
-			return null;
-
-		if (rb.containsKey(key))
-			return MessageFormat.format(rb.getString(key), parameters);
-		else if (key.startsWith("blockly.") && (key.endsWith(".tooltip") || key.endsWith(".tip") || key.endsWith(
-				".description")))
-			return null;
-		else if (isTestingEnvironment)
-			throw new RuntimeException("Failed to load any translation for key: " + key);
-		else if (key.startsWith("blockly.") || key.startsWith("trigger."))
-			return null;
-		else
-			return key;
+		return t_impl(rb, key, parameters);
 	}
 
 	public static String t_en(String key, Object... parameters) {
+		return t_impl(rb_en, key, parameters);
+	}
+
+	private static String t_impl(ResourceBundle resourceBundle, String key, Object... parameters) {
 		if (key == null)
 			return null;
 
-		if (rb_en.containsKey(key))
-			return MessageFormat.format(rb_en.getString(key), parameters);
+		if (resourceBundle.containsKey(key))
+			return MessageFormat.format(resourceBundle.getString(key), parameters);
 		else if (key.startsWith("blockly.") && (key.endsWith(".tooltip") || key.endsWith(".tip") || key.endsWith(
 				".description")))
 			return null;
 		else if (isTestingEnvironment)
 			throw new RuntimeException("Failed to load any translation for key: " + key);
-		else if (key.startsWith("blockly.") || key.startsWith("trigger."))
+		else if (key.startsWith("blockly.") || key.startsWith("trigger.") || key.startsWith(GeneratorSelector.covpfx))
 			return null;
 		else
 			return key;


### PR DESCRIPTION
Fixes problem introduced in #4005 where all mapping lists are shown automatically.

We or plugin authors may not want to show all of them + users think something is terribly broken when they see this:

![image](https://github.com/MCreator/MCreator/assets/16374228/63324967-8e62-473f-b2e7-c9c808d827e3)

Now if the key is not provided, data list display in this window is omitted