### PR TITLE
Fix Blockly undo not triggering the change listener

### DIFF
--- a/src/main/resources/blockly/js/mcreator_blockly.js
+++ b/src/main/resources/blockly/js/mcreator_blockly.js
@@ -31,9 +31,6 @@ workspace.addChangeListener(function (event) {
     if (event.isUiEvent)
         return; // Don't update on UI-only events.
 
-    if (!event.recordUndo)
-        return; // Don't update if change does not record undo
-
     if (typeof javabridge !== "undefined")
         javabridge.triggerEvent();
 });


### PR DESCRIPTION
This PR fixes a bug introduced in #4802 where undoing wouldn't trigger the change listener