### PR TITLE
Fix mod element code viewer misfires

### DIFF
--- a/src/main/java/net/mcreator/ui/modgui/ModElementChangedListener.java
+++ b/src/main/java/net/mcreator/ui/modgui/ModElementChangedListener.java
@@ -115,12 +115,7 @@ public interface ModElementChangedListener
 	}
 
 	@Override default void actionPerformed(ActionEvent e) {
-		if (e.getSource() instanceof JComboBox) {
-			if (e.getModifiers() != 0)
-				modElementChanged();
-		} else {
-			modElementChanged();
-		}
+		modElementChanged();
 	}
 
 	@Override default void stateChanged(ChangeEvent e) {

--- a/src/main/java/net/mcreator/ui/modgui/codeviewer/ModElementCodeViewer.java
+++ b/src/main/java/net/mcreator/ui/modgui/codeviewer/ModElementCodeViewer.java
@@ -37,7 +37,6 @@ import net.mcreator.util.image.ImageUtils;
 import org.apache.commons.io.FilenameUtils;
 
 import javax.swing.*;
-import javax.swing.plaf.metal.MetalTabbedPaneUI;
 import java.awt.*;
 import java.awt.event.ComponentAdapter;
 import java.awt.event.ComponentEvent;
@@ -54,8 +53,10 @@ public class ModElementCodeViewer<T extends GeneratableElement> extends JTabbedP
 	private final Map<GeneratorFile, FileCodeViewer<T>> cache = new HashMap<>();
 	private final Map<String, JTabbedPane> listPager = new HashMap<>();
 
-	private boolean updateRunning = false;
 	private final ModElementChangedListener codeChangeListener;
+
+	private boolean updateRunning = false;
+	private boolean updateMisfired = false;
 
 	public ModElementCodeViewer(ModElementGUI<T> modElementGUI) {
 		super(JTabbedPane.BOTTOM, JTabbedPane.SCROLL_TAB_LAYOUT);
@@ -79,7 +80,8 @@ public class ModElementCodeViewer<T extends GeneratableElement> extends JTabbedP
 		modElementGUI.getModElement().getGenerator().getModElementListTemplates(modElementGUI.getElementFromGUI())
 				.stream().map(GeneratorTemplatesList::groupName).forEach(listName -> {
 					JTabbedPane listPane = new JTabbedPane(JTabbedPane.LEFT, JTabbedPane.SCROLL_TAB_LAYOUT);
-					listPane.putClientProperty(FlatClientProperties.TABBED_PANE_TAB_ROTATION, FlatClientProperties.TABBED_PANE_TAB_ROTATION_LEFT);
+					listPane.putClientProperty(FlatClientProperties.TABBED_PANE_TAB_ROTATION,
+							FlatClientProperties.TABBED_PANE_TAB_ROTATION_LEFT);
 					listPane.setBackground(Theme.current().getAltBackgroundColor());
 					listPane.setOpaque(true);
 					listPane.addComponentListener(new ComponentAdapter() {
@@ -101,7 +103,10 @@ public class ModElementCodeViewer<T extends GeneratableElement> extends JTabbedP
 	}
 
 	private synchronized void reload() {
-		if (isVisible() && !updateRunning) {
+		if (!isVisible())
+			return;
+
+		if (!updateRunning) {
 			updateRunning = true;
 			new Thread(() -> {
 				try {
@@ -186,7 +191,15 @@ public class ModElementCodeViewer<T extends GeneratableElement> extends JTabbedP
 									Theme.current().getAltForegroundColor())));
 
 				updateRunning = false;
+
+				// if update was misfired (requested during refresh), we need to reload again
+				if (updateMisfired) {
+					updateMisfired = false;
+					reload();
+				}
 			}, "CodePreviewReloader").start();
+		} else {
+			updateMisfired = true;
 		}
 	}
 

--- a/src/main/java/net/mcreator/ui/modgui/codeviewer/ModElementCodeViewer.java
+++ b/src/main/java/net/mcreator/ui/modgui/codeviewer/ModElementCodeViewer.java
@@ -80,8 +80,7 @@ public class ModElementCodeViewer<T extends GeneratableElement> extends JTabbedP
 		modElementGUI.getModElement().getGenerator().getModElementListTemplates(modElementGUI.getElementFromGUI())
 				.stream().map(GeneratorTemplatesList::groupName).forEach(listName -> {
 					JTabbedPane listPane = new JTabbedPane(JTabbedPane.LEFT, JTabbedPane.SCROLL_TAB_LAYOUT);
-					listPane.putClientProperty(FlatClientProperties.TABBED_PANE_TAB_ROTATION,
-							FlatClientProperties.TABBED_PANE_TAB_ROTATION_LEFT);
+					listPane.putClientProperty(FlatClientProperties.TABBED_PANE_TAB_ROTATION, FlatClientProperties.TABBED_PANE_TAB_ROTATION_LEFT);
 					listPane.setBackground(Theme.current().getAltBackgroundColor());
 					listPane.setOpaque(true);
 					listPane.addComponentListener(new ComponentAdapter() {


### PR DESCRIPTION
This PR tries to fix what was tried to be fixed in #4710 + other cases where another action during the current action could result in out-of-date code.

We can now also remove the checkbox modifiers check, as we can't rely on modifiers to make sure the action is from the user or not.