### PR TITLE
Minor JMinMaxSpinner refactoring

### DIFF
--- a/src/main/java/net/mcreator/ui/component/JMinMaxSpinner.java
+++ b/src/main/java/net/mcreator/ui/component/JMinMaxSpinner.java
@@ -146,8 +146,9 @@ public class JMinMaxSpinner extends JPanel {
 		directValueSet = false;
 	}
 
-	public void setAllowEqualValues(boolean allowEqualValues) {
-		this.allowEqualValues = allowEqualValues;
+	public JMinMaxSpinner allowEqualValues() {
+		this.allowEqualValues = true;
+		return this;
 	}
 
 }

--- a/src/main/java/net/mcreator/ui/minecraft/loottable/JLootTableEntry.java
+++ b/src/main/java/net/mcreator/ui/minecraft/loottable/JLootTableEntry.java
@@ -38,9 +38,9 @@ public class JLootTableEntry extends JPanel {
 	private final MCItemHolder item;
 	private final JSpinner weight = new JSpinner(new SpinnerNumberModel(1, 0, 64000, 1));
 
-	private final JMinMaxSpinner count = new JMinMaxSpinner(1, 1, 0, 64000, 1);
+	private final JMinMaxSpinner count = new JMinMaxSpinner(1, 1, 0, 64000, 1).allowEqualValues();
 
-	private final JMinMaxSpinner enchantmentsLevel = new JMinMaxSpinner(0, 0, 0, 64000, 1);
+	private final JMinMaxSpinner enchantmentsLevel = new JMinMaxSpinner(0, 0, 0, 64000, 1).allowEqualValues();
 
 	private final JCheckBox affectedByFortune = L10N.checkbox("elementgui.loot_table.affected_by_fortune");
 	private final JCheckBox explosionDecay = L10N.checkbox("elementgui.loot_table.enable_explosion_decay");
@@ -57,11 +57,9 @@ public class JLootTableEntry extends JPanel {
 		count.setBorder(BorderFactory.createCompoundBorder(
 				BorderFactory.createLineBorder(Theme.current().getAltBackgroundColor()),
 				BorderFactory.createEmptyBorder(2, 2, 2, 2)));
-		count.setAllowEqualValues(true);
 		enchantmentsLevel.setBorder(BorderFactory.createCompoundBorder(
 				BorderFactory.createLineBorder(Theme.current().getAltBackgroundColor()),
 				BorderFactory.createEmptyBorder(2, 2, 2, 2)));
-		enchantmentsLevel.setAllowEqualValues(true);
 
 		final JComponent container = PanelUtils.expandHorizontally(this);
 

--- a/src/main/java/net/mcreator/ui/minecraft/loottable/JLootTablePool.java
+++ b/src/main/java/net/mcreator/ui/minecraft/loottable/JLootTablePool.java
@@ -37,8 +37,8 @@ import java.util.Objects;
 
 public class JLootTablePool extends JEntriesList {
 
-	private final JMinMaxSpinner rolls = new JMinMaxSpinner(1, 1, 0, 64000, 1);
-	private final JMinMaxSpinner bonusrolls = new JMinMaxSpinner(1, 1, 0, 64000, 1);
+	private final JMinMaxSpinner rolls = new JMinMaxSpinner(1, 1, 0, 64000, 1).allowEqualValues();
+	private final JMinMaxSpinner bonusrolls = new JMinMaxSpinner(1, 1, 0, 64000, 1).allowEqualValues();
 	private final JCheckBox hasbonusrolls = L10N.checkbox("elementgui.loot_table.enable_pool_rolls");
 
 	private final List<JLootTableEntry> entryList = new ArrayList<>();
@@ -59,11 +59,9 @@ public class JLootTablePool extends JEntriesList {
 		rolls.setBorder(BorderFactory.createCompoundBorder(
 				BorderFactory.createLineBorder(Theme.current().getSecondAltBackgroundColor()),
 				BorderFactory.createEmptyBorder(2, 2, 2, 2)));
-		rolls.setAllowEqualValues(true);
 		bonusrolls.setBorder(BorderFactory.createCompoundBorder(
 				BorderFactory.createLineBorder(Theme.current().getSecondAltBackgroundColor()),
 				BorderFactory.createEmptyBorder(2, 2, 2, 2)));
-		bonusrolls.setAllowEqualValues(true);
 		hasbonusrolls.setOpaque(false);
 
 		JPanel topbar = new JPanel(new FlowLayout(FlowLayout.LEFT));

--- a/src/main/java/net/mcreator/ui/minecraft/spawntypes/JSpawnListEntry.java
+++ b/src/main/java/net/mcreator/ui/minecraft/spawntypes/JSpawnListEntry.java
@@ -40,7 +40,7 @@ import java.util.stream.Collectors;
 public class JSpawnListEntry extends JSimpleListEntry<Biome.SpawnEntry> {
 
 	private final JSpinner spawningProbability = new JSpinner(new SpinnerNumberModel(20, 1, 1000, 1));
-	private final JMinMaxSpinner numberOfMobsPerGroup = new JMinMaxSpinner(4, 4, 1, 1000, 1);
+	private final JMinMaxSpinner numberOfMobsPerGroup = new JMinMaxSpinner(4, 4, 1, 1000, 1).allowEqualValues();
 	private final JComboBox<String> mobSpawningType = new SearchableComboBox<>(
 			ElementUtil.getDataListAsStringArray("mobspawntypes"));
 	private final JComboBox<String> entityType = new SearchableComboBox<>();
@@ -55,7 +55,6 @@ public class JSpawnListEntry extends JSimpleListEntry<Biome.SpawnEntry> {
 		numberOfMobsPerGroup.setBorder(BorderFactory.createCompoundBorder(
 				BorderFactory.createLineBorder(Theme.current().getAltBackgroundColor()),
 				BorderFactory.createEmptyBorder(2, 2, 2, 2)));
-		numberOfMobsPerGroup.setAllowEqualValues(true);
 
 		line.add(L10N.label("dialog.spawn_list_entry.entity"));
 		line.add(entityType);

--- a/src/main/java/net/mcreator/ui/modgui/BlockGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/BlockGUI.java
@@ -171,7 +171,7 @@ public class BlockGUI extends ModElementGUI<Block> {
 	private final MCItemHolder customDrop = new MCItemHolder(mcreator, ElementUtil::loadBlocksAndItems);
 
 	private final JComboBox<String> generationShape = new JComboBox<>(new String[] { "UNIFORM", "TRIANGLE" });
-	private final JMinMaxSpinner generateHeight = new JMinMaxSpinner(0, 64, -2032, 2016, 1);
+	private final JMinMaxSpinner generateHeight = new JMinMaxSpinner(0, 64, -2032, 2016, 1).allowEqualValues();
 	private final JSpinner frequencyPerChunks = new JSpinner(new SpinnerNumberModel(10, 1, 64, 1));
 	private final JSpinner frequencyOnChunk = new JSpinner(new SpinnerNumberModel(16, 1, 64, 1));
 	private BiomeListField restrictionBiomes;
@@ -277,7 +277,6 @@ public class BlockGUI extends ModElementGUI<Block> {
 		guiBoundTo = new SingleModElementSelector(mcreator, ModElementType.GUI);
 
 		blocksToReplace.setListElements(List.of(new MItemBlock(mcreator.getWorkspace(), "TAG:stone_ore_replaceables")));
-		generateHeight.setAllowEqualValues(true);
 
 		generateFeature.setOpaque(false);
 

--- a/src/main/java/net/mcreator/ui/modgui/LivingEntityGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/LivingEntityGUI.java
@@ -121,7 +121,7 @@ public class LivingEntityGUI extends ModElementGUI<LivingEntity> implements IBlo
 	private final JSpinner rangedAttackRadius = new JSpinner(new SpinnerNumberModel(10, 0, 1024, 0.1));
 
 	private final JSpinner spawningProbability = new JSpinner(new SpinnerNumberModel(20, 1, 1000, 1));
-	private final JMinMaxSpinner numberOfMobsPerGroup = new JMinMaxSpinner(4, 4, 1, 1000, 1);
+	private final JMinMaxSpinner numberOfMobsPerGroup = new JMinMaxSpinner(4, 4, 1, 1000, 1).allowEqualValues();
 
 	private final JSpinner modelWidth = new JSpinner(new SpinnerNumberModel(0.6, 0, 1024, 0.1));
 	private final JSpinner modelHeight = new JSpinner(new SpinnerNumberModel(1.8, 0, 1024, 0.1));
@@ -375,8 +375,6 @@ public class LivingEntityGUI extends ModElementGUI<LivingEntity> implements IBlo
 		breedTriggerItems = new MCItemListField(mcreator, ElementUtil::loadBlocksAndItemsAndTags, false, true);
 		entityDataList = new JEntityDataList(mcreator, this);
 		guiBoundTo = new SingleModElementSelector(mcreator, ModElementType.GUI);
-
-		numberOfMobsPerGroup.setAllowEqualValues(true);
 
 		mobModelTexture = new TextureComboBox(mcreator, TextureType.ENTITY).requireValue(
 				"elementgui.living_entity.error_entity_model_needs_texture");

--- a/src/main/java/net/mcreator/ui/modgui/StructureGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/StructureGUI.java
@@ -102,7 +102,6 @@ public class StructureGUI extends ModElementGUI<Structure> {
 		ignoreBlocks = new MCItemListField(mcreator, ElementUtil::loadBlocks);
 		jigsaw = new JJigsawPoolsList(mcreator, this, modElement);
 
-		separation_spacing.setAllowEqualValues(false);
 		terrainAdaptation.addActionListener(e -> {
 			int max = "none".equals(terrainAdaptation.getSelectedItem()) ? 128 : 116;
 			SpinnerNumberModel spinnerModel = (SpinnerNumberModel) maxDistanceFromCenter.getModel();


### PR DESCRIPTION
This PR replaces the `setAllowEqualValues` method with one that can be chained to the constructor (similar to many ProcedureSelector settings).