### PR TITLE
Add custom code snippet blocks to Command builder Blockly editor

### DIFF
--- a/plugins/mcreator-core/blockly/toolboxes/toolbox_command.xml
+++ b/plugins/mcreator-core/blockly/toolboxes/toolbox_command.xml
@@ -24,4 +24,8 @@
         <block type="old_command"/>
         <custom-actions/>
     </category>
+    <category name="${t:blockly.category.advanced}" colour="250">
+        <block type="java_code"/>
+        <custom-aiadvanced/>
+    </category>
 </xml>


### PR DESCRIPTION
This PR adds the custom code snippet to the Command builder editor