### PR TITLE
Add a general ResourceFilterModel class

### DIFF
--- a/src/main/java/net/mcreator/ui/workspace/resources/ResourceFilterModel.java
+++ b/src/main/java/net/mcreator/ui/workspace/resources/ResourceFilterModel.java
@@ -1,0 +1,111 @@
+/*
+ * MCreator (https://mcreator.net/)
+ * Copyright (C) 2012-2020, Pylo
+ * Copyright (C) 2020-2023, Pylo, opensource contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package net.mcreator.ui.workspace.resources;
+
+import net.mcreator.ui.workspace.WorkspacePanel;
+
+import javax.swing.*;
+import java.util.*;
+import java.util.function.Predicate;
+
+/**
+ * <p>A general filter model that is used inside resources-related workspace panels.
+ * It defines how a general resource panel's list of elements behaves.</p>
+ *
+ * @param <T>
+ */
+public class ResourceFilterModel<T> extends DefaultListModel<T> {
+	private final List<T> items;
+	private final List<T> filterItems;
+	private final WorkspacePanel workspacePanel;
+	private final Predicate<T> refilterItemsFilter;
+	private final Comparator<T> resourceNameProvider ;
+
+	/**
+	 *
+	 * @param workspacePanel <p>The {@link WorkspacePanel} of the current workspace</p>
+	 * @param refilterItemsFilter <p>Defines which elements should be contained inside the filtered list of elements.</p>
+	 * @param resourceNameProvider  <p>Defines how the filtered elements will be ordered.</p>
+	 */
+	public ResourceFilterModel(WorkspacePanel workspacePanel, Predicate<T> refilterItemsFilter,
+			Comparator<T> resourceNameProvider ) {
+		super();
+		this.workspacePanel = workspacePanel;
+		this.refilterItemsFilter = refilterItemsFilter;
+		this.resourceNameProvider  = resourceNameProvider ;
+
+		items = new ArrayList<>();
+		filterItems = new ArrayList<>();
+	}
+
+	@Override public int indexOf(Object elem) {
+		try {
+			return filterItems.indexOf(elem);
+		} catch (ClassCastException e) {
+			return -1;
+		}
+	}
+
+	@Override public T getElementAt(int index) {
+		if (index < filterItems.size())
+			return filterItems.get(index);
+		else
+			return null;
+	}
+
+	@Override public int getSize() {
+		return filterItems.size();
+	}
+
+	@Override public void addElement(T o) {
+		items.add(o);
+		refilter();
+	}
+
+	@Override public void removeAllElements() {
+		super.removeAllElements();
+		items.clear();
+		filterItems.clear();
+	}
+
+	@Override public boolean removeElement(Object a) {
+		if (a != null) {
+			try {
+				items.remove(a);
+				filterItems.remove(a);
+			} catch (ClassCastException ignored) {
+			}
+		}
+		return super.removeElement(a);
+	}
+
+	void refilter() {
+		filterItems.clear();
+		filterItems.addAll(items.stream().filter(Objects::nonNull).filter(refilterItemsFilter).toList());
+
+		if (workspacePanel.sortName.isSelected())
+			filterItems.sort(resourceNameProvider );
+
+		if (workspacePanel.desc.isSelected())
+			Collections.reverse(filterItems);
+
+		fireContentsChanged(this, 0, getSize());
+	}
+}

--- a/src/main/java/net/mcreator/ui/workspace/resources/ResourceFilterModel.java
+++ b/src/main/java/net/mcreator/ui/workspace/resources/ResourceFilterModel.java
@@ -23,7 +23,8 @@ import net.mcreator.ui.workspace.WorkspacePanel;
 
 import javax.swing.*;
 import java.util.*;
-import java.util.function.Predicate;
+import java.util.function.BiFunction;
+import java.util.function.Function;
 
 /**
  * <p>A general filter model that is used inside resources-related workspace panels.
@@ -35,27 +36,31 @@ public class ResourceFilterModel<T> extends DefaultListModel<T> {
 	private final List<T> items;
 	private final List<T> filterItems;
 	private final WorkspacePanel workspacePanel;
-	private final Predicate<T> refilterItemsFilter;
-	private final Comparator<T> resourceNameProvider ;
+	private final BiFunction<T, String, Boolean> refilterItemsFilter;
+	private final Function<T, String> resourceNameSupplier;
+
+	public ResourceFilterModel(WorkspacePanel workspacePanel, Function<T, String> resourceNameSupplier) {
+		this(workspacePanel,
+				(item, query) -> resourceNameSupplier.apply(item).toLowerCase(Locale.ENGLISH).contains(query),
+				Object::toString);
+	}
 
 	/**
-	 *
-	 * @param workspacePanel <p>The {@link WorkspacePanel} of the current workspace</p>
-	 * @param refilterItemsFilter <p>Defines which elements should be contained inside the filtered list of elements.</p>
-	 * @param resourceNameProvider  <p>Defines how the filtered elements will be ordered.</p>
+	 * @param workspacePanel       <p>The {@link WorkspacePanel} of the current workspace</p>
+	 * @param refilterItemsFilter  <p>Defines which elements should be contained inside the filtered list of elements.</p>
+	 * @param resourceNameSupplier <p>Provides resource name used for sort-by-name sorter.</p>
 	 */
-	public ResourceFilterModel(WorkspacePanel workspacePanel, Predicate<T> refilterItemsFilter,
-			Comparator<T> resourceNameProvider ) {
-		super();
+	public ResourceFilterModel(WorkspacePanel workspacePanel, BiFunction<T, String, Boolean> refilterItemsFilter,
+			Function<T, String> resourceNameSupplier) {
 		this.workspacePanel = workspacePanel;
 		this.refilterItemsFilter = refilterItemsFilter;
-		this.resourceNameProvider  = resourceNameProvider ;
+		this.resourceNameSupplier = resourceNameSupplier;
 
 		items = new ArrayList<>();
 		filterItems = new ArrayList<>();
 	}
 
-	@Override public int indexOf(Object elem) {
+	@SuppressWarnings("SuspiciousMethodCalls") @Override public int indexOf(Object elem) {
 		try {
 			return filterItems.indexOf(elem);
 		} catch (ClassCastException e) {
@@ -85,7 +90,7 @@ public class ResourceFilterModel<T> extends DefaultListModel<T> {
 		filterItems.clear();
 	}
 
-	@Override public boolean removeElement(Object a) {
+	@SuppressWarnings("SuspiciousMethodCalls") @Override public boolean removeElement(Object a) {
 		if (a != null) {
 			try {
 				items.remove(a);
@@ -98,14 +103,16 @@ public class ResourceFilterModel<T> extends DefaultListModel<T> {
 
 	void refilter() {
 		filterItems.clear();
-		filterItems.addAll(items.stream().filter(Objects::nonNull).filter(refilterItemsFilter).toList());
+		filterItems.addAll(items.stream().filter(Objects::nonNull).filter(item -> refilterItemsFilter.apply(item,
+				workspacePanel.search.getText().toLowerCase(Locale.ENGLISH))).toList());
 
 		if (workspacePanel.sortName.isSelected())
-			filterItems.sort(resourceNameProvider );
+			filterItems.sort(Comparator.comparing(resourceNameSupplier));
 
 		if (workspacePanel.desc.isSelected())
 			Collections.reverse(filterItems);
 
 		fireContentsChanged(this, 0, getSize());
 	}
+
 }

--- a/src/main/java/net/mcreator/ui/workspace/resources/WorkspacePanelModels.java
+++ b/src/main/java/net/mcreator/ui/workspace/resources/WorkspacePanelModels.java
@@ -43,15 +43,16 @@ import java.awt.event.KeyEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.io.File;
-import java.util.List;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class WorkspacePanelModels extends JPanel implements IReloadableFilterable {
 
 	private final WorkspacePanel workspacePanel;
 
-	private final ResourceFilterModel<Model> filterModel ;
+	private final ResourceFilterModel<Model> filterModel;
 	private final JList<Model> modelList;
 
 	WorkspacePanelModels(WorkspacePanel workspacePanel) {
@@ -59,9 +60,10 @@ public class WorkspacePanelModels extends JPanel implements IReloadableFilterabl
 		setOpaque(false);
 
 		this.workspacePanel = workspacePanel;
-		this.filterModel  = new ResourceFilterModel<>(workspacePanel, item -> predicateCheck(workspacePanel, item),
-				Comparator.comparing(Model::getReadableName));
-		modelList = new JList<>(filterModel );
+		this.filterModel = new ResourceFilterModel<>(workspacePanel,
+				(item, query) -> item.getReadableName().toLowerCase(Locale.ENGLISH).contains(query) || item.getType()
+						.name().toLowerCase(Locale.ENGLISH).contains(query), Model::getReadableName);
+		modelList = new JList<>(filterModel);
 
 		modelList.setOpaque(false);
 		modelList.setCellRenderer(new Render());
@@ -182,12 +184,6 @@ public class WorkspacePanelModels extends JPanel implements IReloadableFilterabl
 		add("North", bar);
 	}
 
-	private static boolean predicateCheck(WorkspacePanel workspacePanel, Model item) {
-		return item.getReadableName().toLowerCase(Locale.ENGLISH)
-				.contains(workspacePanel.search.getText().toLowerCase(Locale.ENGLISH)) || item.getType().name()
-				.toLowerCase(Locale.ENGLISH).contains(workspacePanel.search.getText().toLowerCase(Locale.ENGLISH));
-	}
-
 	private void deleteCurrentlySelected() {
 		Model model = modelList.getSelectedValue();
 		if (model != null) {
@@ -276,13 +272,13 @@ public class WorkspacePanelModels extends JPanel implements IReloadableFilterabl
 	}
 
 	@Override public void reloadElements() {
-		filterModel .removeAllElements();
-		Model.getModels(workspacePanel.getMCreator().getWorkspace()).forEach(filterModel ::addElement);
+		filterModel.removeAllElements();
+		Model.getModels(workspacePanel.getMCreator().getWorkspace()).forEach(filterModel::addElement);
 		refilterElements();
 	}
 
 	@Override public void refilterElements() {
-		filterModel .refilter();
+		filterModel.refilter();
 	}
 
 	static class Render extends JLabel implements ListCellRenderer<Model> {

--- a/src/main/java/net/mcreator/ui/workspace/resources/WorkspacePanelScreenshots.java
+++ b/src/main/java/net/mcreator/ui/workspace/resources/WorkspacePanelScreenshots.java
@@ -39,21 +39,27 @@ import java.awt.event.KeyEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.io.File;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
-import java.util.*;
+import java.util.Locale;
 
 class WorkspacePanelScreenshots extends JPanel implements IReloadableFilterable {
 
 	private final WorkspacePanel workspacePanel;
 
-	private final FilterModel listmodel = new FilterModel();
-	private final JSelectableList<File> screenshotsList = new JSelectableList<>(listmodel);
+	private final ResourceFilterModel<File> filterModel;
+	private final JSelectableList<File> screenshotsList;
 
 	WorkspacePanelScreenshots(WorkspacePanel workspacePanel) {
 		super(new BorderLayout());
 		setOpaque(false);
 
 		this.workspacePanel = workspacePanel;
+		filterModel = new ResourceFilterModel<>(workspacePanel, item -> item.getName().toLowerCase(Locale.ENGLISH)
+				.contains(workspacePanel.search.getText().toLowerCase(Locale.ENGLISH)),
+				Comparator.comparing(File::getName));
+		screenshotsList = new JSelectableList<>(filterModel);
 
 		screenshotsList.setOpaque(false);
 		screenshotsList.setCellRenderer(new Render());
@@ -141,11 +147,11 @@ class WorkspacePanelScreenshots extends JPanel implements IReloadableFilterable 
 	@Override public void reloadElements() {
 		List<File> selected = screenshotsList.getSelectedValuesList();
 
-		listmodel.removeAllElements();
+		filterModel.removeAllElements();
 		File[] screenshots = new File(workspacePanel.getMCreator().getWorkspaceFolder(),
 				"run/screenshots/").listFiles();
 		if (screenshots != null)
-			Arrays.stream(screenshots).forEach(listmodel::addElement);
+			Arrays.stream(screenshots).forEach(filterModel::addElement);
 
 		ListUtil.setSelectedValues(screenshotsList, selected);
 
@@ -153,72 +159,7 @@ class WorkspacePanelScreenshots extends JPanel implements IReloadableFilterable 
 	}
 
 	@Override public void refilterElements() {
-		listmodel.refilter();
-	}
-
-	private class FilterModel extends DefaultListModel<File> {
-		List<File> items;
-		List<File> filterItems;
-
-		FilterModel() {
-			super();
-			items = new ArrayList<>();
-			filterItems = new ArrayList<>();
-		}
-
-		@Override public int indexOf(Object elem) {
-			if (elem instanceof File)
-				return filterItems.indexOf(elem);
-			else
-				return -1;
-		}
-
-		@Override public File getElementAt(int index) {
-			if (index < filterItems.size())
-				return filterItems.get(index);
-			else
-				return null;
-		}
-
-		@Override public int getSize() {
-			return filterItems.size();
-		}
-
-		@Override public void addElement(File o) {
-			items.add(o);
-			refilter();
-		}
-
-		@Override public void removeAllElements() {
-			super.removeAllElements();
-			items.clear();
-			filterItems.clear();
-		}
-
-		@Override public boolean removeElement(Object a) {
-			if (a instanceof File) {
-				items.remove(a);
-				filterItems.remove(a);
-			}
-			return super.removeElement(a);
-		}
-
-		void refilter() {
-			filterItems.clear();
-			String term = workspacePanel.search.getText();
-			filterItems.addAll(items.stream().filter(Objects::nonNull)
-					.filter(item -> item.getName().toLowerCase(Locale.ENGLISH)
-							.contains(term.toLowerCase(Locale.ENGLISH))).toList());
-
-			if (workspacePanel.sortName.isSelected()) {
-				filterItems.sort(Comparator.comparing(File::getName));
-			}
-
-			if (workspacePanel.desc.isSelected())
-				Collections.reverse(filterItems);
-
-			fireContentsChanged(this, 0, getSize());
-		}
+		filterModel.refilter();
 	}
 
 	static class Render extends JLabel implements ListCellRenderer<File> {

--- a/src/main/java/net/mcreator/ui/workspace/resources/WorkspacePanelScreenshots.java
+++ b/src/main/java/net/mcreator/ui/workspace/resources/WorkspacePanelScreenshots.java
@@ -40,7 +40,6 @@ import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.io.File;
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 
@@ -56,9 +55,7 @@ class WorkspacePanelScreenshots extends JPanel implements IReloadableFilterable 
 		setOpaque(false);
 
 		this.workspacePanel = workspacePanel;
-		filterModel = new ResourceFilterModel<>(workspacePanel, item -> item.getName().toLowerCase(Locale.ENGLISH)
-				.contains(workspacePanel.search.getText().toLowerCase(Locale.ENGLISH)),
-				Comparator.comparing(File::getName));
+		filterModel = new ResourceFilterModel<>(workspacePanel, File::getName);
 		screenshotsList = new JSelectableList<>(filterModel);
 
 		screenshotsList.setOpaque(false);

--- a/src/main/java/net/mcreator/ui/workspace/resources/WorkspacePanelSounds.java
+++ b/src/main/java/net/mcreator/ui/workspace/resources/WorkspacePanelSounds.java
@@ -39,7 +39,6 @@ import java.awt.event.KeyEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.io.File;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 
@@ -54,9 +53,7 @@ public class WorkspacePanelSounds extends JPanel implements IReloadableFilterabl
 		setOpaque(false);
 
 		this.workspacePanel = workspacePanel;
-		this.filterModel = new ResourceFilterModel<>(workspacePanel, item -> item.getName().toLowerCase(Locale.ENGLISH)
-				.contains(workspacePanel.search.getText().toLowerCase(Locale.ENGLISH)),
-				Comparator.comparing(SoundElement::getName));
+		this.filterModel = new ResourceFilterModel<>(workspacePanel, SoundElement::getName);
 
 		JSelectableList<SoundElement> soundElementList = new JSelectableList<>(filterModel);
 		soundElementList.setOpaque(false);

--- a/src/main/java/net/mcreator/ui/workspace/resources/WorkspacePanelStructures.java
+++ b/src/main/java/net/mcreator/ui/workspace/resources/WorkspacePanelStructures.java
@@ -31,22 +31,26 @@ import javax.swing.*;
 import java.awt.*;
 import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
+import java.util.Comparator;
 import java.util.List;
-import java.util.*;
+import java.util.Locale;
 
 public class WorkspacePanelStructures extends JPanel implements IReloadableFilterable {
 
 	private final WorkspacePanel workspacePanel;
 
-	private final FilterModel listmodel = new FilterModel();
+	private final ResourceFilterModel<String> filterModel;
 
 	WorkspacePanelStructures(WorkspacePanel workspacePanel) {
 		super(new BorderLayout());
 		setOpaque(false);
 
 		this.workspacePanel = workspacePanel;
+		this.filterModel = new ResourceFilterModel<>(workspacePanel, item -> (item.toLowerCase(Locale.ENGLISH)
+				.contains(workspacePanel.search.getText().toLowerCase(Locale.ENGLISH))),
+				Comparator.comparing(String::toString));
 
-		JSelectableList<String> structureElementList = new JSelectableList<>(listmodel);
+		JSelectableList<String> structureElementList = new JSelectableList<>(filterModel);
 		structureElementList.setOpaque(false);
 		structureElementList.setCellRenderer(new Render());
 		structureElementList.setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
@@ -120,77 +124,13 @@ public class WorkspacePanelStructures extends JPanel implements IReloadableFilte
 	}
 
 	@Override public void reloadElements() {
-		listmodel.removeAllElements();
-		workspacePanel.getMCreator().getFolderManager().getStructureList().forEach(listmodel::addElement);
+		filterModel.removeAllElements();
+		workspacePanel.getMCreator().getFolderManager().getStructureList().forEach(filterModel::addElement);
 		refilterElements();
 	}
 
 	@Override public void refilterElements() {
-		listmodel.refilter();
-	}
-
-	private class FilterModel extends DefaultListModel<String> {
-		List<String> items;
-		List<String> filterItems;
-
-		FilterModel() {
-			super();
-			items = new ArrayList<>();
-			filterItems = new ArrayList<>();
-		}
-
-		@Override public int indexOf(Object elem) {
-			if (elem instanceof String)
-				return filterItems.indexOf(elem);
-			else
-				return -1;
-		}
-
-		@Override public String getElementAt(int index) {
-			if (index < filterItems.size())
-				return filterItems.get(index);
-			else
-				return null;
-		}
-
-		@Override public int getSize() {
-			return filterItems.size();
-		}
-
-		@Override public void addElement(String o) {
-			items.add(o);
-			refilter();
-		}
-
-		@Override public void removeAllElements() {
-			super.removeAllElements();
-			items.clear();
-			filterItems.clear();
-		}
-
-		@Override public boolean removeElement(Object a) {
-			if (a instanceof String) {
-				items.remove(a);
-				filterItems.remove(a);
-			}
-			return super.removeElement(a);
-		}
-
-		void refilter() {
-			filterItems.clear();
-			String term = workspacePanel.search.getText();
-			filterItems.addAll(items.stream().filter(Objects::nonNull)
-					.filter(e -> (e.toLowerCase(Locale.ENGLISH).contains(term.toLowerCase(Locale.ENGLISH)))).toList());
-
-			if (workspacePanel.sortName.isSelected()) {
-				filterItems.sort(Comparator.comparing(String::toString));
-			}
-
-			if (workspacePanel.desc.isSelected())
-				Collections.reverse(filterItems);
-
-			fireContentsChanged(this, 0, getSize());
-		}
+		filterModel.refilter();
 	}
 
 	static class Render extends JLabel implements ListCellRenderer<String> {

--- a/src/main/java/net/mcreator/ui/workspace/resources/WorkspacePanelStructures.java
+++ b/src/main/java/net/mcreator/ui/workspace/resources/WorkspacePanelStructures.java
@@ -31,9 +31,7 @@ import javax.swing.*;
 import java.awt.*;
 import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
-import java.util.Comparator;
 import java.util.List;
-import java.util.Locale;
 
 public class WorkspacePanelStructures extends JPanel implements IReloadableFilterable {
 
@@ -46,9 +44,7 @@ public class WorkspacePanelStructures extends JPanel implements IReloadableFilte
 		setOpaque(false);
 
 		this.workspacePanel = workspacePanel;
-		this.filterModel = new ResourceFilterModel<>(workspacePanel, item -> (item.toLowerCase(Locale.ENGLISH)
-				.contains(workspacePanel.search.getText().toLowerCase(Locale.ENGLISH))),
-				Comparator.comparing(String::toString));
+		this.filterModel = new ResourceFilterModel<>(workspacePanel, String::toString);
 
 		JSelectableList<String> structureElementList = new JSelectableList<>(filterModel);
 		structureElementList.setOpaque(false);

--- a/src/main/java/net/mcreator/ui/workspace/resources/WorkspacePanelTextures.java
+++ b/src/main/java/net/mcreator/ui/workspace/resources/WorkspacePanelTextures.java
@@ -78,7 +78,6 @@ public class WorkspacePanelTextures extends JPanel implements IReloadableFiltera
 
 		Arrays.stream(TextureType.values()).forEach(section -> {
 			JComponentWithList<File> compList = createListElement(
-					new ResourceFilterModel<>(workspacePanel, File::getName),
 					L10N.t("workspace.textures.category." + section.getID()));
 			respan.add(compList.component());
 			mapLists.put(section.getID(), compList);
@@ -236,8 +235,9 @@ public class WorkspacePanelTextures extends JPanel implements IReloadableFiltera
 		}
 	}
 
-	private JComponentWithList<File> createListElement(ResourceFilterModel<File> filterModel, String title) {
-		JSelectableList<File> listElement = new JSelectableList<>(filterModel);
+	private JComponentWithList<File> createListElement(String title) {
+		JSelectableList<File> listElement = new JSelectableList<>(
+				new ResourceFilterModel<>(workspacePanel, File::getName));
 		listElement.setCellRenderer(textureRender);
 		listElement.setOpaque(false);
 		listElement.setLayoutOrientation(JList.HORIZONTAL_WRAP);
@@ -264,6 +264,8 @@ public class WorkspacePanelTextures extends JPanel implements IReloadableFiltera
 		new Thread(() -> {
 			Arrays.stream(TextureType.values()).forEach(section -> {
 				List<File> selected = mapLists.get(section.getID()).list().getSelectedValuesList();
+
+				// instead of clearing and adding all elements, we just replace the model (less flickering)
 				ResourceFilterModel<File> newfm = new ResourceFilterModel<>(workspacePanel, File::getName);
 				workspacePanel.getMCreator().getFolderManager().getTexturesList(section).forEach(newfm::addElement);
 

--- a/src/main/java/net/mcreator/ui/workspace/resources/WorkspacePanelTextures.java
+++ b/src/main/java/net/mcreator/ui/workspace/resources/WorkspacePanelTextures.java
@@ -77,7 +77,8 @@ public class WorkspacePanelTextures extends JPanel implements IReloadableFiltera
 		respan.setLayout(new BoxLayout(respan, BoxLayout.Y_AXIS));
 
 		Arrays.stream(TextureType.values()).forEach(section -> {
-			JComponentWithList<File> compList = createListElement(new ResourceFilterModel<File>(workspacePanel, File::getName),
+			JComponentWithList<File> compList = createListElement(
+					new ResourceFilterModel<>(workspacePanel, File::getName),
 					L10N.t("workspace.textures.category." + section.getID()));
 			respan.add(compList.component());
 			mapLists.put(section.getID(), compList);
@@ -235,8 +236,8 @@ public class WorkspacePanelTextures extends JPanel implements IReloadableFiltera
 		}
 	}
 
-	private JComponentWithList<File> createListElement(ResourceFilterModel<File> dmlb, String title) {
-		JSelectableList<File> listElement = new JSelectableList<>(dmlb);
+	private JComponentWithList<File> createListElement(ResourceFilterModel<File> filterModel, String title) {
+		JSelectableList<File> listElement = new JSelectableList<>(filterModel);
 		listElement.setCellRenderer(textureRender);
 		listElement.setOpaque(false);
 		listElement.setLayoutOrientation(JList.HORIZONTAL_WRAP);
@@ -284,9 +285,9 @@ public class WorkspacePanelTextures extends JPanel implements IReloadableFiltera
 
 	@Override public void refilterElements() {
 		Arrays.stream(TextureType.values()).map(section -> mapLists.get(section.getID())).forEach(compList -> {
-			ResourceFilterModel<?> model = (ResourceFilterModel<?>) compList.list().getModel();
-			model.refilter();
-			if (model.getSize() > 0) {
+			ResourceFilterModel<?> filterModel = (ResourceFilterModel<?>) compList.list().getModel();
+			filterModel.refilter();
+			if (filterModel.getSize() > 0) {
 				compList.component().setPreferredSize(null);
 				compList.component().setVisible(true);
 			} else {


### PR DESCRIPTION
This PR moves all inner-specific `FilterModel` classes to a new general `ResourceFilterModel` class, as requested inside #4296.

The requested change (changing a variable name) of the original PR was also applied.