### PR TITLE
API mods texture references support

### DIFF
--- a/src/main/java/net/mcreator/plugin/modapis/ModAPIImplementation.java
+++ b/src/main/java/net/mcreator/plugin/modapis/ModAPIImplementation.java
@@ -20,6 +20,7 @@ package net.mcreator.plugin.modapis;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Map;
 
 public record ModAPIImplementation(ModAPI parent, String gradle, @Nullable List<String> update_files,
-								   boolean requiredWhenEnabled) {}
+								   @Nullable Map<String, String> resource_paths, boolean requiredWhenEnabled) {}

--- a/src/main/java/net/mcreator/plugin/modapis/ModAPIManager.java
+++ b/src/main/java/net/mcreator/plugin/modapis/ModAPIManager.java
@@ -61,15 +61,20 @@ public class ModAPIManager {
 						Map<?, ?> impldef = (Map<?, ?>) apiconfiguration.get(keyraw);
 						String gradle = (String) impldef.get("gradle");
 						List<?> updateFiles = (List<?>) impldef.get("update_files");
+						Map<?, ?> resPaths = (Map<?, ?>) impldef.get("resource_paths");
 						boolean requiredWhenEnabled =
 								impldef.get("required_when_enabled") != null && Boolean.parseBoolean(
 										impldef.get("required_when_enabled").toString());
 
 						if (updateFiles == null)
 							updateFiles = Collections.emptyList();
+						if (resPaths == null)
+							resPaths = Collections.emptyMap();
 
 						ModAPIImplementation implementation = new ModAPIImplementation(modAPI, gradle,
 								updateFiles.stream().map(Object::toString).collect(Collectors.toList()),
+								resPaths.entrySet().stream().collect(
+										Collectors.toMap(e -> e.getKey().toString(), e -> e.getValue().toString())),
 								requiredWhenEnabled);
 						modAPI.implementations().put(key, implementation);
 					}

--- a/src/main/java/net/mcreator/workspace/resources/VanillaTexture.java
+++ b/src/main/java/net/mcreator/workspace/resources/VanillaTexture.java
@@ -82,7 +82,7 @@ public final class VanillaTexture extends Texture {
 				for (LibraryInfo libraryInfo : libraryInfos) {
 					File libraryFile = new File(libraryInfo.getLocationAsString());
 					if (libraryFile.isFile() && libraryFile.getName().contains(jarName)) {
-						loadTexturesFrom(libraryFile, path, type, textures);
+						loadTexturesFrom(libraryFile, "minecraft", path, type, textures);
 						break;
 					}
 				}
@@ -99,7 +99,7 @@ public final class VanillaTexture extends Texture {
 
 						File apiLibFile = new File(workspace.getWorkspaceFolder(), jarName);
 						if (apiLibFile.isFile())
-							loadTexturesFrom(apiLibFile, path, type, textures);
+							loadTexturesFrom(apiLibFile, apiImpl.parent().id(), path, type, textures);
 					}
 				}
 			}
@@ -109,12 +109,13 @@ public final class VanillaTexture extends Texture {
 		return CACHE.get(cacheId).values().stream().toList();
 	}
 
-	private static void loadTexturesFrom(File libFile, String path, TextureType type, Map<String, Texture> textures) {
+	private static void loadTexturesFrom(File libFile, String namespace, String path, TextureType type,
+			Map<String, Texture> textures) {
 		try (ZipFile zipFile = ZipIO.openZipFile(libFile)) {
 			List<? extends ZipEntry> entries = Collections.list(zipFile.entries());
 			entries.parallelStream().sorted(Comparator.comparing(ZipEntry::getName)).forEachOrdered(entry -> {
 				if (entry.getName().startsWith(path) && entry.getName().endsWith(".png")) {
-					String textureName = "minecraft:" + FilenameUtils.getBaseName(entry.getName());
+					String textureName = namespace + ":" + FilenameUtils.getBaseName(entry.getName());
 					try {
 						textures.put(textureName, new VanillaTexture(type, textureName,
 								new ImageIcon(ImageIO.read(zipFile.getInputStream(entry)))));


### PR DESCRIPTION
This PR complements #4910, allowing to reference textures from external mods downloaded by API plugins.

The part of the loading method that scans ZIP files was extracted to its own one, the rest of the method was rewritten to not entirely depend on vanilla texture paths configuration.