### PR TITLE
Forgotten help tips

### DIFF
--- a/plugins/mcreator-localization/help/default/block/particle_condition.md
+++ b/plugins/mcreator-localization/help/default/block/particle_condition.md
@@ -1,1 +1,0 @@
-When this conditional procedure is true, the block at x, y, and z will spawn particles based on the settings.

--- a/plugins/mcreator-localization/help/default/block/special_information.md
+++ b/plugins/mcreator-localization/help/default/block/special_information.md
@@ -1,7 +1,2 @@
 This parameter adds a tooltip to the block when you hold your icon over the block in your inventory.
-
-Tips:
-
-* Use commas (",") to separate entries to a new line.
-* Use the backslash with a comma after ("\\,") to insert comma in the text instead of separating entries.
-* If you use a procedure-generated tooltip, and your block is not held by an entity or a gem, the entity dependency will be null.
+If you use a procedure-generated tooltip, and your block is not held by an entity or a gem, the entity dependency will be `null`.

--- a/plugins/mcreator-localization/help/default/entity/particle_condition.md
+++ b/plugins/mcreator-localization/help/default/entity/particle_condition.md
@@ -1,1 +1,0 @@
-When this conditional procedure is true, the entity will spawn particles based on the settings.

--- a/plugins/mcreator-localization/help/default/item/special_information.md
+++ b/plugins/mcreator-localization/help/default/item/special_information.md
@@ -1,7 +1,2 @@
 This parameter adds a tooltip to the item when you hold your icon over the block in your inventory.
-
-Tips:
-
-* Use commas (",") to separate entries to a new line.
-* Use the backslash with a comma after ("\\,") to insert comma in the text instead of separating entries.
-* If you use a procedure-generated tooltip, and your item is not held by an entity or a gem, the entity dependency will be null.
+If you use a procedure-generated tooltip, and your item is not held by an entity or a gem, the entity dependency will be `null`.


### PR DESCRIPTION
* `(block|entity)/particle_condition` in-app tips were not used as of #3312;
* `(block|item)/special_information` UI tips were outdated as of #3686.