### PR TITLE
Fix category description label foreground

### DIFF
--- a/plugins/mcreator-themes/themes/default_dark/styles/blockly.css
+++ b/plugins/mcreator-themes/themes/default_dark/styles/blockly.css
@@ -65,7 +65,7 @@ body {
 }
 
 .whlab > .blocklyFlyoutLabelText {
-    fill: white;
+    fill: white !important;
 }
 
 .blocklyDropDownDiv {

--- a/plugins/mcreator-themes/themes/matrix/styles/blockly.css
+++ b/plugins/mcreator-themes/themes/matrix/styles/blockly.css
@@ -65,7 +65,7 @@ body {
 }
 
 .whlab > .blocklyFlyoutLabelText {
-    fill: white;
+    fill: white !important;
 }
 
 .blocklyDropDownDiv {

--- a/plugins/mcreator-themes/themes/midnight/styles/blockly.css
+++ b/plugins/mcreator-themes/themes/midnight/styles/blockly.css
@@ -65,7 +65,7 @@ body {
 }
 
 .whlab > .blocklyFlyoutLabelText {
-    fill: #eaeaea;
+    fill: #eaeaea !important;
 }
 
 .blocklyDropDownDiv {


### PR DESCRIPTION
Marks color of flyout labels text as an `!important` parameter.

Before:

![image](https://github.com/MCreator/MCreator/assets/71347607/9e576699-a29b-4a51-8aa6-f7af7e12e640)

After:

![image](https://github.com/MCreator/MCreator/assets/71347607/cd4dbf9e-b41b-4b91-99b7-e778c84868a1)