### PR TITLE
Disclose sensitive methods but discourage from using

### DIFF
--- a/src/main/java/net/mcreator/workspace/Workspace.java
+++ b/src/main/java/net/mcreator/workspace/Workspace.java
@@ -275,14 +275,20 @@ public class Workspace implements Closeable, IGeneratorProvider {
 		return changed;
 	}
 
-	protected void reloadModElements() {
+	/**
+	 * @apiNote This method performs sensitive operations on this workspace. Avoid using it!
+	 */
+	public void reloadModElements() {
 		// While reiniting, list may change due to converters, so we need to copy it
 		for (ModElement modElement : Set.copyOf(mod_elements)) {
 			modElement.reinit(this);
 		}
 	}
 
-	protected void reloadFolderStructure() {
+	/**
+	 * @apiNote This method performs sensitive operations on this workspace. Avoid using it!
+	 */
+	public void reloadFolderStructure() {
 		this.foldersRoot.updateStructure();
 
 		Set<String> validPaths = foldersRoot.getRecursiveFolderChildren().stream().map(FolderElement::getPath)
@@ -469,7 +475,11 @@ public class Workspace implements Closeable, IGeneratorProvider {
 
 	// Below are methods that may still be used by some plugins
 
-	@SuppressWarnings("unused") void loadStoredDataFrom(Workspace other) {
+	/**
+	 * @apiNote This method performs sensitive operations on this workspace. Avoid using it!
+	 * @param other The workspace to copy elements and settings from.
+	 */
+	@SuppressWarnings("unused") public void loadStoredDataFrom(Workspace other) {
 		this.mod_elements = other.mod_elements;
 		this.variable_elements = other.variable_elements;
 		this.sound_elements = other.sound_elements;

--- a/src/main/java/net/mcreator/workspace/elements/ModElement.java
+++ b/src/main/java/net/mcreator/workspace/elements/ModElement.java
@@ -283,11 +283,11 @@ public class ModElement implements Serializable, IWorkspaceProvider, IGeneratorP
 				iCommonType.getBaseTypesProvided() :
 				Collections.emptyList();
 	}
+
 	/**
 	 * @apiNote This method performs sensitive operations on this mod element. Avoid using it!
 	 * @param other The mod element to copy settings from.
 	 */
-
 	@SuppressWarnings("unused") public void loadDataFrom(ModElement other) {
 		this.compiles = other.compiles;
 		this.locked_code = other.locked_code;

--- a/src/main/java/net/mcreator/workspace/elements/ModElement.java
+++ b/src/main/java/net/mcreator/workspace/elements/ModElement.java
@@ -105,7 +105,11 @@ public class ModElement implements Serializable, IWorkspaceProvider, IGeneratorP
 		return this.workspace.getModElementManager().loadGeneratableElement(this);
 	}
 
-	public void loadDataFrom(ModElement other) {
+	/**
+	 * @apiNote This method performs sensitive operations on this mod element. Avoid using it!
+	 * @param other The mod element to copy settings from.
+	 */
+	@SuppressWarnings("unused") public void loadDataFrom(ModElement other) {
 		this.compiles = other.compiles;
 		this.locked_code = other.locked_code;
 		this.sortid = other.sortid;

--- a/src/main/java/net/mcreator/workspace/elements/ModElement.java
+++ b/src/main/java/net/mcreator/workspace/elements/ModElement.java
@@ -287,6 +287,7 @@ public class ModElement implements Serializable, IWorkspaceProvider, IGeneratorP
 	 * @apiNote This method performs sensitive operations on this mod element. Avoid using it!
 	 * @param other The mod element to copy settings from.
 	 */
+
 	@SuppressWarnings("unused") public void loadDataFrom(ModElement other) {
 		this.compiles = other.compiles;
 		this.locked_code = other.locked_code;
@@ -297,7 +298,6 @@ public class ModElement implements Serializable, IWorkspaceProvider, IGeneratorP
 		this.elementIcon = other.elementIcon;
 		this.workspace = other.workspace;
 	}
-
 
 	public static class ModElementDeserializer implements JsonDeserializer<ModElement> {
 

--- a/src/main/java/net/mcreator/workspace/elements/ModElementManager.java
+++ b/src/main/java/net/mcreator/workspace/elements/ModElementManager.java
@@ -216,8 +216,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 	/**
 	 * Invalidates the generatable element cache
+	 * @apiNote This method performs sensitive operations on host workspace. Avoid using it!
 	 */
-	public void invalidateCache() {
+	@SuppressWarnings("unused") public void invalidateCache() {
 		cache.clear();
 	}
 


### PR DESCRIPTION
This PR grants `public` access modifier to some sensitive/dangerous methods in `Workspace` class and some others and adds API note to their documentation warning that they should not be used when possible.