### PR TITLE
Add creative tabs to tool packs

### DIFF
--- a/src/main/java/net/mcreator/ui/dialogs/tools/ArmorPackMakerTool.java
+++ b/src/main/java/net/mcreator/ui/dialogs/tools/ArmorPackMakerTool.java
@@ -20,6 +20,7 @@ package net.mcreator.ui.dialogs.tools;
 
 import net.mcreator.element.ModElementType;
 import net.mcreator.element.parts.MItemBlock;
+import net.mcreator.element.parts.TabEntry;
 import net.mcreator.element.types.Armor;
 import net.mcreator.element.types.Recipe;
 import net.mcreator.generator.GeneratorConfiguration;
@@ -150,6 +151,7 @@ public class ArmorPackMakerTool {
 		armor.textureLeggings = name.toLowerCase(Locale.ENGLISH) + "_leggings";
 		armor.textureBoots = name.toLowerCase(Locale.ENGLISH) + "_boots";
 		armor.armorTextureFile = name.toLowerCase(Locale.ENGLISH);
+		armor.creativeTab = new TabEntry(workspace, "COMBAT");
 		armor.maxDamage = (int) Math.round(15 * factor);
 		armor.enchantability = (int) Math.round(9 * factor);
 		armor.toughness = 0;

--- a/src/main/java/net/mcreator/ui/dialogs/tools/OrePackMakerTool.java
+++ b/src/main/java/net/mcreator/ui/dialogs/tools/OrePackMakerTool.java
@@ -19,10 +19,7 @@
 package net.mcreator.ui.dialogs.tools;
 
 import net.mcreator.element.ModElementType;
-import net.mcreator.element.parts.BiomeEntry;
-import net.mcreator.element.parts.MItemBlock;
-import net.mcreator.element.parts.Material;
-import net.mcreator.element.parts.StepSound;
+import net.mcreator.element.parts.*;
 import net.mcreator.element.types.Block;
 import net.mcreator.element.types.Item;
 import net.mcreator.element.types.Recipe;
@@ -182,6 +179,7 @@ public class OrePackMakerTool {
 				new ModElement(workspace, oreItemName, ModElementType.ITEM), false).getElementFromGUI();
 		oreItem.name = name;
 		oreItem.texture = gemTextureName;
+		oreItem.creativeTab = new TabEntry(workspace, "MATERIALS");
 		PackMakerToolUtils.addGeneratableElementToWorkspace(workspace, folder, oreItem);
 
 		// we use Block GUI to get default values for the block element (kinda hacky!)
@@ -204,6 +202,7 @@ public class OrePackMakerTool {
 		oreBlock.maxGenerateHeight = (int) (63 / Math.pow(factor, 0.9));
 		oreBlock.frequencyPerChunks = (int) (11 / Math.pow(factor, 0.9));
 		oreBlock.frequencyOnChunk = (int) (7 / Math.pow(factor, 0.9));
+		oreBlock.creativeTab = new TabEntry(workspace, "BUILDING_BLOCKS");
 		if (type.equals("Dust based")) {
 			oreBlock.dropAmount = 3;
 		}
@@ -224,6 +223,7 @@ public class OrePackMakerTool {
 		oreBlockBlock.breakHarvestLevel = (int) Math.round(2 * factor);
 		oreBlockBlock.requiresCorrectTool = true;
 		oreBlockBlock.renderType = 11; // single texture
+		oreBlockBlock.creativeTab = new TabEntry(workspace, "BUILDING_BLOCKS");
 		PackMakerToolUtils.addGeneratableElementToWorkspace(workspace, folder, oreBlockBlock);
 
 		Recipe itemToBlockRecipe = (Recipe) ModElementType.RECIPE.getModElementGUI(mcreator,

--- a/src/main/java/net/mcreator/ui/dialogs/tools/ToolPackMakerTool.java
+++ b/src/main/java/net/mcreator/ui/dialogs/tools/ToolPackMakerTool.java
@@ -196,6 +196,7 @@ public class ToolPackMakerTool {
 		pickaxeTool.texture = pickaxeTextureName;
 		pickaxeTool.toolType = "Pickaxe";
 		pickaxeTool.repairItems = Collections.singletonList(base);
+		pickaxeTool.creativeTab = new TabEntry(workspace, "TOOLS");
 		setParametersBasedOnFactorAndAddElement(mcreator, factor, pickaxeTool, folder);
 
 		// we use Tool GUI to get default values for the block element (kinda hacky!)
@@ -205,6 +206,7 @@ public class ToolPackMakerTool {
 		axeTool.texture = axeTextureName;
 		axeTool.toolType = "Axe";
 		axeTool.repairItems = Collections.singletonList(base);
+		axeTool.creativeTab = new TabEntry(workspace, "TOOLS");
 		setParametersBasedOnFactorAndAddElement(mcreator, factor, axeTool, folder);
 		axeTool.damageVsEntity = (double) Math.round(9.0f * factor);
 
@@ -226,6 +228,7 @@ public class ToolPackMakerTool {
 		shovelTool.texture = shovelTextureName;
 		shovelTool.toolType = "Spade";
 		shovelTool.repairItems = Collections.singletonList(base);
+		shovelTool.creativeTab = new TabEntry(workspace, "TOOLS");
 		setParametersBasedOnFactorAndAddElement(mcreator, factor, shovelTool, folder);
 
 		// we use Tool GUI to get default values for the block element (kinda hacky!)
@@ -235,6 +238,7 @@ public class ToolPackMakerTool {
 		hoeTool.texture = hoeTextureName;
 		hoeTool.toolType = "Hoe";
 		hoeTool.repairItems = Collections.singletonList(base);
+		hoeTool.creativeTab = new TabEntry(workspace, "TOOLS");
 		setParametersBasedOnFactorAndAddElement(mcreator, factor, hoeTool, folder);
 
 		Recipe pickaxeRecipe = (Recipe) ModElementType.RECIPE.getModElementGUI(mcreator,

--- a/src/main/java/net/mcreator/ui/dialogs/tools/WoodPackMakerTool.java
+++ b/src/main/java/net/mcreator/ui/dialogs/tools/WoodPackMakerTool.java
@@ -172,6 +172,7 @@ public class WoodPackMakerTool {
 		woodBlock.breakHarvestLevel = 0;
 		woodBlock.flammability = (int) Math.round(5 * factor);
 		woodBlock.rotationMode = 5; // log rotation
+		woodBlock.creativeTab = new TabEntry(workspace, "BUILDING_BLOCKS");
 		PackMakerToolUtils.addGeneratableElementToWorkspace(workspace, folder, woodBlock);
 
 		// we use Block GUI to get default values for the block element (kinda hacky!)
@@ -194,6 +195,7 @@ public class WoodPackMakerTool {
 		logBlock.breakHarvestLevel = 0;
 		logBlock.flammability = (int) Math.round(5 * factor);
 		logBlock.rotationMode = 5; // log rotation
+		logBlock.creativeTab = new TabEntry(workspace, "BUILDING_BLOCKS");
 		PackMakerToolUtils.addGeneratableElementToWorkspace(workspace, folder, logBlock);
 
 		// we use Block GUI to get default values for the block element (kinda hacky!)
@@ -210,6 +212,7 @@ public class WoodPackMakerTool {
 		planksBlock.destroyTool = "axe";
 		planksBlock.breakHarvestLevel = 0;
 		planksBlock.flammability = (int) Math.round(5 * factor);
+		planksBlock.creativeTab = new TabEntry(workspace, "BUILDING_BLOCKS");
 		PackMakerToolUtils.addGeneratableElementToWorkspace(workspace, folder, planksBlock);
 
 		// we use Block GUI to get default values for the block element (kinda hacky!)
@@ -243,6 +246,7 @@ public class WoodPackMakerTool {
 		stairsBlock.breakHarvestLevel = 0;
 		stairsBlock.flammability = (int) Math.round(5 * factor);
 		stairsBlock.lightOpacity = 0;
+		stairsBlock.creativeTab = new TabEntry(workspace, "BUILDING_BLOCKS");
 		PackMakerToolUtils.addGeneratableElementToWorkspace(workspace, folder, stairsBlock);
 
 		// we use Block GUI to get default values for the block element (kinda hacky!)
@@ -260,6 +264,7 @@ public class WoodPackMakerTool {
 		slabBlock.breakHarvestLevel = 0;
 		slabBlock.flammability = (int) Math.round(5 * factor);
 		slabBlock.lightOpacity = 0;
+		slabBlock.creativeTab = new TabEntry(workspace, "BUILDING_BLOCKS");
 		PackMakerToolUtils.addGeneratableElementToWorkspace(workspace, folder, slabBlock);
 
 		// we use Block GUI to get default values for the block element (kinda hacky!)
@@ -275,7 +280,7 @@ public class WoodPackMakerTool {
 		fenceBlock.breakHarvestLevel = 0;
 		fenceBlock.flammability = (int) Math.round(5 * factor);
 		fenceBlock.lightOpacity = 0;
-		fenceBlock.creativeTab = new TabEntry(workspace, "DECORATIONS");
+		fenceBlock.creativeTab = new TabEntry(workspace, "BUILDING_BLOCKS");
 		PackMakerToolUtils.addGeneratableElementToWorkspace(workspace, folder, fenceBlock);
 
 		// we use Block GUI to get default values for the block element (kinda hacky!)
@@ -291,7 +296,7 @@ public class WoodPackMakerTool {
 		fenceGateBlock.breakHarvestLevel = 0;
 		fenceGateBlock.flammability = (int) Math.round(5 * factor);
 		fenceGateBlock.lightOpacity = 0;
-		fenceGateBlock.creativeTab = new TabEntry(workspace, "REDSTONE");
+		fenceGateBlock.creativeTab = new TabEntry(workspace, "BUILDING_BLOCKS");
 		PackMakerToolUtils.addGeneratableElementToWorkspace(workspace, folder, fenceGateBlock);
 
 		// we use Block GUI to get default values for the block element (kinda hacky!)
@@ -307,7 +312,7 @@ public class WoodPackMakerTool {
 		pressurePlateBlock.breakHarvestLevel = 0;
 		pressurePlateBlock.flammability = (int) Math.round(5 * factor);
 		pressurePlateBlock.lightOpacity = 0;
-		pressurePlateBlock.creativeTab = new TabEntry(workspace, "REDSTONE");
+		pressurePlateBlock.creativeTab = new TabEntry(workspace, "BUILDING_BLOCKS");
 		PackMakerToolUtils.addGeneratableElementToWorkspace(workspace, folder, pressurePlateBlock);
 
 		// we use Block GUI to get default values for the block element (kinda hacky!)
@@ -323,6 +328,7 @@ public class WoodPackMakerTool {
 		buttonBlock.breakHarvestLevel = 0;
 		buttonBlock.lightOpacity = 0;
 		buttonBlock.flammability = (int) Math.round(5 * factor);
+		buttonBlock.creativeTab = new TabEntry(workspace, "BUILDING_BLOCKS");
 		PackMakerToolUtils.addGeneratableElementToWorkspace(workspace, folder, buttonBlock);
 
 		//Tag - Items


### PR DESCRIPTION
Currently, most mod elements created using a quick tool pack are not added to a creative tab. This PR simply changes their default creative tab to their respective vanilla creative tab.

In the case where the same item is found in multiple categories, I tried to take the creative tab making the most sense.

Some mod elements were also added to a category, but since Minecraft changed creative tabs in 1.19.4, they didn't make sense anymore, so they have also been changed.