### PR TITLE
Added Fire Aspect feature to Loot Tables

### DIFF
--- a/plugins/generator-1.20.1/datapack-1.20.1/templates/loottable.json.ftl
+++ b/plugins/generator-1.20.1/datapack-1.20.1/templates/loottable.json.ftl
@@ -94,6 +94,22 @@
                       "formula": "minecraft:ore_drops"
                     }
                     </#if>
+                    <#if entry.affectedByFire>
+                    ,{
+                      "function": "furnace_smelt",
+                      "conditions": [
+                        {
+                          "condition": "entity_properties",
+                          "entity": "this",
+                          "predicate": {
+                            "flags": {
+                              "is_on_fire": true
+                            }
+                          }
+                        }
+                      ]
+                    }
+                    </#if>
                 ]
               }
                 <#if entry?has_next>,</#if>

--- a/plugins/generator-1.20.4/datapack-1.20.4/templates/loottable.json.ftl
+++ b/plugins/generator-1.20.4/datapack-1.20.4/templates/loottable.json.ftl
@@ -94,6 +94,22 @@
                       "formula": "minecraft:ore_drops"
                     }
                     </#if>
+                    <#if entry.affectedByFire>
+                    ,{
+                      "function": "furnace_smelt",
+                      "conditions": [
+                        {
+                          "condition": "entity_properties",
+                          "entity": "this",
+                          "predicate": {
+                            "flags": {
+                              "is_on_fire": true
+                            }
+                          }
+                        }
+                      ]
+                    }
+                    </#if>
                 ]
               }
                 <#if entry?has_next>,</#if>

--- a/plugins/generator-addon-1.20.x/addon-1.20.x/templates/loottable.json.ftl
+++ b/plugins/generator-addon-1.20.x/addon-1.20.x/templates/loottable.json.ftl
@@ -100,6 +100,22 @@
                       "formula": "minecraft:ore_drops"
                     }
                     </#if>
+                    <#if entry.affectedByFire>
+                    ,{
+                      "function": "furnace_smelt",
+                      "conditions": [
+                        {
+                          "condition": "entity_properties",
+                          "entity": "this",
+                          "predicate": {
+                            "flags": {
+                              "is_on_fire": true
+                            }
+                          }
+                        }
+                      ]
+                    }
+                    </#if>
                 ]
               }
                 <#if entry?has_next>,</#if>

--- a/plugins/mcreator-localization/lang/texts.properties
+++ b/plugins/mcreator-localization/lang/texts.properties
@@ -2630,6 +2630,7 @@ elementgui.loot_table.entry_item=Entry item:
 elementgui.loot_table.entry_weight=Entry weight: 
 elementgui.loot_table.count=Count:
 elementgui.loot_table.silk_touch_mode=Silk touch mode: 
+elementgui.loot_table.affected_by_fire=Affected by fire
 elementgui.loot_table.enchantments_level=Entry item enchantments level:
 elementgui.music_disc.event_entity_hitwith=When living entity is hit with item
 elementgui.music_disc.event_inventory=When item in inventory tick

--- a/src/main/java/net/mcreator/element/types/LootTable.java
+++ b/src/main/java/net/mcreator/element/types/LootTable.java
@@ -55,7 +55,7 @@ import java.util.List;
 
 			public int minEnchantmentLevel, maxEnchantmentLevel;
 
-			public boolean affectedByFortune, explosionDecay;
+			public boolean affectedByFortune, explosionDecay, affectedByFire;
 
 			public int silkTouchMode;
 

--- a/src/main/java/net/mcreator/ui/minecraft/loottable/JLootTableEntry.java
+++ b/src/main/java/net/mcreator/ui/minecraft/loottable/JLootTableEntry.java
@@ -44,6 +44,7 @@ public class JLootTableEntry extends JPanel {
 
 	private final JCheckBox affectedByFortune = L10N.checkbox("elementgui.loot_table.affected_by_fortune");
 	private final JCheckBox explosionDecay = L10N.checkbox("elementgui.loot_table.enable_explosion_decay");
+	private final JCheckBox affectedByFire = L10N.checkbox("elementgui.loot_table.affected_by_fire");
 
 	private final JComboBox<String> silkTouchMode = new JComboBox<>(
 			new String[] { "Ignore silk touch", "Only with silk touch", "Only without silk touch" });
@@ -90,6 +91,10 @@ public class JLootTableEntry extends JPanel {
 
 		line1.add(L10N.label("elementgui.loot_table.silk_touch_mode"));
 		line1.add(silkTouchMode);
+
+		line1.add(new JEmptyBox(15, 5));
+
+		line1.add(affectedByFire);
 
 		affectedByFortune.setOpaque(false);
 		explosionDecay.setOpaque(false);
@@ -140,6 +145,8 @@ public class JLootTableEntry extends JPanel {
 
 		entry.silkTouchMode = silkTouchMode.getSelectedIndex();
 
+		entry.affectedByFire = affectedByFire.isSelected();
+
 		return entry;
 	}
 
@@ -157,5 +164,7 @@ public class JLootTableEntry extends JPanel {
 		explosionDecay.setSelected(e.explosionDecay);
 
 		silkTouchMode.setSelectedIndex(e.silkTouchMode);
+
+		affectedByFire.setSelected(e.affectedByFire);
 	}
 }


### PR DESCRIPTION
This adds the ability to have the drops modified if the target entity is currently on fire.  It was suggested [on the forums](https://mcreator.net/forum/106646/fire-aspect-parameter-loot-tables).  I did test that it worked and it seemed to work fine for both custom and vanilla entities.

With fire:
![2024-05-19_11 04 56](https://github.com/MCreator/MCreator/assets/122882588/ac811188-e397-4685-9d72-4cb8ebdf4e77)

Without fire
![2024-05-19_11 05 12](https://github.com/MCreator/MCreator/assets/122882588/bce9518d-a97b-4d57-946d-fa3fc666da75)
