### PR TITLE
Added the painting mod element to data packs.

### DIFF
--- a/plugins/generator-1.21.1/datapack-1.21.1/generator.yaml
+++ b/plugins/generator-1.21.1/datapack-1.21.1/generator.yaml
@@ -12,6 +12,7 @@ res_root: "@SRCROOT"
 mod_assets_root: "@RESROOT/assets/@modid"
 mod_data_root: "@RESROOT/data/@modid"
 screen_textures_dir: "@MODASSETSROOT/textures/screens"
+other_textures_dir: "@MODASSETSROOT/textures"
 
 # specific resource folders
 structures_dir: "@MODDATAROOT/structures"

--- a/plugins/generator-1.21.1/datapack-1.21.1/painting.definition.yaml
+++ b/plugins/generator-1.21.1/datapack-1.21.1/painting.definition.yaml
@@ -1,0 +1,15 @@
+templates:
+  - template: json/painting.json.ftl
+    writer: json
+    name: "@MODDATAROOT/painting_variant/@registryname.json"
+
+global_templates:
+  - template: json/paintingtag.json.ftl
+    writer: json
+    name: "@RESROOT/data/minecraft/tags/painting_variant/placeable.json"
+
+localizationkeys:
+  - key: painting.@modid.@registryname.title
+    mapto: title
+  - key: painting.@modid.@registryname.author
+    mapto: author

--- a/plugins/generator-1.21.1/datapack-1.21.1/templates/painting.json.ftl
+++ b/plugins/generator-1.21.1/datapack-1.21.1/templates/painting.json.ftl
@@ -1,0 +1,7 @@
+<#-- @formatter:off -->
+{
+  "asset_id": "${modid}:${registryname}",
+  "height": ${(data.height / 16)?int},
+  "width": ${(data.width / 16)?int}
+}
+<#-- @formatter:on -->


### PR DESCRIPTION
Hello,

Recently, I noticed, that the 1.21.1 data pack Generator is missing the painting mod element. This PR adds this mod element to 1.21.1 data packs.

I've tested the PR and it works with no bugs. The example data pack for my city build server which contains some paintings can be downloaded [here](https://github.com/user-attachments/files/17061806/city_essentials-1.0.0-datapack-1.21.1.zip).
.

Kind regards,
Atten007 😊