### PR TITLE
Optimize code of some procedure blocks

### DIFF
--- a/plugins/generator-1.21.1/neoforge-1.21.1/procedures/entity_get_slot.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/procedures/entity_get_slot.java.ftl
@@ -1,9 +1,1 @@
-<#include "mcitems.ftl">
-/*@ItemStack*/(new Object(){
-	public ItemStack getItemStack(int sltid, Entity entity) {
-		if (entity.getCapability(Capabilities.ItemHandler.ENTITY, null) instanceof IItemHandlerModifiable _modHandler) {
-			return _modHandler.getStackInSlot(sltid).copy();
-		}
-		return ItemStack.EMPTY;
-	}
-}.getItemStack(${opt.toInt(input$slotid)}, ${input$entity}))
+/*@ItemStack*/(${input$entity}.getCapability(Capabilities.ItemHandler.ENTITY, null) instanceof IItemHandlerModifiable _modHandler ? _modHandler.getStackInSlot(${opt.toInt(input$slotid)}).copy() : ItemStack.EMPTY)

--- a/plugins/generator-1.21.1/neoforge-1.21.1/procedures/world_entity_inrange_exists.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/procedures/world_entity_inrange_exists.java.ftl
@@ -1,3 +1,3 @@
 (!world.getEntitiesOfClass(${generator.map(field$entity, "entities", 0)}.class,
-	AABB.ofSize(new Vec3(${input$x}, ${input$y}, ${input$z}), ${input$range}, ${input$range}, ${input$range}), e -> true)
+	new AABB(Vec3.ZERO, Vec3.ZERO).move(new Vec3(${input$x}, ${input$y}, ${input$z})).inflate(${input$range} / 2d), e -> true)
 	.isEmpty())

--- a/plugins/generator-1.21.1/neoforge-1.21.1/procedures/world_entity_inrange_foreach.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/procedures/world_entity_inrange_foreach.java.ftl
@@ -1,8 +1,7 @@
 {
 	final Vec3 _center = new Vec3(${input$x}, ${input$y}, ${input$z});
-	List<Entity> _entfound = world.getEntitiesOfClass(Entity.class, new AABB(_center, _center).inflate(${input$range} / 2d), e -> true)
-		.stream().sorted(Comparator.comparingDouble(_entcnd -> _entcnd.distanceToSqr(_center))).toList();
-	for (Entity entityiterator : _entfound) {
+	for (Entity entityiterator : world.getEntitiesOfClass(Entity.class, new AABB(_center, _center).inflate(${input$range} / 2d), e -> true)
+		.stream().sorted(Comparator.comparingDouble(_entcnd -> _entcnd.distanceToSqr(_center))).toList()) {
 		${statement$foreach}
 	}
 }


### PR DESCRIPTION
This PR brings minor optimizations to few procedure blocks, namely:
* `entity_get_slot` - removed anonymous/"utility" `Object`;
* `world_entity_inrange_exists` - rewrote template to use each of nested blocks only once;
* `world_entity_inrange_foreach` - removed extra variable.