### PR TITLE
Require version list for plugins instead of version range

### DIFF
--- a/plugins/generator-1.19.4/plugin.json
+++ b/plugins/generator-1.19.4/plugin.json
@@ -1,6 +1,5 @@
 {
   "id": "generator-1.19.4",
-  "minversion": 202300200000,
   "info": {
     "name": "Minecraft 1.19.4 Java Edition generator"
   }

--- a/plugins/generator-1.20.1/plugin.json
+++ b/plugins/generator-1.20.1/plugin.json
@@ -1,6 +1,5 @@
 {
   "id": "generator-1.20.1",
-  "minversion": 202300200000,
   "info": {
     "name": "Minecraft 1.20.1 Java Edition generator"
   }

--- a/plugins/generator-addon-1.20.x/plugin.json
+++ b/plugins/generator-addon-1.20.x/plugin.json
@@ -1,6 +1,5 @@
 {
   "id": "generator-addon-1.20.x",
-  "minversion": 202200200000,
   "info": {
     "name": "Minecraft 1.20.x Bedrock Edition generator"
   }

--- a/plugins/mcreator-core/plugin.json
+++ b/plugins/mcreator-core/plugin.json
@@ -1,7 +1,6 @@
 {
   "id": "core",
   "weight": 10,
-  "minversion": 202000400000,
   "info": {
     "name": "MCreator core plugin"
   }

--- a/plugins/mcreator-link/plugin.json
+++ b/plugins/mcreator-link/plugin.json
@@ -1,6 +1,5 @@
 {
   "id": "mcreator-link",
-  "minversion": 202000400000,
   "info": {
     "name": "MCreator Link support"
   }

--- a/plugins/mcreator-localization/plugin.json
+++ b/plugins/mcreator-localization/plugin.json
@@ -1,7 +1,6 @@
 {
   "id": "localization",
   "weight": 10,
-  "minversion": 202000400000,
   "info": {
     "name": "MCreator localization plugin"
   }

--- a/plugins/mcreator-themes/plugin.json
+++ b/plugins/mcreator-themes/plugin.json
@@ -1,7 +1,6 @@
 {
   "id": "themes",
   "weight": 10,
-  "minversion": 202100199999,
   "info": {
     "name": "MCreator UI theme plugin"
   }

--- a/src/main/java/net/mcreator/plugin/Plugin.java
+++ b/src/main/java/net/mcreator/plugin/Plugin.java
@@ -130,6 +130,13 @@ public class Plugin implements Comparable<Plugin> {
 	}
 
 	/**
+	 * @return <p>The maximal version of MCreator needed to use the plugin.</p>
+	 */
+	public long getMaxVersion() {
+		return maxversion;
+	}
+
+	/**
 	 * @return <p>The MCreator's version when builtin and the plugin's version in the other case</p>
 	 */
 	public String getPluginVersion() {
@@ -150,6 +157,10 @@ public class Plugin implements Comparable<Plugin> {
 
 	@Nullable public String getLoadFailure() {
 		return loaded_failure;
+	}
+
+	public boolean isJavaPlugin() {
+		return javaplugin != null;
 	}
 
 	@Nullable public String getJavaPlugin() {

--- a/src/main/java/net/mcreator/plugin/Plugin.java
+++ b/src/main/java/net/mcreator/plugin/Plugin.java
@@ -25,6 +25,7 @@ import javax.annotation.Nullable;
 import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.List;
 
 /**
  * <p>A Plugin is a mod for MCreator allowing to alter, improve or extend features. Most of elements inside MCreator are plugin driven.</p>
@@ -38,8 +39,7 @@ public class Plugin implements Comparable<Plugin> {
 	String id;
 	private int weight = 0;
 
-	private long minversion = -1;
-	private long maxversion = -1;
+	@Nullable private List<Long> supportedversions;
 
 	private PluginInfo info;
 
@@ -104,36 +104,20 @@ public class Plugin implements Comparable<Plugin> {
 	}
 
 	/**
-	 * <p>The plugin is compatible when the minimal version is lower or equal to the current MCreator's version and
-	 * the maximal version is higher or equal to the current version. When a field is not defined, the field is considered as compatible.</p>
+	 * <p>The plugin is compatible when the version of MCreator used is included in the supported versions list.</p>
+	 * <p>When the supported versions list is null, the plugin is compatible with all versions of MCreator.</p>
 	 *
 	 * @return <p>If the plugin is compatible with the version used.</p>
 	 */
 	public boolean isCompatible() {
-		if (minversion != -1) {
-			if (Launcher.version.versionlong < minversion)
-				return false;
-		}
-
-		if (maxversion != -1) {
-			return Launcher.version.versionlong <= maxversion;
-		}
-
-		return true;
+		return supportedversions == null || supportedversions.contains(Launcher.version.versionlong);
 	}
 
 	/**
-	 * @return <p>The minimal version of MCreator needed to use the plugin.</p>
+	 * @return <p>The list of supported versions</p>
 	 */
-	public long getMinVersion() {
-		return minversion;
-	}
-
-	/**
-	 * @return <p>The maximal version of MCreator needed to use the plugin.</p>
-	 */
-	public long getMaxVersion() {
-		return maxversion;
+	@Nullable public List<Long> getSupportedVersions() {
+		return supportedversions;
 	}
 
 	/**

--- a/src/main/java/net/mcreator/plugin/PluginLoader.java
+++ b/src/main/java/net/mcreator/plugin/PluginLoader.java
@@ -282,22 +282,16 @@ public class PluginLoader extends URLClassLoader {
 	}
 
 	@Nullable private Plugin validatePlugin(Plugin plugin) {
+		if (!plugin.isBuiltin() && plugin.getSupportedVersions() == null) {
+			failedPlugins.add(new PluginLoadFailure(plugin, "missing supportedversions"));
+			LOG.warn("Plugin " + plugin.getID() + " does not specify supportedversions. Skipping this plugin.");
+			return null;
+		}
+
 		if (!plugin.isCompatible()) {
 			failedPlugins.add(new PluginLoadFailure(plugin, "incompatible version"));
 			LOG.warn("Plugin " + plugin.getID()
 					+ " is not compatible with this MCreator version! Skipping this plugin.");
-			return null;
-		}
-
-		if (plugin.getMinVersion() < 0) {
-			failedPlugins.add(new PluginLoadFailure(plugin, "missing minversion"));
-			LOG.warn("Plugin " + plugin.getID() + " does not specify minversion. Skipping this plugin.");
-			return null;
-		}
-
-		if (plugin.isJavaPlugin() && plugin.getMaxVersion() < 0) {
-			failedPlugins.add(new PluginLoadFailure(plugin, "missing maxversion"));
-			LOG.warn("Plugin " + plugin.getID() + " does not specify maxversion. Skipping this plugin.");
 			return null;
 		}
 

--- a/src/main/java/net/mcreator/plugin/PluginLoader.java
+++ b/src/main/java/net/mcreator/plugin/PluginLoader.java
@@ -114,7 +114,7 @@ public class PluginLoader extends URLClassLoader {
 						+ plugin.getWeight());
 				addURL(plugin.toURL());
 
-				if (PreferencesManager.PREFERENCES.hidden.enableJavaPlugins.get() && plugin.getJavaPlugin() != null) {
+				if (PreferencesManager.PREFERENCES.hidden.enableJavaPlugins.get() && plugin.isJavaPlugin()) {
 					@SuppressWarnings("resource") DynamicURLClassLoader javaPluginCL = new DynamicURLClassLoader(
 							"PluginClassLoader-" + plugin.getID(), new URL[] {},
 							Thread.currentThread().getContextClassLoader()) {
@@ -147,7 +147,7 @@ public class PluginLoader extends URLClassLoader {
 					Constructor<?> ctor = clazz.getConstructor(Plugin.class);
 					JavaPlugin javaPlugin = (JavaPlugin) ctor.newInstance(plugin);
 					javaPlugins.add(javaPlugin);
-				} else if (plugin.getJavaPlugin() != null) {
+				} else if (plugin.isJavaPlugin()) {
 					LOG.warn(plugin.getID() + " is Java plugin, but Java plugins are disabled in preferences");
 
 					plugin.loaded_failure = "Java plugins disabled";
@@ -292,6 +292,12 @@ public class PluginLoader extends URLClassLoader {
 		if (plugin.getMinVersion() < 0) {
 			failedPlugins.add(new PluginLoadFailure(plugin, "missing minversion"));
 			LOG.warn("Plugin " + plugin.getID() + " does not specify minversion. Skipping this plugin.");
+			return null;
+		}
+
+		if (plugin.isJavaPlugin() && plugin.getMaxVersion() < 0) {
+			failedPlugins.add(new PluginLoadFailure(plugin, "missing maxversion"));
+			LOG.warn("Plugin " + plugin.getID() + " does not specify maxversion. Skipping this plugin.");
 			return null;
 		}
 


### PR DESCRIPTION
Due to plugins not using maxversion, we need to enforce this rule. If we do not do this, workspaces will continuously break when users are loading plugins that are not compatible with updates.

In the current state, PR only no longer uses min and max version but instead requires users to specify a list of version IDs for all versions the plugin has been tested with and works with.

This will effectively render all current plugins not work out of the box and require authors to update them to work with new versions which in turn also requires plugin authors to actively test their plugins.

min and max version fields can still be present so the plugin can also load with pre 2024.1 MCreators in case the plugin is simple enough to work with older versions too and nothing changed (very simple procedure plugins, themes, etc.)