### PR TITLE
Add biomes to #is_overworld/#is_nether

### DIFF
--- a/plugins/generator-1.20.1/datapack-1.20.1/biome.definition.yaml
+++ b/plugins/generator-1.20.1/datapack-1.20.1/biome.definition.yaml
@@ -12,6 +12,10 @@ templates:
     name: "@MODDATAROOT/worldgen/placed_feature/@registryname_tree.json"
 
 tags:
+  - tag: BIOMES:minecraft:is_overworld
+    condition: spawnBiome
+  - tag: BIOMES:minecraft:is_nether
+    condition: spawnBiomeNether
   - tag: BIOMES:minecraft:has_structure/mineshaft
     condition: spawnMineshaft
   - tag: BIOMES:minecraft:has_structure/igloo

--- a/plugins/generator-1.20.1/forge-1.20.1/biome.definition.yaml
+++ b/plugins/generator-1.20.1/forge-1.20.1/biome.definition.yaml
@@ -27,6 +27,10 @@ global_templates:
     name: "@SRCROOT/@BASEPACKAGEPATH/init/@JavaModNameBiomes.java"
 
 tags:
+  - tag: BIOMES:minecraft:is_overworld
+    condition: spawnBiome
+  - tag: BIOMES:minecraft:is_nether
+    condition: spawnBiomeNether
   - tag: BIOMES:minecraft:has_structure/mineshaft
     condition: spawnMineshaft
   - tag: BIOMES:minecraft:has_structure/igloo

--- a/plugins/generator-1.20.4/datapack-1.20.4/biome.definition.yaml
+++ b/plugins/generator-1.20.4/datapack-1.20.4/biome.definition.yaml
@@ -12,6 +12,10 @@ templates:
     name: "@MODDATAROOT/worldgen/placed_feature/@registryname_tree.json"
 
 tags:
+  - tag: BIOMES:minecraft:is_overworld
+    condition: spawnBiome
+  - tag: BIOMES:minecraft:is_nether
+    condition: spawnBiomeNether
   - tag: BIOMES:minecraft:has_structure/mineshaft
     condition: spawnMineshaft
   - tag: BIOMES:minecraft:has_structure/igloo

--- a/plugins/generator-1.20.4/neoforge-1.20.4/biome.definition.yaml
+++ b/plugins/generator-1.20.4/neoforge-1.20.4/biome.definition.yaml
@@ -27,6 +27,10 @@ global_templates:
     name: "@SRCROOT/@BASEPACKAGEPATH/init/@JavaModNameBiomes.java"
 
 tags:
+  - tag: BIOMES:minecraft:is_overworld
+    condition: spawnBiome
+  - tag: BIOMES:minecraft:is_nether
+    condition: spawnBiomeNether
   - tag: BIOMES:minecraft:has_structure/mineshaft
     condition: spawnMineshaft
   - tag: BIOMES:minecraft:has_structure/igloo


### PR DESCRIPTION
Add biomes to #is_overworld/#is_nether if spawning in those biomes is enabled.

Concern: would there be a case where one wouldn't want that?