### PR TITLE
Remove Forge version lock

### DIFF
--- a/plugins/generator-1.19.4/forge-1.19.4/templates/modbase/mods.toml.ftl
+++ b/plugins/generator-1.19.4/forge-1.19.4/templates/modbase/mods.toml.ftl
@@ -35,15 +35,6 @@ displayTest="IGNORE_SERVER_VERSION"
     ordering="NONE"
     side="BOTH"
 
-<#if !settings.isDisableForgeVersionCheck()>
-[[dependencies.${settings.getModID()}]]
-    modId="forge"
-    mandatory=true
-    versionRange="[${generator.getGeneratorBuildFileVersion()}]"
-    ordering="NONE"
-    side="BOTH"
-</#if>
-
 <#list settings.getRequiredMods() as e>
 [[dependencies.${settings.getModID()}]]
     modId="${e}"

--- a/plugins/generator-1.20.1/forge-1.20.1/templates/modbase/mods.toml.ftl
+++ b/plugins/generator-1.20.1/forge-1.20.1/templates/modbase/mods.toml.ftl
@@ -35,15 +35,6 @@ displayTest="IGNORE_SERVER_VERSION"
     ordering="NONE"
     side="BOTH"
 
-<#if !settings.isDisableForgeVersionCheck()>
-[[dependencies.${settings.getModID()}]]
-    modId="forge"
-    mandatory=true
-    versionRange="[${generator.getGeneratorBuildFileVersion()}]"
-    ordering="NONE"
-    side="BOTH"
-</#if>
-
 <#list settings.getRequiredMods() as e>
 [[dependencies.${settings.getModID()}]]
     modId="${e}"

--- a/plugins/mcreator-localization/lang/texts.properties
+++ b/plugins/mcreator-localization/lang/texts.properties
@@ -2932,10 +2932,6 @@ dialog.workspace_settings.section.external_apis.tooltip=<html>Checkboxes to add 
   <br><small>WARNING: If your mod uses external APIs, it won''t work without them once you export it
 dialog.workspace_settings.explore_plugins=Explore plugins
 dialog.workspace_settings.plugins_tip=Looking for more APIs? Check MCreator plugins.
-dialog.workspace_settings.version_check=Forge version check
-dialog.workspace_settings.section.version_check=<html>Disable Minecraft Forge version check?\
-  <br><small>If you want to make sure users use the right Minecraft Forge version,\
-  <br>uncheck this and enable Minecraft Forge version checking.
 dialog.workspace_settings.section.advanced=Advanced settings
 dialog.workspace_settings.server_side_only=<html>Is this mod server-side only?
 dialog.workspace_settings.lock_base_files_label=<html>Lock base mod files?<br><small>Use ONLY if needed and you understand Java

--- a/src/main/java/net/mcreator/ui/dialogs/workspace/WorkspaceDialogs.java
+++ b/src/main/java/net/mcreator/ui/dialogs/workspace/WorkspaceDialogs.java
@@ -152,7 +152,6 @@ public class WorkspaceDialogs {
 		JComboBox<String> modPicture = new JComboBox<>();
 		JCheckBox lockBaseModFiles = L10N.checkbox("dialog.workspace_settings.lock_base_files");
 		JCheckBox serverSideOnly = L10N.checkbox("dialog.workspace_settings.server_side_mod");
-		JCheckBox disableForgeVersionCheck = new JCheckBox();
 		JTextField updateJSON = new JTextField(24);
 		JStringListField requiredMods, dependencies, dependants;
 
@@ -350,8 +349,6 @@ public class WorkspaceDialogs {
 			author.setText(System.getProperty("user.name") + ", MCreator");
 			version.setText("1.0.0");
 
-			disableForgeVersionCheck.setSelected(true);
-
 			generator.setUI(new BasicComboBoxUI() {
 				@Override protected JButton createArrowButton() {
 					return new JButton() {
@@ -522,14 +519,6 @@ public class WorkspaceDialogs {
 				_external_apis.add(apiSettings);
 			}
 
-			JComponent forgeVersionCheckPan = PanelUtils.westAndEastElement(
-					L10N.label("dialog.workspace_settings.section.version_check"), disableForgeVersionCheck);
-			forgeVersionCheckPan.setBorder(
-					BorderFactory.createTitledBorder(BorderFactory.createLineBorder(Color.gray, 1),
-							L10N.t("dialog.workspace_settings.version_check")));
-			_advancedSettings.add(forgeVersionCheckPan);
-			_advancedSettings.add(new JEmptyBox(5, 5));
-
 			JPanel advancedSettings = new JPanel(new GridLayout(3, 2, 5, 2));
 			advancedSettings.setBorder(BorderFactory.createTitledBorder(BorderFactory.createLineBorder(Color.gray, 1),
 					L10N.t("dialog.workspace_settings.section.advanced")));
@@ -571,7 +560,6 @@ public class WorkspaceDialogs {
 						workspace.getWorkspaceSettings().getModPicture());
 				serverSideOnly.setSelected(workspace.getWorkspaceSettings().isServerSideOnly());
 				lockBaseModFiles.setSelected(workspace.getWorkspaceSettings().isLockBaseModFiles());
-				disableForgeVersionCheck.setSelected(workspace.getWorkspaceSettings().isDisableForgeVersionCheck());
 				updateJSON.setText(workspace.getWorkspaceSettings().getUpdateURL());
 				credits.setText(workspace.getWorkspaceSettings().getCredits());
 				packageName.setText(workspace.getWorkspaceSettings().getModElementsPackage());
@@ -608,7 +596,6 @@ public class WorkspaceDialogs {
 			retVal.setModElementsPackage(packageName.getText().isEmpty() ? null : packageName.getText());
 			retVal.setServerSideOnly(serverSideOnly.isSelected());
 			retVal.setLockBaseModFiles(lockBaseModFiles.isSelected());
-			retVal.setDisableForgeVersionCheck(disableForgeVersionCheck.isSelected());
 			retVal.setUpdateURL(updateJSON.getText().isEmpty() ? null : updateJSON.getText());
 			retVal.setCurrentGenerator(
 					((GeneratorConfiguration) Objects.requireNonNull(generator.getSelectedItem())).getGeneratorName());

--- a/src/main/java/net/mcreator/workspace/settings/WorkspaceSettings.java
+++ b/src/main/java/net/mcreator/workspace/settings/WorkspaceSettings.java
@@ -43,7 +43,6 @@ import java.util.stream.Stream;
 	private String websiteURL;
 	private String license;
 
-	private boolean disableForgeVersionCheck = true;
 	private boolean serverSideOnly = false;
 	private String updateURL;
 
@@ -74,7 +73,6 @@ import java.util.stream.Stream;
 		this.author = other.author;
 		this.license = other.license;
 		this.websiteURL = other.websiteURL;
-		this.disableForgeVersionCheck = other.disableForgeVersionCheck;
 		this.serverSideOnly = other.serverSideOnly;
 		this.updateURL = other.updateURL;
 		this.modPicture = other.modPicture;
@@ -116,10 +114,6 @@ import java.util.stream.Stream;
 
 	public void setWebsiteURL(String websiteURL) {
 		this.websiteURL = websiteURL;
-	}
-
-	public void setDisableForgeVersionCheck(boolean disableForgeVersionCheck) {
-		this.disableForgeVersionCheck = disableForgeVersionCheck;
 	}
 
 	public void setServerSideOnly(boolean serverSideOnly) {
@@ -230,10 +224,6 @@ import java.util.stream.Stream;
 
 	public boolean isServerSideOnly() {
 		return serverSideOnly;
-	}
-
-	public boolean isDisableForgeVersionCheck() {
-		return disableForgeVersionCheck;
 	}
 
 	public String getUpdateURL() {


### PR DESCRIPTION
This PR removes the Forge version lock parameter because:

* parameter was Forge specific
* it only caused mod incompatibility issues where different mods require different versions. It is on generator to make code that works with as wide range of API versions as possible