### PR TITLE
Follow structure selector in main structure GUI

### DIFF
--- a/src/main/java/net/mcreator/ui/minecraft/jigsaw/JJigsawPart.java
+++ b/src/main/java/net/mcreator/ui/minecraft/jigsaw/JJigsawPart.java
@@ -43,7 +43,7 @@ public class JJigsawPart extends JPanel implements IValidable {
 	private final JButton remove = new JButton(UIRES.get("16px.clear"));
 
 	private final JSpinner weight = new JSpinner(new SpinnerNumberModel(1, 1, 150, 1));
-	private final SearchableComboBox<String> structureSelector = new SearchableComboBox<>();
+	private final SearchableComboBox<String> structureSelector;
 	private final JComboBox<String> projection = new JComboBox<>(new String[] { "rigid", "terrain_matching" });
 	private final MCItemListField ignoreBlocks;
 
@@ -56,6 +56,8 @@ public class JJigsawPart extends JPanel implements IValidable {
 		ignoreBlocks = new MCItemListField(mcreator, ElementUtil::loadBlocks);
 		ignoreBlocks.setPreferredSize(new Dimension(200, 30));
 
+		structureSelector = new SearchableComboBox<>(
+				mcreator.getFolderManager().getStructureList().toArray(String[]::new));
 		structureSelector.setValidator(() -> {
 			if (structureSelector.getSelectedItem() == null || structureSelector.getSelectedItem().isEmpty())
 				return new Validator.ValidationResult(Validator.ValidationResultType.ERROR,


### PR DESCRIPTION
This is an attempt to fix tests sometimes failing on NBT files selected for jigsaw structures:

![image](https://github.com/MCreator/MCreator/assets/71347607/42831e56-d2c5-46d1-a869-479209bea0d5)

If after this PR there are more cases like this, this means jigsaw parts are not the problem.