### PR TITLE
Improve armor texture import

### DIFF
--- a/src/main/java/net/mcreator/ui/dialogs/TextureImportDialogs.java
+++ b/src/main/java/net/mcreator/ui/dialogs/TextureImportDialogs.java
@@ -72,7 +72,7 @@ public class TextureImportDialogs {
 
 		p1.addActionListener(event -> {
 			File[] f1a = FileDialogs.getFileChooserDialog(mcreator, FileChooserType.OPEN, false, null,
-					new FileChooser.ExtensionFilter("Armor layer 1 texture files", "*layer_1.png"));
+					new FileChooser.ExtensionFilter("Armor layer 1 texture files", "*_layer_1.png"));
 			if (f1a != null && f1a.length > 0) {
 				f1.set(f1a[0]);
 				p1.setText(FilenameUtilsPatched.removeExtension(f1.get().getName()));
@@ -81,7 +81,7 @@ public class TextureImportDialogs {
 
 		p2.addActionListener(event -> {
 			File[] f2a = FileDialogs.getFileChooserDialog(mcreator, FileChooserType.OPEN, false, null,
-					new FileChooser.ExtensionFilter("Armor layer 2 texture files", "*layer_2.png"));
+					new FileChooser.ExtensionFilter("Armor layer 2 texture files", "*_layer_2.png"));
 			if (f2a != null && f2a.length > 0) {
 				f2.set(f2a[0]);
 				p2.setText(FilenameUtilsPatched.removeExtension(f2.get().getName()));
@@ -101,6 +101,10 @@ public class TextureImportDialogs {
 						f1.get().getName().toLowerCase(Locale.ENGLISH).replace("layer_1", "")));
 				if (namec.endsWith("_"))
 					namec = namec.substring(0, namec.length() - 1);
+				if (namec.isBlank()) {
+					Toolkit.getDefaultToolkit().beep();
+					return;
+				}
 				File[] armor = mcreator.getFolderManager().getArmorTextureFilesForName(namec);
 				FileIO.copyFile(f1.get(), armor[0]);
 				FileIO.copyFile(f2.get(), armor[1]);

--- a/src/main/java/net/mcreator/ui/modgui/ArmorGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/ArmorGUI.java
@@ -882,9 +882,9 @@ public class ArmorGUI extends ModElementGUI<Armor> {
 	}
 
 	private void updateArmorTexturePreview() {
-		File[] armorTextures = mcreator.getFolderManager()
-				.getArmorTextureFilesForName(armorTextureFile.getTextureName());
-		if (armorTextures[0].isFile() && armorTextures[1].isFile()) {
+		String textureName = armorTextureFile.getTextureName();
+		File[] armorTextures = mcreator.getFolderManager().getArmorTextureFilesForName(textureName);
+		if (!textureName.isBlank() && armorTextures[0].isFile() && armorTextures[1].isFile()) {
 			ImageIcon bg1 = new ImageIcon(
 					ImageUtils.resize(new ImageIcon(armorTextures[0].getAbsolutePath()).getImage(),
 							64 * ARMOR_TEXTURE_SIZE_FACTOR, 32 * ARMOR_TEXTURE_SIZE_FACTOR));

--- a/src/main/java/net/mcreator/workspace/resources/CustomTexture.java
+++ b/src/main/java/net/mcreator/workspace/resources/CustomTexture.java
@@ -76,7 +76,7 @@ public final class CustomTexture extends Texture {
 			customTextureFiles = new ArrayList<>();
 			List<File> armors = workspace.getFolderManager().getTexturesList(TextureType.ARMOR);
 			for (File texture : armors)
-				if (texture.getName().endsWith("_layer_1.png"))
+				if (texture.getName().endsWith("_layer_1.png") && !texture.getName().equals("_layer_1.png"))
 					customTextureFiles.add(texture);
 		} else {
 			customTextureFiles = workspace.getFolderManager().getTexturesList(type);


### PR DESCRIPTION
Improve armor texture import - prevents user from being able to import armor textures without valid prefix that would result in empty armor texture names