### PR TITLE
Mandatory "processors" template pool option

### DIFF
--- a/plugins/generator-1.19.4/datapack-1.19.4/templates/structure/template_pool.json.ftl
+++ b/plugins/generator-1.19.4/datapack-1.19.4/templates/structure/template_pool.json.ftl
@@ -9,8 +9,9 @@
         "element_type": "minecraft:single_pool_element",
         "location": "${modid}:${data.structure}",
         "projection": "${data.projection}",
-        "processors": [
-          <#if data.ignoredBlocks?has_content>
+        "processors": {
+          "processors": [
+            <#if data.ignoredBlocks?has_content>
             {
               "processor_type": "minecraft:block_ignore",
               "blocks": [
@@ -21,8 +22,9 @@
                 </#list>
               ]
             }
-          </#if>
-        ]
+            </#if>
+          ]
+        }
       }
     }
   ]

--- a/plugins/generator-1.19.4/datapack-1.19.4/templates/structure/template_pool.json.ftl
+++ b/plugins/generator-1.19.4/datapack-1.19.4/templates/structure/template_pool.json.ftl
@@ -8,10 +8,9 @@
       "element": {
         "element_type": "minecraft:single_pool_element",
         "location": "${modid}:${data.structure}",
-        "projection": "${data.projection}"
-        <#if data.ignoredBlocks?has_content>,
-        "processors": {
-          "processors": [
+        "projection": "${data.projection}",
+        "processors": [
+          <#if data.ignoredBlocks?has_content>
             {
               "processor_type": "minecraft:block_ignore",
               "blocks": [
@@ -22,9 +21,8 @@
                 </#list>
               ]
             }
-          ]
-        }
-        </#if>
+          </#if>
+        ]
       }
     }
   ]

--- a/plugins/generator-1.20.1/datapack-1.20.1/templates/structure/template_pool.json.ftl
+++ b/plugins/generator-1.20.1/datapack-1.20.1/templates/structure/template_pool.json.ftl
@@ -9,8 +9,9 @@
         "element_type": "minecraft:single_pool_element",
         "location": "${modid}:${data.structure}",
         "projection": "${data.projection}",
-        "processors": [
-          <#if data.ignoredBlocks?has_content>
+        "processors": {
+          "processors": [
+            <#if data.ignoredBlocks?has_content>
             {
               "processor_type": "minecraft:block_ignore",
               "blocks": [
@@ -21,8 +22,9 @@
                 </#list>
               ]
             }
-          </#if>
-        ]
+            </#if>
+          ]
+        }
       }
     }
   ]

--- a/plugins/generator-1.20.1/datapack-1.20.1/templates/structure/template_pool.json.ftl
+++ b/plugins/generator-1.20.1/datapack-1.20.1/templates/structure/template_pool.json.ftl
@@ -8,10 +8,9 @@
       "element": {
         "element_type": "minecraft:single_pool_element",
         "location": "${modid}:${data.structure}",
-        "projection": "${data.projection}"
-        <#if data.ignoredBlocks?has_content>,
-        "processors": {
-          "processors": [
+        "projection": "${data.projection}",
+        "processors": [
+          <#if data.ignoredBlocks?has_content>
             {
               "processor_type": "minecraft:block_ignore",
               "blocks": [
@@ -22,9 +21,8 @@
                 </#list>
               ]
             }
-          ]
-        }
-        </#if>
+          </#if>
+        ]
       }
     }
   ]


### PR DESCRIPTION
Fixes a bug found while testing #4400 when leaving ignored blocks list empty lead to game crashes.