### PR TITLE
Make project browser try to detect folders in libraries' contents

### DIFF
--- a/src/main/java/net/mcreator/ui/browser/WorkspaceFileBrowser.java
+++ b/src/main/java/net/mcreator/ui/browser/WorkspaceFileBrowser.java
@@ -509,7 +509,7 @@ public class WorkspaceFileBrowser extends JPanel {
 				else if (fileNode.data.startsWith("Java "))
 					a.setIcon(UIRES.get("16px.directory.gif"));
 				else
-					a.setIcon(FileIcons.getIconForFile(fileNode.data, fileNode.isLeaf()));
+					a.setIcon(FileIcons.getIconForFile(fileNode.data, !fileNode.isLeaf()));
 			} else if (node.getUserObject() instanceof File fil) {
 				a.setText(fil.getName());
 				a.setIcon(FileIcons.getIconForFile(fil));

--- a/src/main/java/net/mcreator/ui/browser/WorkspaceFileBrowser.java
+++ b/src/main/java/net/mcreator/ui/browser/WorkspaceFileBrowser.java
@@ -512,10 +512,7 @@ public class WorkspaceFileBrowser extends JPanel {
 					a.setIcon(FileIcons.getIconForFile(fileNode.data, fileNode.isLeaf()));
 			} else if (node.getUserObject() instanceof File fil) {
 				a.setText(fil.getName());
-				if (!fil.isDirectory())
-					a.setIcon(FileIcons.getIconForFile(fil));
-				else
-					a.setIcon(UIRES.get("laf.directory.gif"));
+				a.setIcon(FileIcons.getIconForFile(fil));
 			}
 
 			if (node.getFilter() != null && !node.getFilter().isEmpty()) {

--- a/src/main/java/net/mcreator/ui/browser/WorkspaceFileBrowser.java
+++ b/src/main/java/net/mcreator/ui/browser/WorkspaceFileBrowser.java
@@ -509,7 +509,7 @@ public class WorkspaceFileBrowser extends JPanel {
 				else if (fileNode.data.startsWith("Java "))
 					a.setIcon(UIRES.get("16px.directory.gif"));
 				else
-					a.setIcon(FileIcons.getIconForFile(fileNode.data));
+					a.setIcon(FileIcons.getIconForFile(fileNode.data, fileNode.isLeaf()));
 			} else if (node.getUserObject() instanceof File fil) {
 				a.setText(fil.getName());
 				if (!fil.isDirectory())

--- a/src/main/java/net/mcreator/ui/component/JFileBreadCrumb.java
+++ b/src/main/java/net/mcreator/ui/component/JFileBreadCrumb.java
@@ -87,10 +87,7 @@ public class JFileBreadCrumb extends JPanel {
 			JLabel entry = new JLabel(((idx == path.size() - 1 && !filePathPart.isDirectory()) ? "<html><b>" : "")
 					+ filePathPart.getName());
 
-			if (filePathPart.isFile())
-				entry.setIcon(FileIcons.getIconForFile(filePathPart));
-			else
-				entry.setIcon(UIRES.get("laf.directory.gif"));
+			entry.setIcon(FileIcons.getIconForFile(filePathPart));
 
 			add(entry);
 			if (idx < path.size() - 1 || filePathPart.isDirectory()) {
@@ -100,10 +97,7 @@ public class JFileBreadCrumb extends JPanel {
 						File[] files = filePathPart.listFiles();
 						for (File file : files != null ? files : new File[0]) {
 							JMenuItem menuItem = new JMenuItem(file.getName());
-							if (file.isFile())
-								menuItem.setIcon(FileIcons.getIconForFile(file));
-							else
-								menuItem.setIcon(UIRES.get("laf.directory.gif"));
+							menuItem.setIcon(FileIcons.getIconForFile(file));
 							menuItem.addActionListener(e -> {
 								if (file.isFile()) {
 									FileOpener.openFile(mcreator, file);

--- a/src/main/java/net/mcreator/ui/laf/FileIcons.java
+++ b/src/main/java/net/mcreator/ui/laf/FileIcons.java
@@ -30,6 +30,9 @@ public class FileIcons {
 	}
 
 	public static ImageIcon getIconForFile(String file, boolean leaf) {
+		if (!leaf)
+			return UIRES.get("laf.directory.gif");
+
 		if (file.endsWith(".java"))
 			return UIRES.get("16px.class.gif");
 		if (file.endsWith(".ogg"))
@@ -45,7 +48,7 @@ public class FileIcons {
 		if (file.endsWith(".png") || file.endsWith(".gif"))
 			return UIRES.get("laf.image.gif");
 
-		return leaf ? UIRES.get("laf.file.gif") : UIRES.get("laf.directory.gif");
+		return UIRES.get("laf.file.gif");
 	}
 
 }

--- a/src/main/java/net/mcreator/ui/laf/FileIcons.java
+++ b/src/main/java/net/mcreator/ui/laf/FileIcons.java
@@ -26,11 +26,11 @@ import java.io.File;
 public class FileIcons {
 
 	public static ImageIcon getIconForFile(File file) {
-		return getIconForFile(file.getName(), !file.isDirectory());
+		return getIconForFile(file.getName(), file.isDirectory());
 	}
 
-	public static ImageIcon getIconForFile(String file, boolean leaf) {
-		if (!leaf)
+	public static ImageIcon getIconForFile(String file, boolean folder) {
+		if (folder)
 			return UIRES.get("laf.directory.gif");
 
 		if (file.endsWith(".java"))

--- a/src/main/java/net/mcreator/ui/laf/FileIcons.java
+++ b/src/main/java/net/mcreator/ui/laf/FileIcons.java
@@ -26,10 +26,10 @@ import java.io.File;
 public class FileIcons {
 
 	public static ImageIcon getIconForFile(File file) {
-		return getIconForFile(file.getName());
+		return getIconForFile(file.getName(), !file.isDirectory());
 	}
 
-	public static ImageIcon getIconForFile(String file) {
+	public static ImageIcon getIconForFile(String file, boolean leaf) {
 		if (file.endsWith(".java"))
 			return UIRES.get("16px.class.gif");
 		if (file.endsWith(".ogg"))
@@ -45,7 +45,7 @@ public class FileIcons {
 		if (file.endsWith(".png") || file.endsWith(".gif"))
 			return UIRES.get("laf.image.gif");
 
-		return UIRES.get("laf.file.gif");
+		return leaf ? UIRES.get("laf.file.gif") : UIRES.get("laf.directory.gif");
 	}
 
 }


### PR DESCRIPTION
Adds a parameter to method in `FileIcons` to enable picking different icons for regular files and folders.