### PR TITLE
Fix tests failing on blocks with multiple output types

### DIFF
--- a/src/main/java/net/mcreator/blockly/data/ToolboxBlock.java
+++ b/src/main/java/net/mcreator/blockly/data/ToolboxBlock.java
@@ -169,9 +169,14 @@ import java.util.Objects;
 		return blocklyJSON.getAsJsonObject().get("message0").getAsString();
 	}
 
-	public String getOutputType() {
+	public String getOutputTypeForTests() {
 		if (type == IBlockGenerator.BlockType.OUTPUT) {
-			return blocklyJSON.getAsJsonObject().get("output").getAsString();
+			JsonElement output = blocklyJSON.getAsJsonObject().get("output");
+			if (output.isJsonArray()) {
+				return output.getAsJsonArray().get(0).getAsString();
+			} else {
+				return output.getAsString();
+			}
 		} else {
 			return null;
 		}

--- a/src/test/java/net/mcreator/integration/generator/GTFeatureBlocks.java
+++ b/src/test/java/net/mcreator/integration/generator/GTFeatureBlocks.java
@@ -94,7 +94,7 @@ public class GTFeatureBlocks {
 							<value name="border"><block type="mcitem_allblocks"><field name="value">Blocks.STONE</field></block></value>
 						</block></value><next>%s</next></block></xml>""".formatted(testXML);
 			} else {
-				switch (featureBlock.getOutputType()) {
+				switch (featureBlock.getOutputTypeForTests()) {
 				case "Feature" -> feature.featurexml = """
 						<xml xmlns="https://developers.google.com/blockly/xml">
 						<block type="feature_container" deletable="false" x="40" y="40">

--- a/src/test/java/net/mcreator/integration/generator/GTProcedureBlocks.java
+++ b/src/test/java/net/mcreator/integration/generator/GTProcedureBlocks.java
@@ -131,7 +131,7 @@ public class GTProcedureBlocks {
 			if (procedureBlock.getType() == IBlockGenerator.BlockType.PROCEDURAL) {
 				procedure.procedurexml = wrapWithBaseTestXML(testXML);
 			} else { // output block type
-				String rettype = procedureBlock.getOutputType();
+				String rettype = procedureBlock.getOutputTypeForTests();
 				switch (rettype) {
 				case "Number":
 					procedure.procedurexml = wrapWithBaseTestXML("""


### PR DESCRIPTION
This PR fixes tests failing when a block has multiple output types (for example in #4733). In these cases the first output type will be used. The method was also renamed for clarity.