### PR TITLE
Retain user workspace state

### DIFF
--- a/src/main/java/net/mcreator/preferences/data/HiddenSection.java
+++ b/src/main/java/net/mcreator/preferences/data/HiddenSection.java
@@ -23,22 +23,16 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonPrimitive;
 import net.mcreator.preferences.PreferencesEntry;
-import net.mcreator.preferences.PreferencesManager;
 import net.mcreator.preferences.PreferencesSection;
 import net.mcreator.preferences.entries.BooleanEntry;
 import net.mcreator.preferences.entries.HiddenEntry;
-import net.mcreator.preferences.entries.IntegerEntry;
 import net.mcreator.preferences.entries.StringEntry;
 
 import java.io.File;
 
 public class HiddenSection extends PreferencesSection {
 
-	public final PreferencesEntry<IconSize> workspaceModElementIconSize;
 	public final BooleanEntry fullScreen;
-	public final IntegerEntry projectTreeSplitPos;
-	public final BooleanEntry workspaceSortAscending;
-	public final PreferencesEntry<SortType> workspaceSortOrder;
 	public final PreferencesEntry<File> java_home;
 	public final StringEntry uiTheme;
 	public final BooleanEntry enableJavaPlugins;
@@ -47,27 +41,7 @@ public class HiddenSection extends PreferencesSection {
 	HiddenSection(String preferencesIdentifier) {
 		super(preferencesIdentifier);
 
-		workspaceModElementIconSize = addEntry(new HiddenEntry<>("workspaceModElementIconSize", IconSize.TILES) {
-			@Override public void setValueFromJsonElement(JsonElement object) {
-				this.value = IconSize.valueOf(object.getAsString());
-			}
-
-			@Override public JsonElement getSerializedValue() {
-				return PreferencesManager.gson.toJsonTree(value, IconSize.class);
-			}
-		});
 		fullScreen = addEntry(new BooleanEntry("fullScreen", false));
-		projectTreeSplitPos = addEntry(new IntegerEntry("projectTreeSplitPos", 0));
-		workspaceSortAscending = addEntry(new BooleanEntry("workspaceSortAscending", true));
-		workspaceSortOrder = addEntry(new HiddenEntry<>("workspaceSortOrder", SortType.CREATED) {
-			@Override public void setValueFromJsonElement(JsonElement object) {
-				this.value = SortType.valueOf(object.getAsString());
-			}
-
-			@Override public JsonElement getSerializedValue() {
-				return PreferencesManager.gson.toJsonTree(value, SortType.class);
-			}
-		});
 		java_home = addEntry(new HiddenEntry<>("java_home", null) {
 			@Override public void setValueFromJsonElement(JsonElement object) {
 				this.value = new File(object.getAsString());
@@ -92,14 +66,6 @@ public class HiddenSection extends PreferencesSection {
 
 	@Override public String getSectionKey() {
 		return "hidden";
-	}
-
-	public enum SortType {
-		NAME, CREATED, TYPE
-	}
-
-	public enum IconSize {
-		TILES, LARGE, MEDIUM, SMALL, LIST, DETAILS
 	}
 
 }

--- a/src/main/java/net/mcreator/ui/MCreator.java
+++ b/src/main/java/net/mcreator/ui/MCreator.java
@@ -263,7 +263,7 @@ public final class MCreator extends JFrame implements IWorkspaceProvider, IGener
 		splitPane.setOneTouchExpandable(true);
 
 		splitPane.setDividerLocation(280);
-		splitPane.setDividerLocation(PreferencesManager.PREFERENCES.hidden.projectTreeSplitPos.get());
+		splitPane.setDividerLocation(workspace.getWorkspaceUserSettings().projectBrowserSplitPos);
 
 		splitPane.addPropertyChangeListener("dividerLocation", evt -> {
 			if ((Integer) evt.getNewValue() == 0) {
@@ -389,8 +389,7 @@ public final class MCreator extends JFrame implements IWorkspaceProvider, IGener
 			LOG.info("Closing MCreator window ...");
 			PreferencesManager.PREFERENCES.hidden.fullScreen.set(getExtendedState() == MAXIMIZED_BOTH);
 			if (splitPane != null)
-				PreferencesManager.PREFERENCES.hidden.projectTreeSplitPos.set(
-						splitPane.getDividerLocation()); // this one could be stored per workspace in the future
+				workspace.getWorkspaceUserSettings().projectBrowserSplitPos = splitPane.getDividerLocation(); // this one could be stored per workspace in the future
 
 			mcreatorTabs.getTabs().forEach(tab -> {
 				if (tab.getTabClosedListener() != null)

--- a/src/main/java/net/mcreator/ui/browser/WorkspaceFileBrowser.java
+++ b/src/main/java/net/mcreator/ui/browser/WorkspaceFileBrowser.java
@@ -31,6 +31,7 @@ import net.mcreator.ui.MCreator;
 import net.mcreator.ui.component.tree.FilterTreeNode;
 import net.mcreator.ui.component.tree.FilteredTreeModel;
 import net.mcreator.ui.component.tree.JFileTree;
+import net.mcreator.ui.component.tree.SerializableTreeExpansionState;
 import net.mcreator.ui.component.util.ComponentUtils;
 import net.mcreator.ui.component.util.PanelUtils;
 import net.mcreator.ui.component.util.TreeUtils;
@@ -43,6 +44,8 @@ import net.mcreator.util.FilenameUtilsPatched;
 import org.fife.rsta.ac.java.buildpath.LibraryInfo;
 
 import javax.swing.*;
+import javax.swing.event.TreeExpansionEvent;
+import javax.swing.event.TreeExpansionListener;
 import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.DefaultTreeCellRenderer;
 import javax.swing.tree.TreePath;
@@ -175,6 +178,16 @@ public class WorkspaceFileBrowser extends JPanel {
 			}
 
 		});
+
+		tree.addTreeExpansionListener(new TreeExpansionListener() {
+			@Override public void treeExpanded(TreeExpansionEvent treeExpansionEvent) {
+				mcreator.getWorkspaceUserSettings().projectBrowserState = SerializableTreeExpansionState.fromTree(tree);
+			}
+
+			@Override public void treeCollapsed(TreeExpansionEvent treeExpansionEvent) {
+				mcreator.getWorkspaceUserSettings().projectBrowserState = SerializableTreeExpansionState.fromTree(tree);
+			}
+		});
 	}
 
 	private boolean initial = true;
@@ -272,7 +285,11 @@ public class WorkspaceFileBrowser extends JPanel {
 			mods.setRoot(root);
 
 			if (initial) {
-				tree.expandPath(new TreePath(new Object[] { root, node }));
+				SerializableTreeExpansionState expansionState = mcreator.getWorkspaceUserSettings().projectBrowserState;
+				if (expansionState != null)
+					expansionState.applyToTree(tree);
+				else
+					tree.expandPath(new TreePath(new Object[] { root, node }));
 				initial = false;
 			} else {
 				TreeUtils.setExpansionState(tree, state);

--- a/src/main/java/net/mcreator/ui/component/tree/SerializableTreeExpansionState.java
+++ b/src/main/java/net/mcreator/ui/component/tree/SerializableTreeExpansionState.java
@@ -1,0 +1,114 @@
+/*
+ * MCreator (https://mcreator.net/)
+ * Copyright (C) 2012-2020, Pylo
+ * Copyright (C) 2020-2024, Pylo, opensource contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package net.mcreator.ui.component.tree;
+
+import javax.swing.*;
+import javax.swing.tree.TreePath;
+import java.util.ArrayList;
+import java.util.List;
+
+public class SerializableTreeExpansionState {
+
+	private List<String> expandedPaths;
+
+	public SerializableTreeExpansionState() {
+		this.expandedPaths = new ArrayList<>();
+	}
+
+	public SerializableTreeExpansionState(List<String> expandedPaths) {
+		this.expandedPaths = expandedPaths;
+	}
+
+	public List<String> getExpandedPaths() {
+		return expandedPaths;
+	}
+
+	public void setExpandedPaths(List<String> expandedPaths) {
+		this.expandedPaths = expandedPaths;
+	}
+
+	/**
+	 * Captures the expansion state of a JTree.
+	 *
+	 * @param tree the JTree to capture state from
+	 * @return a SerializableTreeExpansionState representing the JTree's expansion state
+	 */
+	public static SerializableTreeExpansionState fromTree(JTree tree) {
+		List<String> expandedPaths = new ArrayList<>();
+		TreePath rootPath = tree.getPathForRow(0); // Assume the root is at row 0
+
+		if (rootPath != null) {
+			captureExpandedPaths(tree, rootPath, expandedPaths);
+		}
+
+		return new SerializableTreeExpansionState(expandedPaths);
+	}
+
+	private static void captureExpandedPaths(JTree tree, TreePath path, List<String> expandedPaths) {
+		if (tree.isExpanded(path)) {
+			expandedPaths.add(path.toString());
+			for (int i = 0; i < tree.getModel().getChildCount(path.getLastPathComponent()); i++) {
+				Object child = tree.getModel().getChild(path.getLastPathComponent(), i);
+				captureExpandedPaths(tree, path.pathByAddingChild(child), expandedPaths);
+			}
+		}
+	}
+
+	/**
+	 * Restores the expansion state to a JTree.
+	 *
+	 * @param tree the JTree to apply the expansion state to
+	 */
+	public void applyToTree(JTree tree) {
+		for (String pathString : expandedPaths) {
+			TreePath path = stringToTreePath(tree, pathString);
+			if (path != null) {
+				tree.expandPath(path);
+			}
+		}
+	}
+
+	private TreePath stringToTreePath(JTree tree, String pathString) {
+		String[] elements = pathString.replace("[", "").replace("]", "").split(", ");
+		Object root = tree.getModel().getRoot();
+		TreePath path = new TreePath(root);
+
+		for (int i = 1; i < elements.length; i++) {
+			Object node = findChildNode(tree, path.getLastPathComponent(), elements[i]);
+			if (node == null) {
+				return null; // If any node in the path is missing, return null
+			}
+			path = path.pathByAddingChild(node);
+		}
+
+		return path;
+	}
+
+	private Object findChildNode(JTree tree, Object parent, String nodeString) {
+		for (int i = 0; i < tree.getModel().getChildCount(parent); i++) {
+			Object child = tree.getModel().getChild(parent, i);
+			if (child.toString().equals(nodeString)) {
+				return child;
+			}
+		}
+		return null;
+	}
+
+}

--- a/src/main/java/net/mcreator/ui/workspace/WorkspacePanel.java
+++ b/src/main/java/net/mcreator/ui/workspace/WorkspacePanel.java
@@ -30,8 +30,6 @@ import net.mcreator.generator.ListTemplate;
 import net.mcreator.io.FileIO;
 import net.mcreator.java.JavaConventions;
 import net.mcreator.minecraft.RegistryNameFixer;
-import net.mcreator.preferences.PreferencesManager;
-import net.mcreator.preferences.data.HiddenSection;
 import net.mcreator.ui.MCreator;
 import net.mcreator.ui.action.UnregisteredAction;
 import net.mcreator.ui.component.*;
@@ -67,6 +65,7 @@ import net.mcreator.workspace.elements.ModElement;
 import net.mcreator.workspace.references.ReferencesFinder;
 import net.mcreator.workspace.resources.CustomTexture;
 import net.mcreator.workspace.resources.Texture;
+import net.mcreator.workspace.settings.user.WorkspaceUserSettings;
 
 import javax.annotation.Nullable;
 import javax.swing.*;
@@ -406,12 +405,12 @@ import java.util.stream.Collectors;
 		JRadioButtonMenuItem tilesIcons = new JRadioButtonMenuItem(L10N.t("workspace.elements.list.tiles"));
 		tilesIcons.addActionListener(e -> {
 			if (tilesIcons.isSelected()) {
-				PreferencesManager.PREFERENCES.hidden.workspaceModElementIconSize.set(HiddenSection.IconSize.TILES);
+				mcreator.getWorkspaceUserSettings().workspacePanelIconSize = WorkspaceUserSettings.IconSize.TILES;
 				updateElementListRenderer();
 			}
 		});
-		tilesIcons.setSelected(PreferencesManager.PREFERENCES.hidden.workspaceModElementIconSize.get()
-				== HiddenSection.IconSize.TILES);
+		tilesIcons.setSelected(
+				mcreator.getWorkspaceUserSettings().workspacePanelIconSize == WorkspaceUserSettings.IconSize.TILES);
 		Arrays.stream(tilesIcons.getChangeListeners()).forEach(e -> e.stateChanged(new ChangeEvent(tilesIcons)));
 		ComponentUtils.deriveFont(tilesIcons, 12);
 		tilesIcons.setBorder(BorderFactory.createEmptyBorder(3, 5, 3, 5));
@@ -419,12 +418,12 @@ import java.util.stream.Collectors;
 		JRadioButtonMenuItem largeIcons = new JRadioButtonMenuItem(L10N.t("workspace.elements.list.large"));
 		largeIcons.addActionListener(e -> {
 			if (largeIcons.isSelected()) {
-				PreferencesManager.PREFERENCES.hidden.workspaceModElementIconSize.set(HiddenSection.IconSize.LARGE);
+				mcreator.getWorkspaceUserSettings().workspacePanelIconSize = WorkspaceUserSettings.IconSize.LARGE;
 				updateElementListRenderer();
 			}
 		});
-		largeIcons.setSelected(PreferencesManager.PREFERENCES.hidden.workspaceModElementIconSize.get()
-				== HiddenSection.IconSize.LARGE);
+		largeIcons.setSelected(
+				mcreator.getWorkspaceUserSettings().workspacePanelIconSize == WorkspaceUserSettings.IconSize.LARGE);
 		Arrays.stream(largeIcons.getChangeListeners()).forEach(e -> e.stateChanged(new ChangeEvent(largeIcons)));
 		ComponentUtils.deriveFont(largeIcons, 12);
 		largeIcons.setBorder(BorderFactory.createEmptyBorder(5, 5, 5, 5));
@@ -432,12 +431,12 @@ import java.util.stream.Collectors;
 		JRadioButtonMenuItem mediumIcons = new JRadioButtonMenuItem(L10N.t("workspace.elements.list.medium"));
 		mediumIcons.addActionListener(e -> {
 			if (mediumIcons.isSelected()) {
-				PreferencesManager.PREFERENCES.hidden.workspaceModElementIconSize.set(HiddenSection.IconSize.MEDIUM);
+				mcreator.getWorkspaceUserSettings().workspacePanelIconSize = WorkspaceUserSettings.IconSize.MEDIUM;
 				updateElementListRenderer();
 			}
 		});
-		mediumIcons.setSelected(PreferencesManager.PREFERENCES.hidden.workspaceModElementIconSize.get()
-				== HiddenSection.IconSize.MEDIUM);
+		mediumIcons.setSelected(
+				mcreator.getWorkspaceUserSettings().workspacePanelIconSize == WorkspaceUserSettings.IconSize.MEDIUM);
 		Arrays.stream(mediumIcons.getChangeListeners()).forEach(e -> e.stateChanged(new ChangeEvent(mediumIcons)));
 		ComponentUtils.deriveFont(mediumIcons, 12);
 		mediumIcons.setBorder(BorderFactory.createEmptyBorder(3, 5, 3, 5));
@@ -445,12 +444,12 @@ import java.util.stream.Collectors;
 		JRadioButtonMenuItem smallIcons = new JRadioButtonMenuItem(L10N.t("workspace.elements.list.small"));
 		smallIcons.addActionListener(e -> {
 			if (smallIcons.isSelected()) {
-				PreferencesManager.PREFERENCES.hidden.workspaceModElementIconSize.set(HiddenSection.IconSize.SMALL);
+				mcreator.getWorkspaceUserSettings().workspacePanelIconSize = WorkspaceUserSettings.IconSize.SMALL;
 				updateElementListRenderer();
 			}
 		});
-		smallIcons.setSelected(PreferencesManager.PREFERENCES.hidden.workspaceModElementIconSize.get()
-				== HiddenSection.IconSize.SMALL);
+		smallIcons.setSelected(
+				mcreator.getWorkspaceUserSettings().workspacePanelIconSize == WorkspaceUserSettings.IconSize.SMALL);
 		Arrays.stream(smallIcons.getChangeListeners()).forEach(e -> e.stateChanged(new ChangeEvent(smallIcons)));
 		ComponentUtils.deriveFont(smallIcons, 12);
 		smallIcons.setBorder(BorderFactory.createEmptyBorder(3, 5, 3, 5));
@@ -458,12 +457,12 @@ import java.util.stream.Collectors;
 		JRadioButtonMenuItem listIcons = new JRadioButtonMenuItem(L10N.t("workspace.elements.list.list"));
 		listIcons.addActionListener(e -> {
 			if (listIcons.isSelected()) {
-				PreferencesManager.PREFERENCES.hidden.workspaceModElementIconSize.set(HiddenSection.IconSize.LIST);
+				mcreator.getWorkspaceUserSettings().workspacePanelIconSize = WorkspaceUserSettings.IconSize.LIST;
 				updateElementListRenderer();
 			}
 		});
 		listIcons.setSelected(
-				PreferencesManager.PREFERENCES.hidden.workspaceModElementIconSize.get() == HiddenSection.IconSize.LIST);
+				mcreator.getWorkspaceUserSettings().workspacePanelIconSize == WorkspaceUserSettings.IconSize.LIST);
 		Arrays.stream(listIcons.getChangeListeners()).forEach(e -> e.stateChanged(new ChangeEvent(listIcons)));
 		ComponentUtils.deriveFont(listIcons, 12);
 		listIcons.setBorder(BorderFactory.createEmptyBorder(3, 5, 3, 5));
@@ -471,12 +470,12 @@ import java.util.stream.Collectors;
 		JRadioButtonMenuItem detailsIcons = new JRadioButtonMenuItem(L10N.t("workspace.elements.list.details"));
 		detailsIcons.addActionListener(e -> {
 			if (detailsIcons.isSelected()) {
-				PreferencesManager.PREFERENCES.hidden.workspaceModElementIconSize.set(HiddenSection.IconSize.DETAILS);
+				mcreator.getWorkspaceUserSettings().workspacePanelIconSize = WorkspaceUserSettings.IconSize.DETAILS;
 				updateElementListRenderer();
 			}
 		});
-		detailsIcons.setSelected(PreferencesManager.PREFERENCES.hidden.workspaceModElementIconSize.get()
-				== HiddenSection.IconSize.DETAILS);
+		detailsIcons.setSelected(
+				mcreator.getWorkspaceUserSettings().workspacePanelIconSize == WorkspaceUserSettings.IconSize.DETAILS);
 		Arrays.stream(detailsIcons.getChangeListeners()).forEach(e -> e.stateChanged(new ChangeEvent(detailsIcons)));
 		ComponentUtils.deriveFont(detailsIcons, 12);
 		detailsIcons.setBorder(BorderFactory.createEmptyBorder(3, 5, 3, 5));
@@ -581,8 +580,8 @@ import java.util.stream.Collectors;
 		EventButtonGroup sortOne = new EventButtonGroup();
 		sortOne.addActionListener(e -> resort());
 		JRadioButtonMenuItem asc = new JRadioButtonMenuItem(L10N.t("workspace.elements.list.ascending"));
-		asc.setSelected(PreferencesManager.PREFERENCES.hidden.workspaceSortAscending.get());
-		desc.setSelected(!PreferencesManager.PREFERENCES.hidden.workspaceSortAscending.get());
+		asc.setSelected(mcreator.getWorkspaceUserSettings().workspacePanelSortAscending);
+		desc.setSelected(!mcreator.getWorkspaceUserSettings().workspacePanelSortAscending);
 		sortOne.add(asc);
 		sortOne.add(desc);
 		sortPopup.add(asc);
@@ -620,9 +619,9 @@ import java.util.stream.Collectors;
 
 		view.addActionListener(e -> viewPopup.show(view, 0, 23));
 
-		if (PreferencesManager.PREFERENCES.hidden.workspaceSortOrder.get() == HiddenSection.SortType.NAME) {
+		if (mcreator.getWorkspaceUserSettings().workspacePanelSortType == WorkspaceUserSettings.SortType.NAME) {
 			sortName.setSelected(true);
-		} else if (PreferencesManager.PREFERENCES.hidden.workspaceSortOrder.get() == HiddenSection.SortType.TYPE) {
+		} else if (mcreator.getWorkspaceUserSettings().workspacePanelSortType == WorkspaceUserSettings.SortType.TYPE) {
 			sortType.setSelected(true);
 		} else {
 			sortDateCreated.setSelected(true);
@@ -923,20 +922,20 @@ import java.util.stream.Collectors;
 
 	private void resort() {
 		if (sortName.isSelected()) {
-			PreferencesManager.PREFERENCES.hidden.workspaceSortOrder.set(HiddenSection.SortType.NAME);
+			mcreator.getWorkspaceUserSettings().workspacePanelSortType = WorkspaceUserSettings.SortType.NAME;
 		} else if (sortType.isSelected()) {
-			PreferencesManager.PREFERENCES.hidden.workspaceSortOrder.set(HiddenSection.SortType.TYPE);
+			mcreator.getWorkspaceUserSettings().workspacePanelSortType = WorkspaceUserSettings.SortType.TYPE;
 		} else {
-			PreferencesManager.PREFERENCES.hidden.workspaceSortOrder.set(HiddenSection.SortType.CREATED);
+			mcreator.getWorkspaceUserSettings().workspacePanelSortType = WorkspaceUserSettings.SortType.CREATED;
 		}
 
-		PreferencesManager.PREFERENCES.hidden.workspaceSortAscending.set(!desc.isSelected());
+		mcreator.getWorkspaceUserSettings().workspacePanelSortAscending = !desc.isSelected();
 
 		sectionTabs.values().forEach(IReloadableFilterable::refilterElements);
 	}
 
 	private void updateElementListRenderer() {
-		switch (PreferencesManager.PREFERENCES.hidden.workspaceModElementIconSize.get()) {
+		switch (mcreator.getWorkspaceUserSettings().workspacePanelIconSize) {
 		case TILES -> {
 			list.setCellRenderer(new TilesModListRender());
 			list.setFixedCellHeight(72);

--- a/src/main/java/net/mcreator/workspace/IWorkspaceProvider.java
+++ b/src/main/java/net/mcreator/workspace/IWorkspaceProvider.java
@@ -20,6 +20,7 @@ package net.mcreator.workspace;
 
 import net.mcreator.workspace.elements.ModElementManager;
 import net.mcreator.workspace.settings.WorkspaceSettings;
+import net.mcreator.workspace.settings.user.WorkspaceUserSettings;
 
 import javax.annotation.Nonnull;
 import java.io.File;
@@ -46,6 +47,10 @@ public interface IWorkspaceProvider {
 
 	default File getWorkspaceFolder() {
 		return getFolderManager().getWorkspaceFolder();
+	}
+
+	default WorkspaceUserSettings getWorkspaceUserSettings() {
+		return getWorkspace().getWorkspaceUserSettings();
 	}
 
 }

--- a/src/main/java/net/mcreator/workspace/Workspace.java
+++ b/src/main/java/net/mcreator/workspace/Workspace.java
@@ -34,6 +34,8 @@ import net.mcreator.workspace.elements.*;
 import net.mcreator.workspace.misc.CreativeTabsOrder;
 import net.mcreator.workspace.misc.WorkspaceInfo;
 import net.mcreator.workspace.settings.WorkspaceSettings;
+import net.mcreator.workspace.settings.user.WorkspaceUserSettings;
+import net.mcreator.workspace.settings.user.WorkspaceUserSettingsManager;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -71,6 +73,7 @@ public class Workspace implements Closeable, IGeneratorProvider {
 	// transient fields
 	private transient boolean changed = false;
 	protected transient WorkspaceFileManager fileManager;
+	private transient WorkspaceUserSettingsManager userSettingsManager;
 	protected transient Generator generator;
 	private transient boolean regenerateRequired = false;
 	private transient boolean failingGradleDependencies = false;
@@ -280,6 +283,10 @@ public class Workspace implements Closeable, IGeneratorProvider {
 		return fileManager.getFolderManager();
 	}
 
+	@Override public WorkspaceUserSettings getWorkspaceUserSettings() {
+		return userSettingsManager.getUserSettings();
+	}
+
 	@Override public Generator getGenerator() {
 		return generator;
 	}
@@ -293,6 +300,7 @@ public class Workspace implements Closeable, IGeneratorProvider {
 
 		generator.close();
 		fileManager.close();
+		userSettingsManager.close();
 	}
 
 	@Override public boolean equals(Object o) {
@@ -376,6 +384,7 @@ public class Workspace implements Closeable, IGeneratorProvider {
 		this.fileManager.close(); // first close current workspace file
 		this.fileManager = null; // reset reference
 		this.fileManager = new WorkspaceFileManager(workspaceFile, this); // new file manager instance for the new file
+		this.userSettingsManager = new WorkspaceUserSettingsManager(this, this.getFolderManager());
 	}
 
 	public void markFailingGradleDependencies() {
@@ -405,6 +414,7 @@ public class Workspace implements Closeable, IGeneratorProvider {
 			try {
 				retval = WorkspaceFileManager.gson.fromJson(workspace_string, Workspace.class);
 				retval.fileManager = new WorkspaceFileManager(workspaceFile, retval);
+				retval.userSettingsManager = new WorkspaceUserSettingsManager(retval, retval.getFolderManager());
 			} catch (Exception e) {
 				throw new CorruptedWorkspaceFileException(e);
 			}
@@ -506,6 +516,7 @@ public class Workspace implements Closeable, IGeneratorProvider {
 			GeneratorConfiguration generatorConfiguration) throws MissingGeneratorFeaturesException {
 		Workspace retval = WorkspaceFileManager.gson.fromJson(FileIO.readFileToString(workspaceFile), Workspace.class);
 		retval.fileManager = new WorkspaceFileManager(workspaceFile, retval);
+		retval.userSettingsManager = new WorkspaceUserSettingsManager(retval, retval.getFolderManager());
 
 		if (Generator.GENERATOR_CACHE.get(retval.getWorkspaceSettings().getCurrentGenerator())
 				!= generatorConfiguration) {
@@ -537,6 +548,7 @@ public class Workspace implements Closeable, IGeneratorProvider {
 		workspaceFile.getParentFile().mkdirs();
 		retval.setMCreatorVersion(Launcher.version.versionlong);
 		retval.fileManager = new WorkspaceFileManager(workspaceFile, retval);
+		retval.userSettingsManager = new WorkspaceUserSettingsManager(retval, retval.getFolderManager());
 		retval.generator = new Generator(retval);
 		retval.fileManager.saveWorkspaceDirectlyAndWait();
 		retval.getWorkspaceSettings().setWorkspace(retval);

--- a/src/main/java/net/mcreator/workspace/settings/user/WorkspaceUserSettings.java
+++ b/src/main/java/net/mcreator/workspace/settings/user/WorkspaceUserSettings.java
@@ -1,0 +1,43 @@
+/*
+ * MCreator (https://mcreator.net/)
+ * Copyright (C) 2012-2020, Pylo
+ * Copyright (C) 2020-2024, Pylo, opensource contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package net.mcreator.workspace.settings.user;
+
+import net.mcreator.ui.component.tree.SerializableTreeExpansionState;
+
+import javax.annotation.Nullable;
+
+public class WorkspaceUserSettings {
+
+	public IconSize workspacePanelIconSize = IconSize.TILES;
+	public SortType workspacePanelSortType = SortType.CREATED;
+	public boolean workspacePanelSortAscending = true;
+
+	public int projectBrowserSplitPos = 0;
+	@Nullable public SerializableTreeExpansionState projectBrowserState = null;
+
+	public enum SortType {
+		NAME, CREATED, TYPE
+	}
+
+	public enum IconSize {
+		TILES, LARGE, MEDIUM, SMALL, LIST, DETAILS
+	}
+
+}

--- a/src/main/java/net/mcreator/workspace/settings/user/WorkspaceUserSettingsManager.java
+++ b/src/main/java/net/mcreator/workspace/settings/user/WorkspaceUserSettingsManager.java
@@ -1,0 +1,77 @@
+/*
+ * MCreator (https://mcreator.net/)
+ * Copyright (C) 2012-2020, Pylo
+ * Copyright (C) 2020-2024, Pylo, opensource contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package net.mcreator.workspace.settings.user;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.Strictness;
+import net.mcreator.io.FileIO;
+import net.mcreator.workspace.Workspace;
+import net.mcreator.workspace.WorkspaceFolderManager;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.Closeable;
+import java.io.File;
+
+public class WorkspaceUserSettingsManager implements Closeable {
+
+	private static final Logger LOG = LogManager.getLogger("Workspace user settings");
+
+	private static final Gson gson = new GsonBuilder().setStrictness(Strictness.LENIENT).setPrettyPrinting().create();
+
+	private final Workspace workspace;
+
+	private final File userSettingsFile;
+
+	private WorkspaceUserSettings userSettings = new WorkspaceUserSettings();
+
+	public WorkspaceUserSettingsManager(Workspace workspace, WorkspaceFolderManager folderManager) {
+		this.workspace = workspace;
+		this.userSettingsFile = new File(folderManager.getWorkspaceCacheDir(), "userSettings");
+
+		if (userSettingsFile.isFile()) {
+			try {
+				String json = FileIO.readFileToString(userSettingsFile);
+				userSettings = gson.fromJson(json, WorkspaceUserSettings.class);
+			} catch (Exception e) {
+				LOG.warn("Failed to read user settings", e);
+			}
+		}
+	}
+
+	public WorkspaceUserSettings getUserSettings() {
+		return userSettings;
+	}
+
+	public Workspace getWorkspace() {
+		return workspace;
+	}
+
+	@Override public void close() {
+		try {
+			LOG.debug("Storing user workspace settings");
+			FileIO.writeStringToFile(gson.toJson(userSettings), userSettingsFile);
+		} catch (Exception e) {
+			LOG.warn("Failed to store user settings", e);
+		}
+	}
+
+}


### PR DESCRIPTION
This PR adds base for retaining workspace state for the user.

This moves certain settings from preferences system to this new "workspace user settings" system:

* project browser expansion state
* workspace element sort order
* workspace element sort type
* workspace element sort asc/desc

It also stores one new state:

* project browser tree expansion state

This PR tries to match MCreator closer with other IDEs that "remember" last state a particular workspace was in from the last session.

In the future this could be expanded to also "remember":

* current tab in workspace "main tab"
* remember tabs and re-open them - would need to refactor some things for this to be well implemented

----------

Changelog:

* Certain workspace parameters such as project browser state and element sorting are now stored per-workspace

---------

Note: existing settings for preferences moved to this system will reset, but due to their insignificance no migration path is provided at this time.