### PR TITLE
Better workspace sections switching

### DIFF
--- a/src/main/java/net/mcreator/ui/workspace/WorkspacePanel.java
+++ b/src/main/java/net/mcreator/ui/workspace/WorkspacePanel.java
@@ -648,20 +648,22 @@ import java.util.stream.Collectors;
 		subTabs.putClientProperty(FlatClientProperties.TABBED_PANE_TAB_ROTATION,
 				FlatClientProperties.TABBED_PANE_TAB_ROTATION_AUTO);
 		subTabs.addChangeListener(e -> {
-			if (subTabs.getComponentAt(subTabs.getSelectedIndex()) instanceof AbstractWorkspacePanel tabComponent) {
-				if (tabComponent.canSwitchToSection()) {
-					currentTabPanel = tabComponent;
-				} else {
-					// Switch to the last tab that can be switched to
-					switchToVerticalTab(currentTabPanel);
+			{
+				if (subTabs.getComponentAt(subTabs.getSelectedIndex()) instanceof AbstractWorkspacePanel tabComponent) {
+					if (tabComponent.canSwitchToSection()) {
+						currentTabPanel = tabComponent;
+					} else {
+						// Switch to the last tab that can be switched to
+						switchToVerticalTab(currentTabPanel);
+					}
 				}
-			}
 
-			search.repaint();
-			reloadElementsInCurrentTab();
-			modElementsBar.setVisible(currentTabPanel instanceof WorkspacePanelMods);
-			subTabs.putClientProperty(FlatClientProperties.TABBED_PANE_SHOW_CONTENT_SEPARATOR,
-					!(currentTabPanel instanceof WorkspacePanelMods));
+				search.repaint();
+				reloadElementsInCurrentTab();
+				modElementsBar.setVisible(currentTabPanel instanceof WorkspacePanelMods);
+				subTabs.putClientProperty(FlatClientProperties.TABBED_PANE_SHOW_CONTENT_SEPARATOR,
+						!(currentTabPanel instanceof WorkspacePanelMods));
+			}
 		});
 
 		slo.add("Center", subTabs);

--- a/src/main/java/net/mcreator/ui/workspace/WorkspacePanel.java
+++ b/src/main/java/net/mcreator/ui/workspace/WorkspacePanel.java
@@ -647,17 +647,17 @@ import java.util.stream.Collectors;
 		subTabs.setOpaque(false);
 		subTabs.putClientProperty(FlatClientProperties.TABBED_PANE_TAB_ROTATION,
 				FlatClientProperties.TABBED_PANE_TAB_ROTATION_AUTO);
-		subTabs.addChangeListener(e -> {
-			{
-				if (subTabs.getComponentAt(subTabs.getSelectedIndex()) instanceof AbstractWorkspacePanel tabComponent) {
+		subTabs.setModel(new DefaultSingleSelectionModel() {
+			@Override public void setSelectedIndex(int index) {
+				if (subTabs.getComponentAt(index) instanceof AbstractWorkspacePanel tabComponent) {
 					if (tabComponent.canSwitchToSection()) {
 						currentTabPanel = tabComponent;
-					} else {
-						// Switch to the last tab that can be switched to
-						switchToVerticalTab(currentTabPanel);
+					} else { // No permission to view the newly selected tab
+						return;
 					}
 				}
 
+				super.setSelectedIndex(index);
 				search.repaint();
 				reloadElementsInCurrentTab();
 				modElementsBar.setVisible(currentTabPanel instanceof WorkspacePanelMods);


### PR DESCRIPTION
Instead of selecting the new `WorkspacePanel` and then checking if the user `canSwitchToSection()`, the tabbed pane now uses a custom selection model that invokes that method before changing the selected tab.