### PR TITLE
Fix: #4212 Pink is labeled twice in block color on map menu

### DIFF
--- a/plugins/mcreator-core/datalists/mapcolors.yaml
+++ b/plugins/mcreator-core/datalists/mapcolors.yaml
@@ -43,7 +43,7 @@
 - PINK:
   readable_name: "Pink"
 - GRAY:
-  readable_name: "Pink"
+  readable_name: "Gray"
 - SILVER:
   readable_name: "Light gray"
 - CYAN:


### PR DESCRIPTION
Changed readable_name for GRAY to Gray (was set to Pink)