### PR TITLE
Fix #5119

### DIFF
--- a/plugins/generator-1.20.1/forge-1.20.1/templates/item/item.java.ftl
+++ b/plugins/generator-1.20.1/forge-1.20.1/templates/item/item.java.ftl
@@ -144,7 +144,7 @@ public class ${name}Item extends Item {
 
 	<@addSpecialInformation data.specialInformation/>
 
-	<#if hasProcedure(data.onRightClickedInAir) || data.hasInventory() || hasProcedure(data.onStoppedUsing) || (data.useDuration > 0) || data.enableRanged>
+	<#if hasProcedure(data.onRightClickedInAir) || data.hasInventory() || ((hasProcedure(data.onStoppedUsing) || !data.isFood) && (data.useDuration > 0)) || data.enableRanged>
 	@Override public InteractionResultHolder<ItemStack> use(Level world, Player entity, InteractionHand hand) {
 		<#if data.enableRanged>
 		InteractionResultHolder<ItemStack> ar = InteractionResultHolder.fail(entity.getItemInHand(hand));
@@ -152,25 +152,23 @@ public class ${name}Item extends Item {
 		InteractionResultHolder<ItemStack> ar = super.use(world, entity, hand);
 		</#if>
 
-		<#if hasProcedure(data.onStoppedUsing) || (data.useDuration > 0) || data.enableRanged>
-			<#if data.enableRanged>
-				<#if hasProcedure(data.rangedUseCondition)>
-				if (<@procedureCode data.rangedUseCondition, {
-					"x": "entity.getX()",
-					"y": "entity.getY()",
-					"z": "entity.getZ()",
-					"world": "world",
-					"entity": "entity",
-					"itemstack": "ar.getObject()"
-				}, false/>)
-				</#if>
-				if (entity.getAbilities().instabuild || findAmmo(entity) != ItemStack.EMPTY) {
-					ar = InteractionResultHolder.success(entity.getItemInHand(hand));
-					entity.startUsingItem(hand);
-				}
-			<#else>
-				entity.startUsingItem(hand);
+		<#if data.enableRanged>
+			<#if hasProcedure(data.rangedUseCondition)>
+			if (<@procedureCode data.rangedUseCondition, {
+				"x": "entity.getX()",
+				"y": "entity.getY()",
+				"z": "entity.getZ()",
+				"world": "world",
+				"entity": "entity",
+				"itemstack": "ar.getObject()"
+			}, false/>)
 			</#if>
+			if (entity.getAbilities().instabuild || findAmmo(entity) != ItemStack.EMPTY) {
+				ar = InteractionResultHolder.success(entity.getItemInHand(hand));
+				entity.startUsingItem(hand);
+			}
+		<#elseif (hasProcedure(data.onStoppedUsing) || !data.isFood) && (data.useDuration > 0)>
+			entity.startUsingItem(hand);
 		</#if>
 
 		<#if data.hasInventory()>

--- a/plugins/generator-1.20.1/forge-1.20.1/templates/item/item.java.ftl
+++ b/plugins/generator-1.20.1/forge-1.20.1/templates/item/item.java.ftl
@@ -144,7 +144,8 @@ public class ${name}Item extends Item {
 
 	<@addSpecialInformation data.specialInformation/>
 
-	<#if hasProcedure(data.onRightClickedInAir) || data.hasInventory() || ((hasProcedure(data.onStoppedUsing) || !data.isFood) && (data.useDuration > 0)) || data.enableRanged>
+	<#assign shouldExplicitlyCallStartUsing = !data.isFood && (data.useDuration > 0)> <#-- ranged items handled in if below so no need to check for that here too -->
+	<#if hasProcedure(data.onRightClickedInAir) || data.hasInventory() || data.enableRanged || shouldExplicitlyCallStartUsing>
 	@Override public InteractionResultHolder<ItemStack> use(Level world, Player entity, InteractionHand hand) {
 		<#if data.enableRanged>
 		InteractionResultHolder<ItemStack> ar = InteractionResultHolder.fail(entity.getItemInHand(hand));
@@ -167,7 +168,7 @@ public class ${name}Item extends Item {
 				ar = InteractionResultHolder.success(entity.getItemInHand(hand));
 				entity.startUsingItem(hand);
 			}
-		<#elseif (hasProcedure(data.onStoppedUsing) || !data.isFood) && (data.useDuration > 0)>
+		<#elseif shouldExplicitlyCallStartUsing>
 			entity.startUsingItem(hand);
 		</#if>
 

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/item/item.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/item/item.java.ftl
@@ -138,7 +138,7 @@ public class ${name}Item extends Item {
 
 	<@addSpecialInformation data.specialInformation/>
 
-	<#if hasProcedure(data.onRightClickedInAir) || data.hasInventory() || hasProcedure(data.onStoppedUsing) || (data.useDuration > 0) || data.enableRanged>
+	<#if hasProcedure(data.onRightClickedInAir) || data.hasInventory() || ((hasProcedure(data.onStoppedUsing) || !data.isFood) && (data.useDuration > 0)) || data.enableRanged>
 	@Override public InteractionResultHolder<ItemStack> use(Level world, Player entity, InteractionHand hand) {
 		<#if data.enableRanged>
 		InteractionResultHolder<ItemStack> ar = InteractionResultHolder.fail(entity.getItemInHand(hand));
@@ -146,25 +146,23 @@ public class ${name}Item extends Item {
 		InteractionResultHolder<ItemStack> ar = super.use(world, entity, hand);
 		</#if>
 
-		<#if hasProcedure(data.onStoppedUsing) || (data.useDuration > 0) || data.enableRanged>
-			<#if data.enableRanged>
-				<#if hasProcedure(data.rangedUseCondition)>
-				if (<@procedureCode data.rangedUseCondition, {
-					"x": "entity.getX()",
-					"y": "entity.getY()",
-					"z": "entity.getZ()",
-					"world": "world",
-					"entity": "entity",
-					"itemstack": "ar.getObject()"
-				}, false/>)
-				</#if>
-				if (entity.getAbilities().instabuild || findAmmo(entity) != ItemStack.EMPTY) {
-					ar = InteractionResultHolder.success(entity.getItemInHand(hand));
-					entity.startUsingItem(hand);
-				}
-			<#else>
-				entity.startUsingItem(hand);
+		<#if data.enableRanged>
+			<#if hasProcedure(data.rangedUseCondition)>
+			if (<@procedureCode data.rangedUseCondition, {
+				"x": "entity.getX()",
+				"y": "entity.getY()",
+				"z": "entity.getZ()",
+				"world": "world",
+				"entity": "entity",
+				"itemstack": "ar.getObject()"
+			}, false/>)
 			</#if>
+			if (entity.getAbilities().instabuild || findAmmo(entity) != ItemStack.EMPTY) {
+				ar = InteractionResultHolder.success(entity.getItemInHand(hand));
+				entity.startUsingItem(hand);
+			}
+		<#elseif (hasProcedure(data.onStoppedUsing) || !data.isFood) && (data.useDuration > 0)>
+			entity.startUsingItem(hand);
 		</#if>
 
 		<#if data.hasInventory()>

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/item/item.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/item/item.java.ftl
@@ -138,7 +138,8 @@ public class ${name}Item extends Item {
 
 	<@addSpecialInformation data.specialInformation/>
 
-	<#if hasProcedure(data.onRightClickedInAir) || data.hasInventory() || ((hasProcedure(data.onStoppedUsing) || !data.isFood) && (data.useDuration > 0)) || data.enableRanged>
+	<#assign shouldExplicitlyCallStartUsing = !data.isFood && (data.useDuration > 0)> <#-- ranged items handled in if below so no need to check for that here too -->
+	<#if hasProcedure(data.onRightClickedInAir) || data.hasInventory() || data.enableRanged || shouldExplicitlyCallStartUsing>
 	@Override public InteractionResultHolder<ItemStack> use(Level world, Player entity, InteractionHand hand) {
 		<#if data.enableRanged>
 		InteractionResultHolder<ItemStack> ar = InteractionResultHolder.fail(entity.getItemInHand(hand));
@@ -161,7 +162,7 @@ public class ${name}Item extends Item {
 				ar = InteractionResultHolder.success(entity.getItemInHand(hand));
 				entity.startUsingItem(hand);
 			}
-		<#elseif (hasProcedure(data.onStoppedUsing) || !data.isFood) && (data.useDuration > 0)>
+		<#elseif shouldExplicitlyCallStartUsing>
 			entity.startUsingItem(hand);
 		</#if>
 


### PR DESCRIPTION
Fixes https://github.com/MCreator/MCreator/issues/5119 by only explicitly calling startUsingItem if item has use duration longer than 0 and either on stopped using a procedure or it is not food (food handles startUsingItem on its own already).

Changelog:

* [Bugfix] Custom food items were always edible even if this parameter was not enabled