### PR TITLE
Added "For each entity between corners" procedure block

### DIFF
--- a/plugins/generator-1.20.1/forge-1.20.1/procedures/world_entity_corners_foreach.java.ftl
+++ b/plugins/generator-1.20.1/forge-1.20.1/procedures/world_entity_corners_foreach.java.ftl
@@ -1,0 +1,3 @@
+for (Entity entityiterator : world.getEntities(${input$exclude}, new AABB(${input$x1}, ${input$y1}, ${input$z1}, ${input$x2}, ${input$y2}, ${input$z2}))) {
+	${statement$foreach}
+}

--- a/plugins/generator-1.21.1/neoforge-1.21.1/procedures/world_entity_corners_foreach.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/procedures/world_entity_corners_foreach.java.ftl
@@ -1,0 +1,3 @@
+for (Entity entityiterator : world.getEntities(${input$exclude}, new AABB(${input$x1}, ${input$y1}, ${input$z1}, ${input$x2}, ${input$y2}, ${input$z2}))) {
+	${statement$foreach}
+}

--- a/plugins/mcreator-core/procedures/world_entity_corners_foreach.json
+++ b/plugins/mcreator-core/procedures/world_entity_corners_foreach.json
@@ -1,0 +1,94 @@
+{
+  "args0": [
+    {
+      "type": "input_value",
+      "name": "exclude",
+      "check": "Entity"
+    },
+    {
+      "type": "input_value",
+      "name": "x1",
+      "check": "Number"
+    },
+    {
+      "type": "input_value",
+      "name": "y1",
+      "check": "Number"
+    },
+    {
+      "type": "input_value",
+      "name": "z1",
+      "check": "Number"
+    },
+    {
+      "type": "input_value",
+      "name": "x2",
+      "check": "Number"
+    },
+    {
+      "type": "input_value",
+      "name": "y2",
+      "check": "Number"
+    },
+    {
+      "type": "input_value",
+      "name": "z2",
+      "check": "Number"
+    },
+    {
+      "type": "input_value",
+      "name": "_placeholder",
+      "check": "Entity"
+    },
+    {
+      "type": "input_statement",
+      "name": "foreach"
+    }
+  ],
+  "extensions": [
+    "is_custom_loop"
+  ],
+  "inputsInline": true,
+  "previousStatement": null,
+  "nextStatement": null,
+  "colour": 35,
+  "mcreator": {
+    "toolbox_id": "worldmanagement",
+    "toolbox_init": [
+      "<value name=\"exclude\"><block type=\"entity_none\"></block></value>",
+      "<value name=\"x1\"><block type=\"coord_x\"></block></value>",
+      "<value name=\"y1\"><block type=\"coord_y\"></block></value>",
+      "<value name=\"z1\"><block type=\"coord_z\"></block></value>",
+      "<value name=\"x2\"><block type=\"coord_x\"></block></value>",
+      "<value name=\"y2\"><block type=\"coord_y\"></block></value>",
+      "<value name=\"z2\"><block type=\"coord_z\"></block></value>",
+      "<value name=\"_placeholder\"><block deletable=\"false\" movable=\"false\" enabled=\"false\" type=\"entity_iterator\"></block></value>"
+    ],
+    "inputs": [
+      "exclude",
+      "x1",
+      "y1",
+      "z1",
+      "x2",
+      "y2",
+      "z2"
+    ],
+    "statements": [
+      {
+        "name": "foreach",
+        "provides": [
+          {
+            "name": "entityiterator",
+            "type": "entity"
+          }
+        ]
+      }
+    ],
+    "dependencies": [
+      {
+        "name": "world",
+        "type": "world"
+      }
+    ]
+  }
+}

--- a/plugins/mcreator-localization/lang/texts.properties
+++ b/plugins/mcreator-localization/lang/texts.properties
@@ -1286,6 +1286,7 @@ blockly.block.world_data_spawn_z=Get current world spawn z coordinate
 blockly.block.world_data_temperature=Get biome temperature at x: %1 y: %2 z: %3
 blockly.block.world_data_isvillage=Is x: %1 y: %2 z: %3 inside a village %4
 blockly.block.world_data_is_chunk_loaded=Has chunk at x: %1 y: %2 z: %3 %4
+blockly.block.world_entity_corners_foreach=For each entity except %1 as %8 between x1: %2 y1: %3 z1: %4 and x2: %5 y2: %6 z2: %7 do %9
 blockly.block.world_entity_inrange=%5 Get nearest entity at x: %1 y: %2 z: %3 in square cube with size %4 of type %6
 blockly.block.world_entity_inrange_exists=Does entity exist at x: %1 y: %2 z: %3 in square cube with size %4 of type %5
 blockly.block.world_entity_inrange_foreach=For each entity as %5 at x: %1 y: %2 z: %3 in square cube with size %4 do %6


### PR DESCRIPTION
This PR adds a procedure block to iterate through entities between two corners (not necessarily a cube) and with the option to exclude a specific entity (the "No entity" block can be used to include all entities). 
Unlike the "Entities in cube" block, entities aren't sorted by distance.

![for each entity](https://github.com/user-attachments/assets/0d2fe7d9-bf43-4a06-91da-c4a97d3cd72e)
