### PR TITLE
File browser min. length change from > 3 to >= 3

### DIFF
--- a/src/main/java/net/mcreator/ui/browser/WorkspaceFileBrowser.java
+++ b/src/main/java/net/mcreator/ui/browser/WorkspaceFileBrowser.java
@@ -117,7 +117,7 @@ public class WorkspaceFileBrowser extends JPanel {
 
 			@Override public void keyReleased(KeyEvent keyEvent) {
 				super.keyReleased(keyEvent);
-				if (jtf1.getText().trim().length() > 3) {
+				if (jtf1.getText().trim().length() >= 3) {
 					if (!searchInAction && Character.isLetterOrDigit(keyEvent.getKeyChar())) {
 						new Thread(() -> {
 							searchInAction = true;


### PR DESCRIPTION
Change min. key length to `>= 3` so that things like vex, gui etc. can be actually searchable