### PR TITLE
Allow access to property parameters

### DIFF
--- a/src/main/java/net/mcreator/ui/minecraft/states/PropertyData.java
+++ b/src/main/java/net/mcreator/ui/minecraft/states/PropertyData.java
@@ -191,6 +191,14 @@ import java.util.stream.Collectors;
 			this.max = max;
 		}
 
+		public int getMin() {
+			return min;
+		}
+
+		public int getMax() {
+			return max;
+		}
+
 		@Override @Nonnull public Integer getDefaultValue() {
 			return 0;
 		}
@@ -234,6 +242,14 @@ import java.util.stream.Collectors;
 			this.max = max;
 		}
 
+		public double getMin() {
+			return min;
+		}
+
+		public double getMax() {
+			return max;
+		}
+
 		@Override @Nonnull public Double getDefaultValue() {
 			return 0d;
 		}
@@ -273,6 +289,10 @@ import java.util.stream.Collectors;
 		public StringType(String name, String[] arrayData) {
 			super(name);
 			this.arrayData = arrayData;
+		}
+
+		public String[] getArrayData() {
+			return arrayData;
 		}
 
 		@Override @Nonnull public String getDefaultValue() {


### PR DESCRIPTION
Adds methods to access value range parameters of `PropertyData<?>` objects. Needed by block state properties, but could also be used in other places so here's the PR.