### PR TITLE
Minor mod element refactoring

### DIFF
--- a/src/main/java/net/mcreator/generator/Generator.java
+++ b/src/main/java/net/mcreator/generator/Generator.java
@@ -23,7 +23,6 @@ import net.mcreator.element.BaseType;
 import net.mcreator.element.GeneratableElement;
 import net.mcreator.element.ModElementType;
 import net.mcreator.element.ModElementTypeLoader;
-import net.mcreator.element.types.interfaces.ICommonType;
 import net.mcreator.generator.setup.WorkspaceGeneratorSetup;
 import net.mcreator.generator.template.MinecraftCodeProvider;
 import net.mcreator.generator.template.TemplateExpressionParser;
@@ -347,15 +346,12 @@ public class Generator implements IGenerator, Closeable {
 
 		Map<BaseType, List<GeneratableElement>> baseTypeListMap = new HashMap<>();
 		for (ModElement modElement : workspace.getModElements()) {
-			GeneratableElement generatableElement = modElement.getGeneratableElement();
-			if (generatableElement instanceof ICommonType) {
-				Collection<BaseType> baseTypes = ((ICommonType) generatableElement).getBaseTypesProvided();
-				for (BaseType baseType : baseTypes) {
-					if (!baseTypeListMap.containsKey(baseType))
-						baseTypeListMap.put(baseType, new ArrayList<>());
+			Collection<BaseType> baseTypes = modElement.getBaseTypesProvided();
+			for (BaseType baseType : baseTypes) {
+				if (!baseTypeListMap.containsKey(baseType))
+					baseTypeListMap.put(baseType, new ArrayList<>());
 
-					baseTypeListMap.get(baseType).add(generatableElement);
-				}
+				baseTypeListMap.get(baseType).add(modElement.getGeneratableElement());
 			}
 		}
 

--- a/src/main/java/net/mcreator/ui/workspace/WorkspacePanel.java
+++ b/src/main/java/net/mcreator/ui/workspace/WorkspacePanel.java
@@ -19,7 +19,6 @@
 package net.mcreator.ui.workspace;
 
 import net.mcreator.element.*;
-import net.mcreator.element.types.interfaces.ICommonType;
 import net.mcreator.generator.GeneratorTemplate;
 import net.mcreator.generator.GeneratorTemplatesList;
 import net.mcreator.generator.ListTemplate;
@@ -1155,13 +1154,10 @@ import java.util.stream.Collectors;
 		List<GeneratorTemplatesList> modElementListFiles = mcreator.getGenerator()
 				.getModElementListTemplates(mu.getGeneratableElement());
 
-		if (mu.getGeneratableElement() instanceof ICommonType) {
-			Collection<BaseType> baseTypes = ((ICommonType) mu.getGeneratableElement()).getBaseTypesProvided();
-			for (BaseType baseType : baseTypes) {
-				modElementGlobalFiles.addAll(mcreator.getGenerator().getGlobalTemplatesListForDefinition(
-						mcreator.getGenerator().getGeneratorConfiguration().getDefinitionsProvider()
-								.getBaseTypeDefinition(baseType), false, new AtomicInteger()));
-			}
+		for (BaseType baseType : mu.getBaseTypesProvided()) {
+			modElementGlobalFiles.addAll(mcreator.getGenerator().getGlobalTemplatesListForDefinition(
+					mcreator.getGenerator().getGeneratorConfiguration().getDefinitionsProvider()
+							.getBaseTypeDefinition(baseType), false, new AtomicInteger()));
 		}
 
 		if (modElementFiles.size() + modElementGlobalFiles.size() > 1)

--- a/src/main/java/net/mcreator/workspace/elements/ModElement.java
+++ b/src/main/java/net/mcreator/workspace/elements/ModElement.java
@@ -19,9 +19,11 @@
 package net.mcreator.workspace.elements;
 
 import com.google.gson.*;
+import net.mcreator.element.BaseType;
 import net.mcreator.element.GeneratableElement;
 import net.mcreator.element.ModElementType;
 import net.mcreator.element.ModElementTypeLoader;
+import net.mcreator.element.types.interfaces.ICommonType;
 import net.mcreator.element.types.interfaces.IMCItemProvider;
 import net.mcreator.generator.IGeneratorProvider;
 import net.mcreator.minecraft.MCItem;
@@ -268,6 +270,11 @@ public class ModElement implements Serializable, IWorkspaceProvider, IGeneratorP
 			this.path = null;
 		else
 			this.path = parent.getPath();
+	}
+
+	public Collection<BaseType> getBaseTypesProvided() {
+		return this.getGeneratableElement() instanceof ICommonType iCommonType ?
+				iCommonType.getBaseTypesProvided() : Collections.emptyList();
 	}
 
 	public static class ModElementDeserializer implements JsonDeserializer<ModElement> {

--- a/src/main/java/net/mcreator/workspace/misc/WorkspaceInfo.java
+++ b/src/main/java/net/mcreator/workspace/misc/WorkspaceInfo.java
@@ -25,7 +25,6 @@ import net.mcreator.element.ModElementTypeLoader;
 import net.mcreator.element.parts.MItemBlock;
 import net.mcreator.element.parts.TabEntry;
 import net.mcreator.element.types.*;
-import net.mcreator.element.types.interfaces.ICommonType;
 import net.mcreator.element.types.interfaces.IItemWithTexture;
 import net.mcreator.element.types.interfaces.ITabContainedElement;
 import net.mcreator.generator.GeneratorWrapper;
@@ -131,12 +130,8 @@ import java.util.*;
 
 	public boolean hasElementsOfBaseType(BaseType baseType) {
 		for (ModElement modElement : workspace.getModElements()) {
-			GeneratableElement generatableElement = modElement.getGeneratableElement();
-			if (generatableElement instanceof ICommonType) {
-				Collection<BaseType> baseTypes = ((ICommonType) generatableElement).getBaseTypesProvided();
-				if (baseTypes.contains(baseType))
-					return true;
-			}
+			if (modElement.getBaseTypesProvided().contains(baseType))
+				return true;
 		}
 		return false;
 	}


### PR DESCRIPTION
This PR adds a helper method to `ModElement` to directly get the base types provided from the associated generatable element