### PR TITLE
Improve some triggers, add missing dependency

### DIFF
--- a/plugins/generator-1.20.1/forge-1.20.1/utils/triggers.java.ftl
+++ b/plugins/generator-1.20.1/forge-1.20.1/utils/triggers.java.ftl
@@ -2,7 +2,7 @@
 
 <#-- Item-related triggers -->
 <#macro addSpecialInformation procedure="" isBlock=false>
-	<#if procedure?has_content || hasProcedure(procedure)>
+	<#if procedure?has_content && (hasProcedure(procedure) || !procedure.getFixedValue().isEmpty())>
 		@Override public void appendHoverText(ItemStack itemstack, <#if isBlock>BlockGetter<#else>Level</#if> level, List<Component> list, TooltipFlag flag) {
 		super.appendHoverText(itemstack, level, list, flag);
 		<#if hasProcedure(procedure)>
@@ -231,15 +231,20 @@
 </#macro>
 
 <#macro piglinNeutral procedure="">
-<#if procedure?has_content || hasProcedure(procedure)>
+<#if procedure?has_content && (hasProcedure(procedure) || procedure.getFixedValue())>
 @Override public boolean makesPiglinsNeutral(ItemStack itemstack, LivingEntity entity) {
 	<#if hasProcedure(procedure)>
-		double x = entity.getX();
-		double y = entity.getY();
-		double z = entity.getZ();
-		Level world = entity.level();
+		return <@procedureCode procedure, {
+			"x": "entity.getX()",
+			"y": "entity.getY()",
+			"z": "entity.getZ()",
+			"world": "entity.level()",
+			"entity": "entity",
+			"itemstack": "itemstack"
+		}/>
+	<#else>
+		return true;
 	</#if>
-	return <@procedureOBJToConditionCode procedure procedure.getFixedValue() false/>;
 }
 </#if>
 </#macro>
@@ -480,10 +485,14 @@
 @Override public boolean isValidBonemealTarget(LevelReader worldIn, BlockPos pos, BlockState blockstate, boolean clientSide) {
 	<#if hasProcedure(isBonemealTargetCondition)>
 	if (worldIn instanceof LevelAccessor world) {
-		int x = pos.getX();
-		int y = pos.getY();
-		int z = pos.getZ();
-		return <@procedureOBJToConditionCode isBonemealTargetCondition/>;
+		return <@procedureCode isBonemealTargetCondition, {
+			"x": "pos.getX()",
+			"y": "pos.getY()",
+			"z": "pos.getZ()",
+			"world": "world",
+			"blockstate": "blockstate",
+			"clientSide": "clientSide"
+		}/>
 	}
 	return false;
 	<#else>
@@ -493,11 +502,13 @@
 
 @Override public boolean isBonemealSuccess(Level world, RandomSource random, BlockPos pos, BlockState blockstate) {
 	<#if hasProcedure(bonemealSuccessCondition)>
-		int x = pos.getX();
-		int y = pos.getY();
-		int z = pos.getZ();
-		return <@procedureOBJToConditionCode bonemealSuccessCondition/>;
-	<#else>
+	return <@procedureCode bonemealSuccessCondition, {
+		"x": "pos.getX()",
+		"y": "pos.getY()",
+		"z": "pos.getZ()",
+		"world": "world",
+		"blockstate": "blockstate"
+	}/>
 	return true;
 	</#if>
 }

--- a/plugins/generator-1.20.1/forge-1.20.1/utils/triggers.java.ftl
+++ b/plugins/generator-1.20.1/forge-1.20.1/utils/triggers.java.ftl
@@ -509,6 +509,7 @@
 		"world": "world",
 		"blockstate": "blockstate"
 	}/>
+	<#else>
 	return true;
 	</#if>
 }

--- a/plugins/generator-1.20.4/neoforge-1.20.4/utils/triggers.java.ftl
+++ b/plugins/generator-1.20.4/neoforge-1.20.4/utils/triggers.java.ftl
@@ -2,7 +2,7 @@
 
 <#-- Item-related triggers -->
 <#macro addSpecialInformation procedure="" isBlock=false>
-	<#if procedure?has_content || hasProcedure(procedure)>
+	<#if procedure?has_content && (hasProcedure(procedure) || !procedure.getFixedValue().isEmpty())>
 		@Override public void appendHoverText(ItemStack itemstack, <#if isBlock>BlockGetter<#else>Level</#if> level, List<Component> list, TooltipFlag flag) {
 		super.appendHoverText(itemstack, level, list, flag);
 		<#if hasProcedure(procedure)>
@@ -231,15 +231,20 @@
 </#macro>
 
 <#macro piglinNeutral procedure="">
-<#if procedure?has_content || hasProcedure(procedure)>
+<#if procedure?has_content && (hasProcedure(procedure) || procedure.getFixedValue())>
 @Override public boolean makesPiglinsNeutral(ItemStack itemstack, LivingEntity entity) {
 	<#if hasProcedure(procedure)>
-		double x = entity.getX();
-		double y = entity.getY();
-		double z = entity.getZ();
-		Level world = entity.level();
+		return <@procedureCode procedure, {
+			"x": "entity.getX()",
+			"y": "entity.getY()",
+			"z": "entity.getZ()",
+			"world": "entity.level()",
+			"entity": "entity",
+			"itemstack": "itemstack"
+		}/>
+	<#else>
+		return true;
 	</#if>
-	return <@procedureOBJToConditionCode procedure procedure.getFixedValue() false/>;
 }
 </#if>
 </#macro>
@@ -480,10 +485,14 @@
 @Override public boolean isValidBonemealTarget(LevelReader worldIn, BlockPos pos, BlockState blockstate) {
 	<#if hasProcedure(isBonemealTargetCondition)>
 	if (worldIn instanceof LevelAccessor world) {
-		int x = pos.getX();
-		int y = pos.getY();
-		int z = pos.getZ();
-		return <@procedureOBJToConditionCode isBonemealTargetCondition/>;
+		return <@procedureCode isBonemealTargetCondition, {
+			"x": "pos.getX()",
+			"y": "pos.getY()",
+			"z": "pos.getZ()",
+			"world": "world",
+			"blockstate": "blockstate",
+			"clientSide": "world.isClientSide()"
+		}/>
 	}
 	return false;
 	<#else>
@@ -493,10 +502,13 @@
 
 @Override public boolean isBonemealSuccess(Level world, RandomSource random, BlockPos pos, BlockState blockstate) {
 	<#if hasProcedure(bonemealSuccessCondition)>
-	int x = pos.getX();
-	int y = pos.getY();
-	int z = pos.getZ();
-	return <@procedureOBJToConditionCode bonemealSuccessCondition/>;
+	return <@procedureCode bonemealSuccessCondition, {
+		"x": "pos.getX()",
+		"y": "pos.getY()",
+		"z": "pos.getZ()",
+		"world": "world",
+		"blockstate": "blockstate"
+	}/>
 	<#else>
 	return true;
 	</#if>


### PR DESCRIPTION
- Re-added a missing dependency to one of the bonemeal triggers in 1.20.4
- Tooltip and piglin neutral methods are no longer overridden when not needed, and improved the code of some conditions