### PR TITLE
Filter locked elements when looking for references

### DIFF
--- a/src/main/java/net/mcreator/workspace/references/ReferencesFinder.java
+++ b/src/main/java/net/mcreator/workspace/references/ReferencesFinder.java
@@ -56,7 +56,8 @@ public class ReferencesFinder {
 	 * @return List of all generatable elements contained in the provided workspace.
 	 */
 	private static List<GeneratableElement> getGeneratableElements(Workspace workspace) {
-		return workspace.getModElements().stream().map(ModElement::getGeneratableElement).collect(Collectors.toList());
+		return workspace.getModElements().stream().filter(me -> !me.isCodeLocked())
+				.map(ModElement::getGeneratableElement).collect(Collectors.toList());
 	}
 
 	//@formatter:off
@@ -80,7 +81,7 @@ public class ReferencesFinder {
 					procedureXmlPattern.matcher(t).find()
 				)
 			)
-			.map(GeneratableElement::getModElement).filter(me -> !me.equals(element) && !me.isCodeLocked()).collect(Collectors.toSet());
+			.map(GeneratableElement::getModElement).filter(me -> !me.equals(element)).collect(Collectors.toSet());
 	}
 
 	public static Set<ModElement> searchTextureUsages(Workspace workspace, File texture, TextureType type) {
@@ -102,7 +103,7 @@ public class ReferencesFinder {
 					return false;
 				})
 			)
-			.map(GeneratableElement::getModElement).filter(me -> !me.isCodeLocked()).collect(Collectors.toSet());
+			.map(GeneratableElement::getModElement).collect(Collectors.toSet());
 	}
 
 	public static Set<ModElement> searchModelUsages(Workspace workspace, Model model) {
@@ -115,7 +116,7 @@ public class ReferencesFinder {
 					model.equals(t) || TexturedModel.getModelTextureMapVariations(model).contains(t)
 				)
 			)
-			.map(GeneratableElement::getModElement).filter(me -> !me.isCodeLocked()).collect(Collectors.toSet());
+			.map(GeneratableElement::getModElement).collect(Collectors.toSet());
 	}
 
 	public static Set<ModElement> searchSoundUsages(Workspace workspace, SoundElement sound) {
@@ -131,7 +132,7 @@ public class ReferencesFinder {
 					t.contains(">CUSTOM:" + sound.getName() + "</field>")
 				)
 			)
-			.map(GeneratableElement::getModElement).filter(me -> !me.isCodeLocked()).collect(Collectors.toSet());
+			.map(GeneratableElement::getModElement).collect(Collectors.toSet());
 	}
 
 	public static Set<ModElement> searchStructureUsages(Workspace workspace, String structure) {
@@ -147,7 +148,7 @@ public class ReferencesFinder {
 					t.contains(">" + structure + "</field>")
 				)
 			)
-			.map(GeneratableElement::getModElement).filter(me -> !me.isCodeLocked()).collect(Collectors.toSet());
+			.map(GeneratableElement::getModElement).collect(Collectors.toSet());
 	}
 
 	public static Set<ModElement> searchGlobalVariableUsages(Workspace workspace, String variableName) {
@@ -157,7 +158,7 @@ public class ReferencesFinder {
 					t.contains("<field name=\"VAR\">global:" + variableName + "</field>")
 				)
 			)
-			.map(GeneratableElement::getModElement).filter(me -> !me.isCodeLocked()).collect(Collectors.toSet());
+			.map(GeneratableElement::getModElement).collect(Collectors.toSet());
 	}
 
 	public static Set<ModElement> searchLocalizationKeyUsages(Workspace workspace, String localizationKey) {
@@ -168,7 +169,7 @@ public class ReferencesFinder {
 					t.contains(">" + localizationKey + "</field>")
 				)
 			)
-			.map(GeneratableElement::getModElement).filter(me -> !me.isCodeLocked()).collect(Collectors.toSet());
+			.map(GeneratableElement::getModElement).collect(Collectors.toSet());
 	}
 
 	//@formatter:on

--- a/src/main/java/net/mcreator/workspace/references/ReferencesFinder.java
+++ b/src/main/java/net/mcreator/workspace/references/ReferencesFinder.java
@@ -80,7 +80,7 @@ public class ReferencesFinder {
 					procedureXmlPattern.matcher(t).find()
 				)
 			)
-			.map(GeneratableElement::getModElement).filter(me -> !me.equals(element)).collect(Collectors.toSet());
+			.map(GeneratableElement::getModElement).filter(me -> !me.equals(element) && !me.isCodeLocked()).collect(Collectors.toSet());
 	}
 
 	public static Set<ModElement> searchTextureUsages(Workspace workspace, File texture, TextureType type) {
@@ -102,7 +102,7 @@ public class ReferencesFinder {
 					return false;
 				})
 			)
-			.map(GeneratableElement::getModElement).collect(Collectors.toSet());
+			.map(GeneratableElement::getModElement).filter(me -> !me.isCodeLocked()).collect(Collectors.toSet());
 	}
 
 	public static Set<ModElement> searchModelUsages(Workspace workspace, Model model) {
@@ -115,7 +115,7 @@ public class ReferencesFinder {
 					model.equals(t) || TexturedModel.getModelTextureMapVariations(model).contains(t)
 				)
 			)
-			.map(GeneratableElement::getModElement).collect(Collectors.toSet());
+			.map(GeneratableElement::getModElement).filter(me -> !me.isCodeLocked()).collect(Collectors.toSet());
 	}
 
 	public static Set<ModElement> searchSoundUsages(Workspace workspace, SoundElement sound) {
@@ -131,7 +131,7 @@ public class ReferencesFinder {
 					t.contains(">CUSTOM:" + sound.getName() + "</field>")
 				)
 			)
-			.map(GeneratableElement::getModElement).collect(Collectors.toSet());
+			.map(GeneratableElement::getModElement).filter(me -> !me.isCodeLocked()).collect(Collectors.toSet());
 	}
 
 	public static Set<ModElement> searchStructureUsages(Workspace workspace, String structure) {
@@ -147,7 +147,7 @@ public class ReferencesFinder {
 					t.contains(">" + structure + "</field>")
 				)
 			)
-			.map(GeneratableElement::getModElement).collect(Collectors.toSet());
+			.map(GeneratableElement::getModElement).filter(me -> !me.isCodeLocked()).collect(Collectors.toSet());
 	}
 
 	public static Set<ModElement> searchGlobalVariableUsages(Workspace workspace, String variableName) {
@@ -157,7 +157,7 @@ public class ReferencesFinder {
 					t.contains("<field name=\"VAR\">global:" + variableName + "</field>")
 				)
 			)
-			.map(GeneratableElement::getModElement).collect(Collectors.toSet());
+			.map(GeneratableElement::getModElement).filter(me -> !me.isCodeLocked()).collect(Collectors.toSet());
 	}
 
 	public static Set<ModElement> searchLocalizationKeyUsages(Workspace workspace, String localizationKey) {
@@ -168,7 +168,7 @@ public class ReferencesFinder {
 					t.contains(">" + localizationKey + "</field>")
 				)
 			)
-			.map(GeneratableElement::getModElement).collect(Collectors.toSet());
+			.map(GeneratableElement::getModElement).filter(me -> !me.isCodeLocked()).collect(Collectors.toSet());
 	}
 
 	//@formatter:on


### PR DESCRIPTION
Adds code lock filter to `ReferencesFinder`'s methods because there's no way to know what references do such elements actually need.