### PR TITLE
Add replaceable blocks to the #replaceable tag

### DIFF
--- a/plugins/generator-1.20.1/forge-1.20.1/block.definition.yaml
+++ b/plugins/generator-1.20.1/forge-1.20.1/block.definition.yaml
@@ -411,3 +411,5 @@ tags:
     condition: "${data.blockBase! == 'Wall'}"
   - tag: BLOCKS:minecraft:leaves
     condition: "${data.blockBase! == 'Leaves'}"
+  - tag: BLOCKS:minecraft:replaceable
+    condition: isReplaceable

--- a/plugins/generator-1.20.1/forge-1.20.1/fluid.definition.yaml
+++ b/plugins/generator-1.20.1/forge-1.20.1/fluid.definition.yaml
@@ -33,3 +33,6 @@ localizationkeys:
   - key: item.@modid.@registryname_bucket
     mapto: bucketName
     condition: generateBucket
+
+tags:
+  - tag: BLOCKS:minecraft:replaceable

--- a/plugins/generator-1.20.1/forge-1.20.1/plant.definition.yaml
+++ b/plugins/generator-1.20.1/forge-1.20.1/plant.definition.yaml
@@ -87,3 +87,7 @@ templates:
 localizationkeys:
   - key: block.@modid.@registryname
     mapto: name
+
+tags:
+  - tag: BLOCKS:minecraft:replaceable
+    condition: isReplaceable

--- a/plugins/generator-1.20.4/neoforge-1.20.4/block.definition.yaml
+++ b/plugins/generator-1.20.4/neoforge-1.20.4/block.definition.yaml
@@ -411,3 +411,5 @@ tags:
     condition: "${data.blockBase! == 'Wall'}"
   - tag: BLOCKS:minecraft:leaves
     condition: "${data.blockBase! == 'Leaves'}"
+  - tag: BLOCKS:minecraft:replaceable
+    condition: isReplaceable

--- a/plugins/generator-1.20.4/neoforge-1.20.4/fluid.definition.yaml
+++ b/plugins/generator-1.20.4/neoforge-1.20.4/fluid.definition.yaml
@@ -33,3 +33,6 @@ localizationkeys:
   - key: item.@modid.@registryname_bucket
     mapto: bucketName
     condition: generateBucket
+
+tags:
+  - tag: BLOCKS:minecraft:replaceable

--- a/plugins/generator-1.20.4/neoforge-1.20.4/plant.definition.yaml
+++ b/plugins/generator-1.20.4/neoforge-1.20.4/plant.definition.yaml
@@ -87,3 +87,7 @@ templates:
 localizationkeys:
   - key: block.@modid.@registryname
     mapto: name
+
+tags:
+  - tag: BLOCKS:minecraft:replaceable
+    condition: isReplaceable


### PR DESCRIPTION
With this PR, replaceable blocks (including fluids) will be automatically added to the `#replaceable` tag