### PR TITLE
Always include dependencies mutation tag

### DIFF
--- a/plugins/mcreator-core/blockly/js/extensions_procedure_deps.js
+++ b/plugins/mcreator-core/blockly/js/extensions_procedure_deps.js
@@ -78,7 +78,9 @@ Blockly.Extensions.registerMutator('procedure_dependencies_mutator', {
 
     // Retrieve number of inputs from XML
     domToMutation: function (xmlElement) {
-        this.inputCount_ = parseInt(xmlElement.getAttribute('inputs'), 10);
+        this.inputCount_ = isNaN(xmlElement.getAttribute('inputs')) ?
+            0 : // If block existed before without this mutator, initialize the property with default value
+            parseInt(xmlElement.getAttribute('inputs'), 10);
         this.updateShape_();
     },
 

--- a/plugins/mcreator-core/blockly/toolboxes/toolbox_command.xml
+++ b/plugins/mcreator-core/blockly/toolboxes/toolbox_command.xml
@@ -20,7 +20,9 @@
 <xml id="toolbox">
     <custom-other/>
     <category name="${t:blockly.category.actions}" colour="250">
-        <block type="call_procedure"/>
+        <block type="call_procedure">
+            <mutation inputs="0"/>
+        </block>
         <block type="old_command"/>
         <custom-actions/>
     </category>

--- a/plugins/mcreator-core/blockly/toolboxes/toolbox_command.xml
+++ b/plugins/mcreator-core/blockly/toolboxes/toolbox_command.xml
@@ -20,9 +20,7 @@
 <xml id="toolbox">
     <custom-other/>
     <category name="${t:blockly.category.actions}" colour="250">
-        <block type="call_procedure">
-            <mutation inputs="0"/>
-        </block>
+        <block type="call_procedure"/>
         <block type="old_command"/>
         <custom-actions/>
     </category>

--- a/plugins/mcreator-core/blockly/toolboxes/toolbox_procedure.xml
+++ b/plugins/mcreator-core/blockly/toolboxes/toolbox_procedure.xml
@@ -99,7 +99,9 @@
     <category name="${t:blockly.category.advanced}" colour="250">
         <block type="cancel_event"/>
         <block type="set_event_result"/>
-        <block type="call_procedure"/>
+        <block type="call_procedure">
+            <mutation inputs="0"/>
+        </block>
         <block type="call_procedure">
             <mutation inputs="3"/>
             <field name="name0">x</field>


### PR DESCRIPTION
Closes #4837 (not entirely sure if it applies to commands though, as the mutator is omitted there).