### PR TITLE
Standardize resource tabs

### DIFF
--- a/src/main/java/net/mcreator/ui/workspace/resources/AbstractResourcePanel.java
+++ b/src/main/java/net/mcreator/ui/workspace/resources/AbstractResourcePanel.java
@@ -33,6 +33,13 @@ import java.awt.event.KeyEvent;
 import java.util.List;
 import java.util.function.Consumer;
 
+/**
+ * <p>An abstract class used to standardize code, methods and features across the different resource tabs.
+ * This class is optional and only expected to be used when the behavior of a tab is similar to the others (e.g. sounds, structures, etc.)
+ * It should not be used in a case where it is different in some way (e.g. textures having multiple lists).</p>
+ *
+ * @param <T>
+ */
 public abstract class AbstractResourcePanel<T> extends JPanel implements IReloadableFilterable {
 
 	protected final WorkspacePanel workspacePanel;

--- a/src/main/java/net/mcreator/ui/workspace/resources/AbstractResourcePanel.java
+++ b/src/main/java/net/mcreator/ui/workspace/resources/AbstractResourcePanel.java
@@ -23,7 +23,6 @@ import net.mcreator.ui.component.JSelectableList;
 import net.mcreator.ui.component.TransparentToolBar;
 import net.mcreator.ui.component.util.ComponentUtils;
 import net.mcreator.ui.init.L10N;
-import net.mcreator.ui.init.UIRES;
 import net.mcreator.ui.laf.SlickDarkScrollBarUI;
 import net.mcreator.ui.workspace.IReloadableFilterable;
 import net.mcreator.ui.workspace.WorkspacePanel;
@@ -35,7 +34,6 @@ import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseAdapter;
 import java.util.List;
-import java.util.function.Consumer;
 
 /**
  * <p>An abstract class used to standardize code, methods and features across the different resource tabs.
@@ -51,10 +49,15 @@ public abstract class AbstractResourcePanel<T> extends JPanel implements IReload
 	protected final ResourceFilterModel<T> filterModel;
 	protected JSelectableList<T> elementList;
 
-	private TransparentToolBar bar = new TransparentToolBar();;
+	private final TransparentToolBar bar = new TransparentToolBar();
 
 	public AbstractResourcePanel(WorkspacePanel workspacePanel, ResourceFilterModel<T> filterModel,
 			ListCellRenderer<T> render) {
+		this(workspacePanel, filterModel, render, JList.VERTICAL);
+	}
+
+	public AbstractResourcePanel(WorkspacePanel workspacePanel, ResourceFilterModel<T> filterModel,
+			ListCellRenderer<T> render, int layoutOrientation) {
 		super(new BorderLayout());
 		setOpaque(false);
 
@@ -65,6 +68,9 @@ public abstract class AbstractResourcePanel<T> extends JPanel implements IReload
 		elementList.setOpaque(false);
 		elementList.setCellRenderer(render);
 		elementList.setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
+		elementList.setLayoutOrientation(layoutOrientation);
+		if (layoutOrientation == JList.HORIZONTAL_WRAP)
+			elementList.setVisibleRowCount(-1);
 
 		JScrollPane sp = new JScrollPane(elementList);
 		sp.setOpaque(false);

--- a/src/main/java/net/mcreator/ui/workspace/resources/AbstractResourcePanel.java
+++ b/src/main/java/net/mcreator/ui/workspace/resources/AbstractResourcePanel.java
@@ -21,15 +21,19 @@ package net.mcreator.ui.workspace.resources;
 
 import net.mcreator.ui.component.JSelectableList;
 import net.mcreator.ui.component.TransparentToolBar;
+import net.mcreator.ui.component.util.ComponentUtils;
 import net.mcreator.ui.init.L10N;
+import net.mcreator.ui.init.UIRES;
 import net.mcreator.ui.laf.SlickDarkScrollBarUI;
 import net.mcreator.ui.workspace.IReloadableFilterable;
 import net.mcreator.ui.workspace.WorkspacePanel;
 
 import javax.swing.*;
 import java.awt.*;
+import java.awt.event.ActionListener;
 import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
+import java.awt.event.MouseAdapter;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -46,6 +50,8 @@ public abstract class AbstractResourcePanel<T> extends JPanel implements IReload
 
 	protected final ResourceFilterModel<T> filterModel;
 	protected JSelectableList<T> elementList;
+
+	private TransparentToolBar bar = new TransparentToolBar();;
 
 	public AbstractResourcePanel(WorkspacePanel workspacePanel, ResourceFilterModel<T> filterModel,
 			ListCellRenderer<T> render) {
@@ -79,12 +85,34 @@ public abstract class AbstractResourcePanel<T> extends JPanel implements IReload
 			}
 		});
 
-		add("North", createToolBar(elementList));
+		bar.setBorder(BorderFactory.createEmptyBorder(3, 5, 3, 0));
+
+		add("North", bar);
 	}
 
-	abstract TransparentToolBar createToolBar(JSelectableList<T> elementList);
-
 	abstract void deleteCurrentlySelected(List<T> elements);
+
+	protected void addToolBarButton(String key, ImageIcon icon, ActionListener action) {
+		addToolBarButton(key, icon, action, null);
+	}
+
+	protected void addToolBarButton(String key, ImageIcon icon, MouseAdapter mouse) {
+		addToolBarButton(key, icon, null, mouse);
+	}
+
+	protected void addToolBarButton(String key, ImageIcon icon, ActionListener action, MouseAdapter mouse) {
+		JButton button = L10N.button(key);
+		button.setIcon(icon);
+		button.setContentAreaFilled(false);
+		button.setOpaque(false);
+		ComponentUtils.deriveFont(button, 12);
+		button.setBorder(BorderFactory.createEmptyBorder(0, 8, 0, 8));
+		if (action != null)
+			button.addActionListener(action);
+		if (mouse != null)
+			button.addMouseListener(mouse);
+		bar.add(button);
+	}
 
 	@Override public abstract void reloadElements();
 

--- a/src/main/java/net/mcreator/ui/workspace/resources/AbstractResourcePanel.java
+++ b/src/main/java/net/mcreator/ui/workspace/resources/AbstractResourcePanel.java
@@ -37,19 +37,18 @@ public abstract class AbstractResourcePanel<T> extends JPanel implements IReload
 
 	protected final WorkspacePanel workspacePanel;
 
-	private final ResourceFilterModel<T> filterModel;
-	private final Consumer<T> deleteSelectedElement;
+	protected final ResourceFilterModel<T> filterModel;
+	protected JSelectableList<T> elementList;
 
 	public AbstractResourcePanel(WorkspacePanel workspacePanel, ResourceFilterModel<T> filterModel,
-			ListCellRenderer<T> render, Consumer<T> deleteSelectedElement) {
+			ListCellRenderer<T> render) {
 		super(new BorderLayout());
 		setOpaque(false);
 
 		this.filterModel = filterModel;
 		this.workspacePanel = workspacePanel;
-		this.deleteSelectedElement = deleteSelectedElement;
 
-		JSelectableList<T> elementList = new JSelectableList<>(filterModel);
+		elementList = new JSelectableList<>(filterModel);
 		elementList.setOpaque(false);
 		elementList.setCellRenderer(render);
 		elementList.setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
@@ -68,28 +67,17 @@ public abstract class AbstractResourcePanel<T> extends JPanel implements IReload
 		elementList.addKeyListener(new KeyAdapter() {
 			@Override public void keyReleased(KeyEvent e) {
 				if (e.getKeyCode() == KeyEvent.VK_DELETE) {
-					deleteCurrentlySelected(elementList);
+					deleteCurrentlySelected(elementList.getSelectedValuesList());
 				}
 			}
 		});
 
-		add("North", createToolBar());
+		add("North", createToolBar(elementList));
 	}
 
-	abstract TransparentToolBar createToolBar();
+	abstract TransparentToolBar createToolBar(JSelectableList<T> elementList);
 
-	private void deleteCurrentlySelected(JSelectableList<T> structureElementList) {
-		List<T> files = structureElementList.getSelectedValuesList();
-		if (!files.isEmpty()) {
-			int n = JOptionPane.showConfirmDialog(workspacePanel.getMCreator(),
-					L10N.t("workspace.structure.confirm_deletion_message"), L10N.t("common.confirmation"),
-					JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE);
-			if (n == 0) {
-				files.forEach(deleteSelectedElement);
-				reloadElements();
-			}
-		}
-	}
+	abstract void deleteCurrentlySelected(List<T> elements);
 
 	@Override public abstract void reloadElements();
 

--- a/src/main/java/net/mcreator/ui/workspace/resources/AbstractResourcePanel.java
+++ b/src/main/java/net/mcreator/ui/workspace/resources/AbstractResourcePanel.java
@@ -1,0 +1,99 @@
+/*
+ * MCreator (https://mcreator.net/)
+ * Copyright (C) 2012-2020, Pylo
+ * Copyright (C) 2020-2023, Pylo, opensource contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package net.mcreator.ui.workspace.resources;
+
+import net.mcreator.ui.component.JSelectableList;
+import net.mcreator.ui.component.TransparentToolBar;
+import net.mcreator.ui.init.L10N;
+import net.mcreator.ui.laf.SlickDarkScrollBarUI;
+import net.mcreator.ui.workspace.IReloadableFilterable;
+import net.mcreator.ui.workspace.WorkspacePanel;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.KeyAdapter;
+import java.awt.event.KeyEvent;
+import java.util.List;
+import java.util.function.Consumer;
+
+public abstract class AbstractResourcePanel<T> extends JPanel implements IReloadableFilterable {
+
+	protected final WorkspacePanel workspacePanel;
+
+	private final ResourceFilterModel<T> filterModel;
+	private final Consumer<T> deleteSelectedElement;
+
+	public AbstractResourcePanel(WorkspacePanel workspacePanel, ResourceFilterModel<T> filterModel,
+			ListCellRenderer<T> render, Consumer<T> deleteSelectedElement) {
+		super(new BorderLayout());
+		setOpaque(false);
+
+		this.filterModel = filterModel;
+		this.workspacePanel = workspacePanel;
+		this.deleteSelectedElement = deleteSelectedElement;
+
+		JSelectableList<T> elementList = new JSelectableList<>(filterModel);
+		elementList.setOpaque(false);
+		elementList.setCellRenderer(render);
+		elementList.setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
+
+		JScrollPane sp = new JScrollPane(elementList);
+		sp.setOpaque(false);
+		sp.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
+		sp.getViewport().setOpaque(false);
+		sp.getVerticalScrollBar().setUnitIncrement(11);
+		sp.getVerticalScrollBar().setUI(new SlickDarkScrollBarUI((Color) UIManager.get("MCreatorLAF.DARK_ACCENT"),
+				(Color) UIManager.get("MCreatorLAF.LIGHT_ACCENT"), sp.getVerticalScrollBar()));
+		sp.getVerticalScrollBar().setPreferredSize(new Dimension(8, 0));
+
+		add("Center", sp);
+
+		elementList.addKeyListener(new KeyAdapter() {
+			@Override public void keyReleased(KeyEvent e) {
+				if (e.getKeyCode() == KeyEvent.VK_DELETE) {
+					deleteCurrentlySelected(elementList);
+				}
+			}
+		});
+
+		add("North", createToolBar());
+	}
+
+	abstract TransparentToolBar createToolBar();
+
+	private void deleteCurrentlySelected(JSelectableList<T> structureElementList) {
+		List<T> files = structureElementList.getSelectedValuesList();
+		if (!files.isEmpty()) {
+			int n = JOptionPane.showConfirmDialog(workspacePanel.getMCreator(),
+					L10N.t("workspace.structure.confirm_deletion_message"), L10N.t("common.confirmation"),
+					JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE);
+			if (n == 0) {
+				files.forEach(deleteSelectedElement);
+				reloadElements();
+			}
+		}
+	}
+
+	@Override public abstract void reloadElements();
+
+	@Override public void refilterElements() {
+		filterModel.refilter();
+	}
+}

--- a/src/main/java/net/mcreator/ui/workspace/resources/ResourceFilterModel.java
+++ b/src/main/java/net/mcreator/ui/workspace/resources/ResourceFilterModel.java
@@ -25,6 +25,12 @@ import javax.swing.*;
 import java.util.*;
 import java.util.function.Predicate;
 
+/**
+ * <p>A general filter model that is used inside a {@link AbstractResourcePanel}.
+ * It defines how a general resource panel's list of elements behaves.</p>
+ *
+ * @param <T>
+ */
 public class ResourceFilterModel<T> extends DefaultListModel<T> {
 	private final List<T> items;
 	private final List<T> filterItems;
@@ -32,6 +38,12 @@ public class ResourceFilterModel<T> extends DefaultListModel<T> {
 	private final Predicate<T> refilterItemsFilter;
 	private final Comparator<T> sortingCondition;
 
+	/**
+	 *
+	 * @param workspacePanel <p>The {@link WorkspacePanel} of the current workspace</p>
+	 * @param refilterItemsFilter <p>Defines which elements should be contained inside the filtered list of elements.</p>
+	 * @param sortingCondition <p>Defines how the filtered elements will be ordered.</p>
+	 */
 	public ResourceFilterModel(WorkspacePanel workspacePanel, Predicate<T> refilterItemsFilter,
 			Comparator<T> sortingCondition) {
 		super();

--- a/src/main/java/net/mcreator/ui/workspace/resources/ResourceFilterModel.java
+++ b/src/main/java/net/mcreator/ui/workspace/resources/ResourceFilterModel.java
@@ -1,0 +1,100 @@
+/*
+ * MCreator (https://mcreator.net/)
+ * Copyright (C) 2012-2020, Pylo
+ * Copyright (C) 2020-2023, Pylo, opensource contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package net.mcreator.ui.workspace.resources;
+
+import net.mcreator.ui.workspace.WorkspacePanel;
+
+import javax.swing.*;
+import java.util.*;
+import java.util.function.Predicate;
+
+public class ResourceFilterModel<T> extends DefaultListModel<T> {
+	private final List<T> items;
+	private final List<T> filterItems;
+	private final WorkspacePanel workspacePanel;
+	private final Predicate<T> predicateFilter;
+	private final Comparator<T> refilterComparator;
+
+	public ResourceFilterModel(WorkspacePanel workspacePanel, Predicate<T> predicateFilter,
+			Comparator<T> refilterComparator) {
+		super();
+		this.workspacePanel = workspacePanel;
+		this.predicateFilter = predicateFilter;
+		this.refilterComparator = refilterComparator;
+
+		items = new ArrayList<>();
+		filterItems = new ArrayList<>();
+	}
+
+	@Override public int indexOf(Object elem) {
+		try {
+			return filterItems.indexOf(elem);
+		} catch (ClassCastException e) {
+			return -1;
+		}
+	}
+
+	@Override public T getElementAt(int index) {
+		if (index < filterItems.size())
+			return filterItems.get(index);
+		else
+			return null;
+	}
+
+	@Override public int getSize() {
+		return filterItems.size();
+	}
+
+	@Override public void addElement(T o) {
+		items.add(o);
+		refilter();
+	}
+
+	@Override public void removeAllElements() {
+		super.removeAllElements();
+		items.clear();
+		filterItems.clear();
+	}
+
+	@Override public boolean removeElement(Object a) {
+		if (a != null) {
+			try {
+				items.remove(a);
+				filterItems.remove(a);
+			} catch (ClassCastException ignored) {
+			}
+		}
+		return super.removeElement(a);
+	}
+
+	void refilter() {
+		filterItems.clear();
+		filterItems.addAll(items.stream().filter(Objects::nonNull).filter(predicateFilter).toList());
+
+		if (workspacePanel.sortName.isSelected()) {
+			filterItems.sort(refilterComparator);
+		}
+
+		if (workspacePanel.desc.isSelected())
+			Collections.reverse(filterItems);
+
+		fireContentsChanged(this, 0, getSize());
+	}
+}

--- a/src/main/java/net/mcreator/ui/workspace/resources/ResourceFilterModel.java
+++ b/src/main/java/net/mcreator/ui/workspace/resources/ResourceFilterModel.java
@@ -29,15 +29,15 @@ public class ResourceFilterModel<T> extends DefaultListModel<T> {
 	private final List<T> items;
 	private final List<T> filterItems;
 	private final WorkspacePanel workspacePanel;
-	private final Predicate<T> predicateFilter;
-	private final Comparator<T> refilterComparator;
+	private final Predicate<T> refilterItemsFilter;
+	private final Comparator<T> sortingCondition;
 
-	public ResourceFilterModel(WorkspacePanel workspacePanel, Predicate<T> predicateFilter,
-			Comparator<T> refilterComparator) {
+	public ResourceFilterModel(WorkspacePanel workspacePanel, Predicate<T> refilterItemsFilter,
+			Comparator<T> sortingCondition) {
 		super();
 		this.workspacePanel = workspacePanel;
-		this.predicateFilter = predicateFilter;
-		this.refilterComparator = refilterComparator;
+		this.refilterItemsFilter = refilterItemsFilter;
+		this.sortingCondition = sortingCondition;
 
 		items = new ArrayList<>();
 		filterItems = new ArrayList<>();
@@ -86,11 +86,10 @@ public class ResourceFilterModel<T> extends DefaultListModel<T> {
 
 	void refilter() {
 		filterItems.clear();
-		filterItems.addAll(items.stream().filter(Objects::nonNull).filter(predicateFilter).toList());
+		filterItems.addAll(items.stream().filter(Objects::nonNull).filter(refilterItemsFilter).toList());
 
-		if (workspacePanel.sortName.isSelected()) {
-			filterItems.sort(refilterComparator);
-		}
+		if (workspacePanel.sortName.isSelected())
+			filterItems.sort(sortingCondition);
 
 		if (workspacePanel.desc.isSelected())
 			Collections.reverse(filterItems);

--- a/src/main/java/net/mcreator/ui/workspace/resources/WorkspacePanelModels.java
+++ b/src/main/java/net/mcreator/ui/workspace/resources/WorkspacePanelModels.java
@@ -22,8 +22,6 @@ import net.mcreator.element.GeneratableElement;
 import net.mcreator.element.ModElementType;
 import net.mcreator.generator.GeneratorStats;
 import net.mcreator.io.FileIO;
-import net.mcreator.ui.component.JSelectableList;
-import net.mcreator.ui.component.TransparentToolBar;
 import net.mcreator.ui.component.util.ComponentUtils;
 import net.mcreator.ui.dialogs.JavaModelAnimationEditorDialog;
 import net.mcreator.ui.dialogs.ProgressDialog;
@@ -49,7 +47,7 @@ public class WorkspacePanelModels extends AbstractResourcePanel<Model> {
 	WorkspacePanelModels(WorkspacePanel workspacePanel) {
 		super(workspacePanel, new ResourceFilterModel<>(workspacePanel, item -> predicateCheck(workspacePanel, item),
 				Comparator.comparing(Model::getReadableName)), new Render());
-		
+
 		elementList.addMouseListener(new MouseAdapter() {
 			@Override public void mouseClicked(MouseEvent e) {
 				if (e.getClickCount() == 2) {
@@ -62,83 +60,34 @@ public class WorkspacePanelModels extends AbstractResourcePanel<Model> {
 				}
 			}
 		});
+
+		if (workspacePanel.getMCreator().getGeneratorStats().getBaseCoverageInfo().get("model_java")
+				!= GeneratorStats.CoverageStatus.NONE)
+			addToolBarButton("action.workspace.resources.import_java_model", UIRES.get("16px.importjavamodel"),
+					e -> workspacePanel.getMCreator().actionRegistry.importJavaModel.doAction());
+
+		if (workspacePanel.getMCreator().getGeneratorStats().getBaseCoverageInfo().get("model_json")
+				!= GeneratorStats.CoverageStatus.NONE)
+			addToolBarButton("action.workspace.resources.import_json_model", UIRES.get("16px.importjsonmodel"),
+					e -> workspacePanel.getMCreator().actionRegistry.importJSONModel.doAction());
+
+		if (workspacePanel.getMCreator().getGeneratorStats().getBaseCoverageInfo().get("model_obj")
+				!= GeneratorStats.CoverageStatus.NONE)
+			addToolBarButton("action.workspace.resources.import_obj_mtl_model", UIRES.get("16px.importobjmodel"),
+					e -> workspacePanel.getMCreator().actionRegistry.importOBJModel.doAction());
+
+		addToolBarButton("workspace.3dmodels.edit_texture_mappings", UIRES.get("16px.edit.gif"),
+				e -> editSelectedModelTextureMappings());
+		addToolBarButton("workspace.3dmodels.redefine_animations", UIRES.get("16px.edit.gif"),
+				e -> editSelectedModelAnimations());
+		addToolBarButton("workspace.3dmodels.delete_selected", UIRES.get("16px.delete.gif"),
+				e -> deleteCurrentlySelected(Collections.emptyList()));
 	}
 
 	private static boolean predicateCheck(WorkspacePanel workspacePanel, Model item) {
 		return item.getReadableName().toLowerCase(Locale.ENGLISH)
 				.contains(workspacePanel.search.getText().toLowerCase(Locale.ENGLISH)) || item.getType().name()
 				.toLowerCase(Locale.ENGLISH).contains(workspacePanel.search.getText().toLowerCase(Locale.ENGLISH));
-	}
-
-	@Override TransparentToolBar createToolBar(JSelectableList<Model> elementList) {
-		TransparentToolBar bar = new TransparentToolBar();
-		bar.setBorder(BorderFactory.createEmptyBorder(3, 5, 3, 0));
-
-		JButton imp1 = L10N.button("action.workspace.resources.import_java_model");
-		imp1.setIcon(UIRES.get("16px.importjavamodel"));
-		imp1.setContentAreaFilled(false);
-		imp1.setOpaque(false);
-		ComponentUtils.deriveFont(imp1, 12);
-		imp1.setBorder(BorderFactory.createEmptyBorder(0, 8, 0, 8));
-
-		if (workspacePanel.getMCreator().getGeneratorStats().getBaseCoverageInfo().get("model_java")
-				!= GeneratorStats.CoverageStatus.NONE)
-			bar.add(imp1);
-
-		imp1.addActionListener(e -> workspacePanel.getMCreator().actionRegistry.importJavaModel.doAction());
-
-		JButton imp2 = L10N.button("action.workspace.resources.import_json_model");
-		imp2.setIcon(UIRES.get("16px.importjsonmodel"));
-		imp2.setContentAreaFilled(false);
-		imp2.setOpaque(false);
-		ComponentUtils.deriveFont(imp2, 12);
-		imp2.setBorder(BorderFactory.createEmptyBorder(0, 8, 0, 8));
-
-		if (workspacePanel.getMCreator().getGeneratorStats().getBaseCoverageInfo().get("model_json")
-				!= GeneratorStats.CoverageStatus.NONE)
-			bar.add(imp2);
-
-		imp2.addActionListener(e -> workspacePanel.getMCreator().actionRegistry.importJSONModel.doAction());
-
-		JButton imp3 = L10N.button("action.workspace.resources.import_obj_mtl_model");
-		imp3.setIcon(UIRES.get("16px.importobjmodel"));
-		imp3.setContentAreaFilled(false);
-		imp3.setOpaque(false);
-		ComponentUtils.deriveFont(imp3, 12);
-		imp3.setBorder(BorderFactory.createEmptyBorder(0, 8, 0, 8));
-
-		if (workspacePanel.getMCreator().getGeneratorStats().getBaseCoverageInfo().get("model_obj")
-				!= GeneratorStats.CoverageStatus.NONE)
-			bar.add(imp3);
-
-		imp3.addActionListener(e -> workspacePanel.getMCreator().actionRegistry.importOBJModel.doAction());
-
-		JButton editTextureMappings = L10N.button("workspace.3dmodels.edit_texture_mappings");
-		editTextureMappings.setIcon(UIRES.get("16px.edit.gif"));
-		editTextureMappings.setOpaque(false);
-		editTextureMappings.setContentAreaFilled(false);
-		editTextureMappings.setBorder(BorderFactory.createEmptyBorder(0, 8, 0, 8));
-		bar.add(editTextureMappings);
-		editTextureMappings.addActionListener(e -> editSelectedModelTextureMappings());
-
-		JButton editModelAnimations = L10N.button("workspace.3dmodels.redefine_animations");
-		editModelAnimations.setIcon(UIRES.get("16px.edit.gif"));
-		editModelAnimations.setOpaque(false);
-		editModelAnimations.setContentAreaFilled(false);
-		editModelAnimations.setBorder(BorderFactory.createEmptyBorder(0, 8, 0, 8));
-		bar.add(editModelAnimations);
-		editModelAnimations.addActionListener(e -> editSelectedModelAnimations());
-
-		JButton del = L10N.button("workspace.3dmodels.delete_selected");
-		del.setIcon(UIRES.get("16px.delete.gif"));
-		del.setOpaque(false);
-		del.setContentAreaFilled(false);
-		del.setBorder(BorderFactory.createEmptyBorder(0, 8, 0, 8));
-		bar.add(del);
-
-		del.addActionListener(e -> deleteCurrentlySelected(Collections.emptyList()));
-
-		return bar;
 	}
 
 	@Override void deleteCurrentlySelected(List<Model> elements) {

--- a/src/main/java/net/mcreator/ui/workspace/resources/WorkspacePanelScreenshots.java
+++ b/src/main/java/net/mcreator/ui/workspace/resources/WorkspacePanelScreenshots.java
@@ -46,7 +46,7 @@ class WorkspacePanelScreenshots extends AbstractResourcePanel<File> {
 		super(workspacePanel, new ResourceFilterModel<>(workspacePanel,
 				item -> item.getName().toLowerCase(Locale.ENGLISH)
 						.contains(workspacePanel.search.getText().toLowerCase(Locale.ENGLISH)),
-				Comparator.comparing(File::getName)), new Render());
+				Comparator.comparing(File::getName)), new Render(), JList.HORIZONTAL_WRAP);
 
 		elementList.addMouseListener(new MouseAdapter() {
 			@Override public void mouseClicked(MouseEvent e) {

--- a/src/main/java/net/mcreator/ui/workspace/resources/WorkspacePanelScreenshots.java
+++ b/src/main/java/net/mcreator/ui/workspace/resources/WorkspacePanelScreenshots.java
@@ -54,40 +54,15 @@ class WorkspacePanelScreenshots extends AbstractResourcePanel<File> {
 					exportSelectedScreenshots();
 			}
 		});
-	}
 
-	@Override TransparentToolBar createToolBar(JSelectableList<File> elementList) {
-		TransparentToolBar bar = new TransparentToolBar();
-		bar.setBorder(BorderFactory.createEmptyBorder(3, 5, 3, 0));
-
-		JButton edit = L10N.button("workspace.screenshots.export_selected");
-		edit.setIcon(UIRES.get("16px.ext.gif"));
-		edit.setOpaque(false);
-		edit.setContentAreaFilled(false);
-		edit.setBorder(BorderFactory.createEmptyBorder(0, 8, 0, 8));
-		bar.add(edit);
-		edit.addActionListener(e -> exportSelectedScreenshots());
-
-		JButton useasbg = L10N.button("workspace.screenshots.use_as_background");
-		useasbg.setIcon(UIRES.get("16px.textures"));
-		useasbg.setOpaque(false);
-		useasbg.setContentAreaFilled(false);
-		useasbg.setBorder(BorderFactory.createEmptyBorder(0, 8, 0, 8));
-		bar.add(useasbg);
-		useasbg.addActionListener(e -> useSelectedAsBackgrounds());
-
-		JButton del = L10N.button("workspace.screenshots.delete_selected");
-		del.setIcon(UIRES.get("16px.delete.gif"));
-		del.setOpaque(false);
-		del.setContentAreaFilled(false);
-		del.setBorder(BorderFactory.createEmptyBorder(0, 8, 0, 8));
-		bar.add(del);
-		del.addActionListener(e -> {
+		addToolBarButton("workspace.screenshots.export_selected", UIRES.get("16px.ext.gif"),
+				e -> exportSelectedScreenshots());
+		addToolBarButton("workspace.screenshots.use_as_background", UIRES.get("16px.textures"),
+				e -> useSelectedAsBackgrounds());
+		addToolBarButton("workspace.screenshots.delete_selected", UIRES.get("16px.delete.gif"), e -> {
 			deleteCurrentlySelected(elementList.getSelectedValuesList());
 			reloadElements();
 		});
-
-		return bar;
 	}
 
 	@Override void deleteCurrentlySelected(List<File> elements) {

--- a/src/main/java/net/mcreator/ui/workspace/resources/WorkspacePanelScreenshots.java
+++ b/src/main/java/net/mcreator/ui/workspace/resources/WorkspacePanelScreenshots.java
@@ -27,51 +27,36 @@ import net.mcreator.ui.component.util.ListUtil;
 import net.mcreator.ui.dialogs.file.FileDialogs;
 import net.mcreator.ui.init.L10N;
 import net.mcreator.ui.init.UIRES;
-import net.mcreator.ui.laf.SlickDarkScrollBarUI;
-import net.mcreator.ui.workspace.IReloadableFilterable;
 import net.mcreator.ui.workspace.WorkspacePanel;
 import net.mcreator.util.image.ImageUtils;
 
 import javax.swing.*;
 import java.awt.*;
-import java.awt.event.KeyAdapter;
-import java.awt.event.KeyEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.io.File;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
-import java.util.*;
+import java.util.Locale;
 
-class WorkspacePanelScreenshots extends JPanel implements IReloadableFilterable {
-
-	private final WorkspacePanel workspacePanel;
-
-	private final FilterModel listmodel = new FilterModel();
-	private final JSelectableList<File> screenshotsList = new JSelectableList<>(listmodel);
+class WorkspacePanelScreenshots extends AbstractResourcePanel<File> {
 
 	WorkspacePanelScreenshots(WorkspacePanel workspacePanel) {
-		super(new BorderLayout());
-		setOpaque(false);
+		super(workspacePanel, new ResourceFilterModel<>(workspacePanel,
+				item -> item.getName().toLowerCase(Locale.ENGLISH)
+						.contains(workspacePanel.search.getText().toLowerCase(Locale.ENGLISH)),
+				Comparator.comparing(File::getName)), new Render());
 
-		this.workspacePanel = workspacePanel;
+		elementList.addMouseListener(new MouseAdapter() {
+			@Override public void mouseClicked(MouseEvent e) {
+				if (e.getClickCount() == 2)
+					exportSelectedScreenshots();
+			}
+		});
+	}
 
-		screenshotsList.setOpaque(false);
-		screenshotsList.setCellRenderer(new Render());
-		screenshotsList.setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
-		screenshotsList.setLayoutOrientation(JList.HORIZONTAL_WRAP);
-		screenshotsList.setVisibleRowCount(-1);
-
-		JScrollPane sp = new JScrollPane(screenshotsList);
-		sp.setOpaque(false);
-		sp.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
-		sp.getViewport().setOpaque(false);
-		sp.getVerticalScrollBar().setUnitIncrement(11);
-		sp.getVerticalScrollBar().setUI(new SlickDarkScrollBarUI((Color) UIManager.get("MCreatorLAF.DARK_ACCENT"),
-				(Color) UIManager.get("MCreatorLAF.LIGHT_ACCENT"), sp.getVerticalScrollBar()));
-		sp.getVerticalScrollBar().setPreferredSize(new Dimension(8, 0));
-
-		add("Center", sp);
-
+	@Override TransparentToolBar createToolBar(JSelectableList<File> elementList) {
 		TransparentToolBar bar = new TransparentToolBar();
 		bar.setBorder(BorderFactory.createEmptyBorder(3, 5, 3, 0));
 
@@ -98,32 +83,33 @@ class WorkspacePanelScreenshots extends JPanel implements IReloadableFilterable 
 		del.setBorder(BorderFactory.createEmptyBorder(0, 8, 0, 8));
 		bar.add(del);
 		del.addActionListener(e -> {
-			screenshotsList.getSelectedValuesList().forEach(File::delete);
+			deleteCurrentlySelected(elementList.getSelectedValuesList());
 			reloadElements();
 		});
-		screenshotsList.addKeyListener(new KeyAdapter() {
-			@Override public void keyPressed(KeyEvent e) {
-				if (e.getKeyCode() == KeyEvent.VK_DELETE) {
-					screenshotsList.getSelectedValuesList().forEach(File::delete);
-					reloadElements();
-				} else if (e.getKeyCode() == KeyEvent.VK_ENTER) {
-					exportSelectedScreenshots();
-				}
-			}
-		});
 
-		screenshotsList.addMouseListener(new MouseAdapter() {
-			@Override public void mouseClicked(MouseEvent e) {
-				if (e.getClickCount() == 2)
-					exportSelectedScreenshots();
-			}
-		});
+		return bar;
+	}
 
-		add("North", bar);
+	@Override void deleteCurrentlySelected(List<File> elements) {
+		elements.forEach(File::delete);
+	}
+
+	@Override public void reloadElements() {
+		List<File> selected = elementList.getSelectedValuesList();
+
+		filterModel.removeAllElements();
+		File[] screenshots = new File(workspacePanel.getMCreator().getWorkspaceFolder(),
+				"run/screenshots/").listFiles();
+		if (screenshots != null)
+			Arrays.stream(screenshots).forEach(filterModel::addElement);
+
+		ListUtil.setSelectedValues(elementList, selected);
+
+		refilterElements();
 	}
 
 	private void useSelectedAsBackgrounds() {
-		screenshotsList.getSelectedValuesList().forEach(
+		elementList.getSelectedValuesList().forEach(
 				f -> FileIO.copyFile(f, new File(UserFolderManager.getFileFromUserFolder("backgrounds"), f.getName())));
 		JOptionPane.showMessageDialog(workspacePanel.getMCreator(),
 				L10N.t("workspace.screenshots.use_background_message"), L10N.t("workspace.screenshots.action_complete"),
@@ -131,94 +117,11 @@ class WorkspacePanelScreenshots extends JPanel implements IReloadableFilterable 
 	}
 
 	private void exportSelectedScreenshots() {
-		screenshotsList.getSelectedValuesList().forEach(f -> {
+		elementList.getSelectedValuesList().forEach(f -> {
 			File to = FileDialogs.getSaveDialog(workspacePanel.getMCreator(), new String[] { ".png" });
 			if (to != null)
 				FileIO.copyFile(f, to);
 		});
-	}
-
-	@Override public void reloadElements() {
-		List<File> selected = screenshotsList.getSelectedValuesList();
-
-		listmodel.removeAllElements();
-		File[] screenshots = new File(workspacePanel.getMCreator().getWorkspaceFolder(),
-				"run/screenshots/").listFiles();
-		if (screenshots != null)
-			Arrays.stream(screenshots).forEach(listmodel::addElement);
-
-		ListUtil.setSelectedValues(screenshotsList, selected);
-
-		refilterElements();
-	}
-
-	@Override public void refilterElements() {
-		listmodel.refilter();
-	}
-
-	private class FilterModel extends DefaultListModel<File> {
-		List<File> items;
-		List<File> filterItems;
-
-		FilterModel() {
-			super();
-			items = new ArrayList<>();
-			filterItems = new ArrayList<>();
-		}
-
-		@Override public int indexOf(Object elem) {
-			if (elem instanceof File)
-				return filterItems.indexOf(elem);
-			else
-				return -1;
-		}
-
-		@Override public File getElementAt(int index) {
-			if (index < filterItems.size())
-				return filterItems.get(index);
-			else
-				return null;
-		}
-
-		@Override public int getSize() {
-			return filterItems.size();
-		}
-
-		@Override public void addElement(File o) {
-			items.add(o);
-			refilter();
-		}
-
-		@Override public void removeAllElements() {
-			super.removeAllElements();
-			items.clear();
-			filterItems.clear();
-		}
-
-		@Override public boolean removeElement(Object a) {
-			if (a instanceof File) {
-				items.remove(a);
-				filterItems.remove(a);
-			}
-			return super.removeElement(a);
-		}
-
-		void refilter() {
-			filterItems.clear();
-			String term = workspacePanel.search.getText();
-			filterItems.addAll(items.stream().filter(Objects::nonNull)
-					.filter(item -> item.getName().toLowerCase(Locale.ENGLISH)
-							.contains(term.toLowerCase(Locale.ENGLISH))).toList());
-
-			if (workspacePanel.sortName.isSelected()) {
-				filterItems.sort(Comparator.comparing(File::getName));
-			}
-
-			if (workspacePanel.desc.isSelected())
-				Collections.reverse(filterItems);
-
-			fireContentsChanged(this, 0, getSize());
-		}
 	}
 
 	static class Render extends JLabel implements ListCellRenderer<File> {

--- a/src/main/java/net/mcreator/ui/workspace/resources/WorkspacePanelSounds.java
+++ b/src/main/java/net/mcreator/ui/workspace/resources/WorkspacePanelSounds.java
@@ -47,6 +47,29 @@ public class WorkspacePanelSounds extends AbstractResourcePanel<SoundElement> {
 	WorkspacePanelSounds(WorkspacePanel workspacePanel) {
 		super(workspacePanel, new ResourceFilterModel<>(workspacePanel, item -> (item.getName().toLowerCase(Locale.ENGLISH)
 				.contains(workspacePanel.search.getText().toLowerCase(Locale.ENGLISH))), Comparator.comparing(SoundElement::getName)), new Render());
+
+		addToolBarButton("action.workspace.resources.import_sound", UIRES.get("16px.open.gif"),
+				e -> workspacePanel.getMCreator().actionRegistry.importSound.doAction());
+		addToolBarButton("workspace.sounds.edit_selected", UIRES.get("16px.edit.gif"),
+				e -> editSelectedSound(elementList.getSelectedValue()));
+		addToolBarButton("workspace.sounds.delete_selected", UIRES.get("16px.delete.gif"),
+				e -> deleteCurrentlySelected(Collections.singletonList(elementList.getSelectedValue())));
+		addToolBarButton("workspace.sounds.play_selected", UIRES.get("16px.play"), new MouseAdapter() {
+			@Override public void mousePressed(MouseEvent e) {
+				SoundElement soundElement = elementList.getSelectedValue();
+				if (soundElement != null) {
+					if (!soundElement.getFiles().isEmpty()) {
+						SoundUtils.playSound(
+								new File(workspacePanel.getMCreator().getWorkspace().getFolderManager().getSoundsDir(),
+										ListUtils.getRandomItem(soundElement.getFiles()) + ".ogg"));
+					}
+				}
+			}
+			@Override public void mouseReleased(MouseEvent e) {
+				SoundUtils.stopAllSounds();
+			}
+
+		});
 	}
 
 	private void editSelectedSound(SoundElement selectedValue) {
@@ -55,66 +78,6 @@ public class WorkspacePanelSounds extends AbstractResourcePanel<SoundElement> {
 			workspacePanel.getMCreator().getWorkspace().markDirty();
 			reloadElements();
 		}
-	}
-
-	@Override TransparentToolBar createToolBar(JSelectableList<SoundElement> elementList) {
-		TransparentToolBar bar = new TransparentToolBar();
-		bar.setBorder(BorderFactory.createEmptyBorder(3, 5, 3, 0));
-
-		JButton importsound = L10N.button("action.workspace.resources.import_sound");
-		importsound.setIcon(UIRES.get("16px.open.gif"));
-		importsound.setContentAreaFilled(false);
-		importsound.setOpaque(false);
-		ComponentUtils.deriveFont(importsound, 12);
-		importsound.setBorder(BorderFactory.createEmptyBorder(0, 8, 0, 8));
-		bar.add(importsound);
-		importsound.addActionListener(e -> workspacePanel.getMCreator().actionRegistry.importSound.doAction());
-
-		JButton edit = L10N.button("workspace.sounds.edit_selected");
-		edit.setIcon(UIRES.get("16px.edit.gif"));
-		edit.setContentAreaFilled(false);
-		edit.setOpaque(false);
-		ComponentUtils.deriveFont(edit, 12);
-		edit.setBorder(BorderFactory.createEmptyBorder(0, 8, 0, 8));
-		bar.add(edit);
-		edit.addActionListener(e -> editSelectedSound(elementList.getSelectedValue()));
-
-		JButton del = L10N.button("workspace.sounds.delete_selected");
-		del.setIcon(UIRES.get("16px.delete.gif"));
-		del.setOpaque(false);
-		del.setContentAreaFilled(false);
-		del.setBorder(BorderFactory.createEmptyBorder(0, 8, 0, 8));
-		bar.add(del);
-
-		del.addActionListener(a -> deleteCurrentlySelected(Collections.singletonList(elementList.getSelectedValue())));
-
-		JButton play = L10N.button("workspace.sounds.play_selected");
-		play.setIcon(UIRES.get("16px.play"));
-		play.setOpaque(false);
-		play.setContentAreaFilled(false);
-		play.setBorder(BorderFactory.createEmptyBorder(0, 8, 0, 8));
-		bar.add(play);
-		play.addMouseListener(new MouseAdapter() {
-			@Override public void mousePressed(MouseEvent e) {
-				SoundElement soundElement = elementList.getSelectedValue();
-				if (soundElement != null) {
-					if (!soundElement.getFiles().isEmpty()) {
-						SoundUtils.playSound(
-								new File(workspacePanel.getMCreator().getWorkspace().getFolderManager().getSoundsDir(),
-										ListUtils.getRandomItem(soundElement.getFiles()) + ".ogg"));
-						play.setEnabled(false);
-					}
-				}
-			}
-
-			@Override public void mouseReleased(MouseEvent e) {
-				SoundUtils.stopAllSounds();
-				play.setEnabled(true);
-			}
-
-		});
-
-		return bar;
 	}
 
 	@Override void deleteCurrentlySelected(List<SoundElement> elements) {

--- a/src/main/java/net/mcreator/ui/workspace/resources/WorkspacePanelStructures.java
+++ b/src/main/java/net/mcreator/ui/workspace/resources/WorkspacePanelStructures.java
@@ -37,40 +37,13 @@ public class WorkspacePanelStructures extends AbstractResourcePanel<String> {
 		super(workspacePanel, new ResourceFilterModel<>(workspacePanel, e -> (e.toLowerCase(Locale.ENGLISH)
 				.contains(workspacePanel.search.getText().toLowerCase(Locale.ENGLISH))),
 				Comparator.comparing(String::toString)), new Render());
-	}
 
-	@Override TransparentToolBar createToolBar(JSelectableList<String> elementList) {
-		TransparentToolBar bar = new TransparentToolBar();
-		bar.setBorder(BorderFactory.createEmptyBorder(3, 5, 3, 0));
-
-		JButton importnbt = L10N.button("action.workspace.resources.import_structure");
-		importnbt.setIcon(UIRES.get("16px.open.gif"));
-		importnbt.setContentAreaFilled(false);
-		importnbt.setOpaque(false);
-		ComponentUtils.deriveFont(importnbt, 12);
-		importnbt.setBorder(BorderFactory.createEmptyBorder(0, 8, 0, 8));
-		bar.add(importnbt);
-		importnbt.addActionListener(e -> workspacePanel.getMCreator().actionRegistry.importStructure.doAction());
-
-		JButton importmc = L10N.button("action.workspace.resources.import_structure_from_minecraft");
-		importmc.setIcon(UIRES.get("16px.open.gif"));
-		importmc.setContentAreaFilled(false);
-		importmc.setOpaque(false);
-		ComponentUtils.deriveFont(importmc, 12);
-		importmc.setBorder(BorderFactory.createEmptyBorder(0, 8, 0, 8));
-		bar.add(importmc);
-		importmc.addActionListener(
+		addToolBarButton("action.workspace.resources.import_structure", UIRES.get("16px.open.gif"),
+				e -> workspacePanel.getMCreator().actionRegistry.importStructure.doAction());
+		addToolBarButton("action.workspace.resources.import_structure_from_minecraft", UIRES.get("16px.open.gif"),
 				e -> workspacePanel.getMCreator().actionRegistry.importStructureFromMinecraft.doAction());
-
-		JButton del = L10N.button("workspace.sounds.delete_selected");
-		del.setIcon(UIRES.get("16px.delete.gif"));
-		del.setOpaque(false);
-		del.setContentAreaFilled(false);
-		del.setBorder(BorderFactory.createEmptyBorder(0, 8, 0, 8));
-		bar.add(del);
-		del.addActionListener(a -> deleteCurrentlySelected(elementList.getSelectedValuesList()));
-
-		return bar;
+		addToolBarButton("workspace.sounds.delete_selected", UIRES.get("16px.delete.gif"),
+				e -> deleteCurrentlySelected(elementList.getSelectedValuesList()));
 	}
 
 	@Override void deleteCurrentlySelected(List<String> elements) {


### PR DESCRIPTION
I plan on adding new features for the different tabs of the Resources panel. However, to avoid duplicating code and use as much as possible a single system that will work for all of them, I tried to move all the code I could into a new `AbstractResourcePanel` as well as making all the FilterModel classes a single general class (`ResourceFilterModel`).

`AbstractResourcePanel` is not intended to be used for everything because it is only a class created to standardize all the similar elements of the panels. This means the textures tab was never intended to be part of the generalization due to its bigger complexity (multiple lists). If a Java plugin wants to use this new class in the future to use the future features, it should be possible too, but it is not the main objective of the PR.

I'm still unsure if I took the right approach on this issue (mainly about the 2 constructor arguments of `ResourceFilterModel`), so I decided to open a first PR that includes only those changes. It will either allow us to improve this new code or to find another better approach.