### PR TITLE
Multiline dynamic GUI tooltips support

### DIFF
--- a/plugins/generator-1.20.1/forge-1.20.1/templates/gui/gui_window.java.ftl
+++ b/plugins/generator-1.20.1/forge-1.20.1/templates/gui/gui_window.java.ftl
@@ -114,10 +114,7 @@ public class ${name}Screen extends AbstractContainerScreen<${name}Menu> {
 					<#if hasProcedure(component.text)>
 					String hoverText = <@procedureOBJToStringCode component.text/>;
 					if (hoverText != null) {
-						if (hoverText.contains("\n"))
-							guiGraphics.renderComponentTooltip(font, Arrays.stream(hoverText.split("\n")).map(Component::literal).collect(Collectors.toList()), mouseX, mouseY);
-						else
-							guiGraphics.renderTooltip(font, Component.literal(hoverText), mouseX, mouseY);
+						guiGraphics.renderComponentTooltip(font, Arrays.stream(hoverText.split("\n")).map(Component::literal).collect(Collectors.toList()), mouseX, mouseY);
 					}
 					<#else>
 						guiGraphics.renderTooltip(font, Component.translatable("gui.${modid}.${registryname}.${component.getName()}"), mouseX, mouseY);

--- a/plugins/generator-1.20.1/forge-1.20.1/templates/gui/gui_window.java.ftl
+++ b/plugins/generator-1.20.1/forge-1.20.1/templates/gui/gui_window.java.ftl
@@ -110,8 +110,19 @@ public class ${name}Screen extends AbstractContainerScreen<${name}Menu> {
 			<#if hasProcedure(component.displayCondition)>
 				if (<@procedureOBJToConditionCode component.displayCondition/>)
 			</#if>
-				if (mouseX > leftPos + ${x} && mouseX < leftPos + ${x + component.width} && mouseY > topPos + ${y} && mouseY < topPos + ${y + component.height})
-					guiGraphics.renderTooltip(font, <#if hasProcedure(component.text)>Component.literal(<@procedureOBJToStringCode component.text/>)<#else>Component.translatable("gui.${modid}.${registryname}.${component.getName()}")</#if>, mouseX, mouseY);
+				if (mouseX > leftPos + ${x} && mouseX < leftPos + ${x + component.width} && mouseY > topPos + ${y} && mouseY < topPos + ${y + component.height}) {
+					<#if hasProcedure(component.text)>
+					String hoverText = <@procedureOBJToStringCode component.text/>;
+					if (hoverText != null) {
+						if (hoverText.contains("\n"))
+							guiGraphics.renderComponentTooltip(font, Arrays.stream(hoverText.split("\n")).map(Component::literal).collect(Collectors.toList()), mouseX, mouseY);
+						else
+							guiGraphics.renderTooltip(font, Component.literal(hoverText), mouseX, mouseY);
+					}
+					<#else>
+						guiGraphics.renderTooltip(font, Component.translatable("gui.${modid}.${registryname}.${component.getName()}") mouseX, mouseY);
+					</#if>
+				}
 		</#list>
 	}
 

--- a/plugins/generator-1.20.1/forge-1.20.1/templates/gui/gui_window.java.ftl
+++ b/plugins/generator-1.20.1/forge-1.20.1/templates/gui/gui_window.java.ftl
@@ -120,7 +120,8 @@ public class ${name}Screen extends AbstractContainerScreen<${name}Menu> {
 							guiGraphics.renderTooltip(font, Component.literal(hoverText), mouseX, mouseY);
 					}
 					<#else>
-						guiGraphics.renderTooltip(font, Component.translatable("gui.${modid}.${registryname}.${component.getName()}") mouseX, mouseY);
+						guiGraphics.renderTooltip(font, Component.translatable("gui.${modid}.${registryname}.${component.getName()}"), mouseX, mouseY);
+
 					</#if>
 				}
 		</#list>

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/gui/gui_window.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/gui/gui_window.java.ftl
@@ -117,10 +117,7 @@ public class ${name}Screen extends AbstractContainerScreen<${name}Menu> {
 					<#if hasProcedure(component.text)>
 					String hoverText = <@procedureOBJToStringCode component.text/>;
 					if (hoverText != null) {
-						if (hoverText.contains("\n"))
-							guiGraphics.renderComponentTooltip(font, Arrays.stream(hoverText.split("\n")).map(Component::literal).collect(Collectors.toList()), mouseX, mouseY);
-						else
-							guiGraphics.renderTooltip(font, Component.literal(hoverText), mouseX, mouseY);
+						guiGraphics.renderComponentTooltip(font, Arrays.stream(hoverText.split("\n")).map(Component::literal).collect(Collectors.toList()), mouseX, mouseY);
 					}
 					<#else>
 						guiGraphics.renderTooltip(font, Component.translatable("gui.${modid}.${registryname}.${component.getName()}"), mouseX, mouseY);

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/gui/gui_window.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/gui/gui_window.java.ftl
@@ -113,8 +113,19 @@ public class ${name}Screen extends AbstractContainerScreen<${name}Menu> {
 			<#if hasProcedure(component.displayCondition)>
 				if (<@procedureOBJToConditionCode component.displayCondition/>)
 			</#if>
-				if (mouseX > leftPos + ${x} && mouseX < leftPos + ${x + component.width} && mouseY > topPos + ${y} && mouseY < topPos + ${y + component.height})
-					guiGraphics.renderTooltip(font, <#if hasProcedure(component.text)>Component.literal(<@procedureOBJToStringCode component.text/>)<#else>Component.translatable("gui.${modid}.${registryname}.${component.getName()}")</#if>, mouseX, mouseY);
+				if (mouseX > leftPos + ${x} && mouseX < leftPos + ${x + component.width} && mouseY > topPos + ${y} && mouseY < topPos + ${y + component.height}) {
+					<#if hasProcedure(component.text)>
+					String hoverText = <@procedureOBJToStringCode component.text/>;
+					if (hoverText != null) {
+						if (hoverText.contains("\n"))
+							guiGraphics.renderComponentTooltip(font, Arrays.stream(hoverText.split("\n")).map(Component::literal).collect(Collectors.toList()), mouseX, mouseY);
+						else
+							guiGraphics.renderTooltip(font, Component.literal(hoverText), mouseX, mouseY);
+					}
+					<#else>
+						guiGraphics.renderTooltip(font, Component.translatable("gui.${modid}.${registryname}.${component.getName()}") mouseX, mouseY);
+					</#if>
+				}
 		</#list>
 	}
 

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/gui/gui_window.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/gui/gui_window.java.ftl
@@ -123,7 +123,8 @@ public class ${name}Screen extends AbstractContainerScreen<${name}Menu> {
 							guiGraphics.renderTooltip(font, Component.literal(hoverText), mouseX, mouseY);
 					}
 					<#else>
-						guiGraphics.renderTooltip(font, Component.translatable("gui.${modid}.${registryname}.${component.getName()}") mouseX, mouseY);
+						guiGraphics.renderTooltip(font, Component.translatable("gui.${modid}.${registryname}.${component.getName()}"), mouseX, mouseY);
+
 					</#if>
 				}
 		</#list>


### PR DESCRIPTION
Tooltip GUI components now follow the item/block descriptions, meaning they can now split the string from procedure on new line symbol as well.