### PR TITLE
Add an install update button for Window users

### DIFF
--- a/plugins/mcreator-localization/lang/texts.properties
+++ b/plugins/mcreator-localization/lang/texts.properties
@@ -535,6 +535,10 @@ dialog.update_notify.no_update_message=You have the latest version of MCreator i
 dialog.update_notify.no_pluin_update_message=There are no plugin updates available at this time!
 dialog.update_notify.no_update_title=No updates
 dialog.update_notify.open_download_page=Open download page
+dialog.update_notify.install=Install the update
+dialog.update_notify.install.message=<html><b>Are you sure you want to download and install the new version?</b><br>\
+  <small>Downloading the executable file can take some time depending on your Internet connection.<br>\
+  On Windows, you will have to allow the installer to use the administrator permission.
 dialog.update_notify.remind_later=Remind me later
 dialog.plugin_update_notify.message=MCreator detected the following plugins can be updated:
 dialog.plugin_update_notify.update=Update plugin

--- a/src/main/java/net/mcreator/ui/dialogs/UpdateNotifyDialog.java
+++ b/src/main/java/net/mcreator/ui/dialogs/UpdateNotifyDialog.java
@@ -76,7 +76,7 @@ public class UpdateNotifyDialog {
 				ar.setText(fullChangelog(updateInfo));
 
 				Object[] options;
-				if (OS.getOS() == OS.WINDOWS) {
+				if (OS.getOS() == OS.WINDOWS && !Launcher.version.isSnapshot()) {
 					options = new Object[] { L10N.t("dialog.update_notify.open_download_page"),
 							L10N.t("dialog.update_notify.remind_later"), L10N.t("dialog.update_notify.install") };
 				} else {
@@ -115,7 +115,7 @@ public class UpdateNotifyDialog {
 						Launcher.version.buildlong));
 
 				Object[] options;
-				if (OS.getOS() == OS.WINDOWS) {
+				if (OS.getOS() == OS.WINDOWS && !Launcher.version.isSnapshot()) {
 					options = new Object[] { L10N.t("dialog.update_notify.open_download_page"),
 							L10N.t("dialog.update_notify.remind_later"), L10N.t("dialog.update_notify.install") };
 				} else {


### PR DESCRIPTION
When an update is detected, an install button is added for users on Windows. This new button will automatically download and run the executable file (.exe) for the detected version.

It only supports Windows as I don't know how Mac and Linux handle that and I can not test easily on Linux (and I can't test at all on Mac).

Snapshots should be completely disabled (from downloading and using the system) because the system only works with `.exe` files and because I don't know if it could cause problems to update from a snapshot/ZIP to another version. If a case with snapshots can work, I'll implement it, but I would need some better explanations on this system... it was quite hard to understand 😅

Note: I tested by changing the version insiide `mcreator.conf` from `2023.4` to `2023.2` with a 2023.3 version installed and it worked fine.
Note 2: Tests from everyone are **HIGHLY** appreciated!