### PR TITLE
Preload workspace in the foreground

### DIFF
--- a/plugins/mcreator-localization/lang/texts.properties
+++ b/plugins/mcreator-localization/lang/texts.properties
@@ -561,6 +561,7 @@ dialog.variables.variable_name=Variable name:
 dialog.variables.variable_type=Variable type: 
 dialog.variables.variable_scope=Variable scope: 
 dialog.variables.new_title=New variable
+workspace.loading=Preloading the workspace...
 workspace.elements.list.locked=Locked
 workspace.elements.folders.add_tooltip=Add new folder into the current folder
 workspace.elements.folders.up_tooltip=Move back to the parent folder

--- a/src/main/java/net/mcreator/ui/MCreator.java
+++ b/src/main/java/net/mcreator/ui/MCreator.java
@@ -31,8 +31,9 @@ import net.mcreator.preferences.PreferencesManager;
 import net.mcreator.ui.action.ActionRegistry;
 import net.mcreator.ui.action.impl.workspace.RegenerateCodeAction;
 import net.mcreator.ui.browser.WorkspaceFileBrowser;
+import net.mcreator.ui.component.BlockingGlassPane;
 import net.mcreator.ui.component.ImagePanel;
-import net.mcreator.ui.component.util.ComponentUtils;
+import net.mcreator.ui.component.JEmptyBox;
 import net.mcreator.ui.component.util.PanelUtils;
 import net.mcreator.ui.dialogs.workspace.WorkspaceGeneratorSetupDialog;
 import net.mcreator.ui.gradle.GradleConsole;
@@ -318,6 +319,7 @@ public final class MCreator extends JFrame implements IWorkspaceProvider, IGener
 				workspace.getModElements().forEach(ModElement::getMCItems);
 
 				getGlassPane().setVisible(false);
+				setGlassPane(new JEmptyBox());
 			}, "ME preloader").start();
 
 			setCursor(new Cursor(Cursor.DEFAULT_CURSOR));
@@ -436,14 +438,7 @@ public final class MCreator extends JFrame implements IWorkspaceProvider, IGener
 	}
 
 	private JComponent getPreloaderPane() {
-		JPanel wrap = new JPanel(new BorderLayout()) {
-			@Override protected void paintComponent(Graphics g) {
-				super.paintComponent(g);
-				g.setColor(new Color(0, 0, 0, 100));
-				g.fillRect(0, 0, getWidth(), getHeight());
-			}
-		};
-		wrap.setOpaque(false);
+		JPanel wrap = new BlockingGlassPane();
 		JLabel loading = L10N.label("workspace.loading");
 		loading.setFont(loading.getFont().deriveFont(16f));
 		loading.setForeground((Color) UIManager.get("MCreatorLAF.GRAY_COLOR"));

--- a/src/main/java/net/mcreator/ui/component/BlockingGlassPane.java
+++ b/src/main/java/net/mcreator/ui/component/BlockingGlassPane.java
@@ -1,0 +1,62 @@
+/*
+ * MCreator (https://mcreator.net/)
+ * Copyright (C) 2012-2020, Pylo
+ * Copyright (C) 2020-2023, Pylo, opensource contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package net.mcreator.ui.component;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.KeyAdapter;
+import java.awt.event.KeyEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseMotionAdapter;
+
+public class BlockingGlassPane extends JPanel {
+
+	public BlockingGlassPane() {
+		super(new BorderLayout());
+		setOpaque(false);
+
+		setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
+
+		setFocusTraversalKeysEnabled(false);
+
+		addMouseListener(new MouseAdapter() {});
+		addMouseMotionListener(new MouseMotionAdapter() {});
+
+		addMouseWheelListener(e -> {
+		});
+
+		addKeyListener(new KeyAdapter() {
+			@Override public void keyPressed(KeyEvent e) {
+				e.consume();
+			}
+
+			@Override public void keyReleased(KeyEvent e) {
+				e.consume();
+			}
+		});
+	}
+
+	@Override protected void paintComponent(Graphics g) {
+		super.paintComponent(g);
+		g.setColor(new Color(0, 0, 0, 150));
+		g.fillRect(0, 0, getWidth(), getHeight());
+	}
+
+}


### PR DESCRIPTION
This PR makes the workspace preload in the foreground.

If the user does actions during preload, due to non-thread safe nature of the generatable element, some things can go south with unpredictable consequences.

Thus user input is blocked while the workspace is being preloaded.