### PR TITLE
Update Tips

### DIFF
--- a/plugins/mcreator-localization/help/default/entity/bounding_box.md
+++ b/plugins/mcreator-localization/help/default/entity/bounding_box.md
@@ -1,6 +1,6 @@
  This parameter controls the size of your mob's hitbox in blocks, as well as the size of its shadow. 
  The first option sets the width and depth, whilst the second option sets the height. 
  The third option sets size in blocks for the radius of the mob's shadow.
- The final option sets mounted entity Y offset.
+ The final option sets the passenger's attachment point on the entity it's riding.
  
  You can get more details on the entity model size [here](https://mcreator.net/wiki/entity-model-sizes).

--- a/plugins/mcreator-localization/help/default/entity/bounding_box.md
+++ b/plugins/mcreator-localization/help/default/entity/bounding_box.md
@@ -1,6 +1,6 @@
  This parameter controls the size of your mob's hitbox in blocks, as well as the size of its shadow. 
  The first option sets the width and depth, whilst the second option sets the height. 
  The third option sets size in blocks for the radius of the mob's shadow.
- The final option sets the passenger's attachment point on the entity it's riding.
+ The final option sets the Y offset of the passenger's attachment point on the entity it's riding.
  
  You can get more details on the entity model size [here](https://mcreator.net/wiki/entity-model-sizes).

--- a/plugins/mcreator-localization/help/default/entity/bounding_box.md
+++ b/plugins/mcreator-localization/help/default/entity/bounding_box.md
@@ -1,5 +1,6 @@
  This parameter controls the size of your mob's hitbox in blocks, as well as the size of its shadow. 
  The first option sets the width and depth, whilst the second option sets the height. 
- The final option sets size in blocks for the radius of the mob's shadow.
+ The third option sets size in blocks for the radius of the mob's shadow.
+ The final option sets Mounted Entity Y Offset.
  
  You can get more details on the entity model size [here](https://mcreator.net/wiki/entity-model-sizes).

--- a/plugins/mcreator-localization/help/default/entity/bounding_box.md
+++ b/plugins/mcreator-localization/help/default/entity/bounding_box.md
@@ -1,6 +1,6 @@
  This parameter controls the size of your mob's hitbox in blocks, as well as the size of its shadow. 
  The first option sets the width and depth, whilst the second option sets the height. 
  The third option sets size in blocks for the radius of the mob's shadow.
- The final option sets Mounted Entity Y Offset.
+ The final option sets mounted entity Y offset.
  
  You can get more details on the entity model size [here](https://mcreator.net/wiki/entity-model-sizes).


### PR DESCRIPTION
It seems like bounding_box.md is outdated
In MCreator:
![屏幕截图 2024-09-22 143253](https://github.com/user-attachments/assets/39b9f8b0-9239-45db-86ba-6e7ac2067589)
You can see the tip only show three options, but there are four options.
I updated the bounding_box.md, if someone find some mistakes in grammar, please comment below.