### PR TITLE
Require correct macOS architecture

### DIFF
--- a/platform/mac/Info.plist
+++ b/platform/mac/Info.plist
@@ -18,6 +18,8 @@
         <string>mcreatorapp.icns</string>
         <key>LSMinimumSystemVersion</key>
         <string>11</string>
+        <key>LSRequiresNativeExecution</key>
+        <true/>
 
         <key>CFBundleInfoDictionaryVersion</key>
         <string>6.0</string>


### PR DESCRIPTION
Adds the key to only allow x86_64 mcreator to be run on intel macs, and not on rosetta. Fixes #4468 
<img width="498" alt="Screenshot 2024-01-18 at 8 07 10 PM" src="https://github.com/MCreator/MCreator/assets/65963376/53a9dd64-8630-42f8-b0ff-549306639f42">
