### PR TITLE
Fixed bug where you couldn't place item frames, buttons, etc on custom stairs and slabs

### DIFF
--- a/plugins/generator-1.20.1/forge-1.20.1/templates/block/block.java.ftl
+++ b/plugins/generator-1.20.1/forge-1.20.1/templates/block/block.java.ftl
@@ -136,9 +136,6 @@ public class ${name}Block extends
 		<#if data.hasTransparency>
 			.isRedstoneConductor((bs, br, bp) -> false)
 		</#if>
-		<#if (data.boundingBoxes?? && !data.blockBase?? && !data.isFullCube() && data.offsetType != "NONE")
-				|| (data.blockBase?has_content && !data.isFullCube())>
-		</#if>
 		<#if data.offsetType != "NONE">
 			.offsetType(Block.OffsetType.${data.offsetType})
 		</#if>

--- a/plugins/generator-1.20.1/forge-1.20.1/templates/block/block.java.ftl
+++ b/plugins/generator-1.20.1/forge-1.20.1/templates/block/block.java.ftl
@@ -138,7 +138,6 @@ public class ${name}Block extends
 		</#if>
 		<#if (data.boundingBoxes?? && !data.blockBase?? && !data.isFullCube() && data.offsetType != "NONE")
 				|| (data.blockBase?has_content && !data.isFullCube())>
-			.dynamicShape()
 		</#if>
 		<#if data.offsetType != "NONE">
 			.offsetType(Block.OffsetType.${data.offsetType})

--- a/plugins/generator-1.20.4/neoforge-1.20.4/templates/block/block.java.ftl
+++ b/plugins/generator-1.20.4/neoforge-1.20.4/templates/block/block.java.ftl
@@ -150,7 +150,6 @@ public class ${name}Block extends
 		</#if>
 		<#if (data.boundingBoxes?? && !data.blockBase?? && !data.isFullCube() && data.offsetType != "NONE")
 				|| (data.blockBase?has_content && !data.isFullCube())>
-			.dynamicShape()
 		</#if>
 		<#if data.offsetType != "NONE">
 			.offsetType(Block.OffsetType.${data.offsetType})

--- a/plugins/generator-1.20.4/neoforge-1.20.4/templates/block/block.java.ftl
+++ b/plugins/generator-1.20.4/neoforge-1.20.4/templates/block/block.java.ftl
@@ -148,9 +148,6 @@ public class ${name}Block extends
 		<#if data.hasTransparency>
 			.isRedstoneConductor((bs, br, bp) -> false)
 		</#if>
-		<#if (data.boundingBoxes?? && !data.blockBase?? && !data.isFullCube() && data.offsetType != "NONE")
-				|| (data.blockBase?has_content && !data.isFullCube())>
-		</#if>
 		<#if data.offsetType != "NONE">
 			.offsetType(Block.OffsetType.${data.offsetType})
 		</#if>


### PR DESCRIPTION
By removing the `.dynamicShape()` when creating blocks, this allows for item frames, buttons, etc to be placed on them again.  [Bug](https://mcreator.net/forum/106636/cant-place-item-frames-custom-stairsslabs).  As far as I could tell through testing, this did not affect anything else.  