### PR TITLE
Simple entries list

### DIFF
--- a/plugins/mcreator-localization/lang/texts.properties
+++ b/plugins/mcreator-localization/lang/texts.properties
@@ -2408,7 +2408,6 @@ elementgui.loot_table.entry_item=Entry item:
 elementgui.loot_table.entry_weight=Entry weight: 
 elementgui.loot_table.count=Count:
 elementgui.loot_table.silk_touch_mode=Silk touch mode: 
-elementgui.loot_table.remove_entry=Remove this entry
 elementgui.loot_table.enchantments_level=Entry item enchantments level:
 elementgui.music_disc.event_entity_hitwith=When living entity is hit with item
 elementgui.music_disc.event_inventory=When item in inventory tick
@@ -2513,7 +2512,6 @@ elementgui.potion.duration=Duration:
 elementgui.potion.amplifier=Amplifier:
 elementgui.potion.ambient=Ambient?
 elementgui.potion.show_particles=Show particles?
-elementgui.potion.remove_entry=Remove this effect entry
 elementgui.potion.error_potion_needs_display_name=Potion needs a display name
 elementgui.procedure.dependencies_added=<html><div style=''width: 110px; padding: 2px; background: #444444;''><span style=''background: yellow; color: black; font-wight: bold;''>&nbsp;&nbsp;!&nbsp;&nbsp;</span>&nbsp;New dependencies were added. Make sure to use the ones that the trigger you use provides.
 elementgui.procedure.dependencies_not_provided=<html><div style=''width: 110px; padding: 2px; background: #444444;''><span style=''background: red; color: white; font-wight: bold;''>&nbsp;X&nbsp;</span>&nbsp;You have selected external trigger that does not provide the following dependencies: {0}
@@ -2974,7 +2972,6 @@ dialog.spawn_list_entry.entity=Entity:
 dialog.spawn_list_entry.type=Spawn type: 
 dialog.spawn_list_entry.weight=Spawn weight: 
 dialog.spawn_list_entry.group_size=Group size:
-dialog.spawn_list_entry.remove_entry=Remove this entry
 dialog.list_field.biome_list_title=Select biomes
 dialog.list_field.biome_list_message=Select biomes you would like to add to the list:
 dialog.list_field.biome_default_feature_title=Select biome default features
@@ -3347,3 +3344,4 @@ notification.patch_available.msg=There is a more recent version of {0} available
   <br>Installed version: {0}.{1}\
   <br>New version: {0}.{2}
 notification.plugin_updates.msg=There are some plugin updates available
+simple_list_entry.remove=Remove this entry

--- a/src/main/java/net/mcreator/ui/component/TechnicalButton.java
+++ b/src/main/java/net/mcreator/ui/component/TechnicalButton.java
@@ -19,12 +19,14 @@
 
 package net.mcreator.ui.component;
 
+import net.mcreator.ui.component.entries.JEntriesList;
+
 import javax.swing.*;
 
 /**
  * This is a special subtype of regular buttons instances of which used as components of
  * {@link net.mcreator.ui.modgui.ModElementGUI ModElementGUIs} perform technical operations when pressed (for instance,
- * add fresh entries to a {@link net.mcreator.ui.minecraft.JEntriesList JEntriesList} or import missing resources)
+ * add fresh entries to a {@link JEntriesList JEntriesList} or import missing resources)
  * and should not trigger {@link net.mcreator.ui.modgui.ModElementChangedListener ModElementChangedListeners}.
  */
 public class TechnicalButton extends JButton {

--- a/src/main/java/net/mcreator/ui/component/entries/JEntriesList.java
+++ b/src/main/java/net/mcreator/ui/component/entries/JEntriesList.java
@@ -62,4 +62,8 @@ public abstract class JEntriesList extends JPanel {
 		add.setEnabled(enabled);
 	}
 
+	public void reloadDataLists() {
+
+	}
+
 }

--- a/src/main/java/net/mcreator/ui/component/entries/JEntriesList.java
+++ b/src/main/java/net/mcreator/ui/component/entries/JEntriesList.java
@@ -1,25 +1,6 @@
 /*
  * MCreator (https://mcreator.net/)
  * Copyright (C) 2012-2020, Pylo
- * Copyright (C) 2020-2023, Pylo, opensource contributors
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
- */
-
-/*
- * MCreator (https://mcreator.net/)
- * Copyright (C) 2012-2020, Pylo
  * Copyright (C) 2020-2021, Pylo, opensource contributors
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/main/java/net/mcreator/ui/component/entries/JEntriesList.java
+++ b/src/main/java/net/mcreator/ui/component/entries/JEntriesList.java
@@ -1,6 +1,25 @@
 /*
  * MCreator (https://mcreator.net/)
  * Copyright (C) 2012-2020, Pylo
+ * Copyright (C) 2020-2023, Pylo, opensource contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/*
+ * MCreator (https://mcreator.net/)
+ * Copyright (C) 2012-2020, Pylo
  * Copyright (C) 2020-2021, Pylo, opensource contributors
  *
  * This program is free software: you can redistribute it and/or modify
@@ -17,7 +36,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package net.mcreator.ui.minecraft;
+package net.mcreator.ui.component.entries;
 
 import net.mcreator.ui.MCreator;
 import net.mcreator.ui.component.TechnicalButton;

--- a/src/main/java/net/mcreator/ui/component/entries/JSimpleEntriesList.java
+++ b/src/main/java/net/mcreator/ui/component/entries/JSimpleEntriesList.java
@@ -50,10 +50,10 @@ public abstract class JSimpleEntriesList<T extends JSimpleListEntry<U>, U> exten
 		return entryList.stream().map(T::getEntry).filter(Objects::nonNull).toList();
 	}
 
-	@Override public final void setEntries(List<U> box) {
+	@Override public final void setEntries(List<U> newEntries) {
 		entryList.clear();
 		entries.removeAll();
-		box.forEach(e -> {
+		newEntries.forEach(e -> {
 			@SuppressWarnings("unchecked") T entry = (T) newEntry(entries, entryList);
 			entry.reloadDataLists();
 			entryList.add(entry);

--- a/src/main/java/net/mcreator/ui/component/entries/JSimpleEntriesList.java
+++ b/src/main/java/net/mcreator/ui/component/entries/JSimpleEntriesList.java
@@ -32,7 +32,7 @@ public abstract class JSimpleEntriesList<T extends JSimpleListEntry<U>, U> exten
 		super(mcreator, gui);
 
 		add.addActionListener(e -> {
-			@SuppressWarnings("unchecked") T entry = (T) newEntry(entries, entryList);
+			T entry = newEntry(entries, entryList);
 			entry.reloadDataLists();
 			entryList.add(entry);
 			entry.setEnabled(this.isEnabled());
@@ -44,7 +44,7 @@ public abstract class JSimpleEntriesList<T extends JSimpleListEntry<U>, U> exten
 	public void entryAddedByUserHandler() {
 	}
 
-	protected abstract JSimpleListEntry<U> newEntry(JPanel parent, List<T> entryList);
+	protected abstract T newEntry(JPanel parent, List<T> entryList);
 
 	@Override public final List<U> getEntries() {
 		return entryList.stream().map(T::getEntry).filter(Objects::nonNull).toList();
@@ -54,7 +54,7 @@ public abstract class JSimpleEntriesList<T extends JSimpleListEntry<U>, U> exten
 		entryList.clear();
 		entries.removeAll();
 		newEntries.forEach(e -> {
-			@SuppressWarnings("unchecked") T entry = (T) newEntry(entries, entryList);
+			T entry = newEntry(entries, entryList);
 			entry.reloadDataLists();
 			entryList.add(entry);
 			entry.setEnabled(isEnabled());

--- a/src/main/java/net/mcreator/ui/component/entries/JSimpleEntriesList.java
+++ b/src/main/java/net/mcreator/ui/component/entries/JSimpleEntriesList.java
@@ -1,0 +1,70 @@
+/*
+ * MCreator (https://mcreator.net/)
+ * Copyright (C) 2012-2020, Pylo
+ * Copyright (C) 2020-2023, Pylo, opensource contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package net.mcreator.ui.component.entries;
+
+import net.mcreator.ui.MCreator;
+import net.mcreator.ui.help.IHelpContext;
+
+import javax.swing.*;
+import java.util.List;
+import java.util.Objects;
+
+public abstract class JSimpleEntriesList<T extends JSimpleListEntry<U>, U> extends JSingleEntriesList<T, U> {
+
+	public JSimpleEntriesList(MCreator mcreator, IHelpContext gui) {
+		super(mcreator, gui);
+
+		add.addActionListener(e -> {
+			@SuppressWarnings("unchecked") T entry = (T) newEntry(entries, entryList);
+			entry.reloadDataLists();
+			entryList.add(entry);
+			entry.setEnabled(this.isEnabled());
+			registerEntryUI(entry);
+			entryAddedByUserHandler();
+		});
+	}
+
+	public void entryAddedByUserHandler() {
+	}
+
+	public abstract JSimpleListEntry<U> newEntry(JPanel parent, List<T> entryList);
+
+	@Override public final List<U> getEntries() {
+		return entryList.stream().map(T::getEntry).filter(Objects::nonNull).toList();
+	}
+
+	@Override public final void setEntries(List<U> box) {
+		entryList.clear();
+		entries.removeAll();
+		box.forEach(e -> {
+			@SuppressWarnings("unchecked") T entry = (T) newEntry(entries, entryList);
+			entry.reloadDataLists();
+			entryList.add(entry);
+			entry.setEnabled(isEnabled());
+			registerEntryUI(entry);
+			entry.setEntry(e);
+		});
+	}
+
+	@Override public void reloadDataLists() {
+		entryList.forEach(JSimpleListEntry::reloadDataLists);
+	}
+
+}

--- a/src/main/java/net/mcreator/ui/component/entries/JSimpleEntriesList.java
+++ b/src/main/java/net/mcreator/ui/component/entries/JSimpleEntriesList.java
@@ -44,7 +44,7 @@ public abstract class JSimpleEntriesList<T extends JSimpleListEntry<U>, U> exten
 	public void entryAddedByUserHandler() {
 	}
 
-	public abstract JSimpleListEntry<U> newEntry(JPanel parent, List<T> entryList);
+	protected abstract JSimpleListEntry<U> newEntry(JPanel parent, List<T> entryList);
 
 	@Override public final List<U> getEntries() {
 		return entryList.stream().map(T::getEntry).filter(Objects::nonNull).toList();

--- a/src/main/java/net/mcreator/ui/component/entries/JSimpleListEntry.java
+++ b/src/main/java/net/mcreator/ui/component/entries/JSimpleListEntry.java
@@ -1,0 +1,83 @@
+/*
+ * MCreator (https://mcreator.net/)
+ * Copyright (C) 2012-2020, Pylo
+ * Copyright (C) 2020-2023, Pylo, opensource contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package net.mcreator.ui.component.entries;
+
+import net.mcreator.ui.component.util.PanelUtils;
+import net.mcreator.ui.init.L10N;
+import net.mcreator.ui.init.UIRES;
+
+import javax.swing.*;
+import java.awt.*;
+import java.util.List;
+
+public abstract class JSimpleListEntry<T> extends JPanel {
+
+	protected final JPanel line = new JPanel(new FlowLayout(FlowLayout.LEFT));
+
+	private final JButton remove = new JButton(UIRES.get("16px.clear"));
+
+	protected final JPanel parent;
+
+	public JSimpleListEntry(JPanel parent, List<? extends JSimpleListEntry<T>> entryList) {
+		this.parent = parent;
+
+		setBackground(((Color) UIManager.get("MCreatorLAF.LIGHT_ACCENT")).darker());
+		setLayout(new BoxLayout(this, BoxLayout.PAGE_AXIS));
+
+		JComponent container = PanelUtils.expandHorizontally(this);
+
+		line.setOpaque(false);
+
+		parent.add(container);
+
+		remove.setText(L10N.t("simple_list_entry.remove"));
+		remove.addActionListener(e -> {
+			entryList.remove(this);
+			parent.remove(container);
+			parent.revalidate();
+			parent.repaint();
+			entryRemovedByUserHandler();
+		});
+
+		add(PanelUtils.centerAndEastElement(line, PanelUtils.join(remove)));
+
+		parent.revalidate();
+		parent.repaint();
+	}
+
+	protected void entryRemovedByUserHandler() {
+	}
+
+	public void reloadDataLists() {
+	}
+
+	@Override public void setEnabled(boolean enabled) {
+		super.setEnabled(enabled);
+		remove.setEnabled(enabled);
+		setEntryEnabled(enabled);
+	}
+
+	protected abstract void setEntryEnabled(boolean enabled);
+
+	public abstract T getEntry();
+
+	public abstract void setEntry(T entry);
+
+}

--- a/src/main/java/net/mcreator/ui/component/entries/JSingleEntriesList.java
+++ b/src/main/java/net/mcreator/ui/component/entries/JSingleEntriesList.java
@@ -62,6 +62,11 @@ public abstract class JSingleEntriesList<T extends JPanel, U> extends JEntriesLi
 		add("Center", scrollPane);
 	}
 
+	@Override public void setEnabled(boolean enabled) {
+		super.setEnabled(enabled);
+		entryList.forEach(e -> e.setEnabled(enabled));
+	}
+
 	public abstract List<U> getEntries();
 
 	public abstract void setEntries(List<U> box);

--- a/src/main/java/net/mcreator/ui/component/entries/JSingleEntriesList.java
+++ b/src/main/java/net/mcreator/ui/component/entries/JSingleEntriesList.java
@@ -17,25 +17,6 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-/*
- * MCreator (https://mcreator.net/)
- * Copyright (C) 2012-2020, Pylo
- * Copyright (C) 2020-2023, Pylo, opensource contributors
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package net.mcreator.ui.component.entries;
 
 import net.mcreator.ui.MCreator;

--- a/src/main/java/net/mcreator/ui/component/entries/JSingleEntriesList.java
+++ b/src/main/java/net/mcreator/ui/component/entries/JSingleEntriesList.java
@@ -17,7 +17,26 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package net.mcreator.ui.minecraft;
+/*
+ * MCreator (https://mcreator.net/)
+ * Copyright (C) 2012-2020, Pylo
+ * Copyright (C) 2020-2023, Pylo, opensource contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package net.mcreator.ui.component.entries;
 
 import net.mcreator.ui.MCreator;
 import net.mcreator.ui.component.util.PanelUtils;
@@ -28,14 +47,14 @@ import java.awt.*;
 import java.util.ArrayList;
 import java.util.List;
 
-public abstract class JSimpleEntriesList<T extends JPanel, U> extends JEntriesList {
+public abstract class JSingleEntriesList<T extends JPanel, U> extends JEntriesList {
 
 	protected final List<T> entryList = new ArrayList<>();
 	protected final JPanel entries = new JPanel(new GridLayout(0, 1, 0, 2));
 
 	protected JPanel topbar = new JPanel(new FlowLayout(FlowLayout.LEFT));
 
-	public JSimpleEntriesList(MCreator mcreator, IHelpContext gui) {
+	public JSingleEntriesList(MCreator mcreator, IHelpContext gui) {
 		super(mcreator, new BorderLayout(), gui);
 		setOpaque(false);
 

--- a/src/main/java/net/mcreator/ui/minecraft/JEntriesList.java
+++ b/src/main/java/net/mcreator/ui/minecraft/JEntriesList.java
@@ -57,4 +57,9 @@ public abstract class JEntriesList extends JPanel {
 		return mcreator;
 	}
 
+	@Override public void setEnabled(boolean enabled) {
+		super.setEnabled(enabled);
+		add.setEnabled(enabled);
+	}
+
 }

--- a/src/main/java/net/mcreator/ui/minecraft/JSimpleEntriesList.java
+++ b/src/main/java/net/mcreator/ui/minecraft/JSimpleEntriesList.java
@@ -42,13 +42,25 @@ public abstract class JSimpleEntriesList<T extends JPanel, U> extends JEntriesLi
 
 		topbar.setBackground((Color) UIManager.get("MCreatorLAF.LIGHT_ACCENT"));
 
-		add.setText(L10N.t("elementgui.common.add_bounding_box"));
 		topbar.add(add);
 		add("North", topbar);
 
 		entries.setOpaque(false);
 
-		add("Center", new JScrollPane(PanelUtils.pullElementUp(entries)));
+		JScrollPane scrollPane = new JScrollPane(PanelUtils.pullElementUp(entries)) {
+			@Override protected void paintComponent(Graphics g) {
+				Graphics2D g2d = (Graphics2D) g.create();
+				g2d.setColor((Color) UIManager.get("MCreatorLAF.LIGHT_ACCENT"));
+				g2d.setComposite(AlphaComposite.SrcOver.derive(0.45f));
+				g2d.fillRect(0, 0, getWidth(), getHeight());
+				g2d.dispose();
+				super.paintComponent(g);
+			}
+		};
+		scrollPane.getViewport().setOpaque(false);
+		scrollPane.setOpaque(false);
+		scrollPane.getVerticalScrollBar().setUnitIncrement(15);
+		add("Center", scrollPane);
 	}
 
 	public abstract List<U> getEntries();

--- a/src/main/java/net/mcreator/ui/minecraft/JSimpleEntriesList.java
+++ b/src/main/java/net/mcreator/ui/minecraft/JSimpleEntriesList.java
@@ -1,0 +1,57 @@
+/*
+ * MCreator (https://mcreator.net/)
+ * Copyright (C) 2012-2020, Pylo
+ * Copyright (C) 2020-2023, Pylo, opensource contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package net.mcreator.ui.minecraft;
+
+import net.mcreator.ui.MCreator;
+import net.mcreator.ui.component.util.PanelUtils;
+import net.mcreator.ui.help.IHelpContext;
+import net.mcreator.ui.init.L10N;
+
+import javax.swing.*;
+import java.awt.*;
+import java.util.ArrayList;
+import java.util.List;
+
+public abstract class JSimpleEntriesList<T extends JPanel, U> extends JEntriesList {
+
+	protected final List<T> entryList = new ArrayList<>();
+	protected final JPanel entries = new JPanel(new GridLayout(0, 1, 0, 2));
+
+	protected JPanel topbar = new JPanel(new FlowLayout(FlowLayout.LEFT));
+
+	public JSimpleEntriesList(MCreator mcreator, LayoutManager layout, IHelpContext gui) {
+		super(mcreator, layout, gui);
+
+		topbar.setBackground((Color) UIManager.get("MCreatorLAF.LIGHT_ACCENT"));
+
+		add.setText(L10N.t("elementgui.common.add_bounding_box"));
+		topbar.add(add);
+		add("North", topbar);
+
+		entries.setOpaque(false);
+
+		add("Center", new JScrollPane(PanelUtils.pullElementUp(entries)));
+	}
+
+	public abstract List<U> getEntries();
+
+	public abstract void setEntries(List<U> box);
+
+}

--- a/src/main/java/net/mcreator/ui/minecraft/JSimpleEntriesList.java
+++ b/src/main/java/net/mcreator/ui/minecraft/JSimpleEntriesList.java
@@ -22,7 +22,6 @@ package net.mcreator.ui.minecraft;
 import net.mcreator.ui.MCreator;
 import net.mcreator.ui.component.util.PanelUtils;
 import net.mcreator.ui.help.IHelpContext;
-import net.mcreator.ui.init.L10N;
 
 import javax.swing.*;
 import java.awt.*;
@@ -36,8 +35,8 @@ public abstract class JSimpleEntriesList<T extends JPanel, U> extends JEntriesLi
 
 	protected JPanel topbar = new JPanel(new FlowLayout(FlowLayout.LEFT));
 
-	public JSimpleEntriesList(MCreator mcreator, LayoutManager layout, IHelpContext gui) {
-		super(mcreator, layout, gui);
+	public JSimpleEntriesList(MCreator mcreator, IHelpContext gui) {
+		super(mcreator, new BorderLayout(), gui);
 		setOpaque(false);
 
 		topbar.setBackground((Color) UIManager.get("MCreatorLAF.LIGHT_ACCENT"));

--- a/src/main/java/net/mcreator/ui/minecraft/JSimpleEntriesList.java
+++ b/src/main/java/net/mcreator/ui/minecraft/JSimpleEntriesList.java
@@ -38,6 +38,7 @@ public abstract class JSimpleEntriesList<T extends JPanel, U> extends JEntriesLi
 
 	public JSimpleEntriesList(MCreator mcreator, LayoutManager layout, IHelpContext gui) {
 		super(mcreator, layout, gui);
+		setOpaque(false);
 
 		topbar.setBackground((Color) UIManager.get("MCreatorLAF.LIGHT_ACCENT"));
 

--- a/src/main/java/net/mcreator/ui/minecraft/boundingboxes/JBoundingBoxEntry.java
+++ b/src/main/java/net/mcreator/ui/minecraft/boundingboxes/JBoundingBoxEntry.java
@@ -20,15 +20,14 @@ package net.mcreator.ui.minecraft.boundingboxes;
 
 import net.mcreator.element.types.interfaces.IBlockWithBoundingBox;
 import net.mcreator.ui.component.JEmptyBox;
-import net.mcreator.ui.component.util.PanelUtils;
+import net.mcreator.ui.component.entries.JSimpleListEntry;
 import net.mcreator.ui.init.L10N;
-import net.mcreator.ui.init.UIRES;
 
 import javax.swing.*;
-import java.awt.*;
 import java.util.List;
 
-public class JBoundingBoxEntry extends JPanel {
+public class JBoundingBoxEntry extends JSimpleListEntry<IBlockWithBoundingBox.BoxEntry> {
+
 	private final JSpinner mx = new JSpinner(new SpinnerNumberModel(0, -100, 100, 0.1));
 	private final JSpinner my = new JSpinner(new SpinnerNumberModel(0, -100, 100, 0.1));
 	private final JSpinner mz = new JSpinner(new SpinnerNumberModel(0, -100, 100, 0.1));
@@ -36,20 +35,11 @@ public class JBoundingBoxEntry extends JPanel {
 	private final JSpinner My = new JSpinner(new SpinnerNumberModel(16, -100, 100, 0.1));
 	private final JSpinner Mz = new JSpinner(new SpinnerNumberModel(16, -100, 100, 0.1));
 	private final JCheckBox subtract = new JCheckBox();
-	private final JButton remove = new JButton(UIRES.get("16px.clear"));
 
 	public JBoundingBoxEntry(JPanel parent, List<JBoundingBoxEntry> entryList) {
-		setLayout(new BoxLayout(this, BoxLayout.PAGE_AXIS));
+		super(parent, entryList);
 
-		setBackground(((Color) UIManager.get("MCreatorLAF.LIGHT_ACCENT")).darker());
-
-		final JComponent container = PanelUtils.expandHorizontally(this);
-
-		parent.add(container);
-		entryList.add(this);
-
-		JPanel line = new JPanel(new FlowLayout(FlowLayout.LEFT));
-		line.setOpaque(false);
+		subtract.setOpaque(false);
 
 		line.add(L10N.label("elementgui.block.bounding_block_min_x"));
 		line.add(mx);
@@ -71,16 +61,6 @@ public class JBoundingBoxEntry extends JPanel {
 
 		line.add(L10N.label("elementgui.common.subtract"));
 		line.add(subtract);
-		subtract.setOpaque(false);
-
-		remove.setText(L10N.t("elementgui.loot_table.remove_entry"));
-		remove.addActionListener(e -> {
-			entryList.remove(this);
-			parent.remove(container);
-			parent.revalidate();
-			parent.repaint();
-			parent.firePropertyChange("boundingBoxChanged", false, true);
-		});
 
 		mx.addChangeListener(e -> parent.firePropertyChange("boundingBoxChanged", false, true));
 		my.addChangeListener(e -> parent.firePropertyChange("boundingBoxChanged", false, true));
@@ -89,14 +69,13 @@ public class JBoundingBoxEntry extends JPanel {
 		My.addChangeListener(e -> parent.firePropertyChange("boundingBoxChanged", false, true));
 		Mz.addChangeListener(e -> parent.firePropertyChange("boundingBoxChanged", false, true));
 		subtract.addActionListener(e -> parent.firePropertyChange("boundingBoxChanged", false, true));
-
-		add(PanelUtils.centerAndEastElement(line, PanelUtils.join(remove)));
-
-		parent.revalidate();
-		parent.repaint();
 	}
 
-	public JBoundingBoxEntry setEntryEnabled(boolean enabled) {
+	@Override protected void entryRemovedByUserHandler() {
+		parent.firePropertyChange("boundingBoxChanged", false, true);
+	}
+
+	@Override public void setEntryEnabled(boolean enabled) {
 		mx.setEnabled(enabled);
 		my.setEnabled(enabled);
 		mz.setEnabled(enabled);
@@ -104,9 +83,28 @@ public class JBoundingBoxEntry extends JPanel {
 		My.setEnabled(enabled);
 		Mz.setEnabled(enabled);
 		subtract.setEnabled(enabled);
-		remove.setEnabled(enabled);
+	}
 
-		return this;
+	@Override public IBlockWithBoundingBox.BoxEntry getEntry() {
+		IBlockWithBoundingBox.BoxEntry entry = new IBlockWithBoundingBox.BoxEntry();
+		entry.mx = (double) mx.getValue();
+		entry.my = (double) my.getValue();
+		entry.mz = (double) mz.getValue();
+		entry.Mx = (double) Mx.getValue();
+		entry.My = (double) My.getValue();
+		entry.Mz = (double) Mz.getValue();
+		entry.subtract = subtract.isSelected();
+		return entry;
+	}
+
+	@Override public void setEntry(IBlockWithBoundingBox.BoxEntry box) {
+		mx.setValue(box.mx);
+		my.setValue(box.my);
+		mz.setValue(box.mz);
+		Mx.setValue(box.Mx);
+		My.setValue(box.My);
+		Mz.setValue(box.Mz);
+		subtract.setSelected(box.subtract);
 	}
 
 	public boolean isNotEmpty() {
@@ -117,26 +115,4 @@ public class JBoundingBoxEntry extends JPanel {
 		return this.getEntry().isFullCube();
 	}
 
-	public IBlockWithBoundingBox.BoxEntry getEntry() {
-		IBlockWithBoundingBox.BoxEntry entry = new IBlockWithBoundingBox.BoxEntry();
-		entry.mx = (double) mx.getValue();
-		entry.my = (double) my.getValue();
-		entry.mz = (double) mz.getValue();
-		entry.Mx = (double) Mx.getValue();
-		entry.My = (double) My.getValue();
-		entry.Mz = (double) Mz.getValue();
-		entry.subtract = subtract.isSelected();
-
-		return entry;
-	}
-
-	public void setEntry(IBlockWithBoundingBox.BoxEntry box) {
-		mx.setValue(box.mx);
-		my.setValue(box.my);
-		mz.setValue(box.mz);
-		Mx.setValue(box.Mx);
-		My.setValue(box.My);
-		Mz.setValue(box.Mz);
-		subtract.setSelected(box.subtract);
-	}
 }

--- a/src/main/java/net/mcreator/ui/minecraft/boundingboxes/JBoundingBoxList.java
+++ b/src/main/java/net/mcreator/ui/minecraft/boundingboxes/JBoundingBoxList.java
@@ -26,9 +26,10 @@ import net.mcreator.element.types.interfaces.IBlockWithBoundingBox;
 import net.mcreator.io.FileIO;
 import net.mcreator.ui.MCreator;
 import net.mcreator.ui.component.TechnicalButton;
+import net.mcreator.ui.component.entries.JSimpleEntriesList;
+import net.mcreator.ui.component.entries.JSimpleListEntry;
 import net.mcreator.ui.help.IHelpContext;
 import net.mcreator.ui.init.L10N;
-import net.mcreator.ui.component.entries.JSingleEntriesList;
 import net.mcreator.workspace.resources.Model;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -38,14 +39,14 @@ import javax.swing.*;
 import java.awt.*;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.function.Supplier;
 
-public class JBoundingBoxList extends JSingleEntriesList<JBoundingBoxEntry, IBlockWithBoundingBox.BoxEntry> {
+public class JBoundingBoxList extends JSimpleEntriesList<JBoundingBoxEntry, IBlockWithBoundingBox.BoxEntry> {
 
 	private static final Logger LOG = LogManager.getLogger(JBoundingBoxList.class);
 
 	@Nullable private final Supplier<Model> modelProvider;
+
 	private final TechnicalButton genFromModel = L10N.technicalbutton("elementgui.common.gen_from_block_model");
 
 	public JBoundingBoxList(MCreator mcreator, IHelpContext gui, @Nullable Supplier<Model> modelProvider) {
@@ -59,11 +60,6 @@ public class JBoundingBoxList extends JSingleEntriesList<JBoundingBoxEntry, IBlo
 		}
 
 		add.setText(L10N.t("elementgui.common.add_bounding_box"));
-		add.addActionListener(e -> {
-			JBoundingBoxEntry entry = new JBoundingBoxEntry(entries, entryList).setEntryEnabled(this.isEnabled());
-			registerEntryUI(entry);
-			firePropertyChange("boundingBoxChanged", false, true);
-		});
 
 		entries.addPropertyChangeListener("boundingBoxChanged",
 				e -> firePropertyChange("boundingBoxChanged", false, true));
@@ -75,9 +71,13 @@ public class JBoundingBoxList extends JSingleEntriesList<JBoundingBoxEntry, IBlo
 		setPreferredSize(new Dimension(getPreferredSize().width, (int) (mcreator.getSize().height * 0.6)));
 	}
 
-	@Override public void setEnabled(boolean enabled) {
-		super.setEnabled(enabled);
-		entryList.forEach(e -> e.setEntryEnabled(enabled));
+	@Override public void entryAddedByUserHandler() {
+		firePropertyChange("boundingBoxChanged", false, true);
+	}
+
+	@Override
+	public JSimpleListEntry<IBlockWithBoundingBox.BoxEntry> newEntry(JPanel parent, List<JBoundingBoxEntry> entryList) {
+		return new JBoundingBoxEntry(parent, entryList);
 	}
 
 	public void modelChanged() {
@@ -120,20 +120,6 @@ public class JBoundingBoxList extends JSingleEntriesList<JBoundingBoxEntry, IBlo
 				}
 			}
 		}
-	}
-
-	@Override public List<IBlockWithBoundingBox.BoxEntry> getEntries() {
-		return entryList.stream().map(JBoundingBoxEntry::getEntry).filter(Objects::nonNull).toList();
-	}
-
-	@Override public void setEntries(List<IBlockWithBoundingBox.BoxEntry> box) {
-		entryList.clear(); // Fixes failing tests
-		entries.removeAll();
-		box.forEach(e -> {
-			JBoundingBoxEntry entry = new JBoundingBoxEntry(entries, entryList).setEntryEnabled(isEnabled());
-			registerEntryUI(entry);
-			entry.setEntry(e);
-		});
 	}
 
 	public boolean isFullCube() {

--- a/src/main/java/net/mcreator/ui/minecraft/boundingboxes/JBoundingBoxList.java
+++ b/src/main/java/net/mcreator/ui/minecraft/boundingboxes/JBoundingBoxList.java
@@ -58,6 +58,7 @@ public class JBoundingBoxList extends JSimpleEntriesList<JBoundingBoxEntry, IBlo
 			modelChanged();
 		}
 
+		add.setText(L10N.t("elementgui.common.add_bounding_box"));
 		add.addActionListener(e -> {
 			JBoundingBoxEntry entry = new JBoundingBoxEntry(entries, entryList).setEntryEnabled(this.isEnabled());
 			registerEntryUI(entry);

--- a/src/main/java/net/mcreator/ui/minecraft/boundingboxes/JBoundingBoxList.java
+++ b/src/main/java/net/mcreator/ui/minecraft/boundingboxes/JBoundingBoxList.java
@@ -28,7 +28,7 @@ import net.mcreator.ui.MCreator;
 import net.mcreator.ui.component.TechnicalButton;
 import net.mcreator.ui.help.IHelpContext;
 import net.mcreator.ui.init.L10N;
-import net.mcreator.ui.minecraft.JSimpleEntriesList;
+import net.mcreator.ui.component.entries.JSingleEntriesList;
 import net.mcreator.workspace.resources.Model;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -41,7 +41,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.function.Supplier;
 
-public class JBoundingBoxList extends JSimpleEntriesList<JBoundingBoxEntry, IBlockWithBoundingBox.BoxEntry> {
+public class JBoundingBoxList extends JSingleEntriesList<JBoundingBoxEntry, IBlockWithBoundingBox.BoxEntry> {
 
 	private static final Logger LOG = LogManager.getLogger(JBoundingBoxList.class);
 

--- a/src/main/java/net/mcreator/ui/minecraft/boundingboxes/JBoundingBoxList.java
+++ b/src/main/java/net/mcreator/ui/minecraft/boundingboxes/JBoundingBoxList.java
@@ -67,7 +67,6 @@ public class JBoundingBoxList extends JSimpleEntriesList<JBoundingBoxEntry, IBlo
 		entries.addPropertyChangeListener("boundingBoxChanged",
 				e -> firePropertyChange("boundingBoxChanged", false, true));
 
-		setOpaque(false);
 		setBorder(BorderFactory.createTitledBorder(
 				BorderFactory.createLineBorder((Color) UIManager.get("MCreatorLAF.BRIGHT_COLOR"), 1),
 				L10N.t("elementgui.common.bounding_box_entries"), 0, 0, getFont().deriveFont(12.0f),

--- a/src/main/java/net/mcreator/ui/minecraft/boundingboxes/JBoundingBoxList.java
+++ b/src/main/java/net/mcreator/ui/minecraft/boundingboxes/JBoundingBoxList.java
@@ -76,7 +76,7 @@ public class JBoundingBoxList extends JSimpleEntriesList<JBoundingBoxEntry, IBlo
 	}
 
 	@Override
-	public JSimpleListEntry<IBlockWithBoundingBox.BoxEntry> newEntry(JPanel parent, List<JBoundingBoxEntry> entryList) {
+	protected JSimpleListEntry<IBlockWithBoundingBox.BoxEntry> newEntry(JPanel parent, List<JBoundingBoxEntry> entryList) {
 		return new JBoundingBoxEntry(parent, entryList);
 	}
 

--- a/src/main/java/net/mcreator/ui/minecraft/boundingboxes/JBoundingBoxList.java
+++ b/src/main/java/net/mcreator/ui/minecraft/boundingboxes/JBoundingBoxList.java
@@ -76,7 +76,7 @@ public class JBoundingBoxList extends JSimpleEntriesList<JBoundingBoxEntry, IBlo
 	}
 
 	@Override
-	protected JSimpleListEntry<IBlockWithBoundingBox.BoxEntry> newEntry(JPanel parent, List<JBoundingBoxEntry> entryList) {
+	protected JBoundingBoxEntry newEntry(JPanel parent, List<JBoundingBoxEntry> entryList) {
 		return new JBoundingBoxEntry(parent, entryList);
 	}
 

--- a/src/main/java/net/mcreator/ui/minecraft/boundingboxes/JBoundingBoxList.java
+++ b/src/main/java/net/mcreator/ui/minecraft/boundingboxes/JBoundingBoxList.java
@@ -49,7 +49,7 @@ public class JBoundingBoxList extends JSimpleEntriesList<JBoundingBoxEntry, IBlo
 	private final TechnicalButton genFromModel = L10N.technicalbutton("elementgui.common.gen_from_block_model");
 
 	public JBoundingBoxList(MCreator mcreator, IHelpContext gui, @Nullable Supplier<Model> modelProvider) {
-		super(mcreator, new BorderLayout(), gui);
+		super(mcreator, gui);
 		this.modelProvider = modelProvider;
 
 		if (modelProvider != null) {

--- a/src/main/java/net/mcreator/ui/minecraft/loottable/JLootTableEntry.java
+++ b/src/main/java/net/mcreator/ui/minecraft/loottable/JLootTableEntry.java
@@ -94,7 +94,7 @@ public class JLootTableEntry extends JPanel {
 		explosionDecay.setOpaque(false);
 
 		JButton remove = new JButton(UIRES.get("16px.clear"));
-		remove.setText(L10N.t("elementgui.loot_table.remove_entry"));
+		remove.setText(L10N.t("simple_list_entry.remove"));
 		remove.addActionListener(e -> {
 			entryList.remove(this);
 			parent.remove(container);

--- a/src/main/java/net/mcreator/ui/minecraft/loottable/JLootTablePool.java
+++ b/src/main/java/net/mcreator/ui/minecraft/loottable/JLootTablePool.java
@@ -26,7 +26,7 @@ import net.mcreator.ui.component.util.PanelUtils;
 import net.mcreator.ui.help.IHelpContext;
 import net.mcreator.ui.init.L10N;
 import net.mcreator.ui.init.UIRES;
-import net.mcreator.ui.minecraft.JEntriesList;
+import net.mcreator.ui.component.entries.JEntriesList;
 
 import javax.swing.*;
 import java.awt.*;

--- a/src/main/java/net/mcreator/ui/minecraft/loottable/JLootTablePool.java
+++ b/src/main/java/net/mcreator/ui/minecraft/loottable/JLootTablePool.java
@@ -116,7 +116,7 @@ public class JLootTablePool extends JEntriesList {
 		parent.repaint();
 	}
 
-	public void reloadDataLists() {
+	@Override public void reloadDataLists() {
 		entryList.forEach(JLootTableEntry::reloadDataLists);
 	}
 

--- a/src/main/java/net/mcreator/ui/minecraft/loottable/JLootTablePoolsList.java
+++ b/src/main/java/net/mcreator/ui/minecraft/loottable/JLootTablePoolsList.java
@@ -47,7 +47,7 @@ public class JLootTablePoolsList extends JSingleEntriesList<JLootTablePool, Loot
 		setBorder(BorderFactory.createEmptyBorder(5, 5, 5, 5));
 	}
 
-	public void reloadDataLists() {
+	@Override public void reloadDataLists() {
 		entryList.forEach(JLootTablePool::reloadDataLists);
 	}
 

--- a/src/main/java/net/mcreator/ui/minecraft/loottable/JLootTablePoolsList.java
+++ b/src/main/java/net/mcreator/ui/minecraft/loottable/JLootTablePoolsList.java
@@ -21,78 +21,52 @@ package net.mcreator.ui.minecraft.loottable;
 
 import net.mcreator.element.types.LootTable;
 import net.mcreator.ui.MCreator;
-import net.mcreator.ui.component.util.PanelUtils;
 import net.mcreator.ui.help.IHelpContext;
 import net.mcreator.ui.init.L10N;
-import net.mcreator.ui.minecraft.JEntriesList;
+import net.mcreator.ui.minecraft.JSimpleEntriesList;
 
 import javax.swing.*;
-import java.awt.*;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-public class JLootTablePoolsList extends JEntriesList {
-
-	private final List<JLootTablePool> poolList = new ArrayList<>();
-
-	private final JPanel pools = new JPanel();
+public class JLootTablePoolsList extends JSimpleEntriesList<JLootTablePool, LootTable.Pool> {
 
 	public JLootTablePoolsList(MCreator mcreator, IHelpContext gui) {
-		super(mcreator, new BorderLayout(), gui);
+		super(mcreator, gui);
 		setOpaque(false);
 
-		pools.setLayout(new BoxLayout(pools, BoxLayout.PAGE_AXIS));
-		pools.setOpaque(false);
-
-		JToolBar bar = new JToolBar();
-		bar.setFloatable(false);
+		entries.setLayout(new BoxLayout(entries, BoxLayout.PAGE_AXIS));
 
 		add.setText(L10N.t("elementgui.loot_table.add_pool"));
 		add.addActionListener(e -> {
-			JLootTablePool pool = new JLootTablePool(mcreator, gui, pools, poolList);
+			JLootTablePool pool = new JLootTablePool(mcreator, gui, entries, entryList);
 			registerEntryUI(pool);
 			pool.addInitialEntry();
 		});
-		bar.add(add);
-		add("North", bar);
 
-		JScrollPane sp = new JScrollPane(PanelUtils.pullElementUp(pools)) {
-			@Override protected void paintComponent(Graphics g) {
-				Graphics2D g2d = (Graphics2D) g.create();
-				g2d.setColor((Color) UIManager.get("MCreatorLAF.LIGHT_ACCENT"));
-				g2d.setComposite(AlphaComposite.SrcOver.derive(0.45f));
-				g2d.fillRect(0, 0, getWidth(), getHeight());
-				g2d.dispose();
-				super.paintComponent(g);
-			}
-		};
-		sp.setOpaque(false);
-		sp.getViewport().setOpaque(false);
-		sp.getVerticalScrollBar().setUnitIncrement(11);
-		sp.setBorder(BorderFactory.createEmptyBorder(5, 5, 5, 5));
-		add("Center", sp);
+		setBorder(BorderFactory.createEmptyBorder(5, 5, 5, 5));
 	}
 
 	public void reloadDataLists() {
-		poolList.forEach(JLootTablePool::reloadDataLists);
+		entryList.forEach(JLootTablePool::reloadDataLists);
 	}
 
 	public void addInitialPool() {
-		JLootTablePool pool = new JLootTablePool(mcreator, gui, pools, poolList);
+		JLootTablePool pool = new JLootTablePool(mcreator, gui, entries, entryList);
 		registerEntryUI(pool);
 		pool.addInitialEntry();
 	}
 
-	public List<LootTable.Pool> getPools() {
-		return poolList.stream().map(JLootTablePool::getPool).filter(Objects::nonNull).toList();
+	@Override public List<LootTable.Pool> getEntries() {
+		return entryList.stream().map(JLootTablePool::getPool).filter(Objects::nonNull).toList();
 	}
 
-	public void setPools(List<LootTable.Pool> lootTablePools) {
+	@Override public void setEntries(List<LootTable.Pool> lootTablePools) {
 		lootTablePools.forEach(e -> {
-			JLootTablePool pool = new JLootTablePool(mcreator, gui, pools, poolList);
+			JLootTablePool pool = new JLootTablePool(mcreator, gui, entries, entryList);
 			registerEntryUI(pool);
 			pool.setPool(e);
 		});
 	}
+
 }

--- a/src/main/java/net/mcreator/ui/minecraft/loottable/JLootTablePoolsList.java
+++ b/src/main/java/net/mcreator/ui/minecraft/loottable/JLootTablePoolsList.java
@@ -23,13 +23,13 @@ import net.mcreator.element.types.LootTable;
 import net.mcreator.ui.MCreator;
 import net.mcreator.ui.help.IHelpContext;
 import net.mcreator.ui.init.L10N;
-import net.mcreator.ui.minecraft.JSimpleEntriesList;
+import net.mcreator.ui.component.entries.JSingleEntriesList;
 
 import javax.swing.*;
 import java.util.List;
 import java.util.Objects;
 
-public class JLootTablePoolsList extends JSimpleEntriesList<JLootTablePool, LootTable.Pool> {
+public class JLootTablePoolsList extends JSingleEntriesList<JLootTablePool, LootTable.Pool> {
 
 	public JLootTablePoolsList(MCreator mcreator, IHelpContext gui) {
 		super(mcreator, gui);

--- a/src/main/java/net/mcreator/ui/minecraft/potions/JPotionList.java
+++ b/src/main/java/net/mcreator/ui/minecraft/potions/JPotionList.java
@@ -44,7 +44,7 @@ public class JPotionList extends JSimpleEntriesList<JPotionListEntry, Potion.Cus
 	}
 
 	@Override
-	public JSimpleListEntry<Potion.CustomEffectEntry> newEntry(JPanel parent, List<JPotionListEntry> entryList) {
+	protected JSimpleListEntry<Potion.CustomEffectEntry> newEntry(JPanel parent, List<JPotionListEntry> entryList) {
 		return new JPotionListEntry(mcreator, gui, entries, entryList);
 	}
 

--- a/src/main/java/net/mcreator/ui/minecraft/potions/JPotionList.java
+++ b/src/main/java/net/mcreator/ui/minecraft/potions/JPotionList.java
@@ -35,8 +35,8 @@ public class JPotionList extends JSimpleEntriesList<JPotionListEntry, Potion.Cus
 
 	public JPotionList(MCreator mcreator, IHelpContext gui) {
 		super(mcreator, new BorderLayout(), gui);
-		add.setText(L10N.t("elementgui.potion.add_entry"));
 
+		add.setText(L10N.t("elementgui.potion.add_entry"));
 		add.addActionListener(e -> {
 			JPotionListEntry entry = new JPotionListEntry(mcreator, gui, entries, entryList);
 			registerEntryUI(entry);

--- a/src/main/java/net/mcreator/ui/minecraft/potions/JPotionList.java
+++ b/src/main/java/net/mcreator/ui/minecraft/potions/JPotionList.java
@@ -21,26 +21,21 @@ package net.mcreator.ui.minecraft.potions;
 
 import net.mcreator.element.types.Potion;
 import net.mcreator.ui.MCreator;
+import net.mcreator.ui.component.entries.JSimpleEntriesList;
+import net.mcreator.ui.component.entries.JSimpleListEntry;
 import net.mcreator.ui.help.IHelpContext;
 import net.mcreator.ui.init.L10N;
-import net.mcreator.ui.component.entries.JSingleEntriesList;
 
 import javax.swing.*;
 import java.awt.*;
 import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
 
-public class JPotionList extends JSingleEntriesList<JPotionListEntry, Potion.CustomEffectEntry> {
+public class JPotionList extends JSimpleEntriesList<JPotionListEntry, Potion.CustomEffectEntry> {
 
 	public JPotionList(MCreator mcreator, IHelpContext gui) {
 		super(mcreator, gui);
 
 		add.setText(L10N.t("elementgui.potion.add_entry"));
-		add.addActionListener(e -> {
-			JPotionListEntry entry = new JPotionListEntry(mcreator, gui, entries, entryList);
-			registerEntryUI(entry);
-		});
 
 		setBorder(BorderFactory.createTitledBorder(
 				BorderFactory.createLineBorder((Color) UIManager.get("MCreatorLAF.BRIGHT_COLOR"), 1),
@@ -48,16 +43,9 @@ public class JPotionList extends JSingleEntriesList<JPotionListEntry, Potion.Cus
 				(Color) UIManager.get("MCreatorLAF.BRIGHT_COLOR")));
 	}
 
-	@Override public List<Potion.CustomEffectEntry> getEntries() {
-		return entryList.stream().map(JPotionListEntry::getEntry).filter(Objects::nonNull).collect(Collectors.toList());
-	}
-
-	@Override public void setEntries(List<Potion.CustomEffectEntry> pool) {
-		pool.forEach(e -> {
-			JPotionListEntry entry = new JPotionListEntry(mcreator, gui, entries, entryList);
-			registerEntryUI(entry);
-			entry.setEntry(e);
-		});
+	@Override
+	public JSimpleListEntry<Potion.CustomEffectEntry> newEntry(JPanel parent, List<JPotionListEntry> entryList) {
+		return new JPotionListEntry(mcreator, gui, entries, entryList);
 	}
 
 }

--- a/src/main/java/net/mcreator/ui/minecraft/potions/JPotionList.java
+++ b/src/main/java/net/mcreator/ui/minecraft/potions/JPotionList.java
@@ -23,7 +23,7 @@ import net.mcreator.element.types.Potion;
 import net.mcreator.ui.MCreator;
 import net.mcreator.ui.help.IHelpContext;
 import net.mcreator.ui.init.L10N;
-import net.mcreator.ui.minecraft.JSimpleEntriesList;
+import net.mcreator.ui.component.entries.JSingleEntriesList;
 
 import javax.swing.*;
 import java.awt.*;
@@ -31,7 +31,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-public class JPotionList extends JSimpleEntriesList<JPotionListEntry, Potion.CustomEffectEntry> {
+public class JPotionList extends JSingleEntriesList<JPotionListEntry, Potion.CustomEffectEntry> {
 
 	public JPotionList(MCreator mcreator, IHelpContext gui) {
 		super(mcreator, gui);

--- a/src/main/java/net/mcreator/ui/minecraft/potions/JPotionList.java
+++ b/src/main/java/net/mcreator/ui/minecraft/potions/JPotionList.java
@@ -21,44 +21,26 @@ package net.mcreator.ui.minecraft.potions;
 
 import net.mcreator.element.types.Potion;
 import net.mcreator.ui.MCreator;
-import net.mcreator.ui.component.util.PanelUtils;
 import net.mcreator.ui.help.IHelpContext;
 import net.mcreator.ui.init.L10N;
-import net.mcreator.ui.minecraft.JEntriesList;
+import net.mcreator.ui.minecraft.JSimpleEntriesList;
 
 import javax.swing.*;
 import java.awt.*;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-public class JPotionList extends JEntriesList {
-
-	private final List<JPotionListEntry> entryList = new ArrayList<>();
-
-	private final JPanel entries = new JPanel(new GridLayout(0, 1, 5, 5));
+public class JPotionList extends JSimpleEntriesList<JPotionListEntry, Potion.CustomEffectEntry> {
 
 	public JPotionList(MCreator mcreator, IHelpContext gui) {
 		super(mcreator, new BorderLayout(), gui);
-		setOpaque(false);
-
-		JPanel topbar = new JPanel(new FlowLayout(FlowLayout.LEFT));
-		topbar.setBackground((Color) UIManager.get("MCreatorLAF.LIGHT_ACCENT"));
-
 		add.setText(L10N.t("elementgui.potion.add_entry"));
-		topbar.add(add);
-
-		add("North", topbar);
-
-		entries.setOpaque(false);
 
 		add.addActionListener(e -> {
 			JPotionListEntry entry = new JPotionListEntry(mcreator, gui, entries, entryList);
 			registerEntryUI(entry);
 		});
-
-		add("Center", PanelUtils.pullElementUp(entries));
 
 		setBorder(BorderFactory.createTitledBorder(
 				BorderFactory.createLineBorder((Color) UIManager.get("MCreatorLAF.BRIGHT_COLOR"), 1),
@@ -66,21 +48,16 @@ public class JPotionList extends JEntriesList {
 				(Color) UIManager.get("MCreatorLAF.BRIGHT_COLOR")));
 	}
 
-	@Override public void setEnabled(boolean enabled) {
-		super.setEnabled(enabled);
-
-		add.setEnabled(false);
-	}
-
-	public List<Potion.CustomEffectEntry> getEffects() {
+	@Override public List<Potion.CustomEffectEntry> getEntries() {
 		return entryList.stream().map(JPotionListEntry::getEntry).filter(Objects::nonNull).collect(Collectors.toList());
 	}
 
-	public void setEffects(List<Potion.CustomEffectEntry> pool) {
+	@Override public void setEntries(List<Potion.CustomEffectEntry> pool) {
 		pool.forEach(e -> {
 			JPotionListEntry entry = new JPotionListEntry(mcreator, gui, entries, entryList);
 			registerEntryUI(entry);
 			entry.setEntry(e);
 		});
 	}
+
 }

--- a/src/main/java/net/mcreator/ui/minecraft/potions/JPotionList.java
+++ b/src/main/java/net/mcreator/ui/minecraft/potions/JPotionList.java
@@ -34,7 +34,7 @@ import java.util.stream.Collectors;
 public class JPotionList extends JSimpleEntriesList<JPotionListEntry, Potion.CustomEffectEntry> {
 
 	public JPotionList(MCreator mcreator, IHelpContext gui) {
-		super(mcreator, new BorderLayout(), gui);
+		super(mcreator, gui);
 
 		add.setText(L10N.t("elementgui.potion.add_entry"));
 		add.addActionListener(e -> {

--- a/src/main/java/net/mcreator/ui/minecraft/potions/JPotionList.java
+++ b/src/main/java/net/mcreator/ui/minecraft/potions/JPotionList.java
@@ -44,7 +44,7 @@ public class JPotionList extends JSimpleEntriesList<JPotionListEntry, Potion.Cus
 	}
 
 	@Override
-	protected JSimpleListEntry<Potion.CustomEffectEntry> newEntry(JPanel parent, List<JPotionListEntry> entryList) {
+	protected JPotionListEntry newEntry(JPanel parent, List<JPotionListEntry> entryList) {
 		return new JPotionListEntry(mcreator, gui, entries, entryList);
 	}
 

--- a/src/main/java/net/mcreator/ui/minecraft/potions/JPotionListEntry.java
+++ b/src/main/java/net/mcreator/ui/minecraft/potions/JPotionListEntry.java
@@ -21,20 +21,21 @@ package net.mcreator.ui.minecraft.potions;
 
 import net.mcreator.element.parts.EffectEntry;
 import net.mcreator.element.types.Potion;
+import net.mcreator.minecraft.DataListEntry;
 import net.mcreator.minecraft.ElementUtil;
 import net.mcreator.ui.MCreator;
-import net.mcreator.ui.component.util.PanelUtils;
+import net.mcreator.ui.component.entries.JSimpleListEntry;
+import net.mcreator.ui.component.util.ComboBoxUtil;
 import net.mcreator.ui.help.HelpUtils;
 import net.mcreator.ui.help.IHelpContext;
 import net.mcreator.ui.init.L10N;
-import net.mcreator.ui.init.UIRES;
 import net.mcreator.workspace.Workspace;
 
 import javax.swing.*;
-import java.awt.*;
 import java.util.List;
+import java.util.stream.Collectors;
 
-public class JPotionListEntry extends JPanel {
+public class JPotionListEntry extends JSimpleListEntry<Potion.CustomEffectEntry> {
 
 	private final JSpinner duration = new JSpinner(new SpinnerNumberModel(3600, 1, 72000, 1));
 	private final JSpinner amplifier = new JSpinner(new SpinnerNumberModel(0, 0, 255, 1));
@@ -45,50 +46,52 @@ public class JPotionListEntry extends JPanel {
 	private final Workspace workspace;
 
 	public JPotionListEntry(MCreator mcreator, IHelpContext gui, JPanel parent, List<JPotionListEntry> entryList) {
-		super(new FlowLayout(FlowLayout.LEFT));
+		super(parent, entryList);
 
 		this.workspace = mcreator.getWorkspace();
 
-		final JComponent container = PanelUtils.expandHorizontally(this);
+		ambient.setOpaque(false);
+		showParticles.setOpaque(false);
 
-		parent.add(container);
-		entryList.add(this);
+		line.add(L10N.label("elementgui.potion.effect"));
+		line.add(effect);
 
-		ElementUtil.loadAllPotionEffects(workspace).forEach(e -> effect.addItem(e.getName()));
+		line.add(HelpUtils.wrapWithHelpButton(gui.withEntry("potion/duration"),
+				L10N.label("elementgui.potion.duration")));
+		line.add(duration);
 
-		add(L10N.label("elementgui.potion.effect"));
-		add(effect);
+		line.add(HelpUtils.wrapWithHelpButton(gui.withEntry("potion/amplifier"),
+				L10N.label("elementgui.potion.amplifier")));
+		line.add(amplifier);
 
-		add(HelpUtils.wrapWithHelpButton(gui.withEntry("potion/duration"), L10N.label("elementgui.potion.duration")));
-		add(duration);
-
-		add(HelpUtils.wrapWithHelpButton(gui.withEntry("potion/amplifier"), L10N.label("elementgui.potion.amplifier")));
-		add(amplifier);
-
-		add(HelpUtils.wrapWithHelpButton(gui.withEntry("potion/show_particles"),
+		line.add(HelpUtils.wrapWithHelpButton(gui.withEntry("potion/show_particles"),
 				L10N.label("elementgui.potion.show_particles")));
-		add(showParticles);
+		line.add(showParticles);
 
-		add(HelpUtils.wrapWithHelpButton(gui.withEntry("potion/ambient"), L10N.label("elementgui.potion.ambient")));
-		add(ambient);
+		line.add(
+				HelpUtils.wrapWithHelpButton(gui.withEntry("potion/ambient"), L10N.label("elementgui.potion.ambient")));
+		line.add(ambient);
 
 		showParticles.setSelected(true);
-
-		JButton remove = new JButton(UIRES.get("16px.clear"));
-		remove.setText(L10N.t("elementgui.potion.remove_entry"));
-		remove.addActionListener(e -> {
-			entryList.remove(this);
-			parent.remove(container);
-			parent.revalidate();
-			parent.repaint();
-		});
-		add(remove);
-
-		parent.revalidate();
-		parent.repaint();
 	}
 
-	public Potion.CustomEffectEntry getEntry() {
+	@Override public void reloadDataLists() {
+		super.reloadDataLists();
+
+		ComboBoxUtil.updateComboBoxContents(effect,
+				ElementUtil.loadAllPotionEffects(workspace).stream().map(DataListEntry::getName)
+						.collect(Collectors.toList()), "SPEED");
+	}
+
+	@Override protected void setEntryEnabled(boolean enabled) {
+		duration.setEnabled(enabled);
+		amplifier.setEnabled(enabled);
+		effect.setEnabled(enabled);
+		ambient.setEnabled(enabled);
+		showParticles.setEnabled(enabled);
+	}
+
+	@Override public Potion.CustomEffectEntry getEntry() {
 		Potion.CustomEffectEntry entry = new Potion.CustomEffectEntry();
 		entry.effect = new EffectEntry(workspace, (String) effect.getSelectedItem());
 		entry.duration = (int) duration.getValue();
@@ -98,11 +101,12 @@ public class JPotionListEntry extends JPanel {
 		return entry;
 	}
 
-	public void setEntry(Potion.CustomEffectEntry e) {
+	@Override public void setEntry(Potion.CustomEffectEntry e) {
 		effect.setSelectedItem(e.effect.getUnmappedValue());
 		duration.setValue(e.duration);
 		amplifier.setValue(e.amplifier);
 		ambient.setSelected(e.ambient);
 		showParticles.setSelected(e.showParticles);
 	}
+
 }

--- a/src/main/java/net/mcreator/ui/minecraft/spawntypes/JSpawnEntriesList.java
+++ b/src/main/java/net/mcreator/ui/minecraft/spawntypes/JSpawnEntriesList.java
@@ -33,7 +33,7 @@ import java.util.stream.Collectors;
 public class JSpawnEntriesList extends JSimpleEntriesList<JSpawnListEntry, Biome.SpawnEntry> {
 
 	public JSpawnEntriesList(MCreator mcreator, IHelpContext gui) {
-		super(mcreator, new BorderLayout(), gui);
+		super(mcreator, gui);
 
 		add.setText(L10N.t("elementgui.spawnlist.add_entry"));
 		add.addActionListener(e -> {

--- a/src/main/java/net/mcreator/ui/minecraft/spawntypes/JSpawnEntriesList.java
+++ b/src/main/java/net/mcreator/ui/minecraft/spawntypes/JSpawnEntriesList.java
@@ -43,7 +43,7 @@ public class JSpawnEntriesList extends JSimpleEntriesList<JSpawnListEntry, Biome
 		setPreferredSize(new Dimension(getPreferredSize().width, (int) (mcreator.getSize().height * 0.6)));
 	}
 
-	@Override public JSimpleListEntry<Biome.SpawnEntry> newEntry(JPanel parent, List<JSpawnListEntry> entryList) {
+	@Override protected JSimpleListEntry<Biome.SpawnEntry> newEntry(JPanel parent, List<JSpawnListEntry> entryList) {
 		return new JSpawnListEntry(mcreator, gui, parent, entryList);
 	}
 

--- a/src/main/java/net/mcreator/ui/minecraft/spawntypes/JSpawnEntriesList.java
+++ b/src/main/java/net/mcreator/ui/minecraft/spawntypes/JSpawnEntriesList.java
@@ -43,7 +43,7 @@ public class JSpawnEntriesList extends JSimpleEntriesList<JSpawnListEntry, Biome
 		setPreferredSize(new Dimension(getPreferredSize().width, (int) (mcreator.getSize().height * 0.6)));
 	}
 
-	@Override protected JSimpleListEntry<Biome.SpawnEntry> newEntry(JPanel parent, List<JSpawnListEntry> entryList) {
+	@Override protected JSpawnListEntry newEntry(JPanel parent, List<JSpawnListEntry> entryList) {
 		return new JSpawnListEntry(mcreator, gui, parent, entryList);
 	}
 

--- a/src/main/java/net/mcreator/ui/minecraft/spawntypes/JSpawnEntriesList.java
+++ b/src/main/java/net/mcreator/ui/minecraft/spawntypes/JSpawnEntriesList.java
@@ -20,58 +20,26 @@ package net.mcreator.ui.minecraft.spawntypes;
 
 import net.mcreator.element.types.Biome;
 import net.mcreator.ui.MCreator;
-import net.mcreator.ui.component.util.PanelUtils;
 import net.mcreator.ui.help.IHelpContext;
 import net.mcreator.ui.init.L10N;
-import net.mcreator.ui.minecraft.JEntriesList;
+import net.mcreator.ui.minecraft.JSimpleEntriesList;
 
 import javax.swing.*;
 import java.awt.*;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-public class JSpawnEntriesList extends JEntriesList {
-
-	private final List<JSpawnListEntry> entryList = new ArrayList<>();
-
-	private final JPanel entries = new JPanel();
+public class JSpawnEntriesList extends JSimpleEntriesList<JSpawnListEntry, Biome.SpawnEntry> {
 
 	public JSpawnEntriesList(MCreator mcreator, IHelpContext gui) {
 		super(mcreator, new BorderLayout(), gui);
-		setOpaque(false);
-
-		JPanel topbar = new JPanel(new FlowLayout(FlowLayout.LEFT));
-		topbar.setBackground((Color) UIManager.get("MCreatorLAF.LIGHT_ACCENT"));
 
 		add.setText(L10N.t("elementgui.spawnlist.add_entry"));
-		topbar.add(add);
-
-		add("North", topbar);
-
-		entries.setLayout(new BoxLayout(entries, BoxLayout.PAGE_AXIS));
-		entries.setOpaque(false);
-
 		add.addActionListener(e -> {
 			JSpawnListEntry entry = new JSpawnListEntry(mcreator, gui, entries, entryList);
 			registerEntryUI(entry);
 		});
-
-		JScrollPane scrollPane = new JScrollPane(PanelUtils.pullElementUp(entries)) {
-			@Override protected void paintComponent(Graphics g) {
-				Graphics2D g2d = (Graphics2D) g.create();
-				g2d.setColor((Color) UIManager.get("MCreatorLAF.LIGHT_ACCENT"));
-				g2d.setComposite(AlphaComposite.SrcOver.derive(0.45f));
-				g2d.fillRect(0, 0, getWidth(), getHeight());
-				g2d.dispose();
-				super.paintComponent(g);
-			}
-		};
-		scrollPane.getViewport().setOpaque(false);
-		scrollPane.setOpaque(false);
-		scrollPane.getVerticalScrollBar().setUnitIncrement(15);
-		add("Center", scrollPane);
 
 		setBorder(BorderFactory.createTitledBorder(
 				BorderFactory.createLineBorder((Color) UIManager.get("MCreatorLAF.BRIGHT_COLOR"), 1),
@@ -80,17 +48,11 @@ public class JSpawnEntriesList extends JEntriesList {
 		setPreferredSize(new Dimension(getPreferredSize().width, (int) (mcreator.getSize().height * 0.6)));
 	}
 
-	@Override public void setEnabled(boolean enabled) {
-		super.setEnabled(enabled);
-
-		add.setEnabled(false);
-	}
-
-	public List<Biome.SpawnEntry> getSpawns() {
+	@Override public List<Biome.SpawnEntry> getEntries() {
 		return entryList.stream().map(JSpawnListEntry::getEntry).filter(Objects::nonNull).collect(Collectors.toList());
 	}
 
-	public void setSpawns(List<Biome.SpawnEntry> pool) {
+	@Override public void setEntries(List<Biome.SpawnEntry> pool) {
 		pool.forEach(e -> {
 			JSpawnListEntry entry = new JSpawnListEntry(mcreator, gui, entries, entryList);
 			registerEntryUI(entry);

--- a/src/main/java/net/mcreator/ui/minecraft/spawntypes/JSpawnEntriesList.java
+++ b/src/main/java/net/mcreator/ui/minecraft/spawntypes/JSpawnEntriesList.java
@@ -22,7 +22,7 @@ import net.mcreator.element.types.Biome;
 import net.mcreator.ui.MCreator;
 import net.mcreator.ui.help.IHelpContext;
 import net.mcreator.ui.init.L10N;
-import net.mcreator.ui.minecraft.JSimpleEntriesList;
+import net.mcreator.ui.component.entries.JSingleEntriesList;
 
 import javax.swing.*;
 import java.awt.*;
@@ -30,7 +30,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-public class JSpawnEntriesList extends JSimpleEntriesList<JSpawnListEntry, Biome.SpawnEntry> {
+public class JSpawnEntriesList extends JSingleEntriesList<JSpawnListEntry, Biome.SpawnEntry> {
 
 	public JSpawnEntriesList(MCreator mcreator, IHelpContext gui) {
 		super(mcreator, gui);

--- a/src/main/java/net/mcreator/ui/minecraft/spawntypes/JSpawnEntriesList.java
+++ b/src/main/java/net/mcreator/ui/minecraft/spawntypes/JSpawnEntriesList.java
@@ -20,26 +20,21 @@ package net.mcreator.ui.minecraft.spawntypes;
 
 import net.mcreator.element.types.Biome;
 import net.mcreator.ui.MCreator;
+import net.mcreator.ui.component.entries.JSimpleEntriesList;
+import net.mcreator.ui.component.entries.JSimpleListEntry;
 import net.mcreator.ui.help.IHelpContext;
 import net.mcreator.ui.init.L10N;
-import net.mcreator.ui.component.entries.JSingleEntriesList;
 
 import javax.swing.*;
 import java.awt.*;
 import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
 
-public class JSpawnEntriesList extends JSingleEntriesList<JSpawnListEntry, Biome.SpawnEntry> {
+public class JSpawnEntriesList extends JSimpleEntriesList<JSpawnListEntry, Biome.SpawnEntry> {
 
 	public JSpawnEntriesList(MCreator mcreator, IHelpContext gui) {
 		super(mcreator, gui);
 
 		add.setText(L10N.t("elementgui.spawnlist.add_entry"));
-		add.addActionListener(e -> {
-			JSpawnListEntry entry = new JSpawnListEntry(mcreator, gui, entries, entryList);
-			registerEntryUI(entry);
-		});
 
 		setBorder(BorderFactory.createTitledBorder(
 				BorderFactory.createLineBorder((Color) UIManager.get("MCreatorLAF.BRIGHT_COLOR"), 1),
@@ -48,16 +43,8 @@ public class JSpawnEntriesList extends JSingleEntriesList<JSpawnListEntry, Biome
 		setPreferredSize(new Dimension(getPreferredSize().width, (int) (mcreator.getSize().height * 0.6)));
 	}
 
-	@Override public List<Biome.SpawnEntry> getEntries() {
-		return entryList.stream().map(JSpawnListEntry::getEntry).filter(Objects::nonNull).collect(Collectors.toList());
-	}
-
-	@Override public void setEntries(List<Biome.SpawnEntry> pool) {
-		pool.forEach(e -> {
-			JSpawnListEntry entry = new JSpawnListEntry(mcreator, gui, entries, entryList);
-			registerEntryUI(entry);
-			entry.setEntry(e);
-		});
+	@Override public JSimpleListEntry<Biome.SpawnEntry> newEntry(JPanel parent, List<JSpawnListEntry> entryList) {
+		return new JSpawnListEntry(mcreator, gui, parent, entryList);
 	}
 
 }

--- a/src/main/java/net/mcreator/ui/minecraft/spawntypes/JSpawnListEntry.java
+++ b/src/main/java/net/mcreator/ui/minecraft/spawntypes/JSpawnListEntry.java
@@ -20,22 +20,24 @@ package net.mcreator.ui.minecraft.spawntypes;
 
 import net.mcreator.element.parts.EntityEntry;
 import net.mcreator.element.types.Biome;
+import net.mcreator.minecraft.DataListEntry;
 import net.mcreator.minecraft.ElementUtil;
 import net.mcreator.ui.MCreator;
 import net.mcreator.ui.component.JMinMaxSpinner;
 import net.mcreator.ui.component.SearchableComboBox;
-import net.mcreator.ui.component.util.PanelUtils;
+import net.mcreator.ui.component.entries.JSimpleListEntry;
+import net.mcreator.ui.component.util.ComboBoxUtil;
 import net.mcreator.ui.help.HelpUtils;
 import net.mcreator.ui.help.IHelpContext;
 import net.mcreator.ui.init.L10N;
-import net.mcreator.ui.init.UIRES;
 import net.mcreator.workspace.Workspace;
 
 import javax.swing.*;
 import java.awt.*;
 import java.util.List;
+import java.util.stream.Collectors;
 
-public class JSpawnListEntry extends JPanel {
+public class JSpawnListEntry extends JSimpleListEntry<Biome.SpawnEntry> {
 
 	private final JSpinner spawningProbability = new JSpinner(new SpinnerNumberModel(20, 1, 1000, 1));
 	private final JMinMaxSpinner numberOfMobsPerGroup = new JMinMaxSpinner(4, 4, 1, 1000, 1);
@@ -46,51 +48,47 @@ public class JSpawnListEntry extends JPanel {
 	private final Workspace workspace;
 
 	public JSpawnListEntry(MCreator mcreator, IHelpContext gui, JPanel parent, List<JSpawnListEntry> entryList) {
-		super(new FlowLayout(FlowLayout.LEFT));
+		super(parent, entryList);
 
 		this.workspace = mcreator.getWorkspace();
 
-		final JComponent container = PanelUtils.expandHorizontally(this);
-
-		parent.add(container);
-		entryList.add(this);
-
-		ElementUtil.loadAllSpawnableEntities(workspace).forEach(e -> entityType.addItem(e.getName()));
 		numberOfMobsPerGroup.setBorder(BorderFactory.createCompoundBorder(
 				BorderFactory.createLineBorder((Color) UIManager.get("MCreatorLAF.LIGHT_ACCENT")),
 				BorderFactory.createEmptyBorder(2, 2, 2, 2)));
 		numberOfMobsPerGroup.setAllowEqualValues(true);
 
-		add(L10N.label("dialog.spawn_list_entry.entity"));
-		add(entityType);
+		line.add(L10N.label("dialog.spawn_list_entry.entity"));
+		line.add(entityType);
 
-		add(HelpUtils.wrapWithHelpButton(gui.withEntry("entity/spawn_type"),
+		line.add(HelpUtils.wrapWithHelpButton(gui.withEntry("entity/spawn_type"),
 				L10N.label("dialog.spawn_list_entry.type")));
-		add(mobSpawningType);
+		line.add(mobSpawningType);
 
-		add(HelpUtils.wrapWithHelpButton(gui.withEntry("entity/spawn_weight"),
+		line.add(HelpUtils.wrapWithHelpButton(gui.withEntry("entity/spawn_weight"),
 				L10N.label("dialog.spawn_list_entry.weight")));
-		add(spawningProbability);
+		line.add(spawningProbability);
 
-		add(HelpUtils.wrapWithHelpButton(gui.withEntry("entity/spawn_group_size"),
+		line.add(HelpUtils.wrapWithHelpButton(gui.withEntry("entity/spawn_group_size"),
 				L10N.label("dialog.spawn_list_entry.group_size")));
-		add(numberOfMobsPerGroup);
-
-		JButton remove = new JButton(UIRES.get("16px.clear"));
-		remove.setText(L10N.t("dialog.spawn_list_entry.remove_entry"));
-		remove.addActionListener(e -> {
-			entryList.remove(this);
-			parent.remove(container);
-			parent.revalidate();
-			parent.repaint();
-		});
-		add(remove);
-
-		parent.revalidate();
-		parent.repaint();
+		line.add(numberOfMobsPerGroup);
 	}
 
-	public Biome.SpawnEntry getEntry() {
+	@Override public void reloadDataLists() {
+		super.reloadDataLists();
+
+		ComboBoxUtil.updateComboBoxContents(entityType,
+				ElementUtil.loadAllSpawnableEntities(workspace).stream().map(DataListEntry::getName)
+						.collect(Collectors.toList()));
+	}
+
+	@Override protected void setEntryEnabled(boolean enabled) {
+		spawningProbability.setEnabled(enabled);
+		numberOfMobsPerGroup.setEnabled(enabled);
+		mobSpawningType.setEnabled(enabled);
+		entityType.setEnabled(enabled);
+	}
+
+	@Override public Biome.SpawnEntry getEntry() {
 		Biome.SpawnEntry entry = new Biome.SpawnEntry();
 		entry.entity = new EntityEntry(workspace, (String) entityType.getSelectedItem());
 		entry.spawnType = (String) mobSpawningType.getSelectedItem();
@@ -100,11 +98,12 @@ public class JSpawnListEntry extends JPanel {
 		return entry;
 	}
 
-	public void setEntry(Biome.SpawnEntry e) {
+	@Override public void setEntry(Biome.SpawnEntry e) {
 		entityType.setSelectedItem(e.entity.getUnmappedValue());
 		mobSpawningType.setSelectedItem(e.spawnType);
 		spawningProbability.setValue(e.weight);
 		numberOfMobsPerGroup.setMinValue(e.minGroup);
 		numberOfMobsPerGroup.setMaxValue(e.maxGroup);
 	}
+
 }

--- a/src/main/java/net/mcreator/ui/minecraft/states/item/JItemPropertiesStatesList.java
+++ b/src/main/java/net/mcreator/ui/minecraft/states/item/JItemPropertiesStatesList.java
@@ -31,7 +31,7 @@ import net.mcreator.ui.help.HelpUtils;
 import net.mcreator.ui.help.IHelpContext;
 import net.mcreator.ui.init.L10N;
 import net.mcreator.ui.init.UIRES;
-import net.mcreator.ui.minecraft.JEntriesList;
+import net.mcreator.ui.component.entries.JEntriesList;
 import net.mcreator.ui.minecraft.states.JStateLabel;
 import net.mcreator.ui.minecraft.states.PropertyData;
 import net.mcreator.ui.minecraft.states.StateMap;

--- a/src/main/java/net/mcreator/ui/minecraft/states/item/JItemPropertiesStatesList.java
+++ b/src/main/java/net/mcreator/ui/minecraft/states/item/JItemPropertiesStatesList.java
@@ -164,7 +164,7 @@ public class JItemPropertiesStatesList extends JEntriesList {
 		stateEntries.setEnabled(enabled);
 	}
 
-	public void reloadDataLists() {
+	@Override public void reloadDataLists() {
 		propertiesList.forEach(JItemPropertiesListEntry::reloadDataLists);
 		statesList.forEach(JItemStatesListEntry::reloadDataLists);
 	}

--- a/src/main/java/net/mcreator/ui/minecraft/villagers/JVillagerTradeProfession.java
+++ b/src/main/java/net/mcreator/ui/minecraft/villagers/JVillagerTradeProfession.java
@@ -29,7 +29,7 @@ import net.mcreator.ui.help.IHelpContext;
 import net.mcreator.ui.init.L10N;
 import net.mcreator.ui.init.UIRES;
 import net.mcreator.ui.minecraft.DataListComboBox;
-import net.mcreator.ui.minecraft.JEntriesList;
+import net.mcreator.ui.component.entries.JEntriesList;
 import net.mcreator.workspace.Workspace;
 
 import javax.swing.*;

--- a/src/main/java/net/mcreator/ui/minecraft/villagers/JVillagerTradeProfession.java
+++ b/src/main/java/net/mcreator/ui/minecraft/villagers/JVillagerTradeProfession.java
@@ -109,7 +109,7 @@ public class JVillagerTradeProfession extends JEntriesList {
 		parent.repaint();
 	}
 
-	public void reloadDataLists() {
+	@Override public void reloadDataLists() {
 		ComboBoxUtil.updateComboBoxContents(villagerProfession, ElementUtil.loadAllVillagerProfessions(workspace));
 	}
 

--- a/src/main/java/net/mcreator/ui/minecraft/villagers/JVillagerTradeProfessionsList.java
+++ b/src/main/java/net/mcreator/ui/minecraft/villagers/JVillagerTradeProfessionsList.java
@@ -47,7 +47,7 @@ public class JVillagerTradeProfessionsList
 		setBorder(BorderFactory.createEmptyBorder(5, 5, 5, 5));
 	}
 
-	public void reloadDataLists() {
+	@Override public void reloadDataLists() {
 		entryList.forEach(JVillagerTradeProfession::reloadDataLists);
 	}
 

--- a/src/main/java/net/mcreator/ui/minecraft/villagers/JVillagerTradeProfessionsList.java
+++ b/src/main/java/net/mcreator/ui/minecraft/villagers/JVillagerTradeProfessionsList.java
@@ -23,15 +23,14 @@ import net.mcreator.element.types.VillagerTrade;
 import net.mcreator.ui.MCreator;
 import net.mcreator.ui.help.IHelpContext;
 import net.mcreator.ui.init.L10N;
-import net.mcreator.ui.minecraft.JSimpleEntriesList;
+import net.mcreator.ui.component.entries.JSingleEntriesList;
 
 import javax.swing.*;
-import java.awt.*;
 import java.util.List;
 import java.util.Objects;
 
 public class JVillagerTradeProfessionsList
-		extends JSimpleEntriesList<JVillagerTradeProfession, VillagerTrade.CustomTradeEntry> {
+		extends JSingleEntriesList<JVillagerTradeProfession, VillagerTrade.CustomTradeEntry> {
 
 	public JVillagerTradeProfessionsList(MCreator mcreator, IHelpContext gui) {
 		super(mcreator, gui);

--- a/src/main/java/net/mcreator/ui/minecraft/villagers/JVillagerTradeProfessionsList.java
+++ b/src/main/java/net/mcreator/ui/minecraft/villagers/JVillagerTradeProfessionsList.java
@@ -21,79 +21,53 @@ package net.mcreator.ui.minecraft.villagers;
 
 import net.mcreator.element.types.VillagerTrade;
 import net.mcreator.ui.MCreator;
-import net.mcreator.ui.component.util.PanelUtils;
 import net.mcreator.ui.help.IHelpContext;
 import net.mcreator.ui.init.L10N;
-import net.mcreator.ui.minecraft.JEntriesList;
+import net.mcreator.ui.minecraft.JSimpleEntriesList;
 
 import javax.swing.*;
 import java.awt.*;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-public class JVillagerTradeProfessionsList extends JEntriesList {
-
-	private final List<JVillagerTradeProfession> professionList = new ArrayList<>();
-
-	private final JPanel professions = new JPanel();
+public class JVillagerTradeProfessionsList
+		extends JSimpleEntriesList<JVillagerTradeProfession, VillagerTrade.CustomTradeEntry> {
 
 	public JVillagerTradeProfessionsList(MCreator mcreator, IHelpContext gui) {
-		super(mcreator, new BorderLayout(), gui);
-		setOpaque(false);
+		super(mcreator, gui);
 
-		professions.setLayout(new BoxLayout(professions, BoxLayout.PAGE_AXIS));
-		professions.setOpaque(false);
+		entries.setLayout(new BoxLayout(entries, BoxLayout.PAGE_AXIS));
 
-		JToolBar bar = new JToolBar();
-		bar.setFloatable(false);
 		add.setText(L10N.t("elementgui.villager_trade.add_profession_trades"));
 		add.addActionListener(e -> {
-			JVillagerTradeProfession profession = new JVillagerTradeProfession(mcreator, gui, professions,
-					professionList);
+			JVillagerTradeProfession profession = new JVillagerTradeProfession(mcreator, gui, entries, entryList);
 			registerEntryUI(profession);
 			profession.addInitialEntry();
 		});
-		bar.add(add);
-		add("North", bar);
 
-		JScrollPane sp = new JScrollPane(PanelUtils.pullElementUp(professions)) {
-			@Override protected void paintComponent(Graphics g) {
-				Graphics2D g2d = (Graphics2D) g.create();
-				g2d.setColor((Color) UIManager.get("MCreatorLAF.LIGHT_ACCENT"));
-				g2d.setComposite(AlphaComposite.SrcOver.derive(0.45f));
-				g2d.fillRect(0, 0, getWidth(), getHeight());
-				g2d.dispose();
-				super.paintComponent(g);
-			}
-		};
-		sp.setOpaque(false);
-		sp.getViewport().setOpaque(false);
-		sp.getVerticalScrollBar().setUnitIncrement(11);
-		sp.setBorder(BorderFactory.createEmptyBorder(5, 5, 5, 5));
-		add("Center", sp);
+		setBorder(BorderFactory.createEmptyBorder(5, 5, 5, 5));
 	}
 
 	public void reloadDataLists() {
-		professionList.forEach(JVillagerTradeProfession::reloadDataLists);
+		entryList.forEach(JVillagerTradeProfession::reloadDataLists);
 	}
 
 	public void addInitialTrade() {
-		JVillagerTradeProfession profession = new JVillagerTradeProfession(mcreator, gui, professions, professionList);
+		JVillagerTradeProfession profession = new JVillagerTradeProfession(mcreator, gui, entries, entryList);
 		registerEntryUI(profession);
 		profession.addInitialEntry();
 	}
 
-	public List<VillagerTrade.CustomTradeEntry> getTrades() {
-		return professionList.stream().map(JVillagerTradeProfession::getTradeEntry).filter(Objects::nonNull).toList();
+	@Override public List<VillagerTrade.CustomTradeEntry> getEntries() {
+		return entryList.stream().map(JVillagerTradeProfession::getTradeEntry).filter(Objects::nonNull).toList();
 	}
 
-	public void setTrades(List<VillagerTrade.CustomTradeEntry> tradesEntries) {
+	@Override public void setEntries(List<VillagerTrade.CustomTradeEntry> tradesEntries) {
 		tradesEntries.forEach(e -> {
-			JVillagerTradeProfession profession = new JVillagerTradeProfession(mcreator, gui, professions,
-					professionList);
+			JVillagerTradeProfession profession = new JVillagerTradeProfession(mcreator, gui, entries, entryList);
 			registerEntryUI(profession);
 			profession.setTradeEntries(e);
 		});
 	}
+
 }

--- a/src/main/java/net/mcreator/ui/modgui/BiomeGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/BiomeGUI.java
@@ -584,6 +584,7 @@ public class BiomeGUI extends ModElementGUI<Biome> {
 	@Override public void reloadDataLists() {
 		super.reloadDataLists();
 		ComboBoxUtil.updateComboBoxContents(particleToSpawn, ElementUtil.loadAllParticles(mcreator.getWorkspace()));
+		spawnEntries.reloadDataLists();
 	}
 
 	@Override protected AggregatedValidationResult validatePage(int page) {

--- a/src/main/java/net/mcreator/ui/modgui/BiomeGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/BiomeGUI.java
@@ -708,7 +708,7 @@ public class BiomeGUI extends ModElementGUI<Biome> {
 		temperature.setValue(biome.temperature);
 		defaultFeatures.setListElements(biome.defaultFeatures);
 		vanillaTreeType.setSelectedItem(biome.vanillaTreeType);
-		spawnEntries.setSpawns(biome.spawnEntries);
+		spawnEntries.setEntries(biome.spawnEntries);
 
 		genTemperature.setMinValue(biome.genTemperature.min);
 		genTemperature.setMaxValue(biome.genTemperature.max);
@@ -757,7 +757,7 @@ public class BiomeGUI extends ModElementGUI<Biome> {
 		biome.temperature = (double) temperature.getValue();
 		biome.defaultFeatures = defaultFeatures.getListElements();
 		biome.vanillaTreeType = (String) vanillaTreeType.getSelectedItem();
-		biome.spawnEntries = spawnEntries.getSpawns();
+		biome.spawnEntries = spawnEntries.getEntries();
 		biome.minHeight = (int) minHeight.getValue();
 		biome.treeVines = treeVines.getBlock();
 		biome.treeStem = treeStem.getBlock();

--- a/src/main/java/net/mcreator/ui/modgui/BlockGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/BlockGUI.java
@@ -638,7 +638,7 @@ public class BlockGUI extends ModElementGUI<Block> {
 		bbPane.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
 
 		if (!isEditingMode()) // add first bounding box
-			boundingBoxList.setBoundingBoxes(Collections.singletonList(new IBlockWithBoundingBox.BoxEntry()));
+			boundingBoxList.setEntries(Collections.singletonList(new IBlockWithBoundingBox.BoxEntry()));
 
 		boundingBoxList.addPropertyChangeListener("boundingBoxChanged", e -> updateParametersBasedOnBoundingBoxSize());
 
@@ -1456,7 +1456,7 @@ public class BlockGUI extends ModElementGUI<Block> {
 		speedFactor.setValue(block.speedFactor);
 
 		disableOffset.setSelected(block.disableOffset);
-		boundingBoxList.setBoundingBoxes(block.boundingBoxes);
+		boundingBoxList.setEntries(block.boundingBoxes);
 
 		specialInfo.setText(
 				block.specialInfo.stream().map(info -> info.replace(",", "\\,")).collect(Collectors.joining(",")));
@@ -1578,7 +1578,7 @@ public class BlockGUI extends ModElementGUI<Block> {
 		block.textureBack = textureBack.getID();
 
 		block.disableOffset = disableOffset.isSelected();
-		block.boundingBoxes = boundingBoxList.getBoundingBoxes();
+		block.boundingBoxes = boundingBoxList.getEntries();
 
 		block.beaconColorModifier = beaconColorModifier.getColor();
 

--- a/src/main/java/net/mcreator/ui/modgui/LootTableGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/LootTableGUI.java
@@ -140,7 +140,7 @@ public class LootTableGUI extends ModElementGUI<LootTable> {
 		namespace.setSelectedItem(loottable.namespace);
 		name.getEditor().setItem(loottable.name);
 
-		lootTablePools.setPools(loottable.pools);
+		lootTablePools.setEntries(loottable.pools);
 	}
 
 	@Override public LootTable getElementFromGUI() {
@@ -151,7 +151,7 @@ public class LootTableGUI extends ModElementGUI<LootTable> {
 		loottable.namespace = (String) namespace.getSelectedItem();
 		loottable.name = name.getEditor().getItem().toString();
 
-		loottable.pools = lootTablePools.getPools();
+		loottable.pools = lootTablePools.getEntries();
 
 		return loottable;
 	}

--- a/src/main/java/net/mcreator/ui/modgui/ModElementChangedListener.java
+++ b/src/main/java/net/mcreator/ui/modgui/ModElementChangedListener.java
@@ -21,7 +21,7 @@ package net.mcreator.ui.modgui;
 
 import javafx.embed.swing.JFXPanel;
 import net.mcreator.ui.component.JItemListField;
-import net.mcreator.ui.minecraft.JEntriesList;
+import net.mcreator.ui.component.entries.JEntriesList;
 import net.mcreator.ui.minecraft.MCItemHolder;
 
 import javax.swing.*;

--- a/src/main/java/net/mcreator/ui/modgui/PlantGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/PlantGUI.java
@@ -438,7 +438,7 @@ public class PlantGUI extends ModElementGUI<Plant> {
 		});
 
 		if (!isEditingMode()) { // Add first bounding box, disable custom bounding box options
-			boundingBoxList.setBoundingBoxes(Collections.singletonList(new IBlockWithBoundingBox.BoxEntry()));
+			boundingBoxList.setEntries(Collections.singletonList(new IBlockWithBoundingBox.BoxEntry()));
 			disableOffset.setEnabled(false);
 			boundingBoxList.setEnabled(false);
 		}
@@ -929,7 +929,7 @@ public class PlantGUI extends ModElementGUI<Plant> {
 
 		customBoundingBox.setSelected(plant.customBoundingBox);
 		disableOffset.setSelected(plant.disableOffset);
-		boundingBoxList.setBoundingBoxes(plant.boundingBoxes);
+		boundingBoxList.setEntries(plant.boundingBoxes);
 
 		Model model = plant.getItemModel();
 		if (model != null && model.getType() != null && model.getReadableName() != null)
@@ -1045,7 +1045,7 @@ public class PlantGUI extends ModElementGUI<Plant> {
 
 		plant.customBoundingBox = customBoundingBox.isSelected();
 		plant.disableOffset = disableOffset.isSelected();
-		plant.boundingBoxes = boundingBoxList.getBoundingBoxes();
+		plant.boundingBoxes = boundingBoxList.getEntries();
 
 		Model model = Objects.requireNonNull(renderType.getSelectedItem());
 		plant.renderType = 12;

--- a/src/main/java/net/mcreator/ui/modgui/PotionGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/PotionGUI.java
@@ -138,6 +138,12 @@ public class PotionGUI extends ModElementGUI<Potion> {
 		}
 	}
 
+	@Override public void reloadDataLists() {
+		super.reloadDataLists();
+
+		effectList.reloadDataLists();
+	}
+
 	@Override protected AggregatedValidationResult validatePage(int page) {
 		if (page == 0)
 			return new AggregatedValidationResult(page1group);

--- a/src/main/java/net/mcreator/ui/modgui/PotionGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/PotionGUI.java
@@ -54,7 +54,7 @@ public class PotionGUI extends ModElementGUI<Potion> {
 	public PotionGUI(MCreator mcreator, @Nonnull ModElement modElement, boolean editingMode) {
 		super(mcreator, modElement, editingMode);
 		this.initGUI();
-		super.finalizeGUI();
+		super.finalizeGUI(false);
 	}
 
 	@Override protected void initGUI() {
@@ -87,17 +87,11 @@ public class PotionGUI extends ModElementGUI<Potion> {
 		ComponentUtils.deriveFont(lingeringName, 16);
 		ComponentUtils.deriveFont(arrowName, 16);
 
-		JPanel mainEditor = new JPanel(new GridLayout());
-
-		JComponent component = PanelUtils.northAndCenterElement(
+		JComponent mainEditor = PanelUtils.northAndCenterElement(
 				HelpUtils.wrapWithHelpButton(this.withEntry("potion/effects"), L10N.label("elementgui.potion.effects")),
 				effectList);
 
-		component.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
-
-		mainEditor.add(component);
-
-		mainEditor.setOpaque(false);
+		mainEditor.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
 
 		potionName.setValidator(
 				new TextFieldValidator(potionName, L10N.t("elementgui.potion.error_potion_needs_display_name")));

--- a/src/main/java/net/mcreator/ui/modgui/PotionGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/PotionGUI.java
@@ -149,7 +149,7 @@ public class PotionGUI extends ModElementGUI<Potion> {
 		splashName.setText(potion.splashName);
 		lingeringName.setText(potion.lingeringName);
 		arrowName.setText(potion.arrowName);
-		effectList.setEffects(potion.effects);
+		effectList.setEntries(potion.effects);
 	}
 
 	@Override public Potion getElementFromGUI() {
@@ -158,7 +158,7 @@ public class PotionGUI extends ModElementGUI<Potion> {
 		potion.splashName = splashName.getText();
 		potion.lingeringName = lingeringName.getText();
 		potion.arrowName = arrowName.getText();
-		potion.effects = effectList.getEffects();
+		potion.effects = effectList.getEntries();
 		return potion;
 	}
 

--- a/src/main/java/net/mcreator/ui/modgui/VillagerTradeGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/VillagerTradeGUI.java
@@ -66,12 +66,12 @@ public class VillagerTradeGUI extends ModElementGUI<VillagerTrade> {
 	}
 
 	@Override public void openInEditingMode(VillagerTrade villagerTrade) {
-		villagerTradeProfessions.setTrades(villagerTrade.tradeEntries);
+		villagerTradeProfessions.setEntries(villagerTrade.tradeEntries);
 	}
 
 	@Override public VillagerTrade getElementFromGUI() {
 		VillagerTrade villagerTrade = new VillagerTrade(modElement);
-		villagerTrade.tradeEntries = villagerTradeProfessions.getTrades();
+		villagerTrade.tradeEntries = villagerTradeProfessions.getEntries();
 		return villagerTrade;
 	}
 }


### PR DESCRIPTION
This PR refactors JEntriesList to have two more variants extending it:

* JSingleEntriesList - for use cases where there is single entries list present and no special handling is needed
* JSimpleEntriesList - abstracts much of logic needed and makes adding new such list much easier

Using these two lists fixes some bugs that were present or could easily be made:

* no scrolling of the entry list
* no enable/disable function
* no automatic updating of the lists (eg. when new ME is added)

Should make life of #3975 easier. Also inspired by #3975 where we found some datalists are implemented differently than others and thus I decided to streamline this.

Changelog:

* [Bugfix] Some entry lists in the UI did not scroll properly when enough content was added
* [Bugfix] Some entry lists did not update the data when mod elements were added or removed