### PR TITLE
Check for null cell bounds in ME list

### DIFF
--- a/src/main/java/net/mcreator/ui/component/JSelectableListMouseListenerWithDND.java
+++ b/src/main/java/net/mcreator/ui/component/JSelectableListMouseListenerWithDND.java
@@ -115,8 +115,10 @@ class JSelectableListMouseListenerWithDND<T> extends MouseAdapter {
 			rubberBand.lineTo(destPoint.x, destPoint.y);
 			rubberBand.lineTo(srcPoint.x, destPoint.y);
 			rubberBand.closePath();
-			int[] selNew = IntStream.range(0, list.getModel().getSize())
-					.filter(i -> rubberBand.intersects(list.getCellBounds(i, i))).toArray();
+			int[] selNew = IntStream.range(0, list.getModel().getSize()).filter(i -> {
+				Rectangle cell = list.getCellBounds(i, i);
+				return cell != null && rubberBand.intersects(cell);
+			}).toArray();
 			int[] curr = list.getSelectedIndices();
 			int[] indices = new int[selNew.length + curr.length];
 			System.arraycopy(selNew, 0, indices, 0, selNew.length);

--- a/src/main/java/net/mcreator/ui/component/JSelectableListMouseListenerWithDND.java
+++ b/src/main/java/net/mcreator/ui/component/JSelectableListMouseListenerWithDND.java
@@ -151,8 +151,8 @@ class JSelectableListMouseListenerWithDND<T> extends MouseAdapter {
 	}
 
 	@Override public void mousePressed(MouseEvent e) {
-		if (list.dndCustom && selection != null && Arrays.stream(selection)
-				.anyMatch(i -> list.getCellBounds(i, i).contains(e.getPoint()))) {
+		if (list.dndCustom && selection != null && Arrays.stream(selection).mapToObj(i -> list.getCellBounds(i, i))
+				.anyMatch(c -> c != null && c.contains(e.getPoint()))) {
 			srcPoint = null; // Initiate DND action
 		} else {
 			int index = list.locationToIndex(e.getPoint());


### PR DESCRIPTION
Adds missing checks to when the ME list tries to `getCellBounds()` and produces an NPE.