### PR TITLE
cp437 support for ZIP files

### DIFF
--- a/src/main/java/net/mcreator/io/zip/ZipIO.java
+++ b/src/main/java/net/mcreator/io/zip/ZipIO.java
@@ -30,6 +30,7 @@ import java.util.*;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.zip.ZipEntry;
+import java.util.zip.ZipException;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipOutputStream;
 
@@ -40,8 +41,8 @@ public class ZipIO {
 	public static ZipFile openZipFile(File zipFile) throws IOException {
 		try {
 			return new ZipFile(zipFile);
-		} catch (Exception e) {
-			return new ZipFile(zipFile, Charset.forName("Cp437"));
+		} catch (ZipException e) {
+			return new ZipFile(zipFile, Charset.forName("cp437"));
 		}
 	}
 

--- a/src/main/java/net/mcreator/io/zip/ZipIO.java
+++ b/src/main/java/net/mcreator/io/zip/ZipIO.java
@@ -22,6 +22,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.*;
+import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
@@ -30,15 +31,42 @@ import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
-import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
 
 public class ZipIO {
 
 	private static final Logger LOG = LogManager.getLogger("ZipIO");
 
+	public static ZipFile openZipFile(File zipFile) throws IOException {
+		try {
+			return new ZipFile(zipFile);
+		} catch (Exception e) {
+			return new ZipFile(zipFile, Charset.forName("Cp437"));
+		}
+	}
+
+	public static void unzip(String strZipFile, String dst) {
+		Path extractFolder = new File(dst).toPath();
+		try (ZipFile zipFile = openZipFile(new File(strZipFile))) {
+			Enumeration<? extends ZipEntry> entries = zipFile.entries();
+			while (entries.hasMoreElements()) {
+				ZipEntry entry = entries.nextElement();
+				Path toPath = extractFolder.resolve(entry.getName());
+				if (entry.isDirectory()) {
+					toPath.toFile().mkdirs();
+				} else {
+					toPath.toFile().getParentFile().mkdirs();
+					Files.copy(zipFile.getInputStream(entry), toPath, StandardCopyOption.REPLACE_EXISTING);
+				}
+			}
+		} catch (IOException e) {
+			LOG.error(e.getMessage(), e);
+			LOG.info("Failed to extract zip file:" + e.getMessage());
+		}
+	}
+
 	public static void iterateZip(File zipFilePointer, Consumer<ZipEntry> action, boolean sortByName) {
-		try (ZipFile zipFile = new ZipFile(zipFilePointer)) {
+		try (ZipFile zipFile = openZipFile(zipFilePointer)) {
 			List<? extends ZipEntry> entries = Collections.list(zipFile.entries());
 			if (sortByName)
 				entries.sort(Comparator.comparing(ZipEntry::getName));
@@ -46,6 +74,24 @@ public class ZipIO {
 		} catch (IOException e) {
 			LOG.error(e.getMessage(), e);
 		}
+	}
+
+	public static <T> T readFileInZip(File zipFilePointer, String path, BiFunction<ZipFile, ZipEntry, T> transformer) {
+		if (path.startsWith("/"))
+			path = path.substring(1);
+
+		try (ZipFile zipFile = openZipFile(zipFilePointer)) {
+			Enumeration<? extends ZipEntry> entries = zipFile.entries();
+			while (entries.hasMoreElements()) {
+				ZipEntry zipEntry = entries.nextElement();
+				if (zipEntry.toString().startsWith(path)) {
+					return transformer.apply(zipFile, zipEntry);
+				}
+			}
+		} catch (IOException e) {
+			LOG.error(e.getMessage(), e);
+		}
+		return null;
 	}
 
 	public static String entryToString(ZipFile file, ZipEntry entry) {
@@ -63,24 +109,6 @@ public class ZipIO {
 
 	public static String readCodeInZip(File zipFilePointer, String path) {
 		return readFileInZip(zipFilePointer, path, ZipIO::entryToString);
-	}
-
-	public static <T> T readFileInZip(File zipFilePointer, String path, BiFunction<ZipFile, ZipEntry, T> transformer) {
-		if (path.startsWith("/"))
-			path = path.substring(1);
-
-		try (ZipFile zipFile = new ZipFile(zipFilePointer)) {
-			Enumeration<? extends ZipEntry> entries = zipFile.entries();
-			while (entries.hasMoreElements()) {
-				ZipEntry zipEntry = entries.nextElement();
-				if (zipEntry.toString().startsWith(path)) {
-					return transformer.apply(zipFile, zipEntry);
-				}
-			}
-		} catch (IOException e) {
-			LOG.error(e.getMessage(), e);
-		}
-		return null;
 	}
 
 	public static void zipDir(String dirName, String nameZipFile, String... excludes) throws IOException {
@@ -154,25 +182,6 @@ public class ZipIO {
 				}
 				in.close();
 			}
-		}
-	}
-
-	public static void unzip(String strZipFile, String dst) {
-		Path extractFolder = new File(dst).toPath();
-		try (ZipInputStream zipInputStream = new ZipInputStream(Files.newInputStream(new File(strZipFile).toPath()))) {
-			ZipEntry entry;
-			while ((entry = zipInputStream.getNextEntry()) != null) {
-				Path toPath = extractFolder.resolve(entry.getName());
-				if (entry.isDirectory()) {
-					toPath.toFile().mkdirs();
-				} else {
-					toPath.toFile().getParentFile().mkdirs();
-					Files.copy(zipInputStream, toPath, StandardCopyOption.REPLACE_EXISTING);
-				}
-			}
-		} catch (IOException e) {
-			LOG.error(e.getMessage(), e);
-			LOG.info("Failed to extract zip file:" + e.getMessage());
 		}
 	}
 

--- a/src/main/java/net/mcreator/java/ClassFinder.java
+++ b/src/main/java/net/mcreator/java/ClassFinder.java
@@ -90,7 +90,7 @@ public class ClassFinder {
 			String classfqdn) {
 		if (sourceLocation != null) {
 			if (sourceLocation instanceof ZipSourceLocation) {
-				try (ZipFile zipFile = new ZipFile(new File(sourceLocation.getLocationAsString()))) {
+				try (ZipFile zipFile = ZipIO.openZipFile(new File(sourceLocation.getLocationAsString()))) {
 					String entryName = classfqdn.replaceAll("\\.", "/");
 					entryName = entryName + ".java";
 

--- a/src/main/java/net/mcreator/java/ImportTreeBuilder.java
+++ b/src/main/java/net/mcreator/java/ImportTreeBuilder.java
@@ -45,7 +45,7 @@ public class ImportTreeBuilder {
 		libraryInfos.parallelStream().forEach(libraryInfo -> {
 			File libraryFile = new File(libraryInfo.getLocationAsString());
 			if (libraryFile.isFile() && (ZipIO.checkIfZip(libraryFile) || libraryFile.getName().endsWith(".jmod"))) {
-				try (ZipFile zipFile = new ZipFile(libraryFile)) {
+				try (ZipFile zipFile = ZipIO.openZipFile(libraryFile)) {
 					Enumeration<? extends ZipEntry> entries = zipFile.entries();
 					boolean isJmod = libraryFile.getName().endsWith(".jmod");
 					while (entries.hasMoreElements()) {

--- a/src/main/java/net/mcreator/java/JModLibraryInfo.java
+++ b/src/main/java/net/mcreator/java/JModLibraryInfo.java
@@ -19,6 +19,7 @@
 
 package net.mcreator.java;
 
+import net.mcreator.io.zip.ZipIO;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -62,7 +63,7 @@ public class JModLibraryInfo extends LibraryInfo {
 
 	@Override public void bulkClassFileCreationStart() {
 		try {
-			bulkCreateZip = new ZipFile(jmodFile);
+			bulkCreateZip = ZipIO.openZipFile(jmodFile);
 		} catch (IOException e) {
 			LOG.error("Failed to start class file creation", e);
 		}


### PR DESCRIPTION
Support to handle Cp437-encoded file names in ZIP files which can happen on some Windows OS locales when zipping files with OS-provided tools