### PR TITLE
[1.20.4] Ported default features datalist

### DIFF
--- a/plugins/generator-1.20.4/datapack-1.20.4/mappings/defaultfeatures.yaml
+++ b/plugins/generator-1.20.4/datapack-1.20.4/mappings/defaultfeatures.yaml
@@ -52,6 +52,7 @@ Ores:
   underground_ores/ore_redstone, 
   underground_ores/ore_redstone_lower, 
   underground_ores/ore_diamond, 
+  underground_ores/ore_diamond_medium, 
   underground_ores/ore_diamond_large, 
   underground_ores/ore_diamond_buried, 
   underground_ores/ore_lapis, 


### PR DESCRIPTION
Only difference is a new `ore_diamond_medium` feature added to the default ores