### PR TITLE
Fix #4964

### DIFF
--- a/plugins/generator-1.20.1/forge-1.20.1/triggers/block_break.java.ftl
+++ b/plugins/generator-1.20.1/forge-1.20.1/triggers/block_break.java.ftl
@@ -3,7 +3,6 @@
 	@SubscribeEvent public static void onBlockBreak(BlockEvent.BreakEvent event) {
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-			"xpAmount": "event.getExpToDrop()",
 			"x": "event.getPos().getX()",
 			"y": "event.getPos().getY()",
 			"z": "event.getPos().getZ()",

--- a/plugins/generator-1.20.6/neoforge-1.20.6/triggers/block_break.java.ftl
+++ b/plugins/generator-1.20.6/neoforge-1.20.6/triggers/block_break.java.ftl
@@ -1,17 +1,16 @@
 <#include "procedures.java.ftl">
 @EventBusSubscriber public class ${name}Procedure {
-	@SubscribeEvent public static void onBlockBreak(BlockDropsEvent event) {
+	@SubscribeEvent public static void onBlockBreak(BlockEvent.BreakEvent event) {
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
-				"xpAmount": "event.getDroppedExperience()",
 				"x": "event.getPos().getX()",
 				"y": "event.getPos().getY()",
 				"z": "event.getPos().getZ()",
-				"px": "event.getBreaker() != null ? event.getBreaker().getX() : event.getPos().getX()",
-				"py": "event.getBreaker() != null ? event.getBreaker().getY() : event.getPos().getY()",
-				"pz": "event.getBreaker() != null ? event.getBreaker().getZ() : event.getPos().getZ()",
+				"px": "event.getPlayer() != null ? event.getPlayer().getX() : event.getPos().getX()",
+				"py": "event.getPlayer() != null ? event.getPlayer().getY() : event.getPos().getY()",
+				"pz": "event.getPlayer() != null ? event.getPlayer().getZ() : event.getPos().getZ()",
 				"world": "event.getLevel()",
-				"entity": "event.getBreaker()",
+				"entity": "event.getPlayer()",
 				"blockstate": "event.getState()"
 			}/>
 		</#compress></#assign>

--- a/plugins/mcreator-core/triggers/block_break.json
+++ b/plugins/mcreator-core/triggers/block_break.json
@@ -35,10 +35,6 @@
     {
       "name": "pz",
       "type": "number"
-    },
-    {
-      "name": "xpAmount",
-      "type": "number"
     }
   ],
   "cancelable": "true",


### PR DESCRIPTION
Fix #4964

Changelog:

* [Bugfix, NF 1.20.6] Block broken global procedure trigger was not triggered in all cases
* [Bugfix, NF 1.20.6] Block broken global procedure trigger cancelation did not cancel breaking but dropping

Release notes:

* XP dropped dependency is no longer present in block broken global procedure trigger