### PR TITLE
Fix repeating field extension always assigning the empty string to new fields

### DIFF
--- a/plugins/mcreator-core/blockly/js/mcreator_extensions.js
+++ b/plugins/mcreator-core/blockly/js/mcreator_extensions.js
@@ -370,8 +370,9 @@ function simpleRepeatingInputMixin(mutatorContainer, mutatorInput, inputName, in
                 }
                 if (fieldValues[i]) {
                     for (let j = 0; j < fieldNames.length; j++) {
-                        let currentField = this.getField(fieldNames[j] + i);
-                        currentField.setValue(fieldValues[i][j] ?? '');
+                        // If this is a new field, then keep its initial value, otherwise assign the stored value
+                        if (fieldValues[i][j] != null)
+                        	this.getField(fieldNames[j] + i).setValue(fieldValues[i][j]);
                     }
                 }
             }


### PR DESCRIPTION
This PR fixes a bug with the repeating field extension, where new fields would have their value always set to the empty string.
The bug doesn't affect currently used extensions (block list, weighted lists), but it does affect e.g. dropdowns or text input fields.