### PR TITLE
Include entities when placing custom structure features

### DIFF
--- a/plugins/generator-1.19.4/forge-1.19.4/templates/feature/structure_feature.java.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/templates/feature/structure_feature.java.ftl
@@ -52,7 +52,7 @@ import com.mojang.serialization.Codec;
 		// Load the structure template
 		StructureTemplateManager structureManager = worldGenLevel.getLevel().getServer().getStructureManager();
 		StructureTemplate template = structureManager.getOrCreate(config.structure());
-		StructurePlaceSettings placeSettings = (new StructurePlaceSettings()).setRotation(rotation).setMirror(mirror).setRandom(random).setIgnoreEntities(true)
+		StructurePlaceSettings placeSettings = (new StructurePlaceSettings()).setRotation(rotation).setMirror(mirror).setRandom(random).setIgnoreEntities(false)
 				.addProcessor(new BlockIgnoreProcessor(config.ignoredBlocks().stream().map(Holder::get).toList()));
 		template.placeInWorld(worldGenLevel, placePos, placePos, placeSettings, random, 4);
 		return true;

--- a/plugins/generator-1.20.1/forge-1.20.1/templates/feature/structure_feature.java.ftl
+++ b/plugins/generator-1.20.1/forge-1.20.1/templates/feature/structure_feature.java.ftl
@@ -52,7 +52,7 @@ import com.mojang.serialization.Codec;
 		// Load the structure template
 		StructureTemplateManager structureManager = worldGenLevel.getLevel().getServer().getStructureManager();
 		StructureTemplate template = structureManager.getOrCreate(config.structure());
-		StructurePlaceSettings placeSettings = (new StructurePlaceSettings()).setRotation(rotation).setMirror(mirror).setRandom(random).setIgnoreEntities(true)
+		StructurePlaceSettings placeSettings = (new StructurePlaceSettings()).setRotation(rotation).setMirror(mirror).setRandom(random).setIgnoreEntities(false)
 				.addProcessor(new BlockIgnoreProcessor(config.ignoredBlocks().stream().map(Holder::get).toList()));
 		template.placeInWorld(worldGenLevel, placePos, placePos, placeSettings, random, 4);
 		return true;


### PR DESCRIPTION
Reverts the `ignoreEntities` setting in the generated code to its value prior to #4247 and #4274. Fixes #4458.