### PR TITLE
Slightly shorter entity GUI texts

### DIFF
--- a/plugins/mcreator-localization/lang/texts.properties
+++ b/plugins/mcreator-localization/lang/texts.properties
@@ -2392,7 +2392,7 @@ elementgui.keybind.error_key_needs_name=Key binding needs a name
 elementgui.keybind.error_key_category_needs_name=Key binding category key name
 elementgui.living_entity.condition_solid_bounding_box=Is bounding box solid?
 elementgui.living_entity.disable_collisions=Disable collisions
-elementgui.living_entity.has_ai=<html><b>Enable AI</b><br><small>When using AI, make sure to have some AI tasks defined below
+elementgui.living_entity.has_ai=<html><b>Enable AI</b><br><small>Make sure to have some AI tasks defined below
 elementgui.living_entity.immune_fire=Fire
 elementgui.living_entity.immune_arrows=Arrows
 elementgui.living_entity.immune_fall_damage=Fall damage
@@ -2414,9 +2414,9 @@ elementgui.living_entity.spawn_dungeons=Spawn in dungeons
 elementgui.living_entity.is_rideable=Rideable
 elementgui.living_entity.control_forward=Forward movement control
 elementgui.living_entity.control_strafe=Strafe movement control
-elementgui.living_entity.is_breedable=<html>Make this entity <b>animal type</b>, breed items:<br><small>Entity base and behaviour type will be ignored if checked
+elementgui.living_entity.is_breedable=<html>Make this entity <b>animal type</b>, breed items:<br><small>Entity base and behaviour type will be ignored
 elementgui.living_entity.is_tameable=<html><b>Can tame</b>
-elementgui.living_entity.is_ranged=<html>Make entity do <b>ranged</b> attacks with item, attack interval and radius:<br>\
+elementgui.living_entity.is_ranged=<html>Enable <b>ranged</b> attacks with item, attack interval and radius:<br>\
   <small>Add at least one <b>Act aggressively against</b> AI task to define attack targets.<br>\
   If \"Default item\" is selected, select projectile item or keep empty to use arrow
 elementgui.living_entity.event_struck_by_lightning=When it is struck by lightning


### PR DESCRIPTION
Shortened some `<small>` texts on **AI and goals** page so they don't force horizontal scroll bar on smaller resolution monitors.