### PR TITLE
Minor generics fix

### DIFF
--- a/src/main/java/net/mcreator/ui/component/entries/JSimpleEntriesList.java
+++ b/src/main/java/net/mcreator/ui/component/entries/JSimpleEntriesList.java
@@ -32,7 +32,7 @@ public abstract class JSimpleEntriesList<T extends JSimpleListEntry<U>, U> exten
 		super(mcreator, gui);
 
 		add.addActionListener(e -> {
-			@SuppressWarnings("unchecked") T entry = (T) newEntry(entries, entryList);
+			T entry = newEntry(entries, entryList);
 			entry.reloadDataLists();
 			entryList.add(entry);
 			entry.setEnabled(this.isEnabled());
@@ -44,7 +44,7 @@ public abstract class JSimpleEntriesList<T extends JSimpleListEntry<U>, U> exten
 	public void entryAddedByUserHandler() {
 	}
 
-	protected abstract JSimpleListEntry<U> newEntry(JPanel parent, List<T> entryList);
+	protected abstract T newEntry(JPanel parent, List<T> entryList);
 
 	@Override public final List<U> getEntries() {
 		return entryList.stream().map(T::getEntry).filter(Objects::nonNull).toList();
@@ -54,7 +54,7 @@ public abstract class JSimpleEntriesList<T extends JSimpleListEntry<U>, U> exten
 		entryList.clear();
 		entries.removeAll();
 		newEntries.forEach(e -> {
-			@SuppressWarnings("unchecked") T entry = (T) newEntry(entries, entryList);
+			T entry = newEntry(entries, entryList);
 			entry.reloadDataLists();
 			entryList.add(entry);
 			entry.setEnabled(isEnabled());

--- a/src/main/java/net/mcreator/ui/minecraft/boundingboxes/JBoundingBoxList.java
+++ b/src/main/java/net/mcreator/ui/minecraft/boundingboxes/JBoundingBoxList.java
@@ -76,7 +76,7 @@ public class JBoundingBoxList extends JSimpleEntriesList<JBoundingBoxEntry, IBlo
 	}
 
 	@Override
-	protected JSimpleListEntry<IBlockWithBoundingBox.BoxEntry> newEntry(JPanel parent, List<JBoundingBoxEntry> entryList) {
+	protected JBoundingBoxEntry newEntry(JPanel parent, List<JBoundingBoxEntry> entryList) {
 		return new JBoundingBoxEntry(parent, entryList);
 	}
 

--- a/src/main/java/net/mcreator/ui/minecraft/potions/JPotionList.java
+++ b/src/main/java/net/mcreator/ui/minecraft/potions/JPotionList.java
@@ -44,7 +44,7 @@ public class JPotionList extends JSimpleEntriesList<JPotionListEntry, Potion.Cus
 	}
 
 	@Override
-	protected JSimpleListEntry<Potion.CustomEffectEntry> newEntry(JPanel parent, List<JPotionListEntry> entryList) {
+	protected JPotionListEntry newEntry(JPanel parent, List<JPotionListEntry> entryList) {
 		return new JPotionListEntry(mcreator, gui, entries, entryList);
 	}
 

--- a/src/main/java/net/mcreator/ui/minecraft/spawntypes/JSpawnEntriesList.java
+++ b/src/main/java/net/mcreator/ui/minecraft/spawntypes/JSpawnEntriesList.java
@@ -43,7 +43,7 @@ public class JSpawnEntriesList extends JSimpleEntriesList<JSpawnListEntry, Biome
 		setPreferredSize(new Dimension(getPreferredSize().width, (int) (mcreator.getSize().height * 0.6)));
 	}
 
-	@Override protected JSimpleListEntry<Biome.SpawnEntry> newEntry(JPanel parent, List<JSpawnListEntry> entryList) {
+	@Override protected JSpawnListEntry newEntry(JPanel parent, List<JSpawnListEntry> entryList) {
 		return new JSpawnListEntry(mcreator, gui, parent, entryList);
 	}
 


### PR DESCRIPTION
I probably did not explain this properly the first time, so here comes the improvement PR. Yes, we can't change return type of the base method on its own, but overriding methods on child classes may use a subclass of the declared return type. This way we don't have to use `@SuppressWarnings` here.
(Even if this will be closed for its unimportance, I just thought I would show what I meant when suggesting to change the method signature.)