### PR TITLE
Pass proper command arguments when selecting file on Windows

### DIFF
--- a/src/main/java/net/mcreator/util/DesktopUtils.java
+++ b/src/main/java/net/mcreator/util/DesktopUtils.java
@@ -179,8 +179,8 @@ public class DesktopUtils {
 
 			if (selectOnly) {
 				if (SystemUtils.IS_OS_WINDOWS) { // https://bugs.openjdk.java.net/browse/JDK-8233994
-					LOG.info("Trying to execute: explorer /select,{}", file.getPath());
-					return Runtime.getRuntime().exec(new String[] { "explorer", "/select," + file.getPath() }) != null;
+					LOG.info("Trying to execute: explorer /select, \"{}\"", file.getPath());
+					return Runtime.getRuntime().exec(new String[] { "explorer", "/select,", "\"" + file.getPath() + "\"" }) != null;
 				} else {
 					LOG.info("Trying to use Desktop.getDesktop().browseFileDirectory() with {}", file.toString());
 					Desktop.getDesktop().browseFileDirectory(file);


### PR DESCRIPTION
Fixes a regression when trying to show file in explorer via project browser would fail due to improperly quoted arguments.