### PR TITLE
Fix ranged items not allowing bow enchantments

### DIFF
--- a/plugins/generator-1.20.1/forge-1.20.1/templates/item/item.java.ftl
+++ b/plugins/generator-1.20.1/forge-1.20.1/templates/item/item.java.ftl
@@ -38,7 +38,7 @@ package ${package}.item;
 import net.minecraft.world.entity.ai.attributes.Attributes;
 
 <#compress>
-public class ${name}Item extends Item {
+public class ${name}Item extends <#if data.enableRanged>Bow</#if>Item {
 
 	public ${name}Item() {
 		super(new Item.Properties()

--- a/plugins/generator-1.20.4/neoforge-1.20.4/templates/item/item.java.ftl
+++ b/plugins/generator-1.20.4/neoforge-1.20.4/templates/item/item.java.ftl
@@ -38,7 +38,7 @@ package ${package}.item;
 import net.minecraft.world.entity.ai.attributes.Attributes;
 
 <#compress>
-public class ${name}Item extends Item {
+public class ${name}Item extends <#if data.enableRanged>Bow</#if>Item {
 
 	public ${name}Item() {
 		super(new Item.Properties()


### PR DESCRIPTION
In this PR I fix ranged items not being able to be enchanted with bow enchantments (power, infinity, flame, punch) by extending BowItem instead of Item when ranged item is enabled.