### PR TITLE
Remove placeholder tab if anything else is added

### DIFF
--- a/src/main/java/net/mcreator/ui/modgui/codeviewer/ModElementCodeViewer.java
+++ b/src/main/java/net/mcreator/ui/modgui/codeviewer/ModElementCodeViewer.java
@@ -178,11 +178,11 @@ public class ModElementCodeViewer<T extends GeneratableElement> extends JTabbedP
 				}
 
 				int noFilesTab = indexOfTab(L10N.t("mod_element_code_viewer.no_files"));
-				if (noFilesTab == -1 && getTabCount() == 0) {
+				if (noFilesTab == -1 && getTabCount() == listPager.size()) {
 					addTab(L10N.t("mod_element_code_viewer.no_files"), PanelUtils.totalCenterInPanel(
 							ComponentUtils.setForeground(L10N.label("mod_element_code_viewer.no_files.desc"),
 									Theme.current().getAltForegroundColor())));
-				} else if (noFilesTab != -1 && getTabCount() > 1) {
+				} else if (noFilesTab != -1 && getTabCount() > listPager.size() + 1) {
 					removeTabAt(noFilesTab);
 				}
 

--- a/src/main/java/net/mcreator/ui/modgui/codeviewer/ModElementCodeViewer.java
+++ b/src/main/java/net/mcreator/ui/modgui/codeviewer/ModElementCodeViewer.java
@@ -177,10 +177,14 @@ public class ModElementCodeViewer<T extends GeneratableElement> extends JTabbedP
 					setBackground(new Color(0x8D5C5C));
 				}
 
-				if (getTabCount() == 0)
+				int noFilesTab = indexOfTab(L10N.t("mod_element_code_viewer.no_files"));
+				if (noFilesTab == -1 && getTabCount() == 0) {
 					addTab(L10N.t("mod_element_code_viewer.no_files"), PanelUtils.totalCenterInPanel(
 							ComponentUtils.setForeground(L10N.label("mod_element_code_viewer.no_files.desc"),
 									Theme.current().getAltForegroundColor())));
+				} else if (noFilesTab != -1 && getTabCount() > 1) {
+					removeTabAt(noFilesTab);
+				}
 
 				updateRunning = false;
 


### PR DESCRIPTION
The root of the issue was the check for tab number being greater than 0, because the placeholder tab is a tab too.