### PR TITLE
Resolve missing texture files denoted by TextureHolders

### DIFF
--- a/src/main/java/net/mcreator/element/parts/TextureHolder.java
+++ b/src/main/java/net/mcreator/element/parts/TextureHolder.java
@@ -91,7 +91,7 @@ import java.lang.reflect.Type;
 	}
 
 	public String getFullTextureName() {
-		return texture == null ? "" : texture;
+		return texture == null ? "" : FilenameUtils.removeExtension(texture);
 	}
 
 	@Override public String toString() {


### PR DESCRIPTION
This is the simplest solution - to remove extension only when returning texture identifier. This does not affect the field contents.
Another solution would be to remove it inside private constructor as all public ones delegate to it with the texture path argument.