### PR TITLE
Proper cursor when searching mod element usages or build errors

### DIFF
--- a/src/main/java/net/mcreator/ui/dialogs/CodeErrorDialog.java
+++ b/src/main/java/net/mcreator/ui/dialogs/CodeErrorDialog.java
@@ -50,7 +50,7 @@ public class CodeErrorDialog {
 	public static boolean showCodeErrorDialog(MCreator mcreator, String stderroutput) {
 		Set<File> problematicFiles = new HashSet<>();
 
-		mcreator.setCursor(new Cursor(Cursor.WAIT_CURSOR));
+		mcreator.mv.setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
 
 		stderroutput.lines().forEach(line -> {
 			if (line.contains(".java:") && line.contains(": error:")) {
@@ -75,7 +75,7 @@ public class CodeErrorDialog {
 			}
 		}
 
-		mcreator.setCursor(Cursor.getDefaultCursor());
+		mcreator.mv.setCursor(Cursor.getDefaultCursor());
 
 		if (moddefinitionfileerrors) { // first we try to fix mod definition errors
 			Object[] options = { L10N.t("dialog.code_error.regenerate_code"),

--- a/src/main/java/net/mcreator/ui/workspace/WorkspacePanel.java
+++ b/src/main/java/net/mcreator/ui/workspace/WorkspacePanel.java
@@ -1068,7 +1068,7 @@ import java.util.stream.Collectors;
 
 	private void searchModElementsUsages() {
 		if (list.getSelectedValuesList().stream().anyMatch(i -> i instanceof ModElement)) {
-			mcreator.setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
+			mcreator.mv.setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
 
 			Set<ModElement> references = new HashSet<>();
 			boolean tagsSelected = false, nonTagsSelected = false;
@@ -1084,7 +1084,7 @@ import java.util.stream.Collectors;
 				}
 			}
 
-			mcreator.setCursor(Cursor.getDefaultCursor());
+			mcreator.mv.setCursor(Cursor.getDefaultCursor());
 			if (tagsSelected) {
 				JOptionPane.showMessageDialog(mcreator, L10N.t("workspace.elements.list.edit.usages.tags"),
 						L10N.t("workspace.elements.list.edit.usages.tags.title"), JOptionPane.WARNING_MESSAGE);
@@ -1211,7 +1211,7 @@ import java.util.stream.Collectors;
 	private void deleteCurrentlySelectedModElement() {
 		if (but3.isEnabled()) {
 			if (list.getSelectedValue() != null) {
-				mcreator.setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
+				mcreator.mv.setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
 
 				Set<ModElement> references = new HashSet<>();
 				for (IElement el : list.getSelectedValuesList()) {
@@ -1221,7 +1221,7 @@ import java.util.stream.Collectors;
 				list.getSelectedValuesList().stream() // exclude usages by other mod elements being removed
 						.filter(e -> e instanceof ModElement).map(e -> (ModElement) e).forEach(references::remove);
 
-				mcreator.setCursor(Cursor.getDefaultCursor());
+				mcreator.mv.setCursor(Cursor.getDefaultCursor());
 
 				if (SearchUsagesDialog.showDeleteDialog(mcreator, L10N.t("dialog.search_usages.type.mod_element"),
 						references, L10N.t("workspace.elements.confirm_delete_msg_suffix"))) {


### PR DESCRIPTION
Modifies the code so that cursor is changed for the `WorkspacePanel` and not for the entire `MCreator`.
Testing on huge workspaces very needed and appreciated.