### PR TITLE
Enormous workspaces support

### DIFF
--- a/plugins/generator-1.20.1/forge-1.20.1/templates/elementinits/blocks.java.ftl
+++ b/plugins/generator-1.20.1/forge-1.20.1/templates/elementinits/blocks.java.ftl
@@ -62,13 +62,35 @@ public class ${JavaModName}Blocks {
 
 	<#list blocks as block>
 		<#if block.getModElement().getTypeString() == "dimension">
-            public static final RegistryObject<Block> ${block.getModElement().getRegistryNameUpper()}_PORTAL =
-				REGISTRY.register("${block.getModElement().getRegistryName()}_portal", () -> new ${block.getModElement().getName()}PortalBlock());
+            public static RegistryObject<Block> ${block.getModElement().getRegistryNameUpper()}_PORTAL;
 		<#else>
-			public static final RegistryObject<Block> ${block.getModElement().getRegistryNameUpper()} =
-				REGISTRY.register("${block.getModElement().getRegistryName()}", () -> new ${block.getModElement().getName()}Block());
+			public static RegistryObject<Block> ${block.getModElement().getRegistryNameUpper()};
 		</#if>
 	</#list>
+
+	<#assign chunks = blocks?chunk(2500)>
+	<#assign chunks_num = chunks?size>
+	<#list chunks as sub_blocks>
+	public static void register<#if chunks_num == 1>(IEventBus modEventBus)<#else>${sub_blocks?index}()</#if> {
+		<#list sub_blocks as block>
+			<#if block.getModElement().getTypeString() == "dimension">
+        	    ${block.getModElement().getRegistryNameUpper()}_PORTAL =
+					REGISTRY.register("${block.getModElement().getRegistryName()}_portal", ${block.getModElement().getName()}PortalBlock::new);
+			<#else>
+				${block.getModElement().getRegistryNameUpper()} =
+					REGISTRY.register("${block.getModElement().getRegistryName()}", ${block.getModElement().getName()}Block::new);
+			</#if>
+		</#list>
+		<#if chunks_num == 1>REGISTRY.register(modEventBus);</#if>
+	}
+	</#list>
+
+	<#if chunks_num gt 1>
+	public static void register(IEventBus modEventBus) {
+		<#list 0..chunks_num-1 as i>register${i}();</#list>
+		REGISTRY.register(modEventBus);
+	}
+	</#if>
 
 	// Start of user code block custom blocks
 	// End of user code block custom blocks

--- a/plugins/generator-1.20.1/forge-1.20.1/templates/elementinits/items.java.ftl
+++ b/plugins/generator-1.20.1/forge-1.20.1/templates/elementinits/items.java.ftl
@@ -51,45 +51,75 @@ public class ${JavaModName}Items {
 
 	<#list items as item>
 		<#if item.getModElement().getTypeString() == "armor">
-			<#if item.enableHelmet>
-			public static final RegistryObject<Item> ${item.getModElement().getRegistryNameUpper()}_HELMET =
-				REGISTRY.register("${item.getModElement().getRegistryName()}_helmet", () -> new ${item.getModElement().getName()}Item.Helmet());
-			</#if>
-			<#if item.enableBody>
-			public static final RegistryObject<Item> ${item.getModElement().getRegistryNameUpper()}_CHESTPLATE =
-				REGISTRY.register("${item.getModElement().getRegistryName()}_chestplate", () -> new ${item.getModElement().getName()}Item.Chestplate());
-			</#if>
-			<#if item.enableLeggings>
-			public static final RegistryObject<Item> ${item.getModElement().getRegistryNameUpper()}_LEGGINGS =
-				REGISTRY.register("${item.getModElement().getRegistryName()}_leggings", () -> new ${item.getModElement().getName()}Item.Leggings());
-			</#if>
-			<#if item.enableBoots>
-			public static final RegistryObject<Item> ${item.getModElement().getRegistryNameUpper()}_BOOTS =
-				REGISTRY.register("${item.getModElement().getRegistryName()}_boots", () -> new ${item.getModElement().getName()}Item.Boots());
-			</#if>
+			<#if item.enableHelmet>public static RegistryObject<Item> ${item.getModElement().getRegistryNameUpper()}_HELMET;</#if>
+			<#if item.enableBody>public static RegistryObject<Item> ${item.getModElement().getRegistryNameUpper()}_CHESTPLATE;</#if>
+			<#if item.enableLeggings>public static RegistryObject<Item> ${item.getModElement().getRegistryNameUpper()}_LEGGINGS;</#if>
+			<#if item.enableBoots>public static RegistryObject<Item> ${item.getModElement().getRegistryNameUpper()}_BOOTS;</#if>
 		<#elseif item.getModElement().getTypeString() == "livingentity">
-			public static final RegistryObject<Item> ${item.getModElement().getRegistryNameUpper()}_SPAWN_EGG =
-				REGISTRY.register("${item.getModElement().getRegistryName()}_spawn_egg", () -> new ForgeSpawnEggItem(${JavaModName}Entities.${item.getModElement().getRegistryNameUpper()},
-						${item.spawnEggBaseColor.getRGB()}, ${item.spawnEggDotColor.getRGB()}, new Item.Properties()));
-		<#elseif item.getModElement().getTypeString() == "dimension" && item.hasIgniter()>
-			public static final RegistryObject<Item> ${item.getModElement().getRegistryNameUpper()} =
-				REGISTRY.register("${item.getModElement().getRegistryName()}", () -> new ${item.getModElement().getName()}Item());
+			public static RegistryObject<Item> ${item.getModElement().getRegistryNameUpper()}_SPAWN_EGG;
 		<#elseif item.getModElement().getTypeString() == "fluid" && item.generateBucket>
-			public static final RegistryObject<Item> ${item.getModElement().getRegistryNameUpper()}_BUCKET =
-				REGISTRY.register("${item.getModElement().getRegistryName()}_bucket", () -> new ${item.getModElement().getName()}Item());
-		<#elseif item.getModElement().getTypeString() == "block" || item.getModElement().getTypeString() == "plant">
-			<#if item.isDoubleBlock()>
-				<#assign hasDoubleBlocks = true>
-				public static final RegistryObject<Item> ${item.getModElement().getRegistryNameUpper()} = doubleBlock(${JavaModName}Blocks.${item.getModElement().getRegistryNameUpper()});
-			<#else>
-				<#assign hasBlocks = true>
-				public static final RegistryObject<Item> ${item.getModElement().getRegistryNameUpper()} = block(${JavaModName}Blocks.${item.getModElement().getRegistryNameUpper()});
-			</#if>
+			public static RegistryObject<Item> ${item.getModElement().getRegistryNameUpper()}_BUCKET;
 		<#else>
-			public static final RegistryObject<Item> ${item.getModElement().getRegistryNameUpper()} =
-				REGISTRY.register("${item.getModElement().getRegistryName()}", () -> new ${item.getModElement().getName()}Item());
+			public static RegistryObject<Item> ${item.getModElement().getRegistryNameUpper()};
 		</#if>
 	</#list>
+
+	<#assign chunks = items?chunk(2500)>
+	<#assign chunks_num = chunks?size>
+	<#list chunks as sub_items>
+	public static void register<#if chunks_num == 1>(IEventBus modEventBus)<#else>${sub_items?index}()</#if> {
+		<#list sub_items as item>
+			<#if item.getModElement().getTypeString() == "armor">
+				<#if item.enableHelmet>
+				${item.getModElement().getRegistryNameUpper()}_HELMET =
+					REGISTRY.register("${item.getModElement().getRegistryName()}_helmet", ${item.getModElement().getName()}Item.Helmet::new);
+				</#if>
+				<#if item.enableBody>
+				${item.getModElement().getRegistryNameUpper()}_CHESTPLATE =
+					REGISTRY.register("${item.getModElement().getRegistryName()}_chestplate", ${item.getModElement().getName()}Item.Chestplate::new);
+				</#if>
+				<#if item.enableLeggings>
+				${item.getModElement().getRegistryNameUpper()}_LEGGINGS =
+					REGISTRY.register("${item.getModElement().getRegistryName()}_leggings", ${item.getModElement().getName()}Item.Leggings::new);
+				</#if>
+				<#if item.enableBoots>
+				${item.getModElement().getRegistryNameUpper()}_BOOTS =
+					REGISTRY.register("${item.getModElement().getRegistryName()}_boots", ${item.getModElement().getName()}Item.Boots::new);
+				</#if>
+			<#elseif item.getModElement().getTypeString() == "livingentity">
+				${item.getModElement().getRegistryNameUpper()}_SPAWN_EGG =
+					REGISTRY.register("${item.getModElement().getRegistryName()}_spawn_egg",
+						() -> new ForgeSpawnEggItem(${JavaModName}Entities.${item.getModElement().getRegistryNameUpper()},
+						${item.spawnEggBaseColor.getRGB()}, ${item.spawnEggDotColor.getRGB()}, new Item.Properties()));
+			<#elseif item.getModElement().getTypeString() == "dimension" && item.hasIgniter()>
+				${item.getModElement().getRegistryNameUpper()} =
+					REGISTRY.register("${item.getModElement().getRegistryName()}", ${item.getModElement().getName()}Item::new);
+			<#elseif item.getModElement().getTypeString() == "fluid" && item.generateBucket>
+				${item.getModElement().getRegistryNameUpper()}_BUCKET =
+					REGISTRY.register("${item.getModElement().getRegistryName()}_bucket", ${item.getModElement().getName()}Item::new);
+			<#elseif item.getModElement().getTypeString() == "block" || item.getModElement().getTypeString() == "plant">
+				<#if item.isDoubleBlock()>
+					<#assign hasDoubleBlocks = true>
+					${item.getModElement().getRegistryNameUpper()} = doubleBlock(${JavaModName}Blocks.${item.getModElement().getRegistryNameUpper()});
+				<#else>
+					<#assign hasBlocks = true>
+					${item.getModElement().getRegistryNameUpper()} = block(${JavaModName}Blocks.${item.getModElement().getRegistryNameUpper()});
+				</#if>
+			<#else>
+				${item.getModElement().getRegistryNameUpper()} =
+					REGISTRY.register("${item.getModElement().getRegistryName()}", ${item.getModElement().getName()}Item::new);
+			</#if>
+		</#list>
+		<#if chunks_num == 1>REGISTRY.register(modEventBus);</#if>
+	}
+	</#list>
+
+	<#if chunks_num gt 1>
+	public static void register(IEventBus modEventBus) {
+		<#list 0..chunks_num-1 as i>register${i}();</#list>
+		REGISTRY.register(modEventBus);
+	}
+	</#if>
 
 	// Start of user code block custom items
 	// End of user code block custom items

--- a/plugins/generator-1.20.1/forge-1.20.1/templates/modbase/mod.java.ftl
+++ b/plugins/generator-1.20.1/forge-1.20.1/templates/modbase/mod.java.ftl
@@ -18,9 +18,9 @@ import org.apache.logging.log4j.Logger;
 
 		IEventBus bus = FMLJavaModLoadingContext.get().getModEventBus();
 		<#if w.hasSounds()>${JavaModName}Sounds.REGISTRY.register(bus);</#if>
-		<#if w.hasElementsOfBaseType("block")>${JavaModName}Blocks.REGISTRY.register(bus);</#if>
+		<#if w.hasElementsOfBaseType("block")>${JavaModName}Blocks.register(bus);</#if>
 		<#if w.hasElementsOfBaseType("blockentity")>${JavaModName}BlockEntities.REGISTRY.register(bus);</#if>
-		<#if w.hasElementsOfBaseType("item")>${JavaModName}Items.REGISTRY.register(bus);</#if>
+		<#if w.hasElementsOfBaseType("item")>${JavaModName}Items.register(bus);</#if>
 		<#if w.hasElementsOfBaseType("entity")>${JavaModName}Entities.REGISTRY.register(bus);</#if>
 		<#if w.hasElementsOfType("enchantment")>${JavaModName}Enchantments.REGISTRY.register(bus);</#if>
 		<#if w.hasItemsInTabs()>${JavaModName}Tabs.REGISTRY.register(bus);</#if>

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/elementinits/blocks.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/elementinits/blocks.java.ftl
@@ -69,7 +69,7 @@ public class ${JavaModName}Blocks {
 		</#if>
 	</#list>
 
-	<#assign chunks = blocks?chunk(2000)>
+	<#assign chunks = blocks?chunk(2500)>
 	<#assign chunks_num = chunks?size>
 	<#list chunks as sub_blocks>
 	public static void register<#if chunks_num == 1>(IEventBus modEventBus)<#else>${sub_blocks?index}()</#if> {

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/elementinits/blocks.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/elementinits/blocks.java.ftl
@@ -56,19 +56,42 @@ package ${package}.init;
 	</#if>
 </#list>
 
+<#compress>
 public class ${JavaModName}Blocks {
 
 	public static final DeferredRegister.Blocks REGISTRY = DeferredRegister.createBlocks(${JavaModName}.MODID);
 
 	<#list blocks as block>
 		<#if block.getModElement().getTypeString() == "dimension">
-            public static final DeferredBlock<Block> ${block.getModElement().getRegistryNameUpper()}_PORTAL =
-				REGISTRY.register("${block.getModElement().getRegistryName()}_portal", ${block.getModElement().getName()}PortalBlock::new);
+            public static DeferredBlock<Block> ${block.getModElement().getRegistryNameUpper()}_PORTAL;
 		<#else>
-			public static final DeferredBlock<Block> ${block.getModElement().getRegistryNameUpper()} =
-				REGISTRY.register("${block.getModElement().getRegistryName()}", ${block.getModElement().getName()}Block::new);
+			public static DeferredBlock<Block> ${block.getModElement().getRegistryNameUpper()};
 		</#if>
 	</#list>
+
+	<#assign chunks = blocks?chunk(1000)>
+	<#assign chunks_num = chunks?size>
+	<#list chunks as sub_blocks>
+	public static void register<#if chunks_num == 1>(IEventBus modEventBus)<#else>${sub_blocks?index}()</#if> {
+		<#list sub_blocks as block>
+			<#if block.getModElement().getTypeString() == "dimension">
+        	    ${block.getModElement().getRegistryNameUpper()}_PORTAL =
+					REGISTRY.register("${block.getModElement().getRegistryName()}_portal", ${block.getModElement().getName()}PortalBlock::new);
+			<#else>
+				${block.getModElement().getRegistryNameUpper()} =
+					REGISTRY.register("${block.getModElement().getRegistryName()}", ${block.getModElement().getName()}Block::new);
+			</#if>
+		</#list>
+		<#if chunks_num == 1>REGISTRY.register(modEventBus);</#if>
+	}
+	</#list>
+
+	<#if chunks_num gt 1>
+	public static void register(IEventBus modEventBus) {
+		<#list 0..chunks_num-1 as i>register${i}();</#list>
+		REGISTRY.register(modEventBus);
+	}
+	</#if>
 
 	// Start of user code block custom blocks
 	// End of user code block custom blocks
@@ -102,5 +125,6 @@ public class ${JavaModName}Blocks {
 	</#if>
 
 }
+</#compress>
 
 <#-- @formatter:on -->

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/elementinits/blocks.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/elementinits/blocks.java.ftl
@@ -69,7 +69,7 @@ public class ${JavaModName}Blocks {
 		</#if>
 	</#list>
 
-	<#assign chunks = blocks?chunk(1000)>
+	<#assign chunks = blocks?chunk(2000)>
 	<#assign chunks_num = chunks?size>
 	<#list chunks as sub_blocks>
 	public static void register<#if chunks_num == 1>(IEventBus modEventBus)<#else>${sub_blocks?index}()</#if> {

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/elementinits/items.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/elementinits/items.java.ftl
@@ -46,51 +46,82 @@ package ${package}.init;
 <#if itemsWithInventory?size != 0>
 @EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD)
 </#if>
+<#compress>
 public class ${JavaModName}Items {
 
-	public static final DeferredRegister.Items REGISTRY = DeferredRegister.createItems(${JavaModName}.MODID);
+	public static DeferredRegister.Items REGISTRY = DeferredRegister.createItems(${JavaModName}.MODID);
 
 	<#list items as item>
 		<#if item.getModElement().getTypeString() == "armor">
-			<#if item.enableHelmet>
-			public static final DeferredItem<Item> ${item.getModElement().getRegistryNameUpper()}_HELMET =
-				REGISTRY.register("${item.getModElement().getRegistryName()}_helmet", ${item.getModElement().getName()}Item.Helmet::new);
-			</#if>
-			<#if item.enableBody>
-			public static final DeferredItem<Item> ${item.getModElement().getRegistryNameUpper()}_CHESTPLATE =
-				REGISTRY.register("${item.getModElement().getRegistryName()}_chestplate", ${item.getModElement().getName()}Item.Chestplate::new);
-			</#if>
-			<#if item.enableLeggings>
-			public static final DeferredItem<Item> ${item.getModElement().getRegistryNameUpper()}_LEGGINGS =
-				REGISTRY.register("${item.getModElement().getRegistryName()}_leggings", ${item.getModElement().getName()}Item.Leggings::new);
-			</#if>
-			<#if item.enableBoots>
-			public static final DeferredItem<Item> ${item.getModElement().getRegistryNameUpper()}_BOOTS =
-				REGISTRY.register("${item.getModElement().getRegistryName()}_boots", ${item.getModElement().getName()}Item.Boots::new);
-			</#if>
+			<#if item.enableHelmet>public static DeferredItem<Item> ${item.getModElement().getRegistryNameUpper()}_HELMET;</#if>
+			<#if item.enableBody>public static DeferredItem<Item> ${item.getModElement().getRegistryNameUpper()}_CHESTPLATE;</#if>
+			<#if item.enableLeggings>public static DeferredItem<Item> ${item.getModElement().getRegistryNameUpper()}_LEGGINGS;</#if>
+			<#if item.enableBoots>public static DeferredItem<Item> ${item.getModElement().getRegistryNameUpper()}_BOOTS;</#if>
 		<#elseif item.getModElement().getTypeString() == "livingentity">
-			public static final DeferredItem<Item> ${item.getModElement().getRegistryNameUpper()}_SPAWN_EGG =
-				REGISTRY.register("${item.getModElement().getRegistryName()}_spawn_egg", () -> new DeferredSpawnEggItem(${JavaModName}Entities.${item.getModElement().getRegistryNameUpper()},
-						${item.spawnEggBaseColor.getRGB()}, ${item.spawnEggDotColor.getRGB()}, new Item.Properties()));
-		<#elseif item.getModElement().getTypeString() == "dimension" && item.hasIgniter()>
-			public static final DeferredItem<Item> ${item.getModElement().getRegistryNameUpper()} =
-				REGISTRY.register("${item.getModElement().getRegistryName()}", ${item.getModElement().getName()}Item::new);
+			public static DeferredItem<Item> ${item.getModElement().getRegistryNameUpper()}_SPAWN_EGG;
 		<#elseif item.getModElement().getTypeString() == "fluid" && item.generateBucket>
-			public static final DeferredItem<Item> ${item.getModElement().getRegistryNameUpper()}_BUCKET =
-				REGISTRY.register("${item.getModElement().getRegistryName()}_bucket", ${item.getModElement().getName()}Item::new);
-		<#elseif item.getModElement().getTypeString() == "block" || item.getModElement().getTypeString() == "plant">
-			<#if item.isDoubleBlock()>
-				<#assign hasDoubleBlocks = true>
-				public static final DeferredItem<Item> ${item.getModElement().getRegistryNameUpper()} = doubleBlock(${JavaModName}Blocks.${item.getModElement().getRegistryNameUpper()});
-			<#else>
-				<#assign hasBlocks = true>
-				public static final DeferredItem<Item> ${item.getModElement().getRegistryNameUpper()} = block(${JavaModName}Blocks.${item.getModElement().getRegistryNameUpper()});
-			</#if>
+			public static DeferredItem<Item> ${item.getModElement().getRegistryNameUpper()}_BUCKET;
 		<#else>
-			public static final DeferredItem<Item> ${item.getModElement().getRegistryNameUpper()} =
-				REGISTRY.register("${item.getModElement().getRegistryName()}", ${item.getModElement().getName()}Item::new);
+			public static DeferredItem<Item> ${item.getModElement().getRegistryNameUpper()};
 		</#if>
 	</#list>
+
+	<#assign chunks = items?chunk(2500)>
+	<#assign chunks_num = chunks?size>
+	<#list chunks as sub_items>
+	public static void register<#if chunks_num == 1>(IEventBus modEventBus)<#else>${sub_items?index}()</#if> {
+		<#list sub_items as item>
+			<#if item.getModElement().getTypeString() == "armor">
+				<#if item.enableHelmet>
+				${item.getModElement().getRegistryNameUpper()}_HELMET =
+					REGISTRY.register("${item.getModElement().getRegistryName()}_helmet", ${item.getModElement().getName()}Item.Helmet::new);
+				</#if>
+				<#if item.enableBody>
+				${item.getModElement().getRegistryNameUpper()}_CHESTPLATE =
+					REGISTRY.register("${item.getModElement().getRegistryName()}_chestplate", ${item.getModElement().getName()}Item.Chestplate::new);
+				</#if>
+				<#if item.enableLeggings>
+				${item.getModElement().getRegistryNameUpper()}_LEGGINGS =
+					REGISTRY.register("${item.getModElement().getRegistryName()}_leggings", ${item.getModElement().getName()}Item.Leggings::new);
+				</#if>
+				<#if item.enableBoots>
+				${item.getModElement().getRegistryNameUpper()}_BOOTS =
+					REGISTRY.register("${item.getModElement().getRegistryName()}_boots", ${item.getModElement().getName()}Item.Boots::new);
+				</#if>
+			<#elseif item.getModElement().getTypeString() == "livingentity">
+				${item.getModElement().getRegistryNameUpper()}_SPAWN_EGG =
+					REGISTRY.register("${item.getModElement().getRegistryName()}_spawn_egg",
+						() -> new DeferredSpawnEggItem(${JavaModName}Entities.${item.getModElement().getRegistryNameUpper()},
+						${item.spawnEggBaseColor.getRGB()}, ${item.spawnEggDotColor.getRGB()}, new Item.Properties()));
+			<#elseif item.getModElement().getTypeString() == "dimension" && item.hasIgniter()>
+				${item.getModElement().getRegistryNameUpper()} =
+					REGISTRY.register("${item.getModElement().getRegistryName()}", ${item.getModElement().getName()}Item::new);
+			<#elseif item.getModElement().getTypeString() == "fluid" && item.generateBucket>
+				${item.getModElement().getRegistryNameUpper()}_BUCKET =
+					REGISTRY.register("${item.getModElement().getRegistryName()}_bucket", ${item.getModElement().getName()}Item::new);
+			<#elseif item.getModElement().getTypeString() == "block" || item.getModElement().getTypeString() == "plant">
+				<#if item.isDoubleBlock()>
+					<#assign hasDoubleBlocks = true>
+					${item.getModElement().getRegistryNameUpper()} = doubleBlock(${JavaModName}Blocks.${item.getModElement().getRegistryNameUpper()});
+				<#else>
+					<#assign hasBlocks = true>
+					${item.getModElement().getRegistryNameUpper()} = block(${JavaModName}Blocks.${item.getModElement().getRegistryNameUpper()});
+				</#if>
+			<#else>
+				${item.getModElement().getRegistryNameUpper()} =
+					REGISTRY.register("${item.getModElement().getRegistryName()}", ${item.getModElement().getName()}Item::new);
+			</#if>
+		</#list>
+		<#if chunks_num == 1>REGISTRY.register(modEventBus);</#if>
+	}
+	</#list>
+
+	<#if chunks_num gt 1>
+	public static void register(IEventBus modEventBus) {
+		<#list 0..chunks_num-1 as i>register${i}();</#list>
+		REGISTRY.register(modEventBus);
+	}
+	</#if>
 
 	// Start of user code block custom items
 	// End of user code block custom items
@@ -156,5 +187,5 @@ public class ${JavaModName}Items {
 	</#if>
 
 }
-
+</#compress>
 <#-- @formatter:on -->

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/modbase/mod.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/modbase/mod.java.ftl
@@ -19,7 +19,7 @@ import org.apache.logging.log4j.Logger;
 		modEventBus.addListener(this::registerNetworking);
 
 		<#if w.hasSounds()>${JavaModName}Sounds.REGISTRY.register(modEventBus);</#if>
-		<#if w.hasElementsOfBaseType("block")>${JavaModName}Blocks.REGISTRY.register(modEventBus);</#if>
+		<#if w.hasElementsOfBaseType("block")>${JavaModName}Blocks.register(modEventBus);</#if>
 		<#if w.hasElementsOfBaseType("blockentity")>${JavaModName}BlockEntities.REGISTRY.register(modEventBus);</#if>
 		<#if w.hasElementsOfBaseType("item")>${JavaModName}Items.REGISTRY.register(modEventBus);</#if>
 		<#if w.hasElementsOfBaseType("entity")>${JavaModName}Entities.REGISTRY.register(modEventBus);</#if>

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/modbase/mod.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/modbase/mod.java.ftl
@@ -21,7 +21,7 @@ import org.apache.logging.log4j.Logger;
 		<#if w.hasSounds()>${JavaModName}Sounds.REGISTRY.register(modEventBus);</#if>
 		<#if w.hasElementsOfBaseType("block")>${JavaModName}Blocks.register(modEventBus);</#if>
 		<#if w.hasElementsOfBaseType("blockentity")>${JavaModName}BlockEntities.REGISTRY.register(modEventBus);</#if>
-		<#if w.hasElementsOfBaseType("item")>${JavaModName}Items.REGISTRY.register(modEventBus);</#if>
+		<#if w.hasElementsOfBaseType("item")>${JavaModName}Items.register(modEventBus);</#if>
 		<#if w.hasElementsOfBaseType("entity")>${JavaModName}Entities.REGISTRY.register(modEventBus);</#if>
 		<#if w.hasItemsInTabs()>${JavaModName}Tabs.REGISTRY.register(modEventBus);</#if>
 		<#if w.hasVariables()>${JavaModName}Variables.ATTACHMENT_TYPES.register(modEventBus);</#if>


### PR DESCRIPTION
This PR tries to add support for very large workspaces with several 10k blocks or items. I did not add this chunking system for other MEs since workspaces tend to have the most blocks and items. Workspace with 10ks of entities would be quite an outlier in the majority we try to cover this.

In some tests, I have found a chunk size of 2500 to be a safe bet.

The downside is that with this approach, deferred entries are not final which is not the nicest.

Fixes #4984 and #4062