### PR TITLE
Blockly resource location field

### DIFF
--- a/plugins/mcreator-core/blockly/js/field_resourcelocation.js
+++ b/plugins/mcreator-core/blockly/js/field_resourcelocation.js
@@ -1,0 +1,17 @@
+class FieldResourceLocation extends Blockly.FieldTextInput {
+
+    doClassValidation_(newValue) {
+        if (typeof newValue != 'string') {
+            return null;
+        }
+
+        if (!/^([a-z0-9_\-\.]+:)?[a-z0-9_\-\.\/]+$/.test(newValue)) {
+            return null;
+        }
+
+        return newValue;
+    }
+
+}
+
+Blockly.fieldRegistry.register('field_resourcelocation', FieldResourceLocation);

--- a/plugins/mcreator-core/blockly/js/mcreator_extensions.js
+++ b/plugins/mcreator-core/blockly/js/mcreator_extensions.js
@@ -170,30 +170,6 @@ Blockly.Extensions.registerMixin('disable_inside_inline_placed_feature',
         }
     });
 
-// Helper function for extensions that validate one or more resource location text fields
-function validateResourceLocationFields(...fields) {
-    return function () {
-        for (let i = 0; i < fields.length; i++) {
-            let field = this.getField(fields[i]);
-            // The validator checks if the new input value is a valid resource location
-            field.setValidator(function (newValue) {
-                if (/^([a-z0-9_\-\.]+:)?[a-z0-9_\-\.\/]+$/.test(newValue))
-                    return newValue;
-                return null;
-            });
-        }
-    }
-}
-
-Blockly.Extensions.register('tag_input_field_validator', validateResourceLocationFields('tag'));
-
-Blockly.Extensions.register('geode_tag_fields_validator',
-    validateResourceLocationFields('cannot_replace_tag', 'invalid_blocks_tag'));
-
-Blockly.Extensions.register('root_system_tag_fields_validator', validateResourceLocationFields('root_replaceable'));
-
-Blockly.Extensions.register('vegetation_patch_tag_fields_validator', validateResourceLocationFields('replaceable'));
-
 Blockly.Extensions.registerMixin('controls_flow_in_loop_check_exclude_wait',
     {
         onchange: function (e) {

--- a/plugins/mcreator-core/features/block_holderset_tag.json
+++ b/plugins/mcreator-core/features/block_holderset_tag.json
@@ -1,13 +1,10 @@
 {
   "args0": [
     {
-      "type": "field_input",
+      "type": "field_resourcelocation",
       "name": "tag",
       "text": "minecraft:dirt"
     }
-  ],
-  "extensions": [
-    "tag_input_field_validator"
   ],
   "output": "BlockHolderSet",
   "colour": "45",

--- a/plugins/mcreator-core/features/feature_geode_simple.json
+++ b/plugins/mcreator-core/features/feature_geode_simple.json
@@ -11,7 +11,7 @@
       "type": "input_dummy"
     },
     {
-      "type": "field_input",
+      "type": "field_resourcelocation",
       "name": "cannot_replace_tag",
       "text": "features_cannot_replace"
     },
@@ -26,7 +26,7 @@
       "precision": 1
     },
     {
-      "type": "field_input",
+      "type": "field_resourcelocation",
       "name": "invalid_blocks_tag",
       "text": "geode_invalid_blocks"
     },
@@ -63,7 +63,6 @@
   "output": "Feature",
   "colour": 0,
   "extensions": [
-    "geode_tag_fields_validator",
     "add_image_to_bsp_inputs"
   ],
   "mutator": "geode_crystal_mutator",

--- a/plugins/mcreator-core/features/feature_root_system.json
+++ b/plugins/mcreator-core/features/feature_root_system.json
@@ -33,7 +33,7 @@
       "type": "input_dummy"
     },
     {
-      "type": "field_input",
+      "type": "field_resourcelocation",
       "name": "root_replaceable",
       "text": "azalea_root_replaceable"
     },
@@ -106,7 +106,6 @@
   "output": "Feature",
   "colour": 0,
   "extensions": [
-    "root_system_tag_fields_validator",
     "add_image_to_bsp_inputs"
   ],
   "mcreator": {

--- a/plugins/mcreator-core/features/feature_vegetation_patch.json
+++ b/plugins/mcreator-core/features/feature_vegetation_patch.json
@@ -59,7 +59,7 @@
       "check": "IntProvider"
     },
     {
-      "type": "field_input",
+      "type": "field_resourcelocation",
       "name": "replaceable",
       "text": "lush_ground_replaceable"
     },
@@ -89,7 +89,6 @@
   "colour": 0,
   "extensions": [
     "add_image_to_bsp_inputs",
-    "vegetation_patch_tag_fields_validator",
     "vegetation_patch_feature_validator"
   ],
   "mcreator": {

--- a/plugins/mcreator-core/features/feature_waterlogged_vegetation_patch.json
+++ b/plugins/mcreator-core/features/feature_waterlogged_vegetation_patch.json
@@ -59,7 +59,7 @@
       "check": "IntProvider"
     },
     {
-      "type": "field_input",
+      "type": "field_resourcelocation",
       "name": "replaceable",
       "text": "lush_ground_replaceable"
     },
@@ -89,7 +89,6 @@
   "colour": 0,
   "extensions": [
     "add_image_to_bsp_inputs",
-    "vegetation_patch_tag_fields_validator",
     "vegetation_patch_feature_validator"
   ],
   "mcreator": {

--- a/plugins/mcreator-core/features/rule_test_tag_match.json
+++ b/plugins/mcreator-core/features/rule_test_tag_match.json
@@ -1,13 +1,10 @@
 {
   "args0": [
     {
-      "type": "field_input",
+      "type": "field_resourcelocation",
       "name": "tag",
       "text": "minecraft:dirt"
     }
-  ],
-  "extensions": [
-    "tag_input_field_validator"
   ],
   "output": "RuleTest",
   "colour": "80",

--- a/src/test/java/net/mcreator/integration/generator/BlocklyTestUtil.java
+++ b/src/test/java/net/mcreator/integration/generator/BlocklyTestUtil.java
@@ -185,7 +185,7 @@ public class BlocklyTestUtil {
 			additionalXML.append("<field name=\"").append(field).append("\">").append(value).append("</field>");
 			processed++;
 		}
-		case "field_input", "field_javaname" -> {
+		case "field_input", "field_javaname", "field_resourcelocation" -> {
 			String value = "test";
 			if (arg.has("text")) {
 				value = arg.get("text").getAsString();


### PR DESCRIPTION
This PR adds a resource location Blockly field (similar to the Java name one), replacing the previous input field + extension system.