### PR TITLE
Improve recursive regeneration of procedures

### DIFF
--- a/src/main/java/net/mcreator/ui/modgui/ProcedureGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/ProcedureGUI.java
@@ -609,6 +609,10 @@ public class ProcedureGUI extends ModElementGUI<net.mcreator.element.types.Proce
 	}
 
 	private void regenerateProcedureCallers(ModElement procedure, Stack<ModElement> recursionLock) {
+		// if there are at least two more procedures referencing each other, with one of them and the current one
+		// calling each other as well, regenerating current procedure would result into circular regeneration
+		// of the other two procedures because neither of them triggered the action
+		// we avoid that by stacking all the elements checked before so that current procedure doesn't regenerate twice
 		if (recursionLock.contains(procedure))
 			return; // skip the procedure if it was handled earlier
 		recursionLock.push(procedure); // otherwise, add it to the list of checked elements

--- a/src/main/java/net/mcreator/ui/modgui/ProcedureGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/ProcedureGUI.java
@@ -610,8 +610,8 @@ public class ProcedureGUI extends ModElementGUI<net.mcreator.element.types.Proce
 
 	private void regenerateProcedureCallers(ModElement procedure, Stack<ModElement> recursionLock) {
 		if (recursionLock.contains(procedure))
-			return;
-		recursionLock.push(procedure);
+			return; // skip the procedure if it was handled earlier
+		recursionLock.push(procedure); // otherwise, add it to the list of checked elements
 		for (ModElement element : ReferencesFinder.searchModElementUsages(mcreator.getWorkspace(), procedure)) {
 			// if this mod element is not locked and has procedures, we try to update dependencies
 			// in this case, we (re)generate mod element code so dependencies get updated in the trigger code
@@ -626,7 +626,7 @@ public class ProcedureGUI extends ModElementGUI<net.mcreator.element.types.Proce
 				}
 			}
 		}
-		recursionLock.pop();
+		recursionLock.pop(); // remove the element after checking all referencing procedures
 	}
 
 	@Override public void openInEditingMode(net.mcreator.element.types.Procedure procedure) {


### PR DESCRIPTION
This PR changes `ProcedureGUI#regenerateProcedureCallers()` so that it uses `Stack<ModElement>` instead of a single element to remember all affected procedures.
Example reproducible case:
* Procedure 1
* Procedure 2, has dependencies
  * Calls procedure 1
  * Calls procedure 3
* Procedure 3, has dependencies
  * Calls procedure 2

Adding procedure 2 call to procedure 1 and saving it will cause `StackOverflowError` before this PR and build fine after it applied.