### PR TITLE
Allow programmatically switching workspace sections

### DIFF
--- a/src/main/java/net/mcreator/ui/workspace/WorkspacePanel.java
+++ b/src/main/java/net/mcreator/ui/workspace/WorkspacePanel.java
@@ -762,7 +762,7 @@ import java.util.stream.Collectors;
 		addVerticalTab("locales", L10N.t("workspace.category.variables"), new WorkspacePanelVariables(this));
 		addVerticalTab("variables", L10N.t("workspace.category.localization"), new WorkspacePanelLocalizations(this));
 
-		verticalTabs.get(0).doClick();
+		switchToVerticalTab("mods");
 
 		elementsBreadcrumb.reloadPath(currentFolder, ModElement.class);
 
@@ -846,6 +846,7 @@ import java.util.stream.Collectors;
 
 		if (section.isSupportedInWorkspace()) {
 			VerticalTabButton tab = new VerticalTabButton(name);
+			tab.setName(id);
 			tab.setContentAreaFilled(false);
 			tab.setMargin(new Insets(7, 1, 7, 2));
 			tab.setBorderPainted(false);
@@ -853,18 +854,7 @@ import java.util.stream.Collectors;
 			tab.setOpaque(true);
 			tab.setBackground((Color) UIManager.get("MCreatorLAF.DARK_ACCENT"));
 			tab.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
-			tab.addActionListener(e -> {
-				if (section.canSwitchToSection()) {
-					for (JButton btt : verticalTabs) {
-						btt.setBackground(btt == tab ?
-								(Color) UIManager.get("MCreatorLAF.LIGHT_ACCENT") :
-								(Color) UIManager.get("MCreatorLAF.DARK_ACCENT"));
-					}
-					cardLayout.show(panels, id);
-					updateMods();
-					modElementsBar.setVisible(id.equals("mods"));
-				}
-			});
+			tab.addActionListener(e -> switchToVerticalTab(id));
 			verticalTabs.add(tab);
 			rotatablePanel.add(tab);
 		}
@@ -872,6 +862,19 @@ import java.util.stream.Collectors;
 
 	public AbstractWorkspacePanel getVerticalTab(String id) {
 		return sectionTabs.get(id);
+	}
+
+	public void switchToVerticalTab(String id) {
+		if (sectionTabs.get(id).canSwitchToSection()) {
+			for (JButton btt : verticalTabs) {
+				btt.setBackground(btt.getName().equals(id) ?
+						(Color) UIManager.get("MCreatorLAF.LIGHT_ACCENT") :
+						(Color) UIManager.get("MCreatorLAF.DARK_ACCENT"));
+			}
+			cardLayout.show(panels, id);
+			updateMods();
+			modElementsBar.setVisible(id.equals("mods"));
+		}
 	}
 
 	public void switchFolder(FolderElement switchTo) {


### PR DESCRIPTION
This PR moves contents of a vertical tab button listener added by `WorkspacePanel` to a separate method so that it's possible to change current workspace section automatically (could be useful for VCS plugin to block the **Remote workspace** page if the remote repository gets unlinked).