### PR TITLE
Infinite effects for potion mod element

### DIFF
--- a/plugins/generator-1.20.1/forge-1.20.1/templates/elementinits/potions.java.ftl
+++ b/plugins/generator-1.20.1/forge-1.20.1/templates/elementinits/potions.java.ftl
@@ -43,7 +43,7 @@ public class ${JavaModName}Potions {
 	<#list potions as potion>
 		public static final RegistryObject<Potion> ${potion.getModElement().getRegistryNameUpper()} = REGISTRY.register("${potion.getModElement().getRegistryName()}", () -> new Potion(
 			<#list potion.effects as effect>
-			new MobEffectInstance(${effect.effect}, ${effect.duration}, ${effect.amplifier}, ${effect.ambient}, ${effect.showParticles})<#sep>,
+			new MobEffectInstance(${effect.effect}, ${effect.getDuration()}, ${effect.amplifier}, ${effect.ambient}, ${effect.showParticles})<#sep>,
 			</#list>));
 	</#list>
 

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/elementinits/potions.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/elementinits/potions.java.ftl
@@ -44,7 +44,7 @@ public class ${JavaModName}Potions {
 		public static final DeferredHolder<Potion, Potion> ${potion.getModElement().getRegistryNameUpper()} = REGISTRY.register("${potion.getModElement().getRegistryName()}",
 			() -> new Potion(
 				<#list potion.effects as effect>
-				new MobEffectInstance(${effect.effect}, ${effect.duration}, ${effect.amplifier}, ${effect.ambient}, ${effect.showParticles})<#sep>,
+				new MobEffectInstance(${effect.effect}, ${effect.getDuration()}, ${effect.amplifier}, ${effect.ambient}, ${effect.showParticles})<#sep>,
 				</#list>
 			)
 		);

--- a/plugins/mcreator-localization/help/default/potion/infinite.md
+++ b/plugins/mcreator-localization/help/default/potion/infinite.md
@@ -1,0 +1,1 @@
+If this option is selected, the effect will have an infinite duration.

--- a/plugins/mcreator-localization/lang/texts.properties
+++ b/plugins/mcreator-localization/lang/texts.properties
@@ -2848,6 +2848,7 @@ elementgui.potion.effects=Effects list
 elementgui.potion.add_entry=Add a new effect entry
 elementgui.potion.effect=Effect:
 elementgui.potion.duration=Duration:
+elementgui.potion.infinite=Is infinite?
 elementgui.potion.amplifier=Amplifier:
 elementgui.potion.ambient=Ambient?
 elementgui.potion.show_particles=Show particles?

--- a/src/main/java/net/mcreator/element/types/Potion.java
+++ b/src/main/java/net/mcreator/element/types/Potion.java
@@ -52,12 +52,17 @@ import java.util.List;
 	public static class CustomEffectEntry {
 		public EffectEntry effect;
 		public int duration;
+		public boolean infinite;
 		public int amplifier;
 		public boolean ambient;
 		public boolean showParticles;
 
 		public int getAmplifier() {
 			return amplifier;
+		}
+
+		public int getDuration() {
+			return infinite ? -1 : duration;
 		}
 
 		public boolean doesShowParticles() {

--- a/src/main/java/net/mcreator/ui/minecraft/potions/JPotionListEntry.java
+++ b/src/main/java/net/mcreator/ui/minecraft/potions/JPotionListEntry.java
@@ -38,6 +38,7 @@ import java.util.stream.Collectors;
 public class JPotionListEntry extends JSimpleListEntry<Potion.CustomEffectEntry> {
 
 	private final JSpinner duration = new JSpinner(new SpinnerNumberModel(3600, 1, 72000, 1));
+	private final JCheckBox infinite = L10N.checkbox("elementgui.common.enable");
 	private final JSpinner amplifier = new JSpinner(new SpinnerNumberModel(0, 0, 255, 1));
 	private final JComboBox<String> effect = new JComboBox<>();
 	private final JCheckBox ambient = L10N.checkbox("elementgui.common.enable");
@@ -59,6 +60,11 @@ public class JPotionListEntry extends JSimpleListEntry<Potion.CustomEffectEntry>
 		line.add(HelpUtils.wrapWithHelpButton(gui.withEntry("potion/duration"),
 				L10N.label("elementgui.potion.duration")));
 		line.add(duration);
+
+		line.add(HelpUtils.wrapWithHelpButton(gui.withEntry("potion/infinite"),
+				L10N.label("elementgui.potion.infinite")));
+		line.add(infinite);
+		infinite.addActionListener(e -> duration.setEnabled(!infinite.isSelected()));
 
 		line.add(HelpUtils.wrapWithHelpButton(gui.withEntry("potion/amplifier"),
 				L10N.label("elementgui.potion.amplifier")));
@@ -84,7 +90,8 @@ public class JPotionListEntry extends JSimpleListEntry<Potion.CustomEffectEntry>
 	}
 
 	@Override protected void setEntryEnabled(boolean enabled) {
-		duration.setEnabled(enabled);
+		duration.setEnabled(enabled && !infinite.isSelected());
+		infinite.setEnabled(enabled);
 		amplifier.setEnabled(enabled);
 		effect.setEnabled(enabled);
 		ambient.setEnabled(enabled);
@@ -95,6 +102,7 @@ public class JPotionListEntry extends JSimpleListEntry<Potion.CustomEffectEntry>
 		Potion.CustomEffectEntry entry = new Potion.CustomEffectEntry();
 		entry.effect = new EffectEntry(workspace, (String) effect.getSelectedItem());
 		entry.duration = (int) duration.getValue();
+		entry.infinite = infinite.isSelected();
 		entry.amplifier = (int) amplifier.getValue();
 		entry.ambient = ambient.isSelected();
 		entry.showParticles = showParticles.isSelected();
@@ -104,9 +112,12 @@ public class JPotionListEntry extends JSimpleListEntry<Potion.CustomEffectEntry>
 	@Override public void setEntry(Potion.CustomEffectEntry e) {
 		effect.setSelectedItem(e.effect.getUnmappedValue());
 		duration.setValue(e.duration);
+		infinite.setSelected(e.infinite);
 		amplifier.setValue(e.amplifier);
 		ambient.setSelected(e.ambient);
 		showParticles.setSelected(e.showParticles);
+
+		duration.setEnabled(!e.infinite);
 	}
 
 }

--- a/src/test/java/net/mcreator/integration/TestWorkspaceDataProvider.java
+++ b/src/test/java/net/mcreator/integration/TestWorkspaceDataProvider.java
@@ -1122,6 +1122,7 @@ public class TestWorkspaceDataProvider {
 				entry1.effect = new EffectEntry(modElement.getWorkspace(),
 						getRandomDataListEntry(random, ElementUtil.loadAllPotionEffects(modElement.getWorkspace())));
 				entry1.duration = 3600;
+				entry1.infinite = _true;
 				entry1.amplifier = 1;
 				entry1.ambient = !_true;
 				entry1.showParticles = !_true;
@@ -1131,6 +1132,7 @@ public class TestWorkspaceDataProvider {
 				entry2.effect = new EffectEntry(modElement.getWorkspace(),
 						getRandomDataListEntry(random, ElementUtil.loadAllPotionEffects(modElement.getWorkspace())));
 				entry2.duration = 7200;
+				entry2.infinite = !_true;
 				entry2.amplifier = 0;
 				entry2.ambient = _true;
 				entry2.showParticles = _true;


### PR DESCRIPTION
This PR makes it possible to add effects with infinite duration to custom potions.

![endless](https://github.com/user-attachments/assets/0f8eeff1-2cbc-4c7c-8d87-c2e560144ac9)
