### PR TITLE
Add Immediate Source Entity dependency to Before Entity is hurt

### DIFF
--- a/plugins/generator-1.19.4/forge-1.19.4/triggers/entity_pre_hurt.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/triggers/entity_pre_hurt.java.ftl
@@ -19,3 +19,4 @@
 			execute(event<#if dependenciesCode?has_content>,</#if>${dependenciesCode});
 		}
 	}
+

--- a/plugins/generator-1.19.4/forge-1.19.4/triggers/entity_pre_hurt.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/triggers/entity_pre_hurt.java.ftl
@@ -12,6 +12,7 @@
 				"entity": "event.getEntity()",
 				"damagesource": "event.getSource()",
 				"sourceentity": "event.getSource().getEntity()",
+				"immediatesourceentity": "event.getSource().getDirectEntity()",
 				"event": "event"
 				}/>
 			</#compress></#assign>

--- a/plugins/generator-1.20.1/forge-1.20.1/triggers/entity_pre_hurt.java.ftl
+++ b/plugins/generator-1.20.1/forge-1.20.1/triggers/entity_pre_hurt.java.ftl
@@ -19,3 +19,4 @@
 			execute(event<#if dependenciesCode?has_content>,</#if>${dependenciesCode});
 		}
 	}
+

--- a/plugins/generator-1.20.1/forge-1.20.1/triggers/entity_pre_hurt.java.ftl
+++ b/plugins/generator-1.20.1/forge-1.20.1/triggers/entity_pre_hurt.java.ftl
@@ -12,6 +12,7 @@
 				"entity": "event.getEntity()",
 				"damagesource": "event.getSource()",
 				"sourceentity": "event.getSource().getEntity()",
+				"immediatesourceentity": "event.getSource().getDirectEntity()",
 				"event": "event"
 				}/>
 			</#compress></#assign>

--- a/plugins/mcreator-core/triggers/entity_pre_hurt.json
+++ b/plugins/mcreator-core/triggers/entity_pre_hurt.json
@@ -40,3 +40,4 @@
   "cancelable": "true",
   "side": "server"
 }
+

--- a/plugins/mcreator-core/triggers/entity_pre_hurt.json
+++ b/plugins/mcreator-core/triggers/entity_pre_hurt.json
@@ -29,6 +29,10 @@
       "type": "number"
     },
     {
+      "name": "immediatesourceentity",
+      "type": "entity"
+    },
+    {
       "name": "damagesource",
       "type": "damagesource"
     }


### PR DESCRIPTION
There's Immediate Source Entity for entity attacked but not before entity is hurt so this adds that for consistency. From what I've tested it works pretty well.