### PR TITLE
[1.20.4] Ported and ordered entities datalist

### DIFF
--- a/plugins/generator-1.20.4/datapack-1.20.4/mappings/entities.yaml
+++ b/plugins/generator-1.20.4/datapack-1.20.4/mappings/entities.yaml
@@ -104,14 +104,14 @@ EntityCreeper:
   - Creeper
   - EntityType.CREEPER
   - creeper
-EntityDonkey:
-  - Donkey
-  - EntityType.DONKEY
-  - donkey
 EntityDolphin:
   - Dolphin
   - EntityType.DOLPHIN
   - dolphin
+EntityDonkey:
+  - Donkey
+  - EntityType.DONKEY
+  - donkey
 EntityDragonFireball:
   - DragonFireball
   - EntityType.DRAGON_FIREBALL
@@ -388,14 +388,14 @@ EntitySniffer:
   - Sniffer
   - EntityType.SNIFFER
   - sniffer
-EntitySnowball:
-  - Snowball
-  - EntityType.SNOWBALL
-  - snowball
 EntitySnowman:
   - SnowGolem
   - EntityType.SNOW_GOLEM
   - snow_golem
+EntitySnowball:
+  - Snowball
+  - EntityType.SNOWBALL
+  - snowball
 EntityMinecartMobSpawner:
   - MinecartSpawner
   - EntityType.SPAWNER_MINECART


### PR DESCRIPTION
This PR ports the entities datalist to 1.20.4 and swaps some entries to match the ordering in `EntityType`. Breeze and wind charges aren't included, since they're locked behind the experimental toggle