### PR TITLE
[1.21.4] Ported blocks/items datalist

### DIFF
--- a/plugins/generator-1.21.4/datapack-1.21.4/mappings/blocksitems.yaml
+++ b/plugins/generator-1.21.4/datapack-1.21.4/mappings/blocksitems.yaml
@@ -55,3 +55,4760 @@ Blocks.DIRT#2:
 Blocks.COBBLESTONE:
   - Blocks.COBBLESTONE
   - "cobblestone"
+Blocks.MOSSY_COBBLESTONE:
+  - Blocks.MOSSY_COBBLESTONE
+  - "mossy_cobblestone"
+Blocks.PLANKS:
+  - Blocks.OAK_PLANKS
+  - "#minecraft:planks"
+Blocks.PLANKS#0:
+  - Blocks.OAK_PLANKS
+  - "oak_planks"
+Blocks.PLANKS#1:
+  - Blocks.SPRUCE_PLANKS
+  - "spruce_planks"
+Blocks.PLANKS#2:
+  - Blocks.BIRCH_PLANKS
+  - "birch_planks"
+Blocks.PLANKS#3:
+  - Blocks.JUNGLE_PLANKS
+  - "jungle_planks"
+Blocks.PLANKS#4:
+  - Blocks.ACACIA_PLANKS
+  - "acacia_planks"
+Blocks.PLANKS#5:
+  - Blocks.DARK_OAK_PLANKS
+  - "dark_oak_planks"
+Blocks.MANGROVE_PLANKS:
+  - Blocks.MANGROVE_PLANKS
+  - "mangrove_planks"
+Blocks.CHERRY_PLANKS:
+  - Blocks.CHERRY_PLANKS
+  - "cherry_planks"
+Blocks.BAMBOO_PLANKS:
+  - Blocks.BAMBOO_PLANKS
+  - "bamboo_planks"
+Blocks.BAMBOO_MOSAIC:
+  - Blocks.BAMBOO_MOSAIC
+  - "bamboo_mosaic"
+Blocks.SAPLING:
+  - Blocks.OAK_SAPLING
+  - "#minecraft:saplings"
+Blocks.SAPLING#0:
+  - Blocks.OAK_SAPLING
+  - "oak_sapling"
+Blocks.SAPLING#1:
+  - Blocks.SPRUCE_SAPLING
+  - "spruce_sapling"
+Blocks.SAPLING#2:
+  - Blocks.BIRCH_SAPLING
+  - "birch_sapling"
+Blocks.SAPLING#3:
+  - Blocks.JUNGLE_SAPLING
+  - "jungle_sapling"
+Blocks.SAPLING#4:
+  - Blocks.ACACIA_SAPLING
+  - "acacia_sapling"
+Blocks.SAPLING#5:
+  - Blocks.DARK_OAK_SAPLING
+  - "dark_oak_sapling"
+Blocks.MANGROVE_PROPAGULE:
+  - Blocks.MANGROVE_PROPAGULE
+  - "mangrove_propagule"
+Blocks.CHERRY_SAPLING:
+  - Blocks.CHERRY_SAPLING
+  - "cherry_sapling"
+Blocks.REEDS:
+  - Blocks.SUGAR_CANE
+  - "sugar_cane"
+Blocks.BEDROCK:
+  - Blocks.BEDROCK
+  - "bedrock"
+Blocks.SAND:
+  - Blocks.SAND
+  - "#minecraft:sand"
+Blocks.SAND#0:
+  - Blocks.SAND
+  - "sand"
+Blocks.SAND#1:
+  - Blocks.RED_SAND
+  - "red_sand"
+Blocks.SUSPICIOUS_SAND:
+  - Blocks.SUSPICIOUS_SAND
+  - "suspicious_sand"
+Blocks.GRAVEL:
+  - Blocks.GRAVEL
+  - "gravel"
+Blocks.SUSPICIOUS_GRAVEL:
+  - Blocks.SUSPICIOUS_GRAVEL
+  - "suspicious_gravel"
+Blocks.FLOWING_WATER:
+  - Blocks.WATER
+  - "water"
+Blocks.WATER:
+  - Blocks.WATER
+  - "water"
+Blocks.FLOWING_LAVA:
+  - Blocks.LAVA
+  - "lava"
+Blocks.LAVA:
+  - Blocks.LAVA
+  - "lava"
+Blocks.MAGMA:
+  - Blocks.MAGMA_BLOCK
+  - "magma_block"
+Blocks.OBSIDIAN:
+  - Blocks.OBSIDIAN
+  - "obsidian"
+Blocks.COAL_ORE:
+  - Blocks.COAL_ORE
+  - "coal_ore"
+Blocks.IRON_ORE:
+  - Blocks.IRON_ORE
+  - "iron_ore"
+Blocks.REDSTONE_ORE:
+  - Blocks.REDSTONE_ORE
+  - "redstone_ore"
+Blocks.LIT_REDSTONE_ORE:
+  - Blocks.REDSTONE_ORE
+  - "redstone_ore"
+Blocks.GOLD_ORE:
+  - Blocks.GOLD_ORE
+  - "gold_ore"
+Blocks.LAPIS_ORE:
+  - Blocks.LAPIS_ORE
+  - "lapis_ore"
+Blocks.DIAMOND_ORE:
+  - Blocks.DIAMOND_ORE
+  - "diamond_ore"
+Blocks.EMERALD_ORE:
+  - Blocks.EMERALD_ORE
+  - "emerald_ore"
+Blocks.COPPER_ORE:
+  - Blocks.COPPER_ORE
+  - "copper_ore"
+Blocks.DEEPSLATE_COAL_ORE:
+  - Blocks.DEEPSLATE_COAL_ORE
+  - "deepslate_coal_ore"
+Blocks.DEEPSLATE_IRON_ORE:
+  - Blocks.DEEPSLATE_IRON_ORE
+  - "deepslate_iron_ore"
+Blocks.DEEPSLATE_REDSTONE_ORE:
+  - Blocks.DEEPSLATE_REDSTONE_ORE
+  - "deepslate_redstone_ore"
+Blocks.DEEPSLATE_GOLD_ORE:
+  - Blocks.DEEPSLATE_GOLD_ORE
+  - "deepslate_gold_ore"
+Blocks.DEEPSLATE_LAPIS_ORE:
+  - Blocks.DEEPSLATE_LAPIS_ORE
+  - "deepslate_lapis_ore"
+Blocks.DEEPSLATE_DIAMOND_ORE:
+  - Blocks.DEEPSLATE_DIAMOND_ORE
+  - "deepslate_diamond_ore"
+Blocks.DEEPSLATE_EMERALD_ORE:
+  - Blocks.DEEPSLATE_EMERALD_ORE
+  - "deepslate_emerald_ore"
+Blocks.DEEPSLATE_COPPER_ORE:
+  - Blocks.DEEPSLATE_COPPER_ORE
+  - "deepslate_copper_ore"
+Blocks.QUARTZ_ORE:
+  - Blocks.NETHER_QUARTZ_ORE
+  - "nether_quartz_ore"
+Blocks.COAL_BLOCK:
+  - Blocks.COAL_BLOCK
+  - "coal_block"
+Blocks.IRON_BLOCK:
+  - Blocks.IRON_BLOCK
+  - "iron_block"
+Blocks.REDSTONE_BLOCK:
+  - Blocks.REDSTONE_BLOCK
+  - "redstone_block"
+Blocks.GOLD_BLOCK:
+  - Blocks.GOLD_BLOCK
+  - "gold_block"
+Blocks.LAPIS_BLOCK:
+  - Blocks.LAPIS_BLOCK
+  - "lapis_block"
+Blocks.DIAMOND_BLOCK:
+  - Blocks.DIAMOND_BLOCK
+  - "diamond_block"
+Blocks.EMERALD_BLOCK:
+  - Blocks.EMERALD_BLOCK
+  - "emerald_block"
+Blocks.QUARTZ_BLOCK:
+  - Blocks.QUARTZ_BLOCK
+  - "#forge:ores/quartz"
+Blocks.QUARTZ_BLOCK#0:
+  - Blocks.SMOOTH_QUARTZ
+  - "smooth_quartz"
+Blocks.QUARTZ_BLOCK#1:
+  - Blocks.CHISELED_QUARTZ_BLOCK
+  - "chiseled_quartz_block"
+Blocks.QUARTZ_BLOCK#2:
+  - Blocks.QUARTZ_PILLAR
+  - "quartz_pillar"
+Blocks.QUARTZ_BLOCK#3:
+  - Blocks.QUARTZ_BLOCK
+  - "quartz_block"
+Blocks.SLIME_BLOCK:
+  - Blocks.SLIME_BLOCK
+  - "slime_block"
+Blocks.LOG:
+  - Blocks.OAK_LOG
+  - "#minecraft:logs"
+Blocks.LOG#0:
+  - Blocks.OAK_LOG
+  - "oak_log"
+Blocks.LOG#1:
+  - Blocks.SPRUCE_LOG
+  - "spruce_log"
+Blocks.LOG#2:
+  - Blocks.BIRCH_LOG
+  - "birch_log"
+Blocks.LOG#3:
+  - Blocks.JUNGLE_LOG
+  - "jungle_log"
+Blocks.LOG2:
+  - Blocks.ACACIA_LOG
+  - "#minecraft:logs"
+Blocks.LOG2#0:
+  - Blocks.ACACIA_LOG
+  - "acacia_log"
+Blocks.LOG2#1:
+  - Blocks.DARK_OAK_LOG
+  - "dark_oak_log"
+Blocks.MANGROVE_LOG:
+  - Blocks.MANGROVE_LOG
+  - "mangrove_log"
+Blocks.CHERRY_LOG:
+  - Blocks.CHERRY_LOG
+  - "cherry_log"
+Blocks.BAMBOO_BLOCK:
+  - Blocks.BAMBOO_BLOCK
+  - "bamboo_block"
+Blocks.LEAVES:
+  - Blocks.OAK_LEAVES
+  - "#minecraft:leaves"
+Blocks.LEAVES#0:
+  - Blocks.OAK_LEAVES
+  - "oak_leaves"
+Blocks.LEAVES#1:
+  - Blocks.SPRUCE_LEAVES
+  - "spruce_leaves"
+Blocks.LEAVES#2:
+  - Blocks.BIRCH_LEAVES
+  - "birch_leaves"
+Blocks.LEAVES#3:
+  - Blocks.JUNGLE_LEAVES
+  - "jungle_leaves"
+Blocks.LEAVES2:
+  - Blocks.ACACIA_LEAVES
+  - "#minecraft:leaves"
+Blocks.LEAVES2#0:
+  - Blocks.ACACIA_LEAVES
+  - "acacia_leaves"
+Blocks.LEAVES2#1:
+  - Blocks.DARK_OAK_LEAVES
+  - "dark_oak_leaves"
+Blocks.AZALEA_LEAVES:
+  - Blocks.AZALEA_LEAVES
+  - "azalea_leaves"
+Blocks.FLOWERING_AZALEA_LEAVES:
+  - Blocks.FLOWERING_AZALEA_LEAVES
+  - "flowering_azalea_leaves"
+Blocks.MANGROVE_LEAVES:
+  - Blocks.MANGROVE_LEAVES
+  - "mangrove_leaves"
+Blocks.CHERRY_LEAVES:
+  - Blocks.CHERRY_LEAVES
+  - "cherry_leaves"
+Blocks.MANGROVE_ROOTS:
+  - Blocks.MANGROVE_ROOTS
+  - "mangrove_roots"
+Blocks.MUDDY_MANGROVE_ROOTS:
+  - Blocks.MUDDY_MANGROVE_ROOTS
+  - "muddy_mangrove_roots"
+Blocks.SPONGE:
+  - Blocks.SPONGE
+  - "sponge"
+Blocks.SPONGE#0:
+  - Blocks.SPONGE
+  - "sponge"
+Blocks.SPONGE#1:
+  - Blocks.WET_SPONGE
+  - "wet_sponge"
+Blocks.SANDSTONE:
+  - Blocks.SANDSTONE
+  - "#c:sandstone/blocks"
+Blocks.SANDSTONE#0:
+  - Blocks.SANDSTONE
+  - "sandstone"
+Blocks.SANDSTONE#1:
+  - Blocks.CHISELED_SANDSTONE
+  - "chiseled_sandstone"
+Blocks.SANDSTONE#2:
+  - Blocks.CUT_SANDSTONE
+  - "cut_sandstone"
+Blocks.RED_SANDSTONE:
+  - Blocks.RED_SANDSTONE
+  - "#c:sandstone/blocks"
+Blocks.RED_SANDSTONE#0:
+  - Blocks.RED_SANDSTONE
+  - "red_sandstone"
+Blocks.RED_SANDSTONE#1:
+  - Blocks.CHISELED_RED_SANDSTONE
+  - "chiseled_red_sandstone"
+Blocks.RED_SANDSTONE#2:
+  - Blocks.CUT_RED_SANDSTONE
+  - "cut_red_sandstone"
+Blocks.NOTEBLOCK:
+  - Blocks.NOTE_BLOCK
+  - "note_block"
+Blocks.RAIL:
+  - Blocks.RAIL
+  - "rail"
+Blocks.GOLDEN_RAIL:
+  - Blocks.POWERED_RAIL
+  - "powered_rail"
+Blocks.DETECTOR_RAIL:
+  - Blocks.DETECTOR_RAIL
+  - "detector_rail"
+Blocks.ACTIVATOR_RAIL:
+  - Blocks.ACTIVATOR_RAIL
+  - "activator_rail"
+Blocks.BED:
+  - Blocks.WHITE_BED
+  - "white_bed"
+Blocks.WEB:
+  - Blocks.COBWEB
+  - "cobweb"
+Blocks.DEADBUSH:
+  - Blocks.DEAD_BUSH
+  - "dead_bush"
+Blocks.TALLGRASS:
+  - Blocks.SHORT_GRASS
+  - "short_grass"
+Blocks.TALLGRASS#0:
+  - Blocks.DEAD_BUSH
+  - "dead_bush"
+Blocks.TALLGRASS#1:
+  - Blocks.SHORT_GRASS
+  - "short_grass"
+Blocks.TALLGRASS#2:
+  - Blocks.FERN
+  - "fern"
+Blocks.PISTON:
+  - Blocks.PISTON
+  - "piston"
+Blocks.STICKY_PISTON:
+  - Blocks.STICKY_PISTON
+  - "sticky_piston"
+Blocks.PISTON_HEAD:
+  - Blocks.PISTON_HEAD
+  - "piston_head"
+Blocks.PISTON_EXTENSION:
+  - Blocks.MOVING_PISTON
+  - "moving_piston"
+Blocks.YELLOW_FLOWER:
+  - Blocks.DANDELION
+  - "dandelion"
+Blocks.RED_FLOWER:
+  - Blocks.POPPY
+  - "#minecraft:small_flowers"
+Blocks.RED_FLOWER#0:
+  - Blocks.POPPY
+  - "poppy"
+Blocks.RED_FLOWER#1:
+  - Blocks.BLUE_ORCHID
+  - "blue_orchid"
+Blocks.RED_FLOWER#2:
+  - Blocks.ALLIUM
+  - "allium"
+Blocks.RED_FLOWER#3:
+  - Blocks.AZURE_BLUET
+  - "azure_bluet"
+Blocks.RED_FLOWER#4:
+  - Blocks.RED_TULIP
+  - "red_tulip"
+Blocks.RED_FLOWER#5:
+  - Blocks.ORANGE_TULIP
+  - "orange_tulip"
+Blocks.RED_FLOWER#6:
+  - Blocks.WHITE_TULIP
+  - "white_tulip"
+Blocks.RED_FLOWER#7:
+  - Blocks.PINK_TULIP
+  - "pink_tulip"
+Blocks.RED_FLOWER#8:
+  - Blocks.OXEYE_DAISY
+  - "oxeye_daisy"
+Blocks.TORCHFLOWER:
+  - Blocks.TORCHFLOWER
+  - "torchflower"
+Blocks.PINK_PETALS:
+  - Blocks.PINK_PETALS
+  - "pink_petals"
+Blocks.DOUBLE_PLANT:
+  - Blocks.SUNFLOWER
+  - "#minecraft:small_flowers"
+Blocks.DOUBLE_PLANT#0:
+  - Blocks.SUNFLOWER
+  - "sunflower"
+Blocks.DOUBLE_PLANT#1:
+  - Blocks.LILAC
+  - "lilac"
+Blocks.DOUBLE_PLANT#2:
+  - Blocks.TALL_GRASS
+  - "tall_grass"
+Blocks.DOUBLE_PLANT#3:
+  - Blocks.LARGE_FERN
+  - "large_fern"
+Blocks.DOUBLE_PLANT#4:
+  - Blocks.ROSE_BUSH
+  - "rose_bush"
+Blocks.DOUBLE_PLANT#5:
+  - Blocks.PEONY
+  - "peony"
+Blocks.PITCHER_PLANT:
+  - Blocks.PITCHER_PLANT
+  - "pitcher_plant"
+Blocks.BROWN_MUSHROOM:
+  - Blocks.BROWN_MUSHROOM
+  - "brown_mushroom"
+Blocks.RED_MUSHROOM:
+  - Blocks.RED_MUSHROOM
+  - "red_mushroom"
+Blocks.BROWN_MUSHROOM_BLOCK:
+  - Blocks.BROWN_MUSHROOM_BLOCK
+  - "brown_mushroom_block"
+Blocks.RED_MUSHROOM_BLOCK:
+  - Blocks.RED_MUSHROOM_BLOCK
+  - "red_mushroom_block"
+Blocks.BRICK_BLOCK:
+  - Blocks.BRICKS
+  - "bricks"
+Blocks.TNT:
+  - Blocks.TNT
+  - "tnt"
+Blocks.BOOKSHELF:
+  - Blocks.BOOKSHELF
+  - "bookshelf"
+Blocks.CHISELED_BOOKSHELF:
+  - Blocks.CHISELED_BOOKSHELF
+  - "chiseled_bookshelf"
+Blocks.TORCH:
+  - Blocks.TORCH
+  - "torch"
+Blocks.FIRE:
+  - Blocks.FIRE
+  - "fire"
+Blocks.MOB_SPAWNER:
+  - Blocks.SPAWNER
+  - "spawner"
+Blocks.OAK_STAIRS:
+  - Blocks.OAK_STAIRS
+  - "oak_stairs"
+Blocks.SPRUCE_STAIRS:
+  - Blocks.SPRUCE_STAIRS
+  - "spruce_stairs"
+Blocks.BIRCH_STAIRS:
+  - Blocks.BIRCH_STAIRS
+  - "birch_stairs"
+Blocks.JUNGLE_STAIRS:
+  - Blocks.JUNGLE_STAIRS
+  - "jungle_stairs"
+Blocks.ACACIA_STAIRS:
+  - Blocks.ACACIA_STAIRS
+  - "acacia_stairs"
+Blocks.DARK_OAK_STAIRS:
+  - Blocks.DARK_OAK_STAIRS
+  - "dark_oak_stairs"
+Blocks.MANGROVE_STAIRS:
+  - Blocks.MANGROVE_STAIRS
+  - "mangrove_stairs"
+Blocks.CHERRY_STAIRS:
+  - Blocks.CHERRY_STAIRS
+  - "cherry_stairs"
+Blocks.BAMBOO_STAIRS:
+  - Blocks.BAMBOO_STAIRS
+  - "bamboo_stairs"
+Blocks.BAMBOO_MOSAIC_STAIRS:
+  - Blocks.BAMBOO_MOSAIC_STAIRS
+  - "bamboo_mosaic_stairs"
+Blocks.SANDSTONE_STAIRS:
+  - Blocks.SANDSTONE_STAIRS
+  - "sandstone_stairs"
+Blocks.RED_SANDSTONE_STAIRS:
+  - Blocks.RED_SANDSTONE_STAIRS
+  - "red_sandstone_stairs"
+Blocks.STONE_STAIRS:
+  - Blocks.COBBLESTONE_STAIRS
+  - "cobblestone_stairs"
+Blocks.BRICK_STAIRS:
+  - Blocks.BRICK_STAIRS
+  - "brick_stairs"
+Blocks.STONE_BRICK_STAIRS:
+  - Blocks.STONE_BRICK_STAIRS
+  - "stone_brick_stairs"
+Blocks.NETHER_BRICK_STAIRS:
+  - Blocks.NETHER_BRICK_STAIRS
+  - "nether_brick_stairs"
+Blocks.QUARTZ_STAIRS:
+  - Blocks.QUARTZ_STAIRS
+  - "quartz_stairs"
+Blocks.PURPUR_STAIRS:
+  - Blocks.PURPUR_STAIRS
+  - "purpur_stairs"
+Blocks.CHEST:
+  - Blocks.CHEST
+  - "chest"
+Blocks.TRAPPED_CHEST:
+  - Blocks.TRAPPED_CHEST
+  - "trapped_chest"
+Blocks.ENDER_CHEST:
+  - Blocks.ENDER_CHEST
+  - "ender_chest"
+Blocks.CRAFTING_TABLE:
+  - Blocks.CRAFTING_TABLE
+  - "crafting_table"
+Blocks.WHEAT:
+  - Blocks.WHEAT
+  - "wheat"
+Blocks.FARMLAND:
+  - Blocks.FARMLAND
+  - "farmland"
+Blocks.FURNACE:
+  - Blocks.FURNACE
+  - "furnace"
+Blocks.STANDING_SIGN:
+  - Blocks.OAK_SIGN
+  - "oak_sign"
+Blocks.WALL_SIGN:
+  - Blocks.OAK_WALL_SIGN
+  - "oak_wall_sign"
+Blocks.OAK_DOOR:
+  - Blocks.OAK_DOOR
+  - "oak_door"
+Blocks.SPRUCE_DOOR:
+  - Blocks.SPRUCE_DOOR
+  - "spruce_door"
+Blocks.BIRCH_DOOR:
+  - Blocks.BIRCH_DOOR
+  - "birch_door"
+Blocks.JUNGLE_DOOR:
+  - Blocks.JUNGLE_DOOR
+  - "jungle_door"
+Blocks.ACACIA_DOOR:
+  - Blocks.ACACIA_DOOR
+  - "acacia_door"
+Blocks.DARK_OAK_DOOR:
+  - Blocks.DARK_OAK_DOOR
+  - "dark_oak_door"
+Blocks.MANGROVE_DOOR:
+  - Blocks.MANGROVE_DOOR
+  - "mangrove_door"
+Blocks.CHERRY_DOOR:
+  - Blocks.CHERRY_DOOR
+  - "cherry_door"
+Blocks.BAMBOO_DOOR:
+  - Blocks.BAMBOO_DOOR
+  - "bamboo_door"
+Blocks.IRON_DOOR:
+  - Blocks.IRON_DOOR
+  - "iron_door"
+Blocks.TRAPDOOR:
+  - Blocks.OAK_TRAPDOOR
+  - "oak_trapdoor"
+Blocks.IRON_TRAPDOOR:
+  - Blocks.IRON_TRAPDOOR
+  - "iron_trapdoor"
+Blocks.COPPER_TRAPDOOR:
+  - Blocks.COPPER_TRAPDOOR
+  - "copper_trapdoor"
+Blocks.EXPOSED_COPPER_TRAPDOOR:
+  - Blocks.EXPOSED_COPPER_TRAPDOOR
+  - "exposed_copper_trapdoor"
+Blocks.OXIDIZED_COPPER_TRAPDOOR:
+  - Blocks.OXIDIZED_COPPER_TRAPDOOR
+  - "oxidized_copper_trapdoor"
+Blocks.WEATHERED_COPPER_TRAPDOOR:
+  - Blocks.WEATHERED_COPPER_TRAPDOOR
+  - "weathered_copper_trapdoor"
+Blocks.WAXED_COPPER_TRAPDOOR:
+  - Blocks.WAXED_COPPER_TRAPDOOR
+  - "waxed_copper_trapdoor"
+Blocks.WAXED_EXPOSED_COPPER_TRAPDOOR:
+  - Blocks.WAXED_EXPOSED_COPPER_TRAPDOOR
+  - "waxed_exposed_copper_trapdoor"
+Blocks.WAXED_OXIDIZED_COPPER_TRAPDOOR:
+  - Blocks.WAXED_OXIDIZED_COPPER_TRAPDOOR
+  - "waxed_oxidized_copper_trapdoor"
+Blocks.WAXED_WEATHERED_COPPER_TRAPDOOR:
+  - Blocks.WAXED_WEATHERED_COPPER_TRAPDOOR
+  - "waxed_weathered_copper_trapdoor"
+Blocks.COPPER_GRATE:
+  - Blocks.COPPER_GRATE
+  - "copper_grate"
+Blocks.EXPOSED_COPPER_GRATE:
+  - Blocks.EXPOSED_COPPER_GRATE
+  - "exposed_copper_grate"
+Blocks.WEATHERED_COPPER_GRATE:
+  - Blocks.WEATHERED_COPPER_GRATE
+  - "weathered_copper_grate"
+Blocks.OXIDIZED_COPPER_GRATE:
+  - Blocks.OXIDIZED_COPPER_GRATE
+  - "oxidized_copper_grate"
+Blocks.WAXED_COPPER_GRATE:
+  - Blocks.WAXED_COPPER_GRATE
+  - "waxed_copper_grate"
+Blocks.WAXED_EXPOSED_COPPER_GRATE:
+  - Blocks.WAXED_EXPOSED_COPPER_GRATE
+  - "waxed_exposed_copper_grate"
+Blocks.WAXED_WEATHERED_COPPER_GRATE:
+  - Blocks.WAXED_WEATHERED_COPPER_GRATE
+  - "waxed_weathered_copper_grate"
+Blocks.WAXED_OXIDIZED_COPPER_GRATE:
+  - Blocks.WAXED_OXIDIZED_COPPER_GRATE
+  - "waxed_oxidized_copper_grate"
+Blocks.COPPER_BULB:
+  - Blocks.COPPER_BULB
+  - "copper_bulb"
+Blocks.EXPOSED_COPPER_BULB:
+  - Blocks.EXPOSED_COPPER_BULB
+  - "exposed_copper_bulb"
+Blocks.WEATHERED_COPPER_BULB:
+  - Blocks.WEATHERED_COPPER_BULB
+  - "weathered_copper_bulb"
+Blocks.OXIDIZED_COPPER_BULB:
+  - Blocks.OXIDIZED_COPPER_BULB
+  - "oxidized_copper_bulb"
+Blocks.WAXED_COPPER_BULB:
+  - Blocks.WAXED_COPPER_BULB
+  - "waxed_copper_bulb"
+Blocks.WAXED_EXPOSED_COPPER_BULB:
+  - Blocks.WAXED_EXPOSED_COPPER_BULB
+  - "waxed_exposed_copper_bulb"
+Blocks.WAXED_WEATHERED_COPPER_BULB:
+  - Blocks.WAXED_WEATHERED_COPPER_BULB
+  - "waxed_weathered_copper_bulb"
+Blocks.WAXED_OXIDIZED_COPPER_BULB:
+  - Blocks.WAXED_OXIDIZED_COPPER_BULB
+  - "waxed_oxidized_copper_bulb"
+Blocks.LADDER:
+  - Blocks.LADDER
+  - "ladder"
+Blocks.LEVER:
+  - Blocks.LEVER
+  - "lever"
+Blocks.STONE_BUTTON:
+  - Blocks.STONE_BUTTON
+  - "stone_button"
+Blocks.WOODEN_BUTTON:
+  - Blocks.OAK_BUTTON
+  - "oak_button"
+Blocks.WOODEN_PRESSURE_PLATE:
+  - Blocks.OAK_PRESSURE_PLATE
+  - "oak_pressure_plate"
+Blocks.STONE_PRESSURE_PLATE:
+  - Blocks.STONE_PRESSURE_PLATE
+  - "stone_pressure_plate"
+Blocks.LIGHT_WEIGHTED_PRESSURE_PLATE:
+  - Blocks.LIGHT_WEIGHTED_PRESSURE_PLATE
+  - "light_weighted_pressure_plate"
+Blocks.HEAVY_WEIGHTED_PRESSURE_PLATE:
+  - Blocks.HEAVY_WEIGHTED_PRESSURE_PLATE
+  - "heavy_weighted_pressure_plate"
+Blocks.TRIPWIRE_HOOK:
+  - Blocks.TRIPWIRE_HOOK
+  - "tripwire_hook"
+Blocks.TRIPWIRE:
+  - Blocks.TRIPWIRE
+  - "tripwire"
+Blocks.DAYLIGHT_DETECTOR:
+  - Blocks.DAYLIGHT_DETECTOR
+  - "daylight_detector"
+Blocks.DAYLIGHT_DETECTOR_INVERTED:
+  - Blocks.DAYLIGHT_DETECTOR
+  - "daylight_detector"
+Blocks.REDSTONE_TORCH:
+  - Blocks.REDSTONE_TORCH
+  - "redstone_torch"
+Blocks.UNLIT_REDSTONE_TORCH:
+  - Blocks.REDSTONE_TORCH
+  - "redstone_torch"
+Blocks.REDSTONE_WIRE:
+  - Blocks.REDSTONE_WIRE
+  - "redstone_wire"
+Blocks.UNPOWERED_REPEATER:
+  - Blocks.REPEATER
+  - "repeater"
+Blocks.POWERED_REPEATER:
+  - Blocks.REPEATER
+  - "repeater"
+Blocks.UNPOWERED_COMPARATOR:
+  - Blocks.COMPARATOR
+  - "comparator"
+Blocks.POWERED_COMPARATOR:
+  - Blocks.COMPARATOR
+  - "comparator"
+Blocks.REDSTONE_LAMP:
+  - Blocks.REDSTONE_LAMP
+  - "redstone_lamp"
+Blocks.LIT_REDSTONE_LAMP:
+  - Blocks.REDSTONE_LAMP
+  - "redstone_lamp"
+Blocks.DISPENSER:
+  - Blocks.DISPENSER
+  - "dispenser"
+Blocks.DROPPER:
+  - Blocks.DROPPER
+  - "dropper"
+Blocks.OBSERVER:
+  - Blocks.OBSERVER
+  - "observer"
+Blocks.HOPPER:
+  - Blocks.HOPPER
+  - "hopper"
+Blocks.COMMAND_BLOCK:
+  - Blocks.COMMAND_BLOCK
+  - "command_block"
+Blocks.REPEATING_COMMAND_BLOCK:
+  - Blocks.REPEATING_COMMAND_BLOCK
+  - "repeating_command_block"
+Blocks.CHAIN_COMMAND_BLOCK:
+  - Blocks.CHAIN_COMMAND_BLOCK
+  - "chain_command_block"
+Blocks.SNOW_LAYER:
+  - Blocks.SNOW
+  - "snow"
+Blocks.SNOW:
+  - Blocks.SNOW_BLOCK
+  - "snow_block"
+Blocks.ICE:
+  - Blocks.ICE
+  - "ice"
+Blocks.PACKED_ICE:
+  - Blocks.PACKED_ICE
+  - "packed_ice"
+Blocks.FROSTED_ICE:
+  - Blocks.FROSTED_ICE
+  - "frosted_ice"
+Blocks.CACTUS:
+  - Blocks.CACTUS
+  - "cactus"
+Blocks.CLAY:
+  - Blocks.CLAY
+  - "clay"
+Blocks.JUKEBOX:
+  - Blocks.JUKEBOX
+  - "jukebox"
+Blocks.OAK_FENCE:
+  - Blocks.OAK_FENCE
+  - "oak_fence"
+Blocks.SPRUCE_FENCE:
+  - Blocks.SPRUCE_FENCE
+  - "spruce_fence"
+Blocks.BIRCH_FENCE:
+  - Blocks.BIRCH_FENCE
+  - "birch_fence"
+Blocks.JUNGLE_FENCE:
+  - Blocks.JUNGLE_FENCE
+  - "jungle_fence"
+Blocks.ACACIA_FENCE:
+  - Blocks.ACACIA_FENCE
+  - "acacia_fence"
+Blocks.DARK_OAK_FENCE:
+  - Blocks.DARK_OAK_FENCE
+  - "dark_oak_fence"
+Blocks.MANGROVE_FENCE:
+  - Blocks.MANGROVE_FENCE
+  - "mangrove_fence"
+Blocks.CHERRY_FENCE:
+  - Blocks.CHERRY_FENCE
+  - "cherry_fence"
+Blocks.BAMBOO_FENCE:
+  - Blocks.BAMBOO_FENCE
+  - "bamboo_fence"
+Blocks.OAK_FENCE_GATE:
+  - Blocks.OAK_FENCE_GATE
+  - "oak_fence_gate"
+Blocks.SPRUCE_FENCE_GATE:
+  - Blocks.SPRUCE_FENCE_GATE
+  - "spruce_fence_gate"
+Blocks.BIRCH_FENCE_GATE:
+  - Blocks.BIRCH_FENCE_GATE
+  - "birch_fence_gate"
+Blocks.JUNGLE_FENCE_GATE:
+  - Blocks.JUNGLE_FENCE_GATE
+  - "jungle_fence_gate"
+Blocks.ACACIA_FENCE_GATE:
+  - Blocks.ACACIA_FENCE_GATE
+  - "acacia_fence_gate"
+Blocks.DARK_OAK_FENCE_GATE:
+  - Blocks.DARK_OAK_FENCE_GATE
+  - "dark_oak_fence_gate"
+Blocks.MANGROVE_FENCE_GATE:
+  - Blocks.MANGROVE_FENCE_GATE
+  - "mangrove_fence_gate"
+Blocks.CHERRY_FENCE_GATE:
+  - Blocks.CHERRY_FENCE_GATE
+  - "cherry_fence_gate"
+Blocks.BAMBOO_FENCE_GATE:
+  - Blocks.BAMBOO_FENCE_GATE
+  - "bamboo_fence_gate"
+Blocks.NETHER_BRICK_FENCE:
+  - Blocks.NETHER_BRICK_FENCE
+  - "nether_brick_fence"
+Blocks.NETHER_BRICK:
+  - Blocks.NETHER_BRICKS
+  - "nether_bricks"
+Blocks.RED_NETHER_BRICK:
+  - Blocks.RED_NETHER_BRICKS
+  - "red_nether_bricks"
+Blocks.NETHERRACK:
+  - Blocks.NETHERRACK
+  - "netherrack"
+Blocks.SOUL_SAND:
+  - Blocks.SOUL_SAND
+  - "soul_sand"
+Blocks.GLOWSTONE:
+  - Blocks.GLOWSTONE
+  - "glowstone"
+Blocks.BONE_BLOCK:
+  - Blocks.BONE_BLOCK
+  - "bone_block"
+Blocks.NETHER_WART:
+  - Blocks.NETHER_WART
+  - "nether_wart"
+Blocks.NETHER_WART_BLOCK:
+  - Blocks.NETHER_WART_BLOCK
+  - "nether_wart_block"
+Blocks.CAKE:
+  - Blocks.CAKE
+  - "cake"
+Blocks.STONEBRICK:
+  - Blocks.STONE_BRICKS
+  - "#minecraft:stone_bricks"
+Blocks.STONEBRICK#0:
+  - Blocks.STONE_BRICKS
+  - "stone_bricks"
+Blocks.STONEBRICK#1:
+  - Blocks.MOSSY_STONE_BRICKS
+  - "mossy_stone_bricks"
+Blocks.STONEBRICK#2:
+  - Blocks.CRACKED_STONE_BRICKS
+  - "cracked_stone_bricks"
+Blocks.STONEBRICK#3:
+  - Blocks.CHISELED_STONE_BRICKS
+  - "chiseled_stone_bricks"
+Blocks.IRON_BARS:
+  - Blocks.IRON_BARS
+  - "iron_bars"
+Blocks.MELON_BLOCK:
+  - Blocks.MELON
+  - "melon"
+Blocks.MELON_STEM:
+  - Blocks.MELON_STEM
+  - "melon_stem"
+Blocks.PUMPKIN:
+  - Blocks.PUMPKIN
+  - "pumpkin"
+Blocks.LIT_PUMPKIN:
+  - Blocks.JACK_O_LANTERN
+  - "jack_o_lantern"
+Blocks.PUMPKIN_STEM:
+  - Blocks.PUMPKIN_STEM
+  - "pumpkin_stem"
+Blocks.VINE:
+  - Blocks.VINE
+  - "vine"
+Blocks.GLOW_LICHEN:
+  - Blocks.GLOW_LICHEN
+  - "glow_lichen"
+Blocks.WATERLILY:
+  - Blocks.LILY_PAD
+  - "lily_pad"
+Blocks.ENCHANTING_TABLE:
+  - Blocks.ENCHANTING_TABLE
+  - "enchanting_table"
+Blocks.BREWING_STAND:
+  - Blocks.BREWING_STAND
+  - "brewing_stand"
+Blocks.CAULDRON:
+  - Blocks.CAULDRON
+  - "cauldron"
+Blocks.WATER_CAULDRON:
+  - Blocks.WATER_CAULDRON
+  - "water_cauldron"
+Blocks.LAVA_CAULDRON:
+  - Blocks.LAVA_CAULDRON
+  - "lava_cauldron"
+Blocks.POWDER_SNOW_CAULDRON:
+  - Blocks.POWDER_SNOW_CAULDRON
+  - "powder_snow_cauldron"
+Blocks.END_PORTAL:
+  - Blocks.END_PORTAL
+  - "end_portal"
+Blocks.END_PORTAL_FRAME:
+  - Blocks.END_PORTAL_FRAME
+  - "end_portal_frame"
+Blocks.END_GATEWAY:
+  - Blocks.END_GATEWAY
+  - "end_gateway"
+Blocks.END_STONE:
+  - Blocks.END_STONE
+  - "end_stone"
+Blocks.END_BRICKS:
+  - Blocks.END_STONE_BRICKS
+  - "end_stone_bricks"
+Blocks.END_ROD:
+  - Blocks.END_ROD
+  - "end_rod"
+Blocks.PURPUR_BLOCK:
+  - Blocks.PURPUR_BLOCK
+  - "purpur_block"
+Blocks.PURPUR_PILLAR:
+  - Blocks.PURPUR_PILLAR
+  - "purpur_pillar"
+Blocks.PURPUR_SLAB:
+  - Blocks.PURPUR_SLAB
+  - "purpur_slab"
+Blocks.PURPUR_DOUBLE_SLAB:
+  - Blocks.PURPUR_SLAB
+  - "purpur_slab"
+Blocks.BEETROOTS:
+  - Blocks.BEETROOTS
+  - "beetroots"
+Blocks.CHORUS_PLANT:
+  - Blocks.CHORUS_PLANT
+  - "chorus_plant"
+Blocks.CHORUS_FLOWER:
+  - Blocks.CHORUS_FLOWER
+  - "chorus_flower"
+Blocks.DRAGON_EGG:
+  - Blocks.DRAGON_EGG
+  - "dragon_egg"
+Blocks.MONSTER_EGG:
+  - Blocks.INFESTED_STONE
+  - "infested_stone"
+Blocks.MONSTER_EGG#0:
+  - Blocks.INFESTED_STONE
+  - "infested_stone"
+Blocks.MONSTER_EGG#1:
+  - Blocks.INFESTED_COBBLESTONE
+  - "infested_cobblestone"
+Blocks.MONSTER_EGG#2:
+  - Blocks.INFESTED_STONE_BRICKS
+  - "infested_stone_bricks"
+Blocks.MONSTER_EGG#3:
+  - Blocks.INFESTED_MOSSY_STONE_BRICKS
+  - "infested_mossy_stone_bricks"
+Blocks.MONSTER_EGG#4:
+  - Blocks.INFESTED_CRACKED_STONE_BRICKS
+  - "infested_cracked_stone_bricks"
+Blocks.MONSTER_EGG#5:
+  - Blocks.INFESTED_CHISELED_STONE_BRICKS
+  - "infested_chiseled_stone_bricks"
+Blocks.MONSTER_EGG#6:
+  - Blocks.INFESTED_DEEPSLATE
+  - "infested_deepslate"
+Blocks.WOODEN_SLAB:
+  - Blocks.OAK_SLAB
+  - "#minecraft:wooden_slabs"
+Blocks.WOODEN_SLAB#0:
+  - Blocks.OAK_SLAB
+  - "oak_slab"
+Blocks.WOODEN_SLAB#1:
+  - Blocks.SPRUCE_SLAB
+  - "spruce_slab"
+Blocks.WOODEN_SLAB#2:
+  - Blocks.BIRCH_SLAB
+  - "birch_slab"
+Blocks.WOODEN_SLAB#3:
+  - Blocks.JUNGLE_SLAB
+  - "jungle_slab"
+Blocks.WOODEN_SLAB#4:
+  - Blocks.ACACIA_SLAB
+  - "acacia_slab"
+Blocks.WOODEN_SLAB#5:
+  - Blocks.DARK_OAK_SLAB
+  - "dark_oak_slab"
+Blocks.MANGROVE_SLAB:
+  - Blocks.MANGROVE_SLAB
+  - "mangrove_slab"
+Blocks.CHERRY_SLAB:
+  - Blocks.CHERRY_SLAB
+  - "cherry_slab"
+Blocks.BAMBOO_SLAB:
+  - Blocks.BAMBOO_SLAB
+  - "bamboo_slab"
+
+Blocks.BAMBOO_MOSAIC_SLAB:
+  - Blocks.BAMBOO_MOSAIC_SLAB
+  - "bamboo_mosaic_slab"
+Blocks.STONE_SLAB:
+  - Blocks.COBBLESTONE_SLAB
+  - "#minecraft:slabs"
+Blocks.STONE_SLAB#0:
+  - Blocks.SMOOTH_STONE_SLAB
+  - "smooth_stone_slab"
+Blocks.STONE_SLAB#1:
+  - Blocks.SANDSTONE_SLAB
+  - "sandstone_slab"
+Blocks.STONE_SLAB#2:
+  - Blocks.PETRIFIED_OAK_SLAB
+  - "petrified_oak_slab"
+Blocks.STONE_SLAB#3:
+  - Blocks.COBBLESTONE_SLAB
+  - "cobblestone_slab"
+Blocks.STONE_SLAB#4:
+  - Blocks.BRICK_SLAB
+  - "brick_slab"
+Blocks.STONE_SLAB#5:
+  - Blocks.STONE_BRICK_SLAB
+  - "stone_brick_slab"
+Blocks.STONE_SLAB#6:
+  - Blocks.NETHER_BRICK_SLAB
+  - "nether_brick_slab"
+Blocks.STONE_SLAB#7:
+  - Blocks.QUARTZ_SLAB
+  - "quartz_slab"
+Blocks.STONE_SLAB2:
+  - Blocks.RED_SANDSTONE_SLAB
+  - "red_sandstone_slab"
+Blocks.COCOA:
+  - Blocks.COCOA
+  - "cocoa"
+Blocks.PORTAL:
+  - Blocks.NETHER_PORTAL
+  - "nether_portal"
+Blocks.ANVIL:
+  - Blocks.ANVIL
+  - "#minecraft:anvil"
+Blocks.ANVIL#0:
+  - Blocks.ANVIL
+  - "anvil"
+Blocks.ANVIL#1:
+  - Blocks.CHIPPED_ANVIL
+  - "chipped_anvil"
+Blocks.ANVIL#2:
+  - Blocks.DAMAGED_ANVIL
+  - "damaged_anvil"
+Blocks.BEACON:
+  - Blocks.BEACON
+  - "beacon"
+Blocks.COBBLESTONE_WALL:
+  - Blocks.COBBLESTONE_WALL
+  - "#minecraft:walls"
+Blocks.COBBLESTONE_WALL#0:
+  - Blocks.COBBLESTONE_WALL
+  - "cobblestone_wall"
+Blocks.COBBLESTONE_WALL#1:
+  - Blocks.MOSSY_COBBLESTONE_WALL
+  - "mossy_cobblestone_wall"
+Blocks.FLOWER_POT:
+  - Blocks.FLOWER_POT
+  - "flower_pot"
+Blocks.CARROTS:
+  - Blocks.CARROTS
+  - "carrots"
+Blocks.POTATOES:
+  - Blocks.POTATOES
+  - "potatoes"
+Blocks.HAY_BLOCK:
+  - Blocks.HAY_BLOCK
+  - "hay_block"
+Blocks.SKULL:
+  - Blocks.SKELETON_SKULL
+  - "#forge:heads"
+Blocks.SKULL#0:
+  - Blocks.SKELETON_SKULL
+  - "skeleton_skull"
+Blocks.SKULL#1:
+  - Blocks.WITHER_SKELETON_SKULL
+  - "wither_skeleton_skull"
+Blocks.SKULL#2:
+  - Blocks.ZOMBIE_HEAD
+  - "zombie_head"
+Blocks.SKULL#3:
+  - Blocks.PLAYER_HEAD
+  - "player_head"
+Blocks.SKULL#4:
+  - Blocks.CREEPER_HEAD
+  - "creeper_head"
+Blocks.SKULL#5:
+  - Blocks.DRAGON_HEAD
+  - "dragon_head"
+Blocks.PIGLIN_HEAD:
+  - Blocks.PIGLIN_HEAD
+  - "piglin_head"
+Blocks.WOOL:
+  - Blocks.WHITE_WOOL
+  - "#minecraft:wool"
+Blocks.WOOL#0:
+  - Blocks.WHITE_WOOL
+  - "white_wool"
+Blocks.WOOL#1:
+  - Blocks.ORANGE_WOOL
+  - "orange_wool"
+Blocks.WOOL#2:
+  - Blocks.MAGENTA_WOOL
+  - "magenta_wool"
+Blocks.WOOL#3:
+  - Blocks.LIGHT_BLUE_WOOL
+  - "light_blue_wool"
+Blocks.WOOL#4:
+  - Blocks.YELLOW_WOOL
+  - "yellow_wool"
+Blocks.WOOL#5:
+  - Blocks.LIME_WOOL
+  - "lime_wool"
+Blocks.WOOL#6:
+  - Blocks.PINK_WOOL
+  - "pink_wool"
+Blocks.WOOL#7:
+  - Blocks.GRAY_WOOL
+  - "gray_wool"
+Blocks.WOOL#8:
+  - Blocks.LIGHT_GRAY_WOOL
+  - "light_gray_wool"
+Blocks.WOOL#9:
+  - Blocks.CYAN_WOOL
+  - "cyan_wool"
+Blocks.WOOL#10:
+  - Blocks.PURPLE_WOOL
+  - "purple_wool"
+Blocks.WOOL#11:
+  - Blocks.BLUE_WOOL
+  - "blue_wool"
+Blocks.WOOL#12:
+  - Blocks.BROWN_WOOL
+  - "brown_wool"
+Blocks.WOOL#13:
+  - Blocks.GREEN_WOOL
+  - "green_wool"
+Blocks.WOOL#14:
+  - Blocks.RED_WOOL
+  - "red_wool"
+Blocks.WOOL#15:
+  - Blocks.BLACK_WOOL
+  - "black_wool"
+Blocks.HARDENED_CLAY:
+  - Blocks.TERRACOTTA
+  - "terracotta"
+Blocks.STAINED_HARDENED_CLAY:
+  - Blocks.WHITE_TERRACOTTA
+  - "#minecraft:terracotta"
+Blocks.STAINED_HARDENED_CLAY#0:
+  - Blocks.WHITE_TERRACOTTA
+  - "white_terracotta"
+Blocks.STAINED_HARDENED_CLAY#1:
+  - Blocks.ORANGE_TERRACOTTA
+  - "orange_terracotta"
+Blocks.STAINED_HARDENED_CLAY#2:
+  - Blocks.MAGENTA_TERRACOTTA
+  - "magenta_terracotta"
+Blocks.STAINED_HARDENED_CLAY#3:
+  - Blocks.LIGHT_BLUE_TERRACOTTA
+  - "light_blue_terracotta"
+Blocks.STAINED_HARDENED_CLAY#4:
+  - Blocks.YELLOW_TERRACOTTA
+  - "yellow_terracotta"
+Blocks.STAINED_HARDENED_CLAY#5:
+  - Blocks.LIME_TERRACOTTA
+  - "lime_terracotta"
+Blocks.STAINED_HARDENED_CLAY#6:
+  - Blocks.PINK_TERRACOTTA
+  - "pink_terracotta"
+Blocks.STAINED_HARDENED_CLAY#7:
+  - Blocks.GRAY_TERRACOTTA
+  - "gray_terracotta"
+Blocks.STAINED_HARDENED_CLAY#8:
+  - Blocks.LIGHT_GRAY_TERRACOTTA
+  - "light_gray_terracotta"
+Blocks.STAINED_HARDENED_CLAY#9:
+  - Blocks.CYAN_TERRACOTTA
+  - "cyan_terracotta"
+Blocks.STAINED_HARDENED_CLAY#10:
+  - Blocks.PURPLE_TERRACOTTA
+  - "purple_terracotta"
+Blocks.STAINED_HARDENED_CLAY#11:
+  - Blocks.BLUE_TERRACOTTA
+  - "blue_terracotta"
+Blocks.STAINED_HARDENED_CLAY#12:
+  - Blocks.BROWN_TERRACOTTA
+  - "brown_terracotta"
+Blocks.STAINED_HARDENED_CLAY#13:
+  - Blocks.GREEN_TERRACOTTA
+  - "green_terracotta"
+Blocks.STAINED_HARDENED_CLAY#14:
+  - Blocks.RED_TERRACOTTA
+  - "red_terracotta"
+Blocks.STAINED_HARDENED_CLAY#15:
+  - Blocks.BLACK_TERRACOTTA
+  - "black_terracotta"
+Blocks.WHITE_GLAZED_TERRACOTTA:
+  - Blocks.WHITE_GLAZED_TERRACOTTA
+  - "white_glazed_terracotta"
+Blocks.ORANGE_GLAZED_TERRACOTTA:
+  - Blocks.ORANGE_GLAZED_TERRACOTTA
+  - "orange_glazed_terracotta"
+Blocks.MAGENTA_GLAZED_TERRACOTTA:
+  - Blocks.MAGENTA_GLAZED_TERRACOTTA
+  - "magenta_glazed_terracotta"
+Blocks.LIGHT_BLUE_GLAZED_TERRACOTTA:
+  - Blocks.LIGHT_BLUE_GLAZED_TERRACOTTA
+  - "light_blue_glazed_terracotta"
+Blocks.YELLOW_GLAZED_TERRACOTTA:
+  - Blocks.YELLOW_GLAZED_TERRACOTTA
+  - "yellow_glazed_terracotta"
+Blocks.LIME_GLAZED_TERRACOTTA:
+  - Blocks.LIME_GLAZED_TERRACOTTA
+  - "lime_glazed_terracotta"
+Blocks.PINK_GLAZED_TERRACOTTA:
+  - Blocks.PINK_GLAZED_TERRACOTTA
+  - "pink_glazed_terracotta"
+Blocks.GRAY_GLAZED_TERRACOTTA:
+  - Blocks.GRAY_GLAZED_TERRACOTTA
+  - "gray_glazed_terracotta"
+Blocks.SILVER_GLAZED_TERRACOTTA:
+  - Blocks.LIGHT_GRAY_GLAZED_TERRACOTTA
+  - "light_gray_glazed_terracotta"
+Blocks.CYAN_GLAZED_TERRACOTTA:
+  - Blocks.CYAN_GLAZED_TERRACOTTA
+  - "cyan_glazed_terracotta"
+Blocks.PURPLE_GLAZED_TERRACOTTA:
+  - Blocks.PURPLE_GLAZED_TERRACOTTA
+  - "purple_glazed_terracotta"
+Blocks.BLUE_GLAZED_TERRACOTTA:
+  - Blocks.BLUE_GLAZED_TERRACOTTA
+  - "blue_glazed_terracotta"
+Blocks.BROWN_GLAZED_TERRACOTTA:
+  - Blocks.BROWN_GLAZED_TERRACOTTA
+  - "brown_glazed_terracotta"
+Blocks.GREEN_GLAZED_TERRACOTTA:
+  - Blocks.GREEN_GLAZED_TERRACOTTA
+  - "green_glazed_terracotta"
+Blocks.RED_GLAZED_TERRACOTTA:
+  - Blocks.RED_GLAZED_TERRACOTTA
+  - "red_glazed_terracotta"
+Blocks.BLACK_GLAZED_TERRACOTTA:
+  - Blocks.BLACK_GLAZED_TERRACOTTA
+  - "black_glazed_terracotta"
+Blocks.CONCRETE_POWDER#0:
+  - Blocks.WHITE_CONCRETE_POWDER
+  - "white_concrete_powder"
+Blocks.CONCRETE_POWDER#1:
+  - Blocks.ORANGE_CONCRETE_POWDER
+  - "orange_concrete_powder"
+Blocks.CONCRETE_POWDER#2:
+  - Blocks.MAGENTA_CONCRETE_POWDER
+  - "magenta_concrete_powder"
+Blocks.CONCRETE_POWDER#3:
+  - Blocks.LIGHT_BLUE_CONCRETE_POWDER
+  - "light_blue_concrete_powder"
+Blocks.CONCRETE_POWDER#4:
+  - Blocks.YELLOW_CONCRETE_POWDER
+  - "yellow_concrete_powder"
+Blocks.CONCRETE_POWDER#5:
+  - Blocks.LIME_CONCRETE_POWDER
+  - "lime_concrete_powder"
+Blocks.CONCRETE_POWDER#6:
+  - Blocks.PINK_CONCRETE_POWDER
+  - "pink_concrete_powder"
+Blocks.CONCRETE_POWDER#7:
+  - Blocks.GRAY_CONCRETE_POWDER
+  - "gray_concrete_powder"
+Blocks.CONCRETE_POWDER#8:
+  - Blocks.LIGHT_GRAY_CONCRETE_POWDER
+  - "light_gray_concrete_powder"
+Blocks.CONCRETE_POWDER#9:
+  - Blocks.CYAN_CONCRETE_POWDER
+  - "cyan_concrete_powder"
+Blocks.CONCRETE_POWDER#10:
+  - Blocks.PURPLE_CONCRETE_POWDER
+  - "purple_concrete_powder"
+Blocks.CONCRETE_POWDER#11:
+  - Blocks.BLUE_CONCRETE_POWDER
+  - "blue_concrete_powder"
+Blocks.CONCRETE_POWDER#12:
+  - Blocks.BROWN_CONCRETE_POWDER
+  - "brown_concrete_powder"
+Blocks.CONCRETE_POWDER#13:
+  - Blocks.GREEN_CONCRETE_POWDER
+  - "green_concrete_powder"
+Blocks.CONCRETE_POWDER#14:
+  - Blocks.RED_CONCRETE_POWDER
+  - "red_concrete_powder"
+Blocks.CONCRETE_POWDER#15:
+  - Blocks.BLACK_CONCRETE_POWDER
+  - "black_concrete_powder"
+Blocks.CONCRETE#0:
+  - Blocks.WHITE_CONCRETE
+  - "white_concrete"
+Blocks.CONCRETE#1:
+  - Blocks.ORANGE_CONCRETE
+  - "orange_concrete"
+Blocks.CONCRETE#2:
+  - Blocks.MAGENTA_CONCRETE
+  - "magenta_concrete"
+Blocks.CONCRETE#3:
+  - Blocks.LIGHT_BLUE_CONCRETE
+  - "light_blue_concrete"
+Blocks.CONCRETE#4:
+  - Blocks.YELLOW_CONCRETE
+  - "yellow_concrete"
+Blocks.CONCRETE#5:
+  - Blocks.LIME_CONCRETE
+  - "lime_concrete"
+Blocks.CONCRETE#6:
+  - Blocks.PINK_CONCRETE
+  - "pink_concrete"
+Blocks.CONCRETE#7:
+  - Blocks.GRAY_CONCRETE
+  - "gray_concrete"
+Blocks.CONCRETE#8:
+  - Blocks.LIGHT_GRAY_CONCRETE
+  - "light_gray_concrete"
+Blocks.CONCRETE#9:
+  - Blocks.CYAN_CONCRETE
+  - "cyan_concrete"
+Blocks.CONCRETE#10:
+  - Blocks.PURPLE_CONCRETE
+  - "purple_concrete"
+Blocks.CONCRETE#11:
+  - Blocks.BLUE_CONCRETE
+  - "blue_concrete"
+Blocks.CONCRETE#12:
+  - Blocks.BROWN_CONCRETE
+  - "brown_concrete"
+Blocks.CONCRETE#13:
+  - Blocks.GREEN_CONCRETE
+  - "green_concrete"
+Blocks.CONCRETE#14:
+  - Blocks.RED_CONCRETE
+  - "red_concrete"
+Blocks.CONCRETE#15:
+  - Blocks.BLACK_CONCRETE
+  - "black_concrete"
+Blocks.CARPET:
+  - Blocks.WHITE_CARPET
+  - "#minecraft:wool_carpets"
+Blocks.CARPET#0:
+  - Blocks.WHITE_CARPET
+  - "white_carpet"
+Blocks.CARPET#1:
+  - Blocks.ORANGE_CARPET
+  - "orange_carpet"
+Blocks.CARPET#2:
+  - Blocks.MAGENTA_CARPET
+  - "magenta_carpet"
+Blocks.CARPET#3:
+  - Blocks.LIGHT_BLUE_CARPET
+  - "light_blue_carpet"
+Blocks.CARPET#4:
+  - Blocks.YELLOW_CARPET
+  - "yellow_carpet"
+Blocks.CARPET#5:
+  - Blocks.LIME_CARPET
+  - "lime_carpet"
+Blocks.CARPET#6:
+  - Blocks.PINK_CARPET
+  - "pink_carpet"
+Blocks.CARPET#7:
+  - Blocks.GRAY_CARPET
+  - "gray_carpet"
+Blocks.CARPET#8:
+  - Blocks.LIGHT_GRAY_CARPET
+  - "light_gray_carpet"
+Blocks.CARPET#9:
+  - Blocks.CYAN_CARPET
+  - "cyan_carpet"
+Blocks.CARPET#10:
+  - Blocks.PURPLE_CARPET
+  - "purple_carpet"
+Blocks.CARPET#11:
+  - Blocks.BLUE_CARPET
+  - "blue_carpet"
+Blocks.CARPET#12:
+  - Blocks.BROWN_CARPET
+  - "brown_carpet"
+Blocks.CARPET#13:
+  - Blocks.GREEN_CARPET
+  - "green_carpet"
+Blocks.CARPET#14:
+  - Blocks.RED_CARPET
+  - "red_carpet"
+Blocks.CARPET#15:
+  - Blocks.BLACK_CARPET
+  - "black_carpet"
+Blocks.GLASS:
+  - Blocks.GLASS
+  - "glass"
+Blocks.STAINED_GLASS:
+  - Blocks.WHITE_STAINED_GLASS
+  - "#forge:stained_glass"
+Blocks.STAINED_GLASS#0:
+  - Blocks.WHITE_STAINED_GLASS
+  - "white_stained_glass"
+Blocks.STAINED_GLASS#1:
+  - Blocks.ORANGE_STAINED_GLASS
+  - "orange_stained_glass"
+Blocks.STAINED_GLASS#2:
+  - Blocks.MAGENTA_STAINED_GLASS
+  - "magenta_stained_glass"
+Blocks.STAINED_GLASS#3:
+  - Blocks.LIGHT_BLUE_STAINED_GLASS
+  - "light_blue_stained_glass"
+Blocks.STAINED_GLASS#4:
+  - Blocks.YELLOW_STAINED_GLASS
+  - "yellow_stained_glass"
+Blocks.STAINED_GLASS#5:
+  - Blocks.LIME_STAINED_GLASS
+  - "lime_stained_glass"
+Blocks.STAINED_GLASS#6:
+  - Blocks.PINK_STAINED_GLASS
+  - "pink_stained_glass"
+Blocks.STAINED_GLASS#7:
+  - Blocks.GRAY_STAINED_GLASS
+  - "gray_stained_glass"
+Blocks.STAINED_GLASS#8:
+  - Blocks.LIGHT_GRAY_STAINED_GLASS
+  - "light_gray_stained_glass"
+Blocks.STAINED_GLASS#9:
+  - Blocks.CYAN_STAINED_GLASS
+  - "cyan_stained_glass"
+Blocks.STAINED_GLASS#10:
+  - Blocks.PURPLE_STAINED_GLASS
+  - "purple_stained_glass"
+Blocks.STAINED_GLASS#11:
+  - Blocks.BLUE_STAINED_GLASS
+  - "blue_stained_glass"
+Blocks.STAINED_GLASS#12:
+  - Blocks.BROWN_STAINED_GLASS
+  - "brown_stained_glass"
+Blocks.STAINED_GLASS#13:
+  - Blocks.GREEN_STAINED_GLASS
+  - "green_stained_glass"
+Blocks.STAINED_GLASS#14:
+  - Blocks.RED_STAINED_GLASS
+  - "red_stained_glass"
+Blocks.STAINED_GLASS#15:
+  - Blocks.BLACK_STAINED_GLASS
+  - "black_stained_glass"
+Blocks.GLASS_PANE:
+  - Blocks.GLASS_PANE
+  - "glass_pane"
+Blocks.STAINED_GLASS_PANE:
+  - Blocks.WHITE_STAINED_GLASS_PANE
+  - "#forge:stained_glass_panes"
+Blocks.STAINED_GLASS_PANE#0:
+  - Blocks.WHITE_STAINED_GLASS_PANE
+  - "white_stained_glass_pane"
+Blocks.STAINED_GLASS_PANE#1:
+  - Blocks.ORANGE_STAINED_GLASS_PANE
+  - "orange_stained_glass_pane"
+Blocks.STAINED_GLASS_PANE#2:
+  - Blocks.MAGENTA_STAINED_GLASS_PANE
+  - "magenta_stained_glass_pane"
+Blocks.STAINED_GLASS_PANE#3:
+  - Blocks.LIGHT_BLUE_STAINED_GLASS_PANE
+  - "light_blue_stained_glass_pane"
+Blocks.STAINED_GLASS_PANE#4:
+  - Blocks.YELLOW_STAINED_GLASS_PANE
+  - "yellow_stained_glass_pane"
+Blocks.STAINED_GLASS_PANE#5:
+  - Blocks.LIME_STAINED_GLASS_PANE
+  - "lime_stained_glass_pane"
+Blocks.STAINED_GLASS_PANE#6:
+  - Blocks.PINK_STAINED_GLASS_PANE
+  - "pink_stained_glass_pane"
+Blocks.STAINED_GLASS_PANE#7:
+  - Blocks.GRAY_STAINED_GLASS_PANE
+  - "gray_stained_glass_pane"
+Blocks.STAINED_GLASS_PANE#8:
+  - Blocks.LIGHT_GRAY_STAINED_GLASS_PANE
+  - "light_gray_stained_glass_pane"
+Blocks.STAINED_GLASS_PANE#9:
+  - Blocks.CYAN_STAINED_GLASS_PANE
+  - "cyan_stained_glass_pane"
+Blocks.STAINED_GLASS_PANE#10:
+  - Blocks.PURPLE_STAINED_GLASS_PANE
+  - "purple_stained_glass_pane"
+Blocks.STAINED_GLASS_PANE#11:
+  - Blocks.BLUE_STAINED_GLASS_PANE
+  - "blue_stained_glass_pane"
+Blocks.STAINED_GLASS_PANE#12:
+  - Blocks.BROWN_STAINED_GLASS_PANE
+  - "brown_stained_glass_pane"
+Blocks.STAINED_GLASS_PANE#13:
+  - Blocks.GREEN_STAINED_GLASS_PANE
+  - "green_stained_glass_pane"
+Blocks.STAINED_GLASS_PANE#14:
+  - Blocks.RED_STAINED_GLASS_PANE
+  - "red_stained_glass_pane"
+Blocks.STAINED_GLASS_PANE#15:
+  - Blocks.BLACK_STAINED_GLASS_PANE
+  - "black_stained_glass_pane"
+Blocks.SEA_LANTERN:
+  - Blocks.SEA_LANTERN
+  - "sea_lantern"
+Blocks.PRISMARINE:
+  - Blocks.PRISMARINE
+  - "prismarine"
+Blocks.PRISMARINE#0:
+  - Blocks.PRISMARINE
+  - "prismarine"
+Blocks.PRISMARINE#1:
+  - Blocks.PRISMARINE_BRICKS
+  - "prismarine_bricks"
+Blocks.PRISMARINE#2:
+  - Blocks.DARK_PRISMARINE
+  - "dark_prismarine"
+Blocks.WHITE_SHULKER_BOX:
+  - Blocks.WHITE_SHULKER_BOX
+  - "white_shulker_box"
+Blocks.ORANGE_SHULKER_BOX:
+  - Blocks.ORANGE_SHULKER_BOX
+  - "orange_shulker_box"
+Blocks.MAGENTA_SHULKER_BOX:
+  - Blocks.MAGENTA_SHULKER_BOX
+  - "magenta_shulker_box"
+Blocks.LIGHT_BLUE_SHULKER_BOX:
+  - Blocks.LIGHT_BLUE_SHULKER_BOX
+  - "light_blue_shulker_box"
+Blocks.YELLOW_SHULKER_BOX:
+  - Blocks.YELLOW_SHULKER_BOX
+  - "yellow_shulker_box"
+Blocks.LIME_SHULKER_BOX:
+  - Blocks.LIME_SHULKER_BOX
+  - "lime_shulker_box"
+Blocks.PINK_SHULKER_BOX:
+  - Blocks.PINK_SHULKER_BOX
+  - "pink_shulker_box"
+Blocks.GRAY_SHULKER_BOX:
+  - Blocks.GRAY_SHULKER_BOX
+  - "gray_shulker_box"
+Blocks.SILVER_SHULKER_BOX:
+  - Blocks.LIGHT_GRAY_SHULKER_BOX
+  - "light_gray_shulker_box"
+Blocks.CYAN_SHULKER_BOX:
+  - Blocks.CYAN_SHULKER_BOX
+  - "cyan_shulker_box"
+Blocks.PURPLE_SHULKER_BOX:
+  - Blocks.PURPLE_SHULKER_BOX
+  - "purple_shulker_box"
+Blocks.BLUE_SHULKER_BOX:
+  - Blocks.BLUE_SHULKER_BOX
+  - "blue_shulker_box"
+Blocks.BROWN_SHULKER_BOX:
+  - Blocks.BROWN_SHULKER_BOX
+  - "brown_shulker_box"
+Blocks.GREEN_SHULKER_BOX:
+  - Blocks.GREEN_SHULKER_BOX
+  - "green_shulker_box"
+Blocks.RED_SHULKER_BOX:
+  - Blocks.RED_SHULKER_BOX
+  - "red_shulker_box"
+Blocks.BLACK_SHULKER_BOX:
+  - Blocks.BLACK_SHULKER_BOX
+  - "black_shulker_box"
+Blocks.STANDING_BANNER:
+  - Blocks.WHITE_BANNER
+  - "white_banner"
+Blocks.WALL_BANNER:
+  - Blocks.WHITE_WALL_BANNER
+  - "white_wall_banner"
+Blocks.BARRIER:
+  - Blocks.BARRIER
+  - "barrier"
+Blocks.STRUCTURE_VOID:
+  - Blocks.STRUCTURE_VOID
+  - "structure_void"
+Blocks.STRUCTURE_BLOCK:
+  - Blocks.STRUCTURE_BLOCK
+  - "structure_block"
+Blocks.STRUCTURE_BLOCK#1:
+  - Blocks.STRUCTURE_BLOCK
+  - "structure_block"
+Blocks.STRUCTURE_BLOCK#2:
+  - Blocks.STRUCTURE_BLOCK
+  - "structure_block"
+Blocks.STRUCTURE_BLOCK#3:
+  - Blocks.STRUCTURE_BLOCK
+  - "structure_block"
+Blocks.STRUCTURE_BLOCK#4:
+  - Blocks.STRUCTURE_BLOCK
+  - "structure_block"
+Blocks.NORMAL_STONE_STAIRS:
+  - Blocks.STONE_STAIRS
+  - "stone_stairs"
+Blocks.SHULKER_BOX:
+  - Blocks.SHULKER_BOX
+  - "shulker_box"
+Blocks.SKELETON_WALL_SKULL:
+  - Blocks.SKELETON_WALL_SKULL
+  - "skeleton_wall_skull"
+Blocks.WITHER_SKELETON_WALL_SKULL:
+  - Blocks.WITHER_SKELETON_WALL_SKULL
+  - "wither_skeleton_wall_skull"
+Blocks.ZOMBIE_WALL_HEAD:
+  - Blocks.ZOMBIE_WALL_HEAD
+  - "zombie_wall_head"
+Blocks.PLAYER_WALL_HEAD:
+  - Blocks.PLAYER_WALL_HEAD
+  - "player_wall_head"
+Blocks.CREEPER_WALL_HEAD:
+  - Blocks.CREEPER_WALL_HEAD
+  - "creeper_wall_head"
+Blocks.DRAGON_WALL_HEAD:
+  - Blocks.DRAGON_WALL_HEAD
+  - "dragon_wall_head"
+Blocks.PIGLIN_WALL_HEAD:
+  - Blocks.PIGLIN_WALL_HEAD
+  - "piglin_wall_head"
+Blocks.STRIPPED_SPRUCE_LOG:
+  - Blocks.STRIPPED_SPRUCE_LOG
+  - "stripped_spruce_log"
+Blocks.STRIPPED_BIRCH_LOG:
+  - Blocks.STRIPPED_BIRCH_LOG
+  - "stripped_birch_log"
+Blocks.STRIPPED_JUNGLE_LOG:
+  - Blocks.STRIPPED_JUNGLE_LOG
+  - "stripped_jungle_log"
+Blocks.STRIPPED_ACACIA_LOG:
+  - Blocks.STRIPPED_ACACIA_LOG
+  - "stripped_acacia_log"
+Blocks.STRIPPED_DARK_OAK_LOG:
+  - Blocks.STRIPPED_DARK_OAK_LOG
+  - "stripped_dark_oak_log"
+Blocks.STRIPPED_OAK_LOG:
+  - Blocks.STRIPPED_OAK_LOG
+  - "stripped_oak_log"
+Blocks.STRIPPED_MANGROVE_LOG:
+  - Blocks.STRIPPED_MANGROVE_LOG
+  - "stripped_mangrove_log"
+Blocks.STRIPPED_CHERRY_LOG:
+  - Blocks.STRIPPED_CHERRY_LOG
+  - "stripped_cherry_log"
+Blocks.STRIPPED_BAMBOO_BLOCK:
+  - Blocks.STRIPPED_BAMBOO_BLOCK
+  - "stripped_bamboo_block"
+Blocks.OAK_WOOD:
+  - Blocks.OAK_WOOD
+  - "oak_wood"
+Blocks.SPRUCE_WOOD:
+  - Blocks.SPRUCE_WOOD
+  - "spruce_wood"
+Blocks.BIRCH_WOOD:
+  - Blocks.BIRCH_WOOD
+  - "birch_wood"
+Blocks.JUNGLE_WOOD:
+  - Blocks.JUNGLE_WOOD
+  - "jungle_wood"
+Blocks.ACACIA_WOOD:
+  - Blocks.ACACIA_WOOD
+  - "acacia_wood"
+Blocks.DARK_OAK_WOOD:
+  - Blocks.DARK_OAK_WOOD
+  - "dark_oak_wood"
+Blocks.MANGROVE_WOOD:
+  - Blocks.MANGROVE_WOOD
+  - "mangrove_wood"
+Blocks.CHERRY_WOOD:
+  - Blocks.CHERRY_WOOD
+  - "cherry_wood"
+Blocks.STRIPPED_OAK_WOOD:
+  - Blocks.STRIPPED_OAK_WOOD
+  - "stripped_oak_wood"
+Blocks.STRIPPED_SPRUCE_WOOD:
+  - Blocks.STRIPPED_SPRUCE_WOOD
+  - "stripped_spruce_wood"
+Blocks.STRIPPED_BIRCH_WOOD:
+  - Blocks.STRIPPED_BIRCH_WOOD
+  - "stripped_birch_wood"
+Blocks.STRIPPED_JUNGLE_WOOD:
+  - Blocks.STRIPPED_JUNGLE_WOOD
+  - "stripped_jungle_wood"
+Blocks.STRIPPED_ACACIA_WOOD:
+  - Blocks.STRIPPED_ACACIA_WOOD
+  - "stripped_acacia_wood"
+Blocks.STRIPPED_DARK_OAK_WOOD:
+  - Blocks.STRIPPED_DARK_OAK_WOOD
+  - "stripped_dark_oak_wood"
+Blocks.STRIPPED_MANGROVE_WOOD:
+  - Blocks.STRIPPED_MANGROVE_WOOD
+  - "stripped_mangrove_wood"
+Blocks.STRIPPED_CHERRY_WOOD:
+  - Blocks.STRIPPED_CHERRY_WOOD
+  - "stripped_cherry_wood"
+Blocks.ORANGE_BED:
+  - Blocks.ORANGE_BED
+  - "orange_bed"
+Blocks.MAGENTA_BED:
+  - Blocks.MAGENTA_BED
+  - "magenta_bed"
+Blocks.LIGHT_BLUE_BED:
+  - Blocks.LIGHT_BLUE_BED
+  - "light_blue_bed"
+Blocks.YELLOW_BED:
+  - Blocks.YELLOW_BED
+  - "yellow_bed"
+Blocks.LIME_BED:
+  - Blocks.LIME_BED
+  - "lime_bed"
+Blocks.PINK_BED:
+  - Blocks.PINK_BED
+  - "pink_bed"
+Blocks.GRAY_BED:
+  - Blocks.GRAY_BED
+  - "gray_bed"
+Blocks.LIGHT_GRAY_BED:
+  - Blocks.LIGHT_GRAY_BED
+  - "light_gray_bed"
+Blocks.CYAN_BED:
+  - Blocks.CYAN_BED
+  - "cyan_bed"
+Blocks.PURPLE_BED:
+  - Blocks.PURPLE_BED
+  - "purple_bed"
+Blocks.BLUE_BED:
+  - Blocks.BLUE_BED
+  - "blue_bed"
+Blocks.BROWN_BED:
+  - Blocks.BROWN_BED
+  - "brown_bed"
+Blocks.GREEN_BED:
+  - Blocks.GREEN_BED
+  - "green_bed"
+Blocks.RED_BED:
+  - Blocks.RED_BED
+  - "red_bed"
+Blocks.BLACK_BED:
+  - Blocks.BLACK_BED
+  - "black_bed"
+Blocks.SEAGRASS:
+  - Blocks.SEAGRASS
+  - "seagrass"
+Blocks.TALL_SEAGRASS:
+  - Blocks.TALL_SEAGRASS
+  - "tall_seagrass"
+Blocks.CORNFLOWER:
+  - Blocks.CORNFLOWER
+  - "cornflower"
+Blocks.WITHER_ROSE:
+  - Blocks.WITHER_ROSE
+  - "wither_rose"
+Blocks.LILY_OF_THE_VALLEY:
+  - Blocks.LILY_OF_THE_VALLEY
+  - "lily_of_the_valley"
+Blocks.WALL_TORCH:
+  - Blocks.WALL_TORCH
+  - "wall_torch"
+Blocks.SPRUCE_SIGN:
+  - Blocks.SPRUCE_SIGN
+  - "spruce_sign"
+Blocks.BIRCH_SIGN:
+  - Blocks.BIRCH_SIGN
+  - "birch_sign"
+Blocks.ACACIA_SIGN:
+  - Blocks.ACACIA_SIGN
+  - "acacia_sign"
+Blocks.JUNGLE_SIGN:
+  - Blocks.JUNGLE_SIGN
+  - "jungle_sign"
+Blocks.DARK_OAK_SIGN:
+  - Blocks.DARK_OAK_SIGN
+  - "dark_oak_sign"
+Blocks.MANGROVE_SIGN:
+  - Blocks.MANGROVE_SIGN
+  - "mangrove_sign"
+Blocks.CHERRY_SIGN:
+  - Blocks.CHERRY_SIGN
+  - "cherry_sign"
+Blocks.BAMBOO_SIGN:
+  - Blocks.BAMBOO_SIGN
+  - "bamboo_sign"
+Blocks.SPRUCE_WALL_SIGN:
+  - Blocks.SPRUCE_WALL_SIGN
+  - "spruce_wall_sign"
+Blocks.BIRCH_WALL_SIGN:
+  - Blocks.BIRCH_WALL_SIGN
+  - "birch_wall_sign"
+Blocks.ACACIA_WALL_SIGN:
+  - Blocks.ACACIA_WALL_SIGN
+  - "acacia_wall_sign"
+Blocks.JUNGLE_WALL_SIGN:
+  - Blocks.JUNGLE_WALL_SIGN
+  - "jungle_wall_sign"
+Blocks.DARK_OAK_WALL_SIGN:
+  - Blocks.DARK_OAK_WALL_SIGN
+  - "dark_oak_wall_sign"
+Blocks.MANGROVE_WALL_SIGN:
+  - Blocks.MANGROVE_WALL_SIGN
+  - "mangrove_wall_sign"
+Blocks.CHERRY_WALL_SIGN:
+  - Blocks.CHERRY_WALL_SIGN
+  - "cherry_wall_sign"
+Blocks.BAMBOO_WALL_SIGN:
+  - Blocks.BAMBOO_WALL_SIGN
+  - "bamboo_wall_sign"
+Blocks.OAK_HANGING_SIGN:
+  - Blocks.OAK_HANGING_SIGN
+  - "oak_hanging_sign"
+Blocks.SPRUCE_HANGING_SIGN:
+  - Blocks.SPRUCE_HANGING_SIGN
+  - "spruce_hanging_sign"
+Blocks.BIRCH_HANGING_SIGN:
+  - Blocks.BIRCH_HANGING_SIGN
+  - "birch_hanging_sign"
+Blocks.ACACIA_HANGING_SIGN:
+  - Blocks.ACACIA_HANGING_SIGN
+  - "acacia_hanging_sign"
+Blocks.JUNGLE_HANGING_SIGN:
+  - Blocks.JUNGLE_HANGING_SIGN
+  - "jungle_hanging_sign"
+Blocks.DARK_OAK_HANGING_SIGN:
+  - Blocks.DARK_OAK_HANGING_SIGN
+  - "dark_oak_hanging_sign"
+Blocks.CRIMSON_HANGING_SIGN:
+  - Blocks.CRIMSON_HANGING_SIGN
+  - "crimson_hanging_sign"
+Blocks.WARPED_HANGING_SIGN:
+  - Blocks.WARPED_HANGING_SIGN
+  - "warped_hanging_sign"
+Blocks.MANGROVE_HANGING_SIGN:
+  - Blocks.MANGROVE_HANGING_SIGN
+  - "mangrove_hanging_sign"
+Blocks.CHERRY_HANGING_SIGN:
+  - Blocks.CHERRY_HANGING_SIGN
+  - "cherry_hanging_sign"
+Blocks.BAMBOO_HANGING_SIGN:
+  - Blocks.BAMBOO_HANGING_SIGN
+  - "bamboo_hanging_sign"
+Blocks.OAK_WALL_HANGING_SIGN:
+  - Blocks.OAK_WALL_HANGING_SIGN
+  - "oak_wall_hanging_sign"
+Blocks.SPRUCE_WALL_HANGING_SIGN:
+  - Blocks.SPRUCE_WALL_HANGING_SIGN
+  - "spruce_wall_hanging_sign"
+Blocks.BIRCH_WALL_HANGING_SIGN:
+  - Blocks.BIRCH_WALL_HANGING_SIGN
+  - "birch_wall_hanging_sign"
+Blocks.ACACIA_WALL_HANGING_SIGN:
+  - Blocks.ACACIA_WALL_HANGING_SIGN
+  - "acacia_wall_hanging_sign"
+Blocks.JUNGLE_WALL_HANGING_SIGN:
+  - Blocks.JUNGLE_WALL_HANGING_SIGN
+  - "jungle_wall_hanging_sign"
+Blocks.DARK_OAK_WALL_HANGING_SIGN:
+  - Blocks.DARK_OAK_WALL_HANGING_SIGN
+  - "dark_oak_wall_hanging_sign"
+Blocks.CRIMSON_WALL_HANGING_SIGN:
+  - Blocks.CRIMSON_WALL_HANGING_SIGN
+  - "crimson_wall_hanging_sign"
+Blocks.WARPED_WALL_HANGING_SIGN:
+  - Blocks.WARPED_WALL_HANGING_SIGN
+  - "warped_wall_hanging_sign"
+Blocks.MANGROVE_WALL_HANGING_SIGN:
+  - Blocks.MANGROVE_WALL_HANGING_SIGN
+  - "mangrove_wall_hanging_sign"
+Blocks.CHERRY_WALL_HANGING_SIGN:
+  - Blocks.CHERRY_WALL_HANGING_SIGN
+  - "cherry_wall_hanging_sign"
+Blocks.BAMBOO_WALL_HANGING_SIGN:
+  - Blocks.BAMBOO_WALL_HANGING_SIGN
+  - "bamboo_wall_hanging_sign"
+Blocks.SPRUCE_PRESSURE_PLATE:
+  - Blocks.SPRUCE_PRESSURE_PLATE
+  - "spruce_pressure_plate"
+Blocks.BIRCH_PRESSURE_PLATE:
+  - Blocks.BIRCH_PRESSURE_PLATE
+  - "birch_pressure_plate"
+Blocks.JUNGLE_PRESSURE_PLATE:
+  - Blocks.JUNGLE_PRESSURE_PLATE
+  - "jungle_pressure_plate"
+Blocks.ACACIA_PRESSURE_PLATE:
+  - Blocks.ACACIA_PRESSURE_PLATE
+  - "acacia_pressure_plate"
+Blocks.DARK_OAK_PRESSURE_PLATE:
+  - Blocks.DARK_OAK_PRESSURE_PLATE
+  - "dark_oak_pressure_plate"
+Blocks.MANGROVE_PRESSURE_PLATE:
+  - Blocks.MANGROVE_PRESSURE_PLATE
+  - "mangrove_pressure_plate"
+Blocks.CHERRY_PRESSURE_PLATE:
+  - Blocks.CHERRY_PRESSURE_PLATE
+  - "cherry_pressure_plate"
+Blocks.BAMBOO_PRESSURE_PLATE:
+  - Blocks.BAMBOO_PRESSURE_PLATE
+  - "bamboo_pressure_plate"
+Blocks.REDSTONE_WALL_TORCH:
+  - Blocks.REDSTONE_WALL_TORCH
+  - "redstone_wall_torch"
+Blocks.CARVED_PUMPKIN:
+  - Blocks.CARVED_PUMPKIN
+  - "carved_pumpkin"
+Blocks.SPRUCE_TRAPDOOR:
+  - Blocks.SPRUCE_TRAPDOOR
+  - "spruce_trapdoor"
+Blocks.BIRCH_TRAPDOOR:
+  - Blocks.BIRCH_TRAPDOOR
+  - "birch_trapdoor"
+Blocks.JUNGLE_TRAPDOOR:
+  - Blocks.JUNGLE_TRAPDOOR
+  - "jungle_trapdoor"
+Blocks.ACACIA_TRAPDOOR:
+  - Blocks.ACACIA_TRAPDOOR
+  - "acacia_trapdoor"
+Blocks.DARK_OAK_TRAPDOOR:
+  - Blocks.DARK_OAK_TRAPDOOR
+  - "dark_oak_trapdoor"
+Blocks.MANGROVE_TRAPDOOR:
+  - Blocks.MANGROVE_TRAPDOOR
+  - "mangrove_trapdoor"
+Blocks.CHERRY_TRAPDOOR:
+  - Blocks.CHERRY_TRAPDOOR
+  - "cherry_trapdoor"
+Blocks.BAMBOO_TRAPDOOR:
+  - Blocks.BAMBOO_TRAPDOOR
+  - "bamboo_trapdoor"
+Blocks.MUSHROOM_STEM:
+  - Blocks.MUSHROOM_STEM
+  - "mushroom_stem"
+Blocks.ATTACHED_PUMPKIN_STEM:
+  - Blocks.ATTACHED_PUMPKIN_STEM
+  - "attached_pumpkin_stem"
+Blocks.ATTACHED_MELON_STEM:
+  - Blocks.ATTACHED_MELON_STEM
+  - "attached_melon_stem"
+Blocks.POTTED_OAK_SAPLING:
+  - Blocks.POTTED_OAK_SAPLING
+  - "potted_oak_sapling"
+Blocks.POTTED_SPRUCE_SAPLING:
+  - Blocks.POTTED_SPRUCE_SAPLING
+  - "potted_spruce_sapling"
+Blocks.POTTED_BIRCH_SAPLING:
+  - Blocks.POTTED_BIRCH_SAPLING
+  - "potted_birch_sapling"
+Blocks.POTTED_JUNGLE_SAPLING:
+  - Blocks.POTTED_JUNGLE_SAPLING
+  - "potted_jungle_sapling"
+Blocks.POTTED_ACACIA_SAPLING:
+  - Blocks.POTTED_ACACIA_SAPLING
+  - "potted_acacia_sapling"
+Blocks.POTTED_DARK_OAK_SAPLING:
+  - Blocks.POTTED_DARK_OAK_SAPLING
+  - "potted_dark_oak_sapling"
+Blocks.POTTED_FERN:
+  - Blocks.POTTED_FERN
+  - "potted_fern"
+Blocks.POTTED_DANDELION:
+  - Blocks.POTTED_DANDELION
+  - "potted_dandelion"
+Blocks.POTTED_POPPY:
+  - Blocks.POTTED_POPPY
+  - "potted_poppy"
+Blocks.POTTED_BLUE_ORCHID:
+  - Blocks.POTTED_BLUE_ORCHID
+  - "potted_blue_orchid"
+Blocks.POTTED_ALLIUM:
+  - Blocks.POTTED_ALLIUM
+  - "potted_allium"
+Blocks.POTTED_AZURE_BLUET:
+  - Blocks.POTTED_AZURE_BLUET
+  - "potted_azure_bluet"
+Blocks.POTTED_RED_TULIP:
+  - Blocks.POTTED_RED_TULIP
+  - "potted_red_tulip"
+Blocks.POTTED_ORANGE_TULIP:
+  - Blocks.POTTED_ORANGE_TULIP
+  - "potted_orange_tulip"
+Blocks.POTTED_WHITE_TULIP:
+  - Blocks.POTTED_WHITE_TULIP
+  - "potted_white_tulip"
+Blocks.POTTED_PINK_TULIP:
+  - Blocks.POTTED_PINK_TULIP
+  - "potted_pink_tulip"
+Blocks.POTTED_OXEYE_DAISY:
+  - Blocks.POTTED_OXEYE_DAISY
+  - "potted_oxeye_daisy"
+Blocks.POTTED_CORNFLOWER:
+  - Blocks.POTTED_CORNFLOWER
+  - "potted_cornflower"
+Blocks.POTTED_LILY_OF_THE_VALLEY:
+  - Blocks.POTTED_LILY_OF_THE_VALLEY
+  - "potted_lily_of_the_valley"
+Blocks.POTTED_WITHER_ROSE:
+  - Blocks.POTTED_WITHER_ROSE
+  - "potted_wither_rose"
+Blocks.POTTED_RED_MUSHROOM:
+  - Blocks.POTTED_RED_MUSHROOM
+  - "potted_red_mushroom"
+Blocks.POTTED_BROWN_MUSHROOM:
+  - Blocks.POTTED_BROWN_MUSHROOM
+  - "potted_brown_mushroom"
+Blocks.POTTED_DEAD_BUSH:
+  - Blocks.POTTED_DEAD_BUSH
+  - "potted_dead_bush"
+Blocks.POTTED_CACTUS:
+  - Blocks.POTTED_CACTUS
+  - "potted_cactus"
+Blocks.SPRUCE_BUTTON:
+  - Blocks.SPRUCE_BUTTON
+  - "spruce_button"
+Blocks.BIRCH_BUTTON:
+  - Blocks.BIRCH_BUTTON
+  - "birch_button"
+Blocks.JUNGLE_BUTTON:
+  - Blocks.JUNGLE_BUTTON
+  - "jungle_button"
+Blocks.ACACIA_BUTTON:
+  - Blocks.ACACIA_BUTTON
+  - "acacia_button"
+Blocks.DARK_OAK_BUTTON:
+  - Blocks.DARK_OAK_BUTTON
+  - "dark_oak_button"
+Blocks.MANGROVE_BUTTON:
+  - Blocks.MANGROVE_BUTTON
+  - "mangrove_button"
+Blocks.CHERRY_BUTTON:
+  - Blocks.CHERRY_BUTTON
+  - "cherry_button"
+Blocks.BAMBOO_BUTTON:
+  - Blocks.BAMBOO_BUTTON
+  - "bamboo_button"
+
+Blocks.PRISMARINE_STAIRS:
+  - Blocks.PRISMARINE_STAIRS
+  - "prismarine_stairs"
+Blocks.PRISMARINE_BRICK_STAIRS:
+  - Blocks.PRISMARINE_BRICK_STAIRS
+  - "prismarine_brick_stairs"
+Blocks.DARK_PRISMARINE_STAIRS:
+  - Blocks.DARK_PRISMARINE_STAIRS
+  - "dark_prismarine_stairs"
+Blocks.PRISMARINE_SLAB:
+  - Blocks.PRISMARINE_SLAB
+  - "prismarine_slab"
+Blocks.PRISMARINE_BRICK_SLAB:
+  - Blocks.PRISMARINE_BRICK_SLAB
+  - "prismarine_brick_slab"
+Blocks.DARK_PRISMARINE_SLAB:
+  - Blocks.DARK_PRISMARINE_SLAB
+  - "dark_prismarine_slab"
+Blocks.WHITE_BANNER:
+  - Blocks.WHITE_BANNER
+  - "white_banner"
+Blocks.ORANGE_BANNER:
+  - Blocks.ORANGE_BANNER
+  - "orange_banner"
+Blocks.MAGENTA_BANNER:
+  - Blocks.MAGENTA_BANNER
+  - "magenta_banner"
+Blocks.LIGHT_BLUE_BANNER:
+  - Blocks.LIGHT_BLUE_BANNER
+  - "light_blue_banner"
+Blocks.YELLOW_BANNER:
+  - Blocks.YELLOW_BANNER
+  - "yellow_banner"
+Blocks.LIME_BANNER:
+  - Blocks.LIME_BANNER
+  - "lime_banner"
+Blocks.PINK_BANNER:
+  - Blocks.PINK_BANNER
+  - "pink_banner"
+Blocks.GRAY_BANNER:
+  - Blocks.GRAY_BANNER
+  - "gray_banner"
+Blocks.LIGHT_GRAY_BANNER:
+  - Blocks.LIGHT_GRAY_BANNER
+  - "light_gray_banner"
+Blocks.CYAN_BANNER:
+  - Blocks.CYAN_BANNER
+  - "cyan_banner"
+Blocks.PURPLE_BANNER:
+  - Blocks.PURPLE_BANNER
+  - "purple_banner"
+Blocks.BLUE_BANNER:
+  - Blocks.BLUE_BANNER
+  - "blue_banner"
+Blocks.BROWN_BANNER:
+  - Blocks.BROWN_BANNER
+  - "brown_banner"
+Blocks.GREEN_BANNER:
+  - Blocks.GREEN_BANNER
+  - "green_banner"
+Blocks.RED_BANNER:
+  - Blocks.RED_BANNER
+  - "red_banner"
+Blocks.BLACK_BANNER:
+  - Blocks.BLACK_BANNER
+  - "black_banner"
+Blocks.WHITE_WALL_BANNER:
+  - Blocks.WHITE_WALL_BANNER
+  - "white_wall_banner"
+Blocks.ORANGE_WALL_BANNER:
+  - Blocks.ORANGE_WALL_BANNER
+  - "orange_wall_banner"
+Blocks.MAGENTA_WALL_BANNER:
+  - Blocks.MAGENTA_WALL_BANNER
+  - "magenta_wall_banner"
+Blocks.LIGHT_BLUE_WALL_BANNER:
+  - Blocks.LIGHT_BLUE_WALL_BANNER
+  - "light_blue_wall_banner"
+Blocks.YELLOW_WALL_BANNER:
+  - Blocks.YELLOW_WALL_BANNER
+  - "yellow_wall_banner"
+Blocks.LIME_WALL_BANNER:
+  - Blocks.LIME_WALL_BANNER
+  - "lime_wall_banner"
+Blocks.PINK_WALL_BANNER:
+  - Blocks.PINK_WALL_BANNER
+  - "pink_wall_banner"
+Blocks.GRAY_WALL_BANNER:
+  - Blocks.GRAY_WALL_BANNER
+  - "gray_wall_banner"
+Blocks.LIGHT_GRAY_WALL_BANNER:
+  - Blocks.LIGHT_GRAY_WALL_BANNER
+  - "light_gray_wall_banner"
+Blocks.CYAN_WALL_BANNER:
+  - Blocks.CYAN_WALL_BANNER
+  - "cyan_wall_banner"
+Blocks.PURPLE_WALL_BANNER:
+  - Blocks.PURPLE_WALL_BANNER
+  - "purple_wall_banner"
+Blocks.BLUE_WALL_BANNER:
+  - Blocks.BLUE_WALL_BANNER
+  - "blue_wall_banner"
+Blocks.BROWN_WALL_BANNER:
+  - Blocks.BROWN_WALL_BANNER
+  - "brown_wall_banner"
+Blocks.GREEN_WALL_BANNER:
+  - Blocks.GREEN_WALL_BANNER
+  - "green_wall_banner"
+Blocks.RED_WALL_BANNER:
+  - Blocks.RED_WALL_BANNER
+  - "red_wall_banner"
+Blocks.BLACK_WALL_BANNER:
+  - Blocks.BLACK_WALL_BANNER
+  - "black_wall_banner"
+Blocks.CUT_RED_SANDSTONE_SLAB:
+  - Blocks.CUT_RED_SANDSTONE_SLAB
+  - "cut_red_sandstone_slab"
+Blocks.CUT_SANDSTONE_SLAB:
+  - Blocks.CUT_SANDSTONE_SLAB
+  - "cut_sandstone_slab"
+Blocks.NORMAL_STONE_SLAB:
+  - Blocks.STONE_SLAB
+  - "stone_slab"
+Blocks.SMOOTH_STONE:
+  - Blocks.SMOOTH_STONE
+  - "smooth_stone"
+Blocks.SMOOTH_SANDSTONE:
+  - Blocks.SMOOTH_SANDSTONE
+  - "smooth_sandstone"
+Blocks.SMOOTH_RED_SANDSTONE:
+  - Blocks.SMOOTH_RED_SANDSTONE
+  - "smooth_red_sandstone"
+Blocks.KELP:
+  - Blocks.KELP
+  - "kelp"
+Blocks.KELP_PLANT:
+  - Blocks.KELP_PLANT
+  - "kelp_plant"
+Blocks.DRIED_KELP_BLOCK:
+  - Blocks.DRIED_KELP_BLOCK
+  - "dried_kelp_block"
+Blocks.TURTLE_EGG:
+  - Blocks.TURTLE_EGG
+  - "turtle_egg"
+Blocks.DEAD_TUBE_CORAL_BLOCK:
+  - Blocks.DEAD_TUBE_CORAL_BLOCK
+  - "dead_tube_coral_block"
+Blocks.DEAD_BRAIN_CORAL_BLOCK:
+  - Blocks.DEAD_BRAIN_CORAL_BLOCK
+  - "dead_brain_coral_block"
+Blocks.DEAD_BUBBLE_CORAL_BLOCK:
+  - Blocks.DEAD_BUBBLE_CORAL_BLOCK
+  - "dead_bubble_coral_block"
+Blocks.DEAD_FIRE_CORAL_BLOCK:
+  - Blocks.DEAD_FIRE_CORAL_BLOCK
+  - "dead_fire_coral_block"
+Blocks.DEAD_HORN_CORAL_BLOCK:
+  - Blocks.DEAD_HORN_CORAL_BLOCK
+  - "dead_horn_coral_block"
+Blocks.TUBE_CORAL_BLOCK:
+  - Blocks.TUBE_CORAL_BLOCK
+  - "tube_coral_block"
+Blocks.BRAIN_CORAL_BLOCK:
+  - Blocks.BRAIN_CORAL_BLOCK
+  - "brain_coral_block"
+Blocks.BUBBLE_CORAL_BLOCK:
+  - Blocks.BUBBLE_CORAL_BLOCK
+  - "bubble_coral_block"
+Blocks.FIRE_CORAL_BLOCK:
+  - Blocks.FIRE_CORAL_BLOCK
+  - "fire_coral_block"
+Blocks.HORN_CORAL_BLOCK:
+  - Blocks.HORN_CORAL_BLOCK
+  - "horn_coral_block"
+Blocks.DEAD_TUBE_CORAL:
+  - Blocks.DEAD_TUBE_CORAL
+  - "dead_tube_coral"
+Blocks.DEAD_BRAIN_CORAL:
+  - Blocks.DEAD_BRAIN_CORAL
+  - "dead_brain_coral"
+Blocks.DEAD_BUBBLE_CORAL:
+  - Blocks.DEAD_BUBBLE_CORAL
+  - "dead_bubble_coral"
+Blocks.DEAD_FIRE_CORAL:
+  - Blocks.DEAD_FIRE_CORAL
+  - "dead_fire_coral"
+Blocks.DEAD_HORN_CORAL:
+  - Blocks.DEAD_HORN_CORAL
+  - "dead_horn_coral"
+Blocks.TUBE_CORAL:
+  - Blocks.TUBE_CORAL
+  - "tube_coral"
+Blocks.BRAIN_CORAL:
+  - Blocks.BRAIN_CORAL
+  - "brain_coral"
+Blocks.BUBBLE_CORAL:
+  - Blocks.BUBBLE_CORAL
+  - "bubble_coral"
+Blocks.FIRE_CORAL:
+  - Blocks.FIRE_CORAL
+  - "fire_coral"
+Blocks.HORN_CORAL:
+  - Blocks.HORN_CORAL
+  - "horn_coral"
+Blocks.DEAD_TUBE_CORAL_FAN:
+  - Blocks.DEAD_TUBE_CORAL_FAN
+  - "dead_tube_coral_fan"
+Blocks.DEAD_BRAIN_CORAL_FAN:
+  - Blocks.DEAD_BRAIN_CORAL_FAN
+  - "dead_brain_coral_fan"
+Blocks.DEAD_BUBBLE_CORAL_FAN:
+  - Blocks.DEAD_BUBBLE_CORAL_FAN
+  - "dead_bubble_coral_fan"
+Blocks.DEAD_FIRE_CORAL_FAN:
+  - Blocks.DEAD_FIRE_CORAL_FAN
+  - "dead_fire_coral_fan"
+Blocks.DEAD_HORN_CORAL_FAN:
+  - Blocks.DEAD_HORN_CORAL_FAN
+  - "dead_horn_coral_fan"
+Blocks.TUBE_CORAL_FAN:
+  - Blocks.TUBE_CORAL_FAN
+  - "tube_coral_fan"
+Blocks.BRAIN_CORAL_FAN:
+  - Blocks.BRAIN_CORAL_FAN
+  - "brain_coral_fan"
+Blocks.BUBBLE_CORAL_FAN:
+  - Blocks.BUBBLE_CORAL_FAN
+  - "bubble_coral_fan"
+Blocks.FIRE_CORAL_FAN:
+  - Blocks.FIRE_CORAL_FAN
+  - "fire_coral_fan"
+Blocks.HORN_CORAL_FAN:
+  - Blocks.HORN_CORAL_FAN
+  - "horn_coral_fan"
+Blocks.DEAD_TUBE_CORAL_WALL_FAN:
+  - Blocks.DEAD_TUBE_CORAL_WALL_FAN
+  - "dead_tube_coral_wall_fan"
+Blocks.DEAD_BRAIN_CORAL_WALL_FAN:
+  - Blocks.DEAD_BRAIN_CORAL_WALL_FAN
+  - "dead_brain_coral_wall_fan"
+Blocks.DEAD_BUBBLE_CORAL_WALL_FAN:
+  - Blocks.DEAD_BUBBLE_CORAL_WALL_FAN
+  - "dead_bubble_coral_wall_fan"
+Blocks.DEAD_FIRE_CORAL_WALL_FAN:
+  - Blocks.DEAD_FIRE_CORAL_WALL_FAN
+  - "dead_fire_coral_wall_fan"
+Blocks.DEAD_HORN_CORAL_WALL_FAN:
+  - Blocks.DEAD_HORN_CORAL_WALL_FAN
+  - "dead_horn_coral_wall_fan"
+Blocks.TUBE_CORAL_WALL_FAN:
+  - Blocks.TUBE_CORAL_WALL_FAN
+  - "tube_coral_wall_fan"
+Blocks.BRAIN_CORAL_WALL_FAN:
+  - Blocks.BRAIN_CORAL_WALL_FAN
+  - "brain_coral_wall_fan"
+Blocks.BUBBLE_CORAL_WALL_FAN:
+  - Blocks.BUBBLE_CORAL_WALL_FAN
+  - "bubble_coral_wall_fan"
+Blocks.FIRE_CORAL_WALL_FAN:
+  - Blocks.FIRE_CORAL_WALL_FAN
+  - "fire_coral_wall_fan"
+Blocks.HORN_CORAL_WALL_FAN:
+  - Blocks.HORN_CORAL_WALL_FAN
+  - "horn_coral_wall_fan"
+Blocks.SEA_PICKLE:
+  - Blocks.SEA_PICKLE
+  - "sea_pickle"
+Blocks.BLUE_ICE:
+  - Blocks.BLUE_ICE
+  - "blue_ice"
+Blocks.CONDUIT:
+  - Blocks.CONDUIT
+  - "conduit"
+Blocks.BAMBOO_SAPLING:
+  - Blocks.BAMBOO_SAPLING
+  - "bamboo_sapling"
+Blocks.BAMBOO:
+  - Blocks.BAMBOO
+  - "bamboo"
+Blocks.POTTED_BAMBOO:
+  - Blocks.POTTED_BAMBOO
+  - "potted_bamboo"
+Blocks.VOID_AIR:
+  - Blocks.VOID_AIR
+  - "void_air"
+Blocks.CAVE_AIR:
+  - Blocks.CAVE_AIR
+  - "cave_air"
+Blocks.BUBBLE_COLUMN:
+  - Blocks.BUBBLE_COLUMN
+  - "bubble_column"
+Blocks.POLISHED_GRANITE_STAIRS:
+  - Blocks.POLISHED_GRANITE_STAIRS
+  - "polished_granite_stairs"
+Blocks.SMOOTH_RED_SANDSTONE_STAIRS:
+  - Blocks.SMOOTH_RED_SANDSTONE_STAIRS
+  - "smooth_red_sandstone_stairs"
+Blocks.MOSSY_STONE_BRICK_STAIRS:
+  - Blocks.MOSSY_STONE_BRICK_STAIRS
+  - "mossy_stone_brick_stairs"
+Blocks.POLISHED_DIORITE_STAIRS:
+  - Blocks.POLISHED_DIORITE_STAIRS
+  - "polished_diorite_stairs"
+Blocks.MOSSY_COBBLESTONE_STAIRS:
+  - Blocks.MOSSY_COBBLESTONE_STAIRS
+  - "mossy_cobblestone_stairs"
+Blocks.END_STONE_BRICK_STAIRS:
+  - Blocks.END_STONE_BRICK_STAIRS
+  - "end_stone_brick_stairs"
+Blocks.SMOOTH_SANDSTONE_STAIRS:
+  - Blocks.SMOOTH_SANDSTONE_STAIRS
+  - "smooth_sandstone_stairs"
+Blocks.SMOOTH_QUARTZ_STAIRS:
+  - Blocks.SMOOTH_QUARTZ_STAIRS
+  - "smooth_quartz_stairs"
+Blocks.GRANITE_STAIRS:
+  - Blocks.GRANITE_STAIRS
+  - "granite_stairs"
+Blocks.ANDESITE_STAIRS:
+  - Blocks.ANDESITE_STAIRS
+  - "andesite_stairs"
+Blocks.RED_NETHER_BRICK_STAIRS:
+  - Blocks.RED_NETHER_BRICK_STAIRS
+  - "red_nether_brick_stairs"
+Blocks.POLISHED_ANDESITE_STAIRS:
+  - Blocks.POLISHED_ANDESITE_STAIRS
+  - "polished_andesite_stairs"
+Blocks.DIORITE_STAIRS:
+  - Blocks.DIORITE_STAIRS
+  - "diorite_stairs"
+Blocks.POLISHED_GRANITE_SLAB:
+  - Blocks.POLISHED_GRANITE_SLAB
+  - "polished_granite_slab"
+Blocks.SMOOTH_RED_SANDSTONE_SLAB:
+  - Blocks.SMOOTH_RED_SANDSTONE_SLAB
+  - "smooth_red_sandstone_slab"
+Blocks.MOSSY_STONE_BRICK_SLAB:
+  - Blocks.MOSSY_STONE_BRICK_SLAB
+  - "mossy_stone_brick_slab"
+Blocks.POLISHED_DIORITE_SLAB:
+  - Blocks.POLISHED_DIORITE_SLAB
+  - "polished_diorite_slab"
+Blocks.MOSSY_COBBLESTONE_SLAB:
+  - Blocks.MOSSY_COBBLESTONE_SLAB
+  - "mossy_cobblestone_slab"
+Blocks.END_STONE_BRICK_SLAB:
+  - Blocks.END_STONE_BRICK_SLAB
+  - "end_stone_brick_slab"
+Blocks.SMOOTH_SANDSTONE_SLAB:
+  - Blocks.SMOOTH_SANDSTONE_SLAB
+  - "smooth_sandstone_slab"
+Blocks.SMOOTH_QUARTZ_SLAB:
+  - Blocks.SMOOTH_QUARTZ_SLAB
+  - "smooth_quartz_slab"
+Blocks.GRANITE_SLAB:
+  - Blocks.GRANITE_SLAB
+  - "granite_slab"
+Blocks.ANDESITE_SLAB:
+  - Blocks.ANDESITE_SLAB
+  - "andesite_slab"
+Blocks.RED_NETHER_BRICK_SLAB:
+  - Blocks.RED_NETHER_BRICK_SLAB
+  - "red_nether_brick_slab"
+Blocks.POLISHED_ANDESITE_SLAB:
+  - Blocks.POLISHED_ANDESITE_SLAB
+  - "polished_andesite_slab"
+Blocks.DIORITE_SLAB:
+  - Blocks.DIORITE_SLAB
+  - "diorite_slab"
+Blocks.BRICK_WALL:
+  - Blocks.BRICK_WALL
+  - "brick_wall"
+Blocks.PRISMARINE_WALL:
+  - Blocks.PRISMARINE_WALL
+  - "prismarine_wall"
+Blocks.RED_SANDSTONE_WALL:
+  - Blocks.RED_SANDSTONE_WALL
+  - "red_sandstone_wall"
+Blocks.MOSSY_STONE_BRICK_WALL:
+  - Blocks.MOSSY_STONE_BRICK_WALL
+  - "mossy_stone_brick_wall"
+Blocks.GRANITE_WALL:
+  - Blocks.GRANITE_WALL
+  - "granite_wall"
+Blocks.STONE_BRICK_WALL:
+  - Blocks.STONE_BRICK_WALL
+  - "stone_brick_wall"
+Blocks.NETHER_BRICK_WALL:
+  - Blocks.NETHER_BRICK_WALL
+  - "nether_brick_wall"
+Blocks.ANDESITE_WALL:
+  - Blocks.ANDESITE_WALL
+  - "andesite_wall"
+Blocks.RED_NETHER_BRICK_WALL:
+  - Blocks.RED_NETHER_BRICK_WALL
+  - "red_nether_brick_wall"
+Blocks.SANDSTONE_WALL:
+  - Blocks.SANDSTONE_WALL
+  - "sandstone_wall"
+Blocks.END_STONE_BRICK_WALL:
+  - Blocks.END_STONE_BRICK_WALL
+  - "end_stone_brick_wall"
+Blocks.DIORITE_WALL:
+  - Blocks.DIORITE_WALL
+  - "diorite_wall"
+Blocks.SCAFFOLDING:
+  - Blocks.SCAFFOLDING
+  - "scaffolding"
+Blocks.LOOM:
+  - Blocks.LOOM
+  - "loom"
+Blocks.BARREL:
+  - Blocks.BARREL
+  - "barrel"
+Blocks.SMOKER:
+  - Blocks.SMOKER
+  - "smoker"
+Blocks.BLAST_FURNACE:
+  - Blocks.BLAST_FURNACE
+  - "blast_furnace"
+Blocks.CARTOGRAPHY_TABLE:
+  - Blocks.CARTOGRAPHY_TABLE
+  - "cartography_table"
+Blocks.FLETCHING_TABLE:
+  - Blocks.FLETCHING_TABLE
+  - "fletching_table"
+Blocks.GRINDSTONE:
+  - Blocks.GRINDSTONE
+  - "grindstone"
+Blocks.LECTERN:
+  - Blocks.LECTERN
+  - "lectern"
+Blocks.SMITHING_TABLE:
+  - Blocks.SMITHING_TABLE
+  - "smithing_table"
+Blocks.STONECUTTER:
+  - Blocks.STONECUTTER
+  - "stonecutter"
+Blocks.BELL:
+  - Blocks.BELL
+  - "bell"
+Blocks.LANTERN:
+  - Blocks.LANTERN
+  - "lantern"
+Blocks.CAMPFIRE:
+  - Blocks.CAMPFIRE
+  - "campfire"
+Blocks.SWEET_BERRY_BUSH:
+  - Blocks.SWEET_BERRY_BUSH
+  - "sweet_berry_bush"
+Blocks.JIGSAW:
+  - Blocks.JIGSAW
+  - "jigsaw"
+Blocks.COMPOSTER:
+  - Blocks.COMPOSTER
+  - "composter"
+Blocks.BEEHIVE:
+  - Blocks.BEEHIVE
+  - "beehive"
+Blocks.BEE_NEST:
+  - Blocks.BEE_NEST
+  - "bee_nest"
+Blocks.HONEY_BLOCK:
+  - Blocks.HONEY_BLOCK
+  - "honey_block"
+Blocks.HONEYCOMB_BLOCK:
+  - Blocks.HONEYCOMB_BLOCK
+  - "honeycomb_block"
+Blocks.NETHER_GOLD_ORE:
+  - Blocks.NETHER_GOLD_ORE
+  - "nether_gold_ore"
+Blocks.SOUL_FIRE:
+  - Blocks.SOUL_FIRE
+  - "soul_fire"
+Blocks.SOUL_SOIL:
+  - Blocks.SOUL_SOIL
+  - "soul_soil"
+Blocks.BASALT:
+  - Blocks.BASALT
+  - "basalt"
+Blocks.POLISHED_BASALT:
+  - Blocks.POLISHED_BASALT
+  - "polished_basalt"
+Blocks.SMOOTH_BASALT:
+  - Blocks.SMOOTH_BASALT
+  - "smooth_basalt"
+Blocks.SOUL_TORCH:
+  - Blocks.SOUL_TORCH
+  - "soul_torch"
+Blocks.SOUL_WALL_TORCH:
+  - Blocks.SOUL_WALL_TORCH
+  - "soul_wall_torch"
+Blocks.CHAIN:
+  - Blocks.CHAIN
+  - "chain"
+Blocks.SOUL_LANTERN:
+  - Blocks.SOUL_LANTERN
+  - "soul_lantern"
+Blocks.SOUL_CAMPFIRE:
+  - Blocks.SOUL_CAMPFIRE
+  - "soul_campfire"
+Blocks.WARPED_STEM:
+  - Blocks.WARPED_STEM
+  - "warped_stem"
+Blocks.STRIPPED_WARPED_STEM:
+  - Blocks.STRIPPED_WARPED_STEM
+  - "stripped_warped_stem"
+Blocks.WARPED_HYPHAE:
+  - Blocks.WARPED_HYPHAE
+  - "warped_hyphae"
+Blocks.STRIPPED_WARPED_HYPHAE:
+  - Blocks.STRIPPED_WARPED_HYPHAE
+  - "stripped_warped_hyphae"
+Blocks.WARPED_NYLIUM:
+  - Blocks.WARPED_NYLIUM
+  - "warped_nylium"
+Blocks.WARPED_FUNGUS:
+  - Blocks.WARPED_FUNGUS
+  - "warped_fungus"
+Blocks.WARPED_WART_BLOCK:
+  - Blocks.WARPED_WART_BLOCK
+  - "warped_wart_block"
+Blocks.WARPED_ROOTS:
+  - Blocks.WARPED_ROOTS
+  - "warped_roots"
+Blocks.NETHER_SPROUTS:
+  - Blocks.NETHER_SPROUTS
+  - "nether_sprouts"
+Blocks.CRIMSON_STEM:
+  - Blocks.CRIMSON_STEM
+  - "crimson_stem"
+Blocks.STRIPPED_CRIMSON_STEM:
+  - Blocks.STRIPPED_CRIMSON_STEM
+  - "stripped_crimson_stem"
+Blocks.CRIMSON_HYPHAE:
+  - Blocks.CRIMSON_HYPHAE
+  - "crimson_hyphae"
+Blocks.STRIPPED_CRIMSON_HYPHAE:
+  - Blocks.STRIPPED_CRIMSON_HYPHAE
+  - "stripped_crimson_hyphae"
+Blocks.CRIMSON_NYLIUM:
+  - Blocks.CRIMSON_NYLIUM
+  - "crimson_nylium"
+Blocks.CRIMSON_FUNGUS:
+  - Blocks.CRIMSON_FUNGUS
+  - "crimson_fungus"
+Blocks.SHROOMLIGHT:
+  - Blocks.SHROOMLIGHT
+  - "shroomlight"
+Blocks.WEEPING_VINES:
+  - Blocks.WEEPING_VINES
+  - "weeping_vines"
+Blocks.WEEPING_VINES_PLANT:
+  - Blocks.WEEPING_VINES_PLANT
+  - "weeping_vines_plant"
+Blocks.TWISTING_VINES:
+  - Blocks.TWISTING_VINES
+  - "twisting_vines"
+Blocks.TWISTING_VINES_PLANT:
+  - Blocks.TWISTING_VINES_PLANT
+  - "twisting_vines_plant"
+Blocks.CRIMSON_ROOTS:
+  - Blocks.CRIMSON_ROOTS
+  - "crimson_roots"
+Blocks.CRIMSON_PLANKS:
+  - Blocks.CRIMSON_PLANKS
+  - "crimson_planks"
+Blocks.WARPED_PLANKS:
+  - Blocks.WARPED_PLANKS
+  - "warped_planks"
+Blocks.CRIMSON_SLAB:
+  - Blocks.CRIMSON_SLAB
+  - "crimson_slab"
+Blocks.WARPED_SLAB:
+  - Blocks.WARPED_SLAB
+  - "warped_slab"
+Blocks.CRIMSON_PRESSURE_PLATE:
+  - Blocks.CRIMSON_PRESSURE_PLATE
+  - "crimson_pressure_plate"
+Blocks.WARPED_PRESSURE_PLATE:
+  - Blocks.WARPED_PRESSURE_PLATE
+  - "warped_pressure_plate"
+Blocks.CRIMSON_FENCE:
+  - Blocks.CRIMSON_FENCE
+  - "crimson_fence"
+Blocks.WARPED_FENCE:
+  - Blocks.WARPED_FENCE
+  - "warped_fence"
+Blocks.CRIMSON_TRAPDOOR:
+  - Blocks.CRIMSON_TRAPDOOR
+  - "crimson_trapdoor"
+Blocks.WARPED_TRAPDOOR:
+  - Blocks.WARPED_TRAPDOOR
+  - "warped_trapdoor"
+Blocks.CRIMSON_FENCE_GATE:
+  - Blocks.CRIMSON_FENCE_GATE
+  - "crimson_fence_gate"
+Blocks.WARPED_FENCE_GATE:
+  - Blocks.WARPED_FENCE_GATE
+  - "warped_fence_gate"
+Blocks.CRIMSON_STAIRS:
+  - Blocks.CRIMSON_STAIRS
+  - "crimson_stairs"
+Blocks.WARPED_STAIRS:
+  - Blocks.WARPED_STAIRS
+  - "warped_stairs"
+Blocks.CRIMSON_BUTTON:
+  - Blocks.CRIMSON_BUTTON
+  - "crimson_button"
+Blocks.WARPED_BUTTON:
+  - Blocks.WARPED_BUTTON
+  - "warped_button"
+Blocks.CRIMSON_DOOR:
+  - Blocks.CRIMSON_DOOR
+  - "crimson_door"
+Blocks.WARPED_DOOR:
+  - Blocks.WARPED_DOOR
+  - "warped_door"
+Blocks.CRIMSON_SIGN:
+  - Blocks.CRIMSON_SIGN
+  - "crimson_sign"
+Blocks.WARPED_SIGN:
+  - Blocks.WARPED_SIGN
+  - "warped_sign"
+Blocks.CRIMSON_WALL_SIGN:
+  - Blocks.CRIMSON_WALL_SIGN
+  - "crimson_wall_sign"
+Blocks.WARPED_WALL_SIGN:
+  - Blocks.WARPED_WALL_SIGN
+  - "warped_wall_sign"
+Blocks.TARGET:
+  - Blocks.TARGET
+  - "target"
+Blocks.NETHERITE_BLOCK:
+  - Blocks.NETHERITE_BLOCK
+  - "netherite_block"
+Blocks.ANCIENT_DEBRIS:
+  - Blocks.ANCIENT_DEBRIS
+  - "ancient_debris"
+Blocks.CRYING_OBSIDIAN:
+  - Blocks.CRYING_OBSIDIAN
+  - "crying_obsidian"
+Blocks.RESPAWN_ANCHOR:
+  - Blocks.RESPAWN_ANCHOR
+  - "respawn_anchor"
+Blocks.POTTED_CRIMSON_FUNGUS:
+  - Blocks.POTTED_CRIMSON_FUNGUS
+  - "potted_crimson_fungus"
+Blocks.POTTED_WARPED_FUNGUS:
+  - Blocks.POTTED_WARPED_FUNGUS
+  - "potted_warped_fungus"
+Blocks.POTTED_CRIMSON_ROOTS:
+  - Blocks.POTTED_CRIMSON_ROOTS
+  - "potted_crimson_roots"
+Blocks.POTTED_WARPED_ROOTS:
+  - Blocks.POTTED_WARPED_ROOTS
+  - "potted_warped_roots"
+Blocks.LODESTONE:
+  - Blocks.LODESTONE
+  - "lodestone"
+Blocks.BLACKSTONE:
+  - Blocks.BLACKSTONE
+  - "blackstone"
+Blocks.BLACKSTONE_STAIRS:
+  - Blocks.BLACKSTONE_STAIRS
+  - "blackstone_stairs"
+Blocks.BLACKSTONE_WALL:
+  - Blocks.BLACKSTONE_WALL
+  - "blackstone_wall"
+Blocks.BLACKSTONE_SLAB:
+  - Blocks.BLACKSTONE_SLAB
+  - "blackstone_slab"
+Blocks.POLISHED_BLACKSTONE:
+  - Blocks.POLISHED_BLACKSTONE
+  - "polished_blackstone"
+Blocks.POLISHED_BLACKSTONE_BRICKS:
+  - Blocks.POLISHED_BLACKSTONE_BRICKS
+  - "polished_blackstone_bricks"
+Blocks.CRACKED_POLISHED_BLACKSTONE_BRICKS:
+  - Blocks.CRACKED_POLISHED_BLACKSTONE_BRICKS
+  - "cracked_polished_blackstone_bricks"
+Blocks.CHISELED_POLISHED_BLACKSTONE:
+  - Blocks.CHISELED_POLISHED_BLACKSTONE
+  - "chiseled_polished_blackstone"
+Blocks.POLISHED_BLACKSTONE_BRICK_SLAB:
+  - Blocks.POLISHED_BLACKSTONE_BRICK_SLAB
+  - "polished_blackstone_brick_slab"
+Blocks.POLISHED_BLACKSTONE_BRICK_STAIRS:
+  - Blocks.POLISHED_BLACKSTONE_BRICK_STAIRS
+  - "polished_blackstone_brick_stairs"
+Blocks.POLISHED_BLACKSTONE_BRICK_WALL:
+  - Blocks.POLISHED_BLACKSTONE_BRICK_WALL
+  - "polished_blackstone_brick_wall"
+Blocks.GILDED_BLACKSTONE:
+  - Blocks.GILDED_BLACKSTONE
+  - "gilded_blackstone"
+Blocks.POLISHED_BLACKSTONE_STAIRS:
+  - Blocks.POLISHED_BLACKSTONE_STAIRS
+  - "polished_blackstone_stairs"
+Blocks.POLISHED_BLACKSTONE_SLAB:
+  - Blocks.POLISHED_BLACKSTONE_SLAB
+  - "polished_blackstone_slab"
+Blocks.POLISHED_BLACKSTONE_PRESSURE_PLATE:
+  - Blocks.POLISHED_BLACKSTONE_PRESSURE_PLATE
+  - "polished_blackstone_pressure_plate"
+Blocks.POLISHED_BLACKSTONE_BUTTON:
+  - Blocks.POLISHED_BLACKSTONE_BUTTON
+  - "polished_blackstone_button"
+Blocks.POLISHED_BLACKSTONE_WALL:
+  - Blocks.POLISHED_BLACKSTONE_WALL
+  - "polished_blackstone_wall"
+Blocks.CHISELED_NETHER_BRICKS:
+  - Blocks.CHISELED_NETHER_BRICKS
+  - "chiseled_nether_bricks"
+Blocks.CRACKED_NETHER_BRICKS:
+  - Blocks.CRACKED_NETHER_BRICKS
+  - "cracked_nether_bricks"
+Blocks.QUARTZ_BRICKS:
+  - Blocks.QUARTZ_BRICKS
+  - "quartz_bricks"
+Blocks.CANDLE:
+  - Blocks.CANDLE
+  - "#minecraft:candles"
+Blocks.CANDLE#0:
+  - Blocks.CANDLE
+  - "candle"
+Blocks.CANDLE#1:
+  - Blocks.WHITE_CANDLE
+  - "white_candle"
+Blocks.CANDLE#2:
+  - Blocks.ORANGE_CANDLE
+  - "orange_candle"
+Blocks.CANDLE#3:
+  - Blocks.MAGENTA_CANDLE
+  - "magenta_candle"
+Blocks.CANDLE#4:
+  - Blocks.LIGHT_BLUE_CANDLE
+  - "light_blue_candle"
+Blocks.CANDLE#5:
+  - Blocks.YELLOW_CANDLE
+  - "yellow_candle"
+Blocks.CANDLE#6:
+  - Blocks.LIME_CANDLE
+  - "lime_candle"
+Blocks.CANDLE#7:
+  - Blocks.PINK_CANDLE
+  - "pink_candle"
+Blocks.CANDLE#8:
+  - Blocks.GRAY_CANDLE
+  - "gray_candle"
+Blocks.CANDLE#9:
+  - Blocks.LIGHT_GRAY_CANDLE
+  - "light_gray_candle"
+Blocks.CANDLE#10:
+  - Blocks.CYAN_CANDLE
+  - "cyan_candle"
+Blocks.CANDLE#11:
+  - Blocks.PURPLE_CANDLE
+  - "purple_candle"
+Blocks.CANDLE#12:
+  - Blocks.BLUE_CANDLE
+  - "blue_candle"
+Blocks.CANDLE#13:
+  - Blocks.BROWN_CANDLE
+  - "brown_candle"
+Blocks.CANDLE#14:
+  - Blocks.GREEN_CANDLE
+  - "green_candle"
+Blocks.CANDLE#15:
+  - Blocks.RED_CANDLE
+  - "red_candle"
+Blocks.CANDLE#16:
+  - Blocks.BLACK_CANDLE
+  - "black_candle"
+Blocks.CANDLE_CAKE:
+  - Blocks.CANDLE_CAKE
+  - "#minecraft:candle_cakes"
+Blocks.CANDLE_CAKE#0:
+  - Blocks.CANDLE_CAKE
+  - "candle_cake"
+Blocks.CANDLE_CAKE#1:
+  - Blocks.WHITE_CANDLE_CAKE
+  - "white_candle_cake"
+Blocks.CANDLE_CAKE#2:
+  - Blocks.ORANGE_CANDLE_CAKE
+  - "orange_candle_cake"
+Blocks.CANDLE_CAKE#3:
+  - Blocks.MAGENTA_CANDLE_CAKE
+  - "magenta_candle_cake"
+Blocks.CANDLE_CAKE#4:
+  - Blocks.LIGHT_BLUE_CANDLE_CAKE
+  - "light_blue_candle_cake"
+Blocks.CANDLE_CAKE#5:
+  - Blocks.YELLOW_CANDLE_CAKE
+  - "yellow_candle_cake"
+Blocks.CANDLE_CAKE#6:
+  - Blocks.LIME_CANDLE_CAKE
+  - "lime_candle_cake"
+Blocks.CANDLE_CAKE#7:
+  - Blocks.PINK_CANDLE_CAKE
+  - "pink_candle_cake"
+Blocks.CANDLE_CAKE#8:
+  - Blocks.GRAY_CANDLE_CAKE
+  - "gray_candle_cake"
+Blocks.CANDLE_CAKE#9:
+  - Blocks.LIGHT_GRAY_CANDLE_CAKE
+  - "light_gray_candle_cake"
+Blocks.CANDLE_CAKE#10:
+  - Blocks.CYAN_CANDLE_CAKE
+  - "cyan_candle_cake"
+Blocks.CANDLE_CAKE#11:
+  - Blocks.PURPLE_CANDLE_CAKE
+  - "purple_candle_cake"
+Blocks.CANDLE_CAKE#12:
+  - Blocks.BLUE_CANDLE_CAKE
+  - "blue_candle_cake"
+Blocks.CANDLE_CAKE#13:
+  - Blocks.BROWN_CANDLE_CAKE
+  - "brown_candle_cake"
+Blocks.CANDLE_CAKE#14:
+  - Blocks.GREEN_CANDLE_CAKE
+  - "green_candle_cake"
+Blocks.CANDLE_CAKE#15:
+  - Blocks.RED_CANDLE_CAKE
+  - "red_candle_cake"
+Blocks.CANDLE_CAKE#16:
+  - Blocks.BLACK_CANDLE_CAKE
+  - "black_candle_cake"
+Blocks.AMETHYST_BLOCK:
+  - Blocks.AMETHYST_BLOCK
+  - "amethyst_block"
+Blocks.BUDDING_AMETHYST:
+  - Blocks.BUDDING_AMETHYST
+  - "budding_amethyst"
+Blocks.AMETHYST_CLUSTER:
+  - Blocks.AMETHYST_CLUSTER
+  - "amethyst_cluster"
+Blocks.LARGE_AMETHYST_BUD:
+  - Blocks.LARGE_AMETHYST_BUD
+  - "large_amethyst_bud"
+Blocks.MEDIUM_AMETHYST_BUD:
+  - Blocks.MEDIUM_AMETHYST_BUD
+  - "medium_amethyst_bud"
+Blocks.SMALL_AMETHYST_BUD:
+  - Blocks.SMALL_AMETHYST_BUD
+  - "small_amethyst_bud"
+Blocks.TUFF:
+  - Blocks.TUFF
+  - "tuff"
+Blocks.TUFF_SLAB:
+  - Blocks.TUFF_SLAB
+  - "tuff_slab"
+Blocks.TUFF_STAIRS:
+  - Blocks.TUFF_STAIRS
+  - "tuff_stairs"
+Blocks.TUFF_WALL:
+  - Blocks.TUFF_WALL
+  - "tuff_wall"
+Blocks.POLISHED_TUFF:
+  - Blocks.POLISHED_TUFF
+  - "polished_tuff"
+Blocks.POLISHED_TUFF_SLAB:
+  - Blocks.POLISHED_TUFF_SLAB
+  - "polished_tuff_slab"
+Blocks.POLISHED_TUFF_STAIRS:
+  - Blocks.POLISHED_TUFF_STAIRS
+  - "polished_tuff_stairs"
+Blocks.POLISHED_TUFF_WALL:
+  - Blocks.POLISHED_TUFF_WALL
+  - "polished_tuff_wall"
+Blocks.CHISELED_TUFF:
+  - Blocks.CHISELED_TUFF
+  - "chiseled_tuff"
+Blocks.TUFF_BRICKS:
+  - Blocks.TUFF_BRICKS
+  - "tuff_bricks"
+Blocks.TUFF_BRICK_SLAB:
+  - Blocks.TUFF_BRICK_SLAB
+  - "tuff_brick_slab"
+Blocks.TUFF_BRICK_STAIRS:
+  - Blocks.TUFF_BRICK_STAIRS
+  - "tuff_brick_stairs"
+Blocks.TUFF_BRICK_WALL:
+  - Blocks.TUFF_BRICK_WALL
+  - "tuff_brick_wall"
+Blocks.CHISELED_TUFF_BRICKS:
+  - Blocks.CHISELED_TUFF_BRICKS
+  - "chiseled_tuff_bricks"
+Blocks.CALCITE:
+  - Blocks.CALCITE
+  - "calcite"
+Blocks.TINTED_GLASS:
+  - Blocks.TINTED_GLASS
+  - "tinted_glass"
+Blocks.POWDER_SNOW:
+  - Blocks.POWDER_SNOW
+  - "powder_snow"
+Blocks.SCULK_SENSOR:
+  - Blocks.SCULK_SENSOR
+  - "sculk_sensor"
+Blocks.CALIBRATED_SCULK_SENSOR:
+  - Blocks.CALIBRATED_SCULK_SENSOR
+  - "calibrated_sculk_sensor"
+Blocks.SCULK:
+  - Blocks.SCULK
+  - "sculk"
+Blocks.SCULK_VEIN:
+  - Blocks.SCULK_VEIN
+  - "sculk_vein"
+Blocks.SCULK_CATALYST:
+  - Blocks.SCULK_CATALYST
+  - "sculk_catalyst"
+Blocks.SCULK_SHRIEKER:
+  - Blocks.SCULK_SHRIEKER
+  - "sculk_shrieker"
+Blocks.OXIDIZED_COPPER:
+  - Blocks.OXIDIZED_COPPER
+  - "oxidized_copper"
+Blocks.WEATHERED_COPPER:
+  - Blocks.WEATHERED_COPPER
+  - "weathered_copper"
+Blocks.EXPOSED_COPPER:
+  - Blocks.EXPOSED_COPPER
+  - "exposed_copper"
+Blocks.COPPER_BLOCK:
+  - Blocks.COPPER_BLOCK
+  - "copper_block"
+Blocks.OXIDIZED_CUT_COPPER:
+  - Blocks.OXIDIZED_CUT_COPPER
+  - "oxidized_cut_copper"
+Blocks.WEATHERED_CUT_COPPER:
+  - Blocks.WEATHERED_CUT_COPPER
+  - "weathered_cut_copper"
+Blocks.EXPOSED_CUT_COPPER:
+  - Blocks.EXPOSED_CUT_COPPER
+  - "exposed_cut_copper"
+Blocks.CUT_COPPER:
+  - Blocks.CUT_COPPER
+  - "cut_copper"
+Blocks.OXIDIZED_CHISELED_COPPER:
+  - Blocks.OXIDIZED_CHISELED_COPPER
+  - "oxidized_chiseled_copper"
+Blocks.WEATHERED_CHISELED_COPPER:
+  - Blocks.WEATHERED_CHISELED_COPPER
+  - "weathered_chiseled_copper"
+Blocks.EXPOSED_CHISELED_COPPER:
+  - Blocks.EXPOSED_CHISELED_COPPER
+  - "exposed_chiseled_copper"
+Blocks.CHISELED_COPPER:
+  - Blocks.CHISELED_COPPER
+  - "chiseled_copper"
+Blocks.WAXED_OXIDIZED_CHISELED_COPPER:
+  - Blocks.WAXED_OXIDIZED_CHISELED_COPPER
+  - "waxed_oxidized_chiseled_copper"
+Blocks.WAXED_WEATHERED_CHISELED_COPPER:
+  - Blocks.WAXED_WEATHERED_CHISELED_COPPER
+  - "waxed_weathered_chiseled_copper"
+Blocks.WAXED_EXPOSED_CHISELED_COPPER:
+  - Blocks.WAXED_EXPOSED_CHISELED_COPPER
+  - "waxed_exposed_chiseled_copper"
+Blocks.WAXED_CHISELED_COPPER:
+  - Blocks.WAXED_CHISELED_COPPER
+  - "waxed_chiseled_copper"
+Blocks.OXIDIZED_CUT_COPPER_STAIRS:
+  - Blocks.OXIDIZED_CUT_COPPER_STAIRS
+  - "oxidized_cut_copper_stairs"
+Blocks.WEATHERED_CUT_COPPER_STAIRS:
+  - Blocks.WEATHERED_CUT_COPPER_STAIRS
+  - "weathered_cut_copper_stairs"
+Blocks.EXPOSED_CUT_COPPER_STAIRS:
+  - Blocks.EXPOSED_CUT_COPPER_STAIRS
+  - "exposed_cut_copper_stairs"
+Blocks.CUT_COPPER_STAIRS:
+  - Blocks.CUT_COPPER_STAIRS
+  - "cut_copper_stairs"
+Blocks.OXIDIZED_CUT_COPPER_SLAB:
+  - Blocks.OXIDIZED_CUT_COPPER_SLAB
+  - "oxidized_cut_copper_slab"
+Blocks.WEATHERED_CUT_COPPER_SLAB:
+  - Blocks.WEATHERED_CUT_COPPER_SLAB
+  - "weathered_cut_copper_slab"
+Blocks.EXPOSED_CUT_COPPER_SLAB:
+  - Blocks.EXPOSED_CUT_COPPER_SLAB
+  - "exposed_cut_copper_slab"
+Blocks.CUT_COPPER_SLAB:
+  - Blocks.CUT_COPPER_SLAB
+  - "cut_copper_slab"
+Blocks.WAXED_COPPER_BLOCK:
+  - Blocks.WAXED_COPPER_BLOCK
+  - "waxed_copper_block"
+Blocks.WAXED_WEATHERED_COPPER:
+  - Blocks.WAXED_WEATHERED_COPPER
+  - "waxed_weathered_copper"
+Blocks.WAXED_EXPOSED_COPPER:
+  - Blocks.WAXED_EXPOSED_COPPER
+  - "waxed_exposed_copper"
+Blocks.WAXED_OXIDIZED_COPPER:
+  - Blocks.WAXED_OXIDIZED_COPPER
+  - "waxed_oxidized_copper"
+Blocks.WAXED_OXIDIZED_CUT_COPPER:
+  - Blocks.WAXED_OXIDIZED_CUT_COPPER
+  - "waxed_oxidized_cut_copper"
+Blocks.WAXED_WEATHERED_CUT_COPPER:
+  - Blocks.WAXED_WEATHERED_CUT_COPPER
+  - "waxed_weathered_cut_copper"
+Blocks.WAXED_EXPOSED_CUT_COPPER:
+  - Blocks.WAXED_EXPOSED_CUT_COPPER
+  - "waxed_exposed_cut_copper"
+Blocks.WAXED_CUT_COPPER:
+  - Blocks.WAXED_CUT_COPPER
+  - "waxed_cut_copper"
+Blocks.WAXED_OXIDIZED_CUT_COPPER_STAIRS:
+  - Blocks.WAXED_OXIDIZED_CUT_COPPER_STAIRS
+  - "waxed_oxidized_cut_copper_stairs"
+Blocks.WAXED_WEATHERED_CUT_COPPER_STAIRS:
+  - Blocks.WAXED_WEATHERED_CUT_COPPER_STAIRS
+  - "waxed_weathered_cut_copper_stairs"
+Blocks.WAXED_EXPOSED_CUT_COPPER_STAIRS:
+  - Blocks.WAXED_EXPOSED_CUT_COPPER_STAIRS
+  - "waxed_exposed_cut_copper_stairs"
+Blocks.WAXED_CUT_COPPER_STAIRS:
+  - Blocks.WAXED_CUT_COPPER_STAIRS
+  - "waxed_cut_copper_stairs"
+Blocks.WAXED_OXIDIZED_CUT_COPPER_SLAB:
+  - Blocks.WAXED_OXIDIZED_CUT_COPPER_SLAB
+  - "waxed_oxidized_cut_copper_slab"
+Blocks.WAXED_WEATHERED_CUT_COPPER_SLAB:
+  - Blocks.WAXED_WEATHERED_CUT_COPPER_SLAB
+  - "waxed_weathered_cut_copper_slab"
+Blocks.WAXED_EXPOSED_CUT_COPPER_SLAB:
+  - Blocks.WAXED_EXPOSED_CUT_COPPER_SLAB
+  - "waxed_exposed_cut_copper_slab"
+Blocks.WAXED_CUT_COPPER_SLAB:
+  - Blocks.WAXED_CUT_COPPER_SLAB
+  - "waxed_cut_copper_slab"
+Blocks.LIGHTNING_ROD:
+  - Blocks.LIGHTNING_ROD
+  - "lightning_rod"
+Blocks.POINTED_DRIPSTONE:
+  - Blocks.POINTED_DRIPSTONE
+  - "pointed_dripstone"
+Blocks.DRIPSTONE_BLOCK:
+  - Blocks.DRIPSTONE_BLOCK
+  - "dripstone_block"
+Blocks.CAVE_VINES:
+  - Blocks.CAVE_VINES
+  - "cave_vines"
+Blocks.CAVE_VINES_PLANT:
+  - Blocks.CAVE_VINES_PLANT
+  - "cave_vines_plant"
+Blocks.SPORE_BLOSSOM:
+  - Blocks.SPORE_BLOSSOM
+  - "spore_blossom"
+Blocks.AZALEA:
+  - Blocks.AZALEA
+  - "azalea"
+Blocks.FLOWERING_AZALEA:
+  - Blocks.FLOWERING_AZALEA
+  - "flowering_azalea"
+Blocks.MOSS_CARPET:
+  - Blocks.MOSS_CARPET
+  - "moss_carpet"
+Blocks.MOSS_BLOCK:
+  - Blocks.MOSS_BLOCK
+  - "moss_block"
+Blocks.BIG_DRIPLEAF:
+  - Blocks.BIG_DRIPLEAF
+  - "big_dripleaf"
+Blocks.BIG_DRIPLEAF_STEM:
+  - Blocks.BIG_DRIPLEAF_STEM
+  - "big_dripleaf_stem"
+Blocks.SMALL_DRIPLEAF:
+  - Blocks.SMALL_DRIPLEAF
+  - "small_dripleaf"
+Blocks.HANGING_ROOTS:
+  - Blocks.HANGING_ROOTS
+  - "hanging_roots"
+Blocks.ROOTED_DIRT:
+  - Blocks.ROOTED_DIRT
+  - "rooted_dirt"
+Blocks.MUD:
+  - Blocks.MUD
+  - "mud"
+Blocks.PACKED_MUD:
+  - Blocks.PACKED_MUD
+  - "packed_mud"
+Blocks.MUD_BRICK_STAIRS:
+  - Blocks.MUD_BRICK_STAIRS
+  - "mud_brick_stairs"
+Blocks.MUD_BRICK_SLAB:
+  - Blocks.MUD_BRICK_SLAB
+  - "mud_brick_slab"
+Blocks.MUD_BRICK_WALL:
+  - Blocks.MUD_BRICK_WALL
+  - "mud_brick_wall"
+Blocks.MUD_BRICKS:
+  - Blocks.MUD_BRICKS
+  - "mud_bricks"
+Blocks.DEEPSLATE:
+  - Blocks.DEEPSLATE
+  - "deepslate"
+Blocks.REINFORCED_DEEPSLATE:
+  - Blocks.REINFORCED_DEEPSLATE
+  - "reinforced_deepslate"
+Blocks.COBBLED_DEEPSLATE:
+  - Blocks.COBBLED_DEEPSLATE
+  - "cobbled_deepslate"
+Blocks.COBBLED_DEEPSLATE_STAIRS:
+  - Blocks.COBBLED_DEEPSLATE_STAIRS
+  - "cobbled_deepslate_stairs"
+Blocks.COBBLED_DEEPSLATE_SLAB:
+  - Blocks.COBBLED_DEEPSLATE_SLAB
+  - "cobbled_deepslate_slab"
+Blocks.COBBLED_DEEPSLATE_WALL:
+  - Blocks.COBBLED_DEEPSLATE_WALL
+  - "cobbled_deepslate_wall"
+Blocks.POLISHED_DEEPSLATE:
+  - Blocks.POLISHED_DEEPSLATE
+  - "polished_deepslate"
+Blocks.POLISHED_DEEPSLATE_STAIRS:
+  - Blocks.POLISHED_DEEPSLATE_STAIRS
+  - "polished_deepslate_stairs"
+Blocks.POLISHED_DEEPSLATE_SLAB:
+  - Blocks.POLISHED_DEEPSLATE_SLAB
+  - "polished_deepslate_slab"
+Blocks.POLISHED_DEEPSLATE_WALL:
+  - Blocks.POLISHED_DEEPSLATE_WALL
+  - "polished_deepslate_wall"
+Blocks.DEEPSLATE_TILES:
+  - Blocks.DEEPSLATE_TILES
+  - "deepslate_tiles"
+Blocks.DEEPSLATE_TILE_STAIRS:
+  - Blocks.DEEPSLATE_TILE_STAIRS
+  - "deepslate_tile_stairs"
+Blocks.DEEPSLATE_TILE_SLAB:
+  - Blocks.DEEPSLATE_TILE_SLAB
+  - "deepslate_tile_slab"
+Blocks.DEEPSLATE_TILE_WALL:
+  - Blocks.DEEPSLATE_TILE_WALL
+  - "deepslate_tile_wall"
+Blocks.DEEPSLATE_BRICKS:
+  - Blocks.DEEPSLATE_BRICKS
+  - "deepslate_bricks"
+Blocks.DEEPSLATE_BRICK_STAIRS:
+  - Blocks.DEEPSLATE_BRICK_STAIRS
+  - "deepslate_brick_stairs"
+Blocks.DEEPSLATE_BRICK_SLAB:
+  - Blocks.DEEPSLATE_BRICK_SLAB
+  - "deepslate_brick_slab"
+Blocks.DEEPSLATE_BRICK_WALL:
+  - Blocks.DEEPSLATE_BRICK_WALL
+  - "deepslate_brick_wall"
+Blocks.CHISELED_DEEPSLATE:
+  - Blocks.CHISELED_DEEPSLATE
+  - "chiseled_deepslate"
+Blocks.CRACKED_DEEPSLATE_BRICKS:
+  - Blocks.CRACKED_DEEPSLATE_BRICKS
+  - "cracked_deepslate_bricks"
+Blocks.CRACKED_DEEPSLATE_TILES:
+  - Blocks.CRACKED_DEEPSLATE_TILES
+  - "cracked_deepslate_tiles"
+Blocks.RAW_IRON_BLOCK:
+  - Blocks.RAW_IRON_BLOCK
+  - "raw_iron_block"
+Blocks.RAW_GOLD_BLOCK:
+  - Blocks.RAW_GOLD_BLOCK
+  - "raw_gold_block"
+Blocks.RAW_COPPER_BLOCK:
+  - Blocks.RAW_COPPER_BLOCK
+  - "raw_copper_block"
+Blocks.LIGHT:
+  - Blocks.LIGHT
+  - "light"
+Blocks.POTTED_AZALEA_BUSH:
+  - Blocks.POTTED_AZALEA
+  - "potted_azalea_bush"
+Blocks.POTTED_FLOWERING_AZALEA_BUSH:
+  - Blocks.POTTED_FLOWERING_AZALEA
+  - "potted_flowering_azalea_bush"
+Blocks.POTTED_MANGROVE_PROPAGULE:
+  - Blocks.POTTED_MANGROVE_PROPAGULE
+  - "potted_mangrove_propagule"
+Blocks.OCHRE_FROGLIGHT:
+  - Blocks.OCHRE_FROGLIGHT
+  - "ochre_froglight"
+Blocks.VERDANT_FROGLIGHT:
+  - Blocks.VERDANT_FROGLIGHT
+  - "verdant_froglight"
+Blocks.PEARLESCENT_FROGLIGHT:
+  - Blocks.PEARLESCENT_FROGLIGHT
+  - "pearlescent_froglight"
+Blocks.FROGSPAWN:
+  - Blocks.FROGSPAWN
+  - "frogspawn"
+Blocks.POTTED_CHERRY_SAPLING:
+  - Blocks.POTTED_CHERRY_SAPLING
+  - "potted_cherry_sapling"
+Blocks.POTTED_TORCHFLOWER:
+  - Blocks.POTTED_TORCHFLOWER
+  - "potted_torchflower"
+Blocks.DECORATED_POT:
+  - Blocks.DECORATED_POT
+  - "decorated_pot"
+Blocks.CRAFTER:
+  - Blocks.CRAFTER
+  - "crafter"
+Blocks.TRIAL_SPAWNER:
+  - Blocks.TRIAL_SPAWNER
+  - "trial_spawner"
+Blocks.VAULT:
+  - Blocks.VAULT
+  - "vault"
+Blocks.HEAVY_CORE:
+  - Blocks.HEAVY_CORE
+  - "heavy_core"
+Blocks.TORCHFLOWER_CROP:
+  - Blocks.TORCHFLOWER_CROP
+  - "torchflower_crop"
+Blocks.PITCHER_CROP:
+  - Blocks.PITCHER_CROP
+  - "pitcher_crop"
+Blocks.SNIFFER_EGG:
+  - Blocks.SNIFFER_EGG
+  - "sniffer_egg"
+Items.DYE:
+  - Items.INK_SAC
+  - "#forge:dyes"
+Items.DYE#0:
+  - Items.INK_SAC
+  - "ink_sac"
+Items.DYE#1:
+  - Items.RED_DYE
+  - "red_dye"
+Items.DYE#2:
+  - Items.GREEN_DYE
+  - "green_dye"
+Items.DYE#3:
+  - Items.COCOA_BEANS
+  - "cocoa_beans"
+Items.DYE#4:
+  - Items.LAPIS_LAZULI
+  - "lapis_lazuli"
+Items.DYE#5:
+  - Items.PURPLE_DYE
+  - "purple_dye"
+Items.DYE#6:
+  - Items.CYAN_DYE
+  - "cyan_dye"
+Items.DYE#7:
+  - Items.LIGHT_GRAY_DYE
+  - "light_gray_dye"
+Items.DYE#8:
+  - Items.GRAY_DYE
+  - "gray_dye"
+Items.DYE#9:
+  - Items.PINK_DYE
+  - "pink_dye"
+Items.DYE#10:
+  - Items.LIME_DYE
+  - "lime_dye"
+Items.DYE#11:
+  - Items.YELLOW_DYE
+  - "yellow_dye"
+Items.DYE#12:
+  - Items.LIGHT_BLUE_DYE
+  - "light_blue_dye"
+Items.DYE#13:
+  - Items.MAGENTA_DYE
+  - "magenta_dye"
+Items.DYE#14:
+  - Items.ORANGE_DYE
+  - "orange_dye"
+Items.DYE#15:
+  - Items.BONE_MEAL
+  - "bone_meal"
+Items.DYE#16:
+  - Items.BLACK_DYE
+  - "black_dye"
+Items.DYE#17:
+  - Items.BROWN_DYE
+  - "brown_dye"
+Items.DYE#18:
+  - Items.BLUE_DYE
+  - "blue_dye"
+Items.DYE#19:
+  - Items.WHITE_DYE
+  - "white_dye"
+Items.COAL#0:
+  - Items.COAL
+  - "coal"
+Items.COAL#1:
+  - Items.CHARCOAL
+  - "charcoal"
+Items.IRON_INGOT:
+  - Items.IRON_INGOT
+  - "iron_ingot"
+Items.IRON_NUGGET:
+  - Items.IRON_NUGGET
+  - "iron_nugget"
+Items.REDSTONE:
+  - Items.REDSTONE
+  - "redstone"
+Items.GOLD_INGOT:
+  - Items.GOLD_INGOT
+  - "gold_ingot"
+Items.GOLD_NUGGET:
+  - Items.GOLD_NUGGET
+  - "gold_nugget"
+Items.DIAMOND:
+  - Items.DIAMOND
+  - "diamond"
+Items.EMERALD:
+  - Items.EMERALD
+  - "emerald"
+Items.QUARTZ:
+  - Items.QUARTZ
+  - "quartz"
+Items.COPPER_INGOT:
+  - Items.COPPER_INGOT
+  - "copper_ingot"
+Items.NETHER_STAR:
+  - Items.NETHER_STAR
+  - "nether_star"
+Items.PRISMARINE_SHARD:
+  - Items.PRISMARINE_SHARD
+  - "prismarine_shard"
+Items.PRISMARINE_CRYSTALS:
+  - Items.PRISMARINE_CRYSTALS
+  - "prismarine_crystals"
+Items.BOW:
+  - Items.BOW
+  - "bow"
+Items.ARROW:
+  - Items.ARROW
+  - "arrow"
+Items.SPECTRAL_ARROW:
+  - Items.SPECTRAL_ARROW
+  - "spectral_arrow"
+Items.TIPPED_ARROW:
+  - Items.TIPPED_ARROW
+  - "tipped_arrow"
+Items.FISHING_ROD:
+  - Items.FISHING_ROD
+  - "fishing_rod"
+Items.CARROT_ON_A_STICK:
+  - Items.CARROT_ON_A_STICK
+  - "carrot_on_a_stick"
+Items.COMPASS:
+  - Items.COMPASS
+  - "compass"
+Items.RECOVERY_COMPASS:
+  - Items.RECOVERY_COMPASS
+  - "recovery_compass"
+Items.CLOCK:
+  - Items.CLOCK
+  - "clock"
+Items.MAP:
+  - Items.MAP
+  - "map"
+Items.FILLED_MAP:
+  - Items.FILLED_MAP
+  - "filled_map"
+Items.TOTEM_OF_UNDYING:
+  - Items.TOTEM_OF_UNDYING
+  - "totem_of_undying"
+Items.LEAD:
+  - Items.LEAD
+  - "lead"
+Items.NAME_TAG:
+  - Items.NAME_TAG
+  - "name_tag"
+Items.SHIELD:
+  - Items.SHIELD
+  - "shield"
+Items.WOODEN_SWORD:
+  - Items.WOODEN_SWORD
+  - "wooden_sword"
+Items.WOODEN_SHOVEL:
+  - Items.WOODEN_SHOVEL
+  - "wooden_shovel"
+Items.WOODEN_PICKAXE:
+  - Items.WOODEN_PICKAXE
+  - "wooden_pickaxe"
+Items.WOODEN_AXE:
+  - Items.WOODEN_AXE
+  - "wooden_axe"
+Items.WOODEN_HOE:
+  - Items.WOODEN_HOE
+  - "wooden_hoe"
+Items.STONE_SWORD:
+  - Items.STONE_SWORD
+  - "stone_sword"
+Items.STONE_SHOVEL:
+  - Items.STONE_SHOVEL
+  - "stone_shovel"
+Items.STONE_PICKAXE:
+  - Items.STONE_PICKAXE
+  - "stone_pickaxe"
+Items.STONE_AXE:
+  - Items.STONE_AXE
+  - "stone_axe"
+Items.STONE_HOE:
+  - Items.STONE_HOE
+  - "stone_hoe"
+Items.IRON_SWORD:
+  - Items.IRON_SWORD
+  - "iron_sword"
+Items.IRON_SHOVEL:
+  - Items.IRON_SHOVEL
+  - "iron_shovel"
+Items.IRON_PICKAXE:
+  - Items.IRON_PICKAXE
+  - "iron_pickaxe"
+Items.IRON_AXE:
+  - Items.IRON_AXE
+  - "iron_axe"
+Items.IRON_HOE:
+  - Items.IRON_HOE
+  - "iron_hoe"
+Items.FLINT_AND_STEEL:
+  - Items.FLINT_AND_STEEL
+  - "flint_and_steel"
+Items.SHEARS:
+  - Items.SHEARS
+  - "shears"
+Items.GOLDEN_SWORD:
+  - Items.GOLDEN_SWORD
+  - "golden_sword"
+Items.GOLDEN_SHOVEL:
+  - Items.GOLDEN_SHOVEL
+  - "golden_shovel"
+Items.GOLDEN_PICKAXE:
+  - Items.GOLDEN_PICKAXE
+  - "golden_pickaxe"
+Items.GOLDEN_AXE:
+  - Items.GOLDEN_AXE
+  - "golden_axe"
+Items.GOLDEN_HOE:
+  - Items.GOLDEN_HOE
+  - "golden_hoe"
+Items.DIAMOND_SWORD:
+  - Items.DIAMOND_SWORD
+  - "diamond_sword"
+Items.DIAMOND_SHOVEL:
+  - Items.DIAMOND_SHOVEL
+  - "diamond_shovel"
+Items.DIAMOND_PICKAXE:
+  - Items.DIAMOND_PICKAXE
+  - "diamond_pickaxe"
+Items.DIAMOND_AXE:
+  - Items.DIAMOND_AXE
+  - "diamond_axe"
+Items.DIAMOND_HOE:
+  - Items.DIAMOND_HOE
+  - "diamond_hoe"
+Items.LEATHER_HELMET:
+  - Items.LEATHER_HELMET
+  - "leather_helmet"
+Items.LEATHER_CHESTPLATE:
+  - Items.LEATHER_CHESTPLATE
+  - "leather_chestplate"
+Items.LEATHER_LEGGINGS:
+  - Items.LEATHER_LEGGINGS
+  - "leather_leggings"
+Items.LEATHER_BOOTS:
+  - Items.LEATHER_BOOTS
+  - "leather_boots"
+Items.CHAINMAIL_HELMET:
+  - Items.CHAINMAIL_HELMET
+  - "chainmail_helmet"
+Items.CHAINMAIL_CHESTPLATE:
+  - Items.CHAINMAIL_CHESTPLATE
+  - "chainmail_chestplate"
+Items.CHAINMAIL_LEGGINGS:
+  - Items.CHAINMAIL_LEGGINGS
+  - "chainmail_leggings"
+Items.CHAINMAIL_BOOTS:
+  - Items.CHAINMAIL_BOOTS
+  - "chainmail_boots"
+Items.IRON_HELMET:
+  - Items.IRON_HELMET
+  - "iron_helmet"
+Items.IRON_CHESTPLATE:
+  - Items.IRON_CHESTPLATE
+  - "iron_chestplate"
+Items.IRON_LEGGINGS:
+  - Items.IRON_LEGGINGS
+  - "iron_leggings"
+Items.IRON_BOOTS:
+  - Items.IRON_BOOTS
+  - "iron_boots"
+Items.GOLDEN_HELMET:
+  - Items.GOLDEN_HELMET
+  - "golden_helmet"
+Items.GOLDEN_CHESTPLATE:
+  - Items.GOLDEN_CHESTPLATE
+  - "golden_chestplate"
+Items.GOLDEN_LEGGINGS:
+  - Items.GOLDEN_LEGGINGS
+  - "golden_leggings"
+Items.GOLDEN_BOOTS:
+  - Items.GOLDEN_BOOTS
+  - "golden_boots"
+Items.DIAMOND_HELMET:
+  - Items.DIAMOND_HELMET
+  - "diamond_helmet"
+Items.DIAMOND_CHESTPLATE:
+  - Items.DIAMOND_CHESTPLATE
+  - "diamond_chestplate"
+Items.DIAMOND_LEGGINGS:
+  - Items.DIAMOND_LEGGINGS
+  - "diamond_leggings"
+Items.DIAMOND_BOOTS:
+  - Items.DIAMOND_BOOTS
+  - "diamond_boots"
+Items.ELYTRA:
+  - Items.ELYTRA
+  - "elytra"
+Items.IRON_HORSE_ARMOR:
+  - Items.IRON_HORSE_ARMOR
+  - "iron_horse_armor"
+Items.GOLDEN_HORSE_ARMOR:
+  - Items.GOLDEN_HORSE_ARMOR
+  - "golden_horse_armor"
+Items.DIAMOND_HORSE_ARMOR:
+  - Items.DIAMOND_HORSE_ARMOR
+  - "diamond_horse_armor"
+Items.ARMOR_STAND:
+  - Items.ARMOR_STAND
+  - "armor_stand"
+Items.FLOWER_POT:
+  - Items.FLOWER_POT
+  - "flower_pot"
+Items.BANNER:
+  - Items.BLACK_BANNER
+  - "#minecraft:banners"
+Items.BANNER#0:
+  - Items.BLACK_BANNER
+  - "black_banner"
+Items.BANNER#1:
+  - Items.RED_BANNER
+  - "red_banner"
+Items.BANNER#2:
+  - Items.GREEN_BANNER
+  - "green_banner"
+Items.BANNER#3:
+  - Items.BROWN_BANNER
+  - "brown_banner"
+Items.BANNER#4:
+  - Items.BLUE_BANNER
+  - "blue_banner"
+Items.BANNER#5:
+  - Items.PURPLE_BANNER
+  - "purple_banner"
+Items.BANNER#6:
+  - Items.CYAN_BANNER
+  - "cyan_banner"
+Items.BANNER#7:
+  - Items.LIGHT_GRAY_BANNER
+  - "light_gray_banner"
+Items.BANNER#8:
+  - Items.GRAY_BANNER
+  - "gray_banner"
+Items.BANNER#9:
+  - Items.PINK_BANNER
+  - "pink_banner"
+Items.BANNER#10:
+  - Items.LIME_BANNER
+  - "lime_banner"
+Items.BANNER#11:
+  - Items.YELLOW_BANNER
+  - "yellow_banner"
+Items.BANNER#12:
+  - Items.LIGHT_BLUE_BANNER
+  - "light_blue_banner"
+Items.BANNER#13:
+  - Items.MAGENTA_BANNER
+  - "magenta_banner"
+Items.BANNER#14:
+  - Items.ORANGE_BANNER
+  - "orange_banner"
+Items.BANNER#15:
+  - Items.WHITE_BANNER
+  - "white_banner"
+Items.PAINTING:
+  - Items.PAINTING
+  - "painting"
+Items.ITEM_FRAME:
+  - Items.ITEM_FRAME
+  - "item_frame"
+Items.SIGN:
+  - Items.OAK_SIGN
+  - "oak_sign"
+Items.OAK_DOOR:
+  - Items.OAK_DOOR
+  - "oak_door"
+Items.SPRUCE_DOOR:
+  - Items.SPRUCE_DOOR
+  - "spruce_door"
+Items.BIRCH_DOOR:
+  - Items.BIRCH_DOOR
+  - "birch_door"
+Items.JUNGLE_DOOR:
+  - Items.JUNGLE_DOOR
+  - "jungle_door"
+Items.ACACIA_DOOR:
+  - Items.ACACIA_DOOR
+  - "acacia_door"
+Items.DARK_OAK_DOOR:
+  - Items.DARK_OAK_DOOR
+  - "dark_oak_door"
+Items.MANGROVE_DOOR:
+  - Items.MANGROVE_DOOR
+  - "mangrove_door"
+Items.CHERRY_DOOR:
+  - Items.CHERRY_DOOR
+  - "cherry_door"
+Items.BAMBOO_DOOR:
+  - Items.BAMBOO_DOOR
+  - "bamboo_door"
+Items.IRON_DOOR:
+  - Items.IRON_DOOR
+  - "iron_door"
+Blocks.COPPER_DOOR:
+  - Blocks.COPPER_DOOR
+  - "copper_door"
+Blocks.EXPOSED_COPPER_DOOR:
+  - Blocks.EXPOSED_COPPER_DOOR
+  - "exposed_copper_door"
+Blocks.OXIDIZED_COPPER_DOOR:
+  - Blocks.OXIDIZED_COPPER_DOOR
+  - "oxidized_copper_door"
+Blocks.WEATHERED_COPPER_DOOR:
+  - Blocks.WEATHERED_COPPER_DOOR
+  - "weathered_copper_door"
+Blocks.WAXED_COPPER_DOOR:
+  - Blocks.WAXED_COPPER_DOOR
+  - "waxed_copper_door"
+Blocks.WAXED_EXPOSED_COPPER_DOOR:
+  - Blocks.WAXED_EXPOSED_COPPER_DOOR
+  - "waxed_exposed_copper_door"
+Blocks.WAXED_OXIDIZED_COPPER_DOOR:
+  - Blocks.WAXED_OXIDIZED_COPPER_DOOR
+  - "waxed_oxidized_copper_door"
+Blocks.WAXED_WEATHERED_COPPER_DOOR:
+  - Blocks.WAXED_WEATHERED_COPPER_DOOR
+  - "waxed_weathered_copper_door"
+Items.CRIMSON_DOOR:
+  - Items.CRIMSON_DOOR
+  - "crimson_door"
+Items.WARPED_DOOR:
+  - Items.WARPED_DOOR
+  - "warped_door"
+Items.BUCKET:
+  - Items.BUCKET
+  - "bucket"
+Items.WATER_BUCKET:
+  - Items.WATER_BUCKET
+  - "water_bucket"
+Items.LAVA_BUCKET:
+  - Items.LAVA_BUCKET
+  - "lava_bucket"
+Items.MILK_BUCKET:
+  - Items.MILK_BUCKET
+  - "milk_bucket"
+Items.MINECART:
+  - Items.MINECART
+  - "minecart"
+Items.CHEST_MINECART:
+  - Items.CHEST_MINECART
+  - "chest_minecart"
+Items.FURNACE_MINECART:
+  - Items.FURNACE_MINECART
+  - "furnace_minecart"
+Items.HOPPER_MINECART:
+  - Items.HOPPER_MINECART
+  - "hopper_minecart"
+Items.TNT_MINECART:
+  - Items.TNT_MINECART
+  - "tnt_minecart"
+Items.COMMAND_BLOCK_MINECART:
+  - Items.COMMAND_BLOCK_MINECART
+  - "command_block_minecart"
+Items.BOAT:
+  - Items.OAK_BOAT
+  - "oak_boat"
+Items.SPRUCE_BOAT:
+  - Items.SPRUCE_BOAT
+  - "spruce_boat"
+Items.BIRCH_BOAT:
+  - Items.BIRCH_BOAT
+  - "birch_boat"
+Items.JUNGLE_BOAT:
+  - Items.JUNGLE_BOAT
+  - "jungle_boat"
+Items.ACACIA_BOAT:
+  - Items.ACACIA_BOAT
+  - "acacia_boat"
+Items.DARK_OAK_BOAT:
+  - Items.DARK_OAK_BOAT
+  - "dark_oak_boat"
+Items.MANGROVE_BOAT:
+  - Items.MANGROVE_BOAT
+  - "mangrove_boat"
+Items.CHERRY_BOAT:
+  - Items.CHERRY_BOAT
+  - "cherry_boat"
+Items.BAMBOO_RAFT:
+  - Items.BAMBOO_RAFT
+  - "bamboo_raft"
+Items.OAK_CHEST_BOAT:
+  - Items.OAK_CHEST_BOAT
+  - "oak_chest_boat"
+Items.SPRUCE_CHEST_BOAT:
+  - Items.SPRUCE_CHEST_BOAT
+  - "spruce_chest_boat"
+Items.BIRCH_CHEST_BOAT:
+  - Items.BIRCH_CHEST_BOAT
+  - "birch_chest_boat"
+Items.JUNGLE_CHEST_BOAT:
+  - Items.JUNGLE_CHEST_BOAT
+  - "jungle_chest_boat"
+Items.ACACIA_CHEST_BOAT:
+  - Items.ACACIA_CHEST_BOAT
+  - "acacia_chest_boat"
+Items.DARK_OAK_CHEST_BOAT:
+  - Items.DARK_OAK_CHEST_BOAT
+  - "dark_oak_chest_boat"
+Items.MANGROVE_CHEST_BOAT:
+  - Items.MANGROVE_CHEST_BOAT
+  - "mangrove_chest_boat"
+Items.CHERRY_CHEST_BOAT:
+  - Items.CHERRY_CHEST_BOAT
+  - "cherry_chest_boat"
+Items.BAMBOO_CHEST_RAFT:
+  - Items.BAMBOO_CHEST_RAFT
+  - "bamboo_chest_raft"
+Items.REPEATER:
+  - Items.REPEATER
+  - "repeater"
+Items.COMPARATOR:
+  - Items.COMPARATOR
+  - "comparator"
+Items.APPLE:
+  - Items.APPLE
+  - "apple"
+Items.GOLDEN_APPLE:
+  - Items.GOLDEN_APPLE
+  - "golden_apple"
+Items.GOLDEN_APPLE#0:
+  - Items.GOLDEN_APPLE
+  - "golden_apple"
+Items.GOLDEN_APPLE#1:
+  - Items.ENCHANTED_GOLDEN_APPLE
+  - "enchanted_golden_apple"
+Items.STICK:
+  - Items.STICK
+  - "stick"
+Items.BOWL:
+  - Items.BOWL
+  - "bowl"
+Items.MUSHROOM_STEW:
+  - Items.MUSHROOM_STEW
+  - "mushroom_stew"
+Items.STRING:
+  - Items.STRING
+  - "string"
+Items.FEATHER:
+  - Items.FEATHER
+  - "feather"
+Items.GUNPOWDER:
+  - Items.GUNPOWDER
+  - "gunpowder"
+Items.WHEAT_SEEDS:
+  - Items.WHEAT_SEEDS
+  - "wheat_seeds"
+Items.WHEAT:
+  - Items.WHEAT
+  - "wheat"
+Items.CARROT:
+  - Items.CARROT
+  - "carrot"
+Items.POTATO:
+  - Items.POTATO
+  - "potato"
+Items.BAKED_POTATO:
+  - Items.BAKED_POTATO
+  - "baked_potato"
+Items.POISONOUS_POTATO:
+  - Items.POISONOUS_POTATO
+  - "poisonous_potato"
+Items.PUMPKIN_PIE:
+  - Items.PUMPKIN_PIE
+  - "pumpkin_pie"
+Items.GOLDEN_CARROT:
+  - Items.GOLDEN_CARROT
+  - "golden_carrot"
+Items.BREAD:
+  - Items.BREAD
+  - "bread"
+Items.PUMPKIN_SEEDS:
+  - Items.PUMPKIN_SEEDS
+  - "pumpkin_seeds"
+Items.FLINT:
+  - Items.FLINT
+  - "flint"
+Items.LEATHER:
+  - Items.LEATHER
+  - "leather"
+Items.SADDLE:
+  - Items.SADDLE
+  - "saddle"
+Items.BRICK:
+  - Items.BRICK
+  - "brick"
+Items.NETHERBRICK:
+  - Items.NETHER_BRICK
+  - "nether_brick"
+Items.CLAY_BALL:
+  - Items.CLAY_BALL
+  - "clay_ball"
+Items.REEDS:
+  - Items.SUGAR_CANE
+  - "sugar_cane"
+Items.PAPER:
+  - Items.PAPER
+  - "paper"
+Items.SLIME_BALL:
+  - Items.SLIME_BALL
+  - "slime_ball"
+Items.EGG:
+  - Items.EGG
+  - "egg"
+Items.GLOWSTONE_DUST:
+  - Items.GLOWSTONE_DUST
+  - "glowstone_dust"
+Items.BONE:
+  - Items.BONE
+  - "bone"
+Items.SUGAR:
+  - Items.SUGAR
+  - "sugar"
+Items.CAKE:
+  - Items.CAKE
+  - "cake"
+Items.BED:
+  - Items.WHITE_BED
+  - "white_bed"
+Items.COOKIE:
+  - Items.COOKIE
+  - "cookie"
+Items.MELON:
+  - Items.MELON_SLICE
+  - "melon_slice"
+Items.MELON_SEEDS:
+  - Items.MELON_SEEDS
+  - "melon_seeds"
+Items.FISH#0:
+  - Items.COD
+  - "cod"
+Items.FISH#1:
+  - Items.SALMON
+  - "salmon"
+Items.FISH#2:
+  - Items.TROPICAL_FISH
+  - "tropical_fish"
+Items.FISH#3:
+  - Items.PUFFERFISH
+  - "pufferfish"
+Items.COOKED_FISH#0:
+  - Items.COOKED_COD
+  - "cooked_cod"
+Items.COOKED_FISH#1:
+  - Items.COOKED_SALMON
+  - "cooked_salmon"
+Items.PORKCHOP:
+  - Items.PORKCHOP
+  - "porkchop"
+Items.COOKED_PORKCHOP:
+  - Items.COOKED_PORKCHOP
+  - "cooked_porkchop"
+Items.BEEF:
+  - Items.BEEF
+  - "beef"
+Items.COOKED_BEEF:
+  - Items.COOKED_BEEF
+  - "cooked_beef"
+Items.CHICKEN:
+  - Items.CHICKEN
+  - "chicken"
+Items.COOKED_CHICKEN:
+  - Items.COOKED_CHICKEN
+  - "cooked_chicken"
+Items.RABBIT:
+  - Items.RABBIT
+  - "rabbit"
+Items.COOKED_RABBIT:
+  - Items.COOKED_RABBIT
+  - "cooked_rabbit"
+Items.RABBIT_FOOT:
+  - Items.RABBIT_FOOT
+  - "rabbit_foot"
+Items.RABBIT_HIDE:
+  - Items.RABBIT_HIDE
+  - "rabbit_hide"
+Items.RABBIT_STEW:
+  - Items.RABBIT_STEW
+  - "rabbit_stew"
+Items.MUTTON:
+  - Items.MUTTON
+  - "mutton"
+Items.COOKED_MUTTON:
+  - Items.COOKED_MUTTON
+  - "cooked_mutton"
+Items.ROTTEN_FLESH:
+  - Items.ROTTEN_FLESH
+  - "rotten_flesh"
+Items.ENDER_PEARL:
+  - Items.ENDER_PEARL
+  - "ender_pearl"
+Items.ENDER_EYE:
+  - Items.ENDER_EYE
+  - "ender_eye"
+Items.END_CRYSTAL:
+  - Items.END_CRYSTAL
+  - "end_crystal"
+Items.SHULKER_SHELL:
+  - Items.SHULKER_SHELL
+  - "shulker_shell"
+Items.CHORUS_FRUIT:
+  - Items.CHORUS_FRUIT
+  - "chorus_fruit"
+Items.CHORUS_FRUIT_POPPED:
+  - Items.POPPED_CHORUS_FRUIT
+  - "popped_chorus_fruit"
+Items.BEETROOT:
+  - Items.BEETROOT
+  - "beetroot"
+Items.BEETROOT_SEEDS:
+  - Items.BEETROOT_SEEDS
+  - "beetroot_seeds"
+Items.BEETROOT_SOUP:
+  - Items.BEETROOT_SOUP
+  - "beetroot_soup"
+Items.GHAST_TEAR:
+  - Items.GHAST_TEAR
+  - "ghast_tear"
+Items.NETHER_WART:
+  - Items.NETHER_WART
+  - "nether_wart"
+Items.GLASS_BOTTLE:
+  - Items.GLASS_BOTTLE
+  - "glass_bottle"
+Items.POTIONITEM:
+  - Items.POTION
+  - "potion"
+Items.SPLASH_POTION:
+  - Items.SPLASH_POTION
+  - "splash_potion"
+Items.LINGERING_POTION:
+  - Items.LINGERING_POTION
+  - "lingering_potion"
+Items.DRAGON_BREATH:
+  - Items.DRAGON_BREATH
+  - "dragon_breath"
+Items.SPIDER_EYE:
+  - Items.SPIDER_EYE
+  - "spider_eye"
+Items.FERMENTED_SPIDER_EYE:
+  - Items.FERMENTED_SPIDER_EYE
+  - "fermented_spider_eye"
+Items.BLAZE_ROD:
+  - Items.BLAZE_ROD
+  - "blaze_rod"
+Items.BLAZE_POWDER:
+  - Items.BLAZE_POWDER
+  - "blaze_powder"
+Items.MAGMA_CREAM:
+  - Items.MAGMA_CREAM
+  - "magma_cream"
+Items.BREWING_STAND:
+  - Items.BREWING_STAND
+  - "brewing_stand"
+Items.CAULDRON:
+  - Items.CAULDRON
+  - "cauldron"
+Items.SPECKLED_MELON:
+  - Items.GLISTERING_MELON_SLICE
+  - "glistering_melon_slice"
+Items.SPAWN_EGG:
+  - Items.CREEPER_SPAWN_EGG
+  - "#forge:eggs"
+Items.SPAWN_EGG#50:
+  - Items.CREEPER_SPAWN_EGG
+  - "creeper_spawn_egg"
+Items.SPAWN_EGG#51:
+  - Items.SKELETON_SPAWN_EGG
+  - "skeleton_spawn_egg"
+Items.SPAWN_EGG#52:
+  - Items.SPIDER_SPAWN_EGG
+  - "spider_spawn_egg"
+Items.SPAWN_EGG#54:
+  - Items.ZOMBIE_SPAWN_EGG
+  - "zombie_spawn_egg"
+Items.SPAWN_EGG#55:
+  - Items.SLIME_SPAWN_EGG
+  - "slime_spawn_egg"
+Items.SPAWN_EGG#56:
+  - Items.GHAST_SPAWN_EGG
+  - "ghast_spawn_egg"
+Items.SPAWN_EGG#57:
+  - Items.ZOMBIFIED_PIGLIN_SPAWN_EGG
+  - "zombified_piglin_spawn_egg"
+Items.SPAWN_EGG#58:
+  - Items.ENDERMAN_SPAWN_EGG
+  - "enderman_spawn_egg"
+Items.SPAWN_EGG#59:
+  - Items.CAVE_SPIDER_SPAWN_EGG
+  - "cave_spider_spawn_egg"
+Items.SPAWN_EGG#60:
+  - Items.SILVERFISH_SPAWN_EGG
+  - "silverfish_spawn_egg"
+Items.SPAWN_EGG#61:
+  - Items.BLAZE_SPAWN_EGG
+  - "blaze_spawn_egg"
+Items.SPAWN_EGG#62:
+  - Items.MAGMA_CUBE_SPAWN_EGG
+  - "magma_cube_spawn_egg"
+Items.SPAWN_EGG#65:
+  - Items.BAT_SPAWN_EGG
+  - "bat_spawn_egg"
+Items.SPAWN_EGG#66:
+  - Items.WITCH_SPAWN_EGG
+  - "witch_spawn_egg"
+Items.SPAWN_EGG#67:
+  - Items.ENDERMITE_SPAWN_EGG
+  - "endermite_spawn_egg"
+Items.SPAWN_EGG#68:
+  - Items.GUARDIAN_SPAWN_EGG
+  - "guardian_spawn_egg"
+Items.SPAWN_EGG#90:
+  - Items.PIG_SPAWN_EGG
+  - "pig_spawn_egg"
+Items.SPAWN_EGG#91:
+  - Items.SHEEP_SPAWN_EGG
+  - "sheep_spawn_egg"
+Items.SPAWN_EGG#92:
+  - Items.COW_SPAWN_EGG
+  - "cow_spawn_egg"
+Items.SPAWN_EGG#93:
+  - Items.CHICKEN_SPAWN_EGG
+  - "chicken_spawn_egg"
+Items.SPAWN_EGG#94:
+  - Items.SQUID_SPAWN_EGG
+  - "squid_spawn_egg"
+Items.SPAWN_EGG#95:
+  - Items.WOLF_SPAWN_EGG
+  - "wolf_spawn_egg"
+Items.SPAWN_EGG#96:
+  - Items.MOOSHROOM_SPAWN_EGG
+  - "mooshroom_spawn_egg"
+Items.SPAWN_EGG#98:
+  - Items.OCELOT_SPAWN_EGG
+  - "ocelot_spawn_egg"
+Items.SPAWN_EGG#100:
+  - Items.HORSE_SPAWN_EGG
+  - "horse_spawn_egg"
+Items.SPAWN_EGG#101:
+  - Items.RABBIT_SPAWN_EGG
+  - "rabbit_spawn_egg"
+Items.SPAWN_EGG#120:
+  - Items.VILLAGER_SPAWN_EGG
+  - "villager_spawn_egg"
+Items.EXPERIENCE_BOTTLE:
+  - Items.EXPERIENCE_BOTTLE
+  - "experience_bottle"
+Items.FIRE_CHARGE:
+  - Items.FIRE_CHARGE
+  - "fire_charge"
+Items.WIND_CHARGE:
+  - Items.WIND_CHARGE
+  - "wind_charge"
+Items.SNOWBALL:
+  - Items.SNOWBALL
+  - "snowball"
+Items.BOOK:
+  - Items.BOOK
+  - "book"
+Items.WRITABLE_BOOK:
+  - Items.WRITABLE_BOOK
+  - "writable_book"
+Items.WRITTEN_BOOK:
+  - Items.WRITTEN_BOOK
+  - "written_book"
+Items.MACE:
+  - Items.MACE
+  - "mace"
+Items.ENCHANTED_BOOK:
+  - Items.ENCHANTED_BOOK
+  - "enchanted_book"
+Items.KNOWLEDGE_BOOK:
+  - Items.KNOWLEDGE_BOOK
+  - "knowledge_book"
+Items.RECORD_13:
+  - Items.MUSIC_DISC_13
+  - "music_disc_13"
+Items.RECORD_CAT:
+  - Items.MUSIC_DISC_CAT
+  - "music_disc_cat"
+Items.RECORD_BLOCKS:
+  - Items.MUSIC_DISC_BLOCKS
+  - "music_disc_blocks"
+Items.RECORD_CREATOR:
+  - Items.MUSIC_DISC_CREATOR
+  - "music_disc_creator"
+Items.RECORD_CREATOR_MUSIC_BOX:
+  - Items.MUSIC_DISC_CREATOR_MUSIC_BOX
+  - "music_disc_creator_music_box"
+Items.RECORD_PRECIPICE:
+  - Items.MUSIC_DISC_PRECIPICE
+  - "music_disc_precipice"
+Items.RECORD_CHIRP:
+  - Items.MUSIC_DISC_CHIRP
+  - "music_disc_chirp"
+Items.RECORD_FAR:
+  - Items.MUSIC_DISC_FAR
+  - "music_disc_far"
+Items.RECORD_MALL:
+  - Items.MUSIC_DISC_MALL
+  - "music_disc_mall"
+Items.RECORD_MELLOHI:
+  - Items.MUSIC_DISC_MELLOHI
+  - "music_disc_mellohi"
+Items.RECORD_STAL:
+  - Items.MUSIC_DISC_STAL
+  - "music_disc_stal"
+Items.RECORD_STRAD:
+  - Items.MUSIC_DISC_STRAD
+  - "music_disc_strad"
+Items.RECORD_WARD:
+  - Items.MUSIC_DISC_WARD
+  - "music_disc_ward"
+Items.RECORD_11:
+  - Items.MUSIC_DISC_11
+  - "music_disc_11"
+Items.RECORD_WAIT:
+  - Items.MUSIC_DISC_WAIT
+  - "music_disc_wait"
+Items.MUSIC_DISC_PIGSTEP:
+  - Items.MUSIC_DISC_PIGSTEP
+  - "music_disc_pigstep"
+Items.MUSIC_DISC_OTHERSIDE:
+  - Items.MUSIC_DISC_OTHERSIDE
+  - "music_disc_otherside"
+Items.MUSIC_DISC_5:
+  - Items.MUSIC_DISC_5
+  - "music_disc_5"
+Items.MUSIC_DISC_RELIC:
+  - Items.MUSIC_DISC_RELIC
+  - "music_disc_relic"
+Items.DISC_FRAGMENT_5:
+  - Items.DISC_FRAGMENT_5
+  - "disc_fragment_5"
+Items.SKULL:
+  - Items.SKELETON_SKULL
+  - "#forge:heads"
+Items.SKULL#0:
+  - Items.SKELETON_SKULL
+  - "skeleton_skull"
+Items.SKULL#1:
+  - Items.WITHER_SKELETON_SKULL
+  - "wither_skeleton_skull"
+Items.SKULL#2:
+  - Items.PLAYER_HEAD
+  - "player_head"
+Items.SKULL#3:
+  - Items.ZOMBIE_HEAD
+  - "zombie_head"
+Items.SKULL#4:
+  - Items.CREEPER_HEAD
+  - "creeper_head"
+Items.SKULL#5:
+  - Items.DRAGON_HEAD
+  - "dragon_head"
+Items.PIGLIN_HEAD:
+  - Items.PIGLIN_HEAD
+  - "piglin_head"
+Items.FIREWORK_CHARGE:
+  - Items.FIREWORK_STAR
+  - "firework_star"
+Items.FIREWORKS:
+  - Items.FIREWORK_ROCKET
+  - "firework_rocket"
+Items.TURTLE_HELMET:
+  - Items.TURTLE_HELMET
+  - "turtle_helmet"
+Items.SCUTE:
+  - Items.TURTLE_SCUTE
+  - "turtle_scute"
+Items.SPRUCE_SIGN:
+  - Items.SPRUCE_SIGN
+  - "spruce_sign"
+Items.BIRCH_SIGN:
+  - Items.BIRCH_SIGN
+  - "birch_sign"
+Items.JUNGLE_SIGN:
+  - Items.JUNGLE_SIGN
+  - "jungle_sign"
+Items.ACACIA_SIGN:
+  - Items.ACACIA_SIGN
+  - "acacia_sign"
+Items.DARK_OAK_SIGN:
+  - Items.DARK_OAK_SIGN
+  - "dark_oak_sign"
+Items.MANGROVE_SIGN:
+  - Items.MANGROVE_SIGN
+  - "mangrove_sign"
+Items.CHERRY_SIGN:
+  - Items.CHERRY_SIGN
+  - "cherry_sign"
+Items.BAMBOO_SIGN:
+  - Items.BAMBOO_SIGN
+  - "bamboo_sign"
+Items.OAK_HANGING_SIGN:
+  - Items.OAK_HANGING_SIGN
+  - "oak_hanging_sign"
+Items.SPRUCE_HANGING_SIGN:
+  - Items.SPRUCE_HANGING_SIGN
+  - "spruce_hanging_sign"
+Items.BIRCH_HANGING_SIGN:
+  - Items.BIRCH_HANGING_SIGN
+  - "birch_hanging_sign"
+Items.JUNGLE_HANGING_SIGN:
+  - Items.JUNGLE_HANGING_SIGN
+  - "jungle_hanging_sign"
+Items.ACACIA_HANGING_SIGN:
+  - Items.ACACIA_HANGING_SIGN
+  - "acacia_hanging_sign"
+Items.DARK_OAK_HANGING_SIGN:
+  - Items.DARK_OAK_HANGING_SIGN
+  - "dark_oak_hanging_sign"
+Items.CRIMSON_HANGING_SIGN:
+  - Items.CRIMSON_HANGING_SIGN
+  - "crimson_hanging_sign"
+Items.WARPED_HANGING_SIGN:
+  - Items.WARPED_HANGING_SIGN
+  - "warped_hanging_sign"
+Items.MANGROVE_HANGING_SIGN:
+  - Items.MANGROVE_HANGING_SIGN
+  - "mangrove_hanging_sign"
+Items.CHERRY_HANGING_SIGN:
+  - Items.CHERRY_HANGING_SIGN
+  - "cherry_hanging_sign"
+Items.BAMBOO_HANGING_SIGN:
+  - Items.BAMBOO_HANGING_SIGN
+  - "bamboo_hanging_sign"
+Items.PUFFERFISH_BUCKET:
+  - Items.PUFFERFISH_BUCKET
+  - "pufferfish_bucket"
+Items.SALMON_BUCKET:
+  - Items.SALMON_BUCKET
+  - "salmon_bucket"
+Items.COD_BUCKET:
+  - Items.COD_BUCKET
+  - "cod_bucket"
+Items.TROPICAL_FISH_BUCKET:
+  - Items.TROPICAL_FISH_BUCKET
+  - "tropical_fish_bucket"
+Items.TADPOLE_BUCKET:
+  - Items.TADPOLE_BUCKET
+  - "tadpole_bucket"
+Items.DRIED_KELP:
+  - Items.DRIED_KELP
+  - "dried_kelp"
+Items.CAT_SPAWN_EGG:
+  - Items.CAT_SPAWN_EGG
+  - "cat_spawn_egg"
+Items.COD_SPAWN_EGG:
+  - Items.COD_SPAWN_EGG
+  - "cod_spawn_egg"
+Items.BOGGED_SPAWN_EGG:
+  - Items.BOGGED_SPAWN_EGG
+  - "bogged_spawn_egg"
+Items.BREEZE_SPAWN_EGG:
+  - Items.BREEZE_SPAWN_EGG
+  - "breeze_spawn_egg"
+Items.DOLPHIN_SPAWN_EGG:
+  - Items.DOLPHIN_SPAWN_EGG
+  - "dolphin_spawn_egg"
+Items.DONKEY_SPAWN_EGG:
+  - Items.DONKEY_SPAWN_EGG
+  - "donkey_spawn_egg"
+Items.DROWNED_SPAWN_EGG:
+  - Items.DROWNED_SPAWN_EGG
+  - "drowned_spawn_egg"
+Items.ELDER_GUARDIAN_SPAWN_EGG:
+  - Items.ELDER_GUARDIAN_SPAWN_EGG
+  - "elder_guardian_spawn_egg"
+Items.EVOKER_SPAWN_EGG:
+  - Items.EVOKER_SPAWN_EGG
+  - "evoker_spawn_egg"
+Items.FOX_SPAWN_EGG:
+  - Items.FOX_SPAWN_EGG
+  - "fox_spawn_egg"
+Items.HUSK_SPAWN_EGG:
+  - Items.HUSK_SPAWN_EGG
+  - "husk_spawn_egg"
+Items.LLAMA_SPAWN_EGG:
+  - Items.LLAMA_SPAWN_EGG
+  - "llama_spawn_egg"
+Items.MULE_SPAWN_EGG:
+  - Items.MULE_SPAWN_EGG
+  - "mule_spawn_egg"
+Items.PANDA_SPAWN_EGG:
+  - Items.PANDA_SPAWN_EGG
+  - "panda_spawn_egg"
+Items.PARROT_SPAWN_EGG:
+  - Items.PARROT_SPAWN_EGG
+  - "parrot_spawn_egg"
+Items.PHANTOM_SPAWN_EGG:
+  - Items.PHANTOM_SPAWN_EGG
+  - "phantom_spawn_egg"
+Items.PILLAGER_SPAWN_EGG:
+  - Items.PILLAGER_SPAWN_EGG
+  - "pillager_spawn_egg"
+Items.POLAR_BEAR_SPAWN_EGG:
+  - Items.POLAR_BEAR_SPAWN_EGG
+  - "polar_bear_spawn_egg"
+Items.PUFFERFISH_SPAWN_EGG:
+  - Items.PUFFERFISH_SPAWN_EGG
+  - "pufferfish_spawn_egg"
+Items.RAVAGER_SPAWN_EGG:
+  - Items.RAVAGER_SPAWN_EGG
+  - "ravager_spawn_egg"
+Items.SALMON_SPAWN_EGG:
+  - Items.SALMON_SPAWN_EGG
+  - "salmon_spawn_egg"
+Items.SHULKER_SPAWN_EGG:
+  - Items.SHULKER_SPAWN_EGG
+  - "shulker_spawn_egg"
+Items.SKELETON_HORSE_SPAWN_EGG:
+  - Items.SKELETON_HORSE_SPAWN_EGG
+  - "skeleton_horse_spawn_egg"
+Items.STRAY_SPAWN_EGG:
+  - Items.STRAY_SPAWN_EGG
+  - "stray_spawn_egg"
+Items.TRADER_LLAMA_SPAWN_EGG:
+  - Items.TRADER_LLAMA_SPAWN_EGG
+  - "trader_llama_spawn_egg"
+Items.TROPICAL_FISH_SPAWN_EGG:
+  - Items.TROPICAL_FISH_SPAWN_EGG
+  - "tropical_fish_spawn_egg"
+Items.TURTLE_SPAWN_EGG:
+  - Items.TURTLE_SPAWN_EGG
+  - "turtle_spawn_egg"
+Items.VEX_SPAWN_EGG:
+  - Items.VEX_SPAWN_EGG
+  - "vex_spawn_egg"
+Items.VINDICATOR_SPAWN_EGG:
+  - Items.VINDICATOR_SPAWN_EGG
+  - "vindicator_spawn_egg"
+Items.WANDERING_TRADER_SPAWN_EGG:
+  - Items.WANDERING_TRADER_SPAWN_EGG
+  - "wandering_trader_spawn_egg"
+Items.WITHER_SKELETON_SPAWN_EGG:
+  - Items.WITHER_SKELETON_SPAWN_EGG
+  - "wither_skeleton_spawn_egg"
+Items.ZOMBIE_HORSE_SPAWN_EGG:
+  - Items.ZOMBIE_HORSE_SPAWN_EGG
+  - "zombie_horse_spawn_egg"
+Items.ZOMBIE_VILLAGER_SPAWN_EGG:
+  - Items.ZOMBIE_VILLAGER_SPAWN_EGG
+  - "zombie_villager_spawn_egg"
+Items.LEATHER_HORSE_ARMOR:
+  - Items.LEATHER_HORSE_ARMOR
+  - "leather_horse_armor"
+Items.DEBUG_STICK:
+  - Items.DEBUG_STICK
+  - "debug_stick"
+Items.TRIDENT:
+  - Items.TRIDENT
+  - "trident"
+Items.PHANTOM_MEMBRANE:
+  - Items.PHANTOM_MEMBRANE
+  - "phantom_membrane"
+Items.NAUTILUS_SHELL:
+  - Items.NAUTILUS_SHELL
+  - "nautilus_shell"
+Items.HEART_OF_THE_SEA:
+  - Items.HEART_OF_THE_SEA
+  - "heart_of_the_sea"
+Items.CROSSBOW:
+  - Items.CROSSBOW
+  - "crossbow"
+Items.SUSPICIOUS_STEW:
+  - Items.SUSPICIOUS_STEW
+  - "suspicious_stew"
+Items.FLOWER_BANNER_PATTERN:
+  - Items.FLOWER_BANNER_PATTERN
+  - "flower_banner_pattern"
+Items.CREEPER_BANNER_PATTERN:
+  - Items.CREEPER_BANNER_PATTERN
+  - "creeper_banner_pattern"
+Items.SKULL_BANNER_PATTERN:
+  - Items.SKULL_BANNER_PATTERN
+  - "skull_banner_pattern"
+Items.THING_BANNER_PATTERN:
+  - Items.MOJANG_BANNER_PATTERN
+  - "mojang_banner_pattern"
+Items.GLOBE_BANNER_PATTERN:
+  - Items.GLOBE_BANNER_PATTERN
+  - "globe_banner_pattern"
+Items.SWEET_BERRIES:
+  - Items.SWEET_BERRIES
+  - "sweet_berries"
+Items.BEE_SPAWN_EGG:
+  - Items.BEE_SPAWN_EGG
+  - "bee_spawn_egg"
+Items.HONEYCOMB:
+  - Items.HONEYCOMB
+  - "honeycomb"
+Items.HONEY_BOTTLE:
+  - Items.HONEY_BOTTLE
+  - "honey_bottle"
+Items.TORCH:
+  - Items.TORCH
+  - "torch"
+Items.REDSTONE_TORCH:
+  - Items.REDSTONE_TORCH
+  - "redstone_torch"
+Items.SOUL_TORCH:
+  - Items.SOUL_TORCH
+  - "soul_torch"
+Items.NETHERITE_INGOT:
+  - Items.NETHERITE_INGOT
+  - "netherite_ingot"
+Items.NETHERITE_SCRAP:
+  - Items.NETHERITE_SCRAP
+  - "netherite_scrap"
+Items.NETHERITE_SWORD:
+  - Items.NETHERITE_SWORD
+  - "netherite_sword"
+Items.NETHERITE_SHOVEL:
+  - Items.NETHERITE_SHOVEL
+  - "netherite_shovel"
+Items.NETHERITE_PICKAXE:
+  - Items.NETHERITE_PICKAXE
+  - "netherite_pickaxe"
+Items.NETHERITE_AXE:
+  - Items.NETHERITE_AXE
+  - "netherite_axe"
+Items.NETHERITE_HOE:
+  - Items.NETHERITE_HOE
+  - "netherite_hoe"
+Items.NETHERITE_HELMET:
+  - Items.NETHERITE_HELMET
+  - "netherite_helmet"
+Items.NETHERITE_CHESTPLATE:
+  - Items.NETHERITE_CHESTPLATE
+  - "netherite_chestplate"
+Items.NETHERITE_LEGGINGS:
+  - Items.NETHERITE_LEGGINGS
+  - "netherite_leggings"
+Items.NETHERITE_BOOTS:
+  - Items.NETHERITE_BOOTS
+  - "netherite_boots"
+Items.CRIMSON_SIGN:
+  - Items.CRIMSON_SIGN
+  - "crimson_sign"
+Items.WARPED_SIGN:
+  - Items.WARPED_SIGN
+  - "warped_sign"
+Items.HOGLIN_SPAWN_EGG:
+  - Items.HOGLIN_SPAWN_EGG
+  - "hoglin_spawn_egg"
+Items.PIGLIN_SPAWN_EGG:
+  - Items.PIGLIN_SPAWN_EGG
+  - "piglin_spawn_egg"
+Items.PIGLIN_BRUTE_SPAWN_EGG:
+  - Items.PIGLIN_BRUTE_SPAWN_EGG
+  - "piglin_brute_spawn_egg"
+Items.STRIDER_SPAWN_EGG:
+  - Items.STRIDER_SPAWN_EGG
+  - "strider_spawn_egg"
+Items.ZOGLIN_SPAWN_EGG:
+  - Items.ZOGLIN_SPAWN_EGG
+  - "zoglin_spawn_egg"
+Items.WARPED_FUNGUS_ON_A_STICK:
+  - Items.WARPED_FUNGUS_ON_A_STICK
+  - "warped_fungus_on_a_stick"
+Items.PIGLIN_BANNER_PATTERN:
+  - Items.PIGLIN_BANNER_PATTERN
+  - "piglin_banner_pattern"
+Items.FLOW_BANNER_PATTERN:
+  - Items.FLOW_BANNER_PATTERN
+  - "flow_banner_pattern"
+Items.GUSTER_BANNER_PATTERN:
+  - Items.GUSTER_BANNER_PATTERN
+  - "guster_banner_pattern"
+Items.AXOLOTL_SPAWN_EGG:
+  - Items.AXOLOTL_SPAWN_EGG
+  - "axolotl_spawn_egg"
+Items.GLOW_SQUID_SPAWN_EGG:
+  - Items.GLOW_SQUID_SPAWN_EGG
+  - "glow_squid_spawn_egg"
+Items.GOAT_SPAWN_EGG:
+  - Items.GOAT_SPAWN_EGG
+  - "goat_spawn_egg"
+Items.ALLAY_SPAWN_EGG:
+  - Items.ALLAY_SPAWN_EGG
+  - "allay_spawn_egg"
+Items.FROG_SPAWN_EGG:
+  - Items.FROG_SPAWN_EGG
+  - "frog_spawn_egg"
+Items.TADPOLE_SPAWN_EGG:
+  - Items.TADPOLE_SPAWN_EGG
+  - "tadpole_spawn_egg"
+Items.WARDEN_SPAWN_EGG:
+  - Items.WARDEN_SPAWN_EGG
+  - "warden_spawn_egg"
+Items.AXOLOTL_BUCKET:
+  - Items.AXOLOTL_BUCKET
+  - "axolotl_bucket"
+Items.POWDER_SNOW_BUCKET:
+  - Items.POWDER_SNOW_BUCKET
+  - "powder_snow_bucket"
+Items.GLOW_BERRIES:
+  - Items.GLOW_BERRIES
+  - "glow_berries"
+Items.GLOW_INK_SAC:
+  - Items.GLOW_INK_SAC
+  - "glow_ink_sac"
+Items.GLOW_ITEM_FRAME:
+  - Items.GLOW_ITEM_FRAME
+  - "glow_item_frame"
+Items.AMETHYST_SHARD:
+  - Items.AMETHYST_SHARD
+  - "amethyst_shard"
+Items.BUNDLE:
+  - Items.BUNDLE
+  - "bundle"
+Items.RAW_IRON:
+  - Items.RAW_IRON
+  - "raw_iron"
+Items.RAW_GOLD:
+  - Items.RAW_GOLD
+  - "raw_gold"
+Items.RAW_COPPER:
+  - Items.RAW_COPPER
+  - "raw_copper"
+Items.SPYGLASS:
+  - Items.SPYGLASS
+  - "spyglass"
+Items.GOAT_HORN:
+  - Items.GOAT_HORN
+  - "goat_horn"
+Items.ECHO_SHARD:
+  - Items.ECHO_SHARD
+  - "echo_shard"
+Items.IRON_GOLEM_SPAWN_EGG:
+  - Items.IRON_GOLEM_SPAWN_EGG
+  - "iron_golem_spawn_egg"
+Items.SNOW_GOLEM_SPAWN_EGG:
+  - Items.SNOW_GOLEM_SPAWN_EGG
+  - "snow_golem_spawn_egg"
+Items.WITHER_SPAWN_EGG:
+  - Items.WITHER_SPAWN_EGG
+  - "wither_spawn_egg"
+Items.ENDER_DRAGON_SPAWN_EGG:
+  - Items.ENDER_DRAGON_SPAWN_EGG
+  - "ender_dragon_spawn_egg"
+Items.BRUSH:
+  - Items.BRUSH
+  - "brush"
+Items.TORCHFLOWER_SEEDS:
+  - Items.TORCHFLOWER_SEEDS
+  - "torchflower_seeds"
+Items.PITCHER_POD:
+  - Items.PITCHER_POD
+  - "pitcher_pod"
+Items.CAMEL_SPAWN_EGG:
+  - Items.CAMEL_SPAWN_EGG
+  - "camel_spawn_egg"
+Items.SNIFFER_SPAWN_EGG:
+  - Items.SNIFFER_SPAWN_EGG
+  - "sniffer_spawn_egg"
+Items.NETHERITE_UPGRADE:
+  - Items.NETHERITE_UPGRADE_SMITHING_TEMPLATE
+  - "netherite_upgrade_smithing_template"
+Items.SENTRY_ARMOR_TRIM:
+  - Items.SENTRY_ARMOR_TRIM_SMITHING_TEMPLATE
+  - "sentry_armor_trim_smithing_template"
+Items.DUNE_ARMOR_TRIM:
+  - Items.DUNE_ARMOR_TRIM_SMITHING_TEMPLATE
+  - "dune_armor_trim_smithing_template"
+Items.COAST_ARMOR_TRIM:
+  - Items.COAST_ARMOR_TRIM_SMITHING_TEMPLATE
+  - "coast_armor_trim_smithing_template"
+Items.WILD_ARMOR_TRIM:
+  - Items.WILD_ARMOR_TRIM_SMITHING_TEMPLATE
+  - "wild_armor_trim_smithing_template"
+Items.WARD_ARMOR_TRIM:
+  - Items.WARD_ARMOR_TRIM_SMITHING_TEMPLATE
+  - "ward_armor_trim_smithing_template"
+Items.EYE_ARMOR_TRIM:
+  - Items.EYE_ARMOR_TRIM_SMITHING_TEMPLATE
+  - "eye_armor_trim_smithing_template"
+Items.VEX_ARMOR_TRIM:
+  - Items.VEX_ARMOR_TRIM_SMITHING_TEMPLATE
+  - "vex_armor_trim_smithing_template"
+Items.TIDE_ARMOR_TRIM:
+  - Items.TIDE_ARMOR_TRIM_SMITHING_TEMPLATE
+  - "tide_armor_trim_smithing_template"
+Items.SNOUT_ARMOR_TRIM:
+  - Items.SNOUT_ARMOR_TRIM_SMITHING_TEMPLATE
+  - "snout_armor_trim_smithing_template"
+Items.RIB_ARMOR_TRIM:
+  - Items.RIB_ARMOR_TRIM_SMITHING_TEMPLATE
+  - "rib_armor_trim_smithing_template"
+Items.SPIRE_ARMOR_TRIM:
+  - Items.SPIRE_ARMOR_TRIM_SMITHING_TEMPLATE
+  - "spire_armor_trim_smithing_template"
+Items.WAYFINDER_ARMOR_TRIM:
+  - Items.WAYFINDER_ARMOR_TRIM_SMITHING_TEMPLATE
+  - "wayfinder_armor_trim_smithing_template"
+Items.SHAPER_ARMOR_TRIM:
+  - Items.SHAPER_ARMOR_TRIM_SMITHING_TEMPLATE
+  - "shaper_armor_trim_smithing_template"
+Items.SILENCE_ARMOR_TRIM:
+  - Items.SILENCE_ARMOR_TRIM_SMITHING_TEMPLATE
+  - "silence_armor_trim_smithing_template"
+Items.RAISER_ARMOR_TRIM:
+  - Items.RAISER_ARMOR_TRIM_SMITHING_TEMPLATE
+  - "raiser_armor_trim_smithing_template"
+Items.HOST_ARMOR_TRIM:
+  - Items.HOST_ARMOR_TRIM_SMITHING_TEMPLATE
+  - "host_armor_trim_smithing_template"
+Items.FLOW_ARMOR_TRIM:
+  - Items.FLOW_ARMOR_TRIM_SMITHING_TEMPLATE
+  - "flow_armor_trim_smithing_template"
+Items.BOLT_ARMOR_TRIM:
+  - Items.BOLT_ARMOR_TRIM_SMITHING_TEMPLATE
+  - "bolt_armor_trim_smithing_template"
+Items.ANGLER_POTTERY_SHERD:
+  - Items.ANGLER_POTTERY_SHERD
+  - "angler_pottery_sherd"
+Items.ARCHER_POTTERY_SHERD:
+  - Items.ARCHER_POTTERY_SHERD
+  - "archer_pottery_sherd"
+Items.ARMS_UP_POTTERY_SHERD:
+  - Items.ARMS_UP_POTTERY_SHERD
+  - "arms_up_pottery_sherd"
+Items.BLADE_POTTERY_SHERD:
+  - Items.BLADE_POTTERY_SHERD
+  - "blade_pottery_sherd"
+Items.BREWER_POTTERY_SHERD:
+  - Items.BREWER_POTTERY_SHERD
+  - "brewer_pottery_sherd"
+Items.BURN_POTTERY_SHERD:
+  - Items.BURN_POTTERY_SHERD
+  - "burn_pottery_sherd"
+Items.DANGER_POTTERY_SHERD:
+  - Items.DANGER_POTTERY_SHERD
+  - "danger_pottery_sherd"
+Items.EXPLORER_POTTERY_SHERD:
+  - Items.EXPLORER_POTTERY_SHERD
+  - "explorer_pottery_sherd"
+Items.FLOW_POTTERY_SHERD:
+  - Items.FLOW_POTTERY_SHERD
+  - "flow_pottery_sherd"
+Items.GUSTER_POTTERY_SHERD:
+  - Items.GUSTER_POTTERY_SHERD
+  - "guster_pottery_sherd"
+Items.SCRAPE_POTTERY_SHERD:
+  - Items.SCRAPE_POTTERY_SHERD
+  - "scrape_pottery_sherd"
+Items.FRIEND_POTTERY_SHERD:
+  - Items.FRIEND_POTTERY_SHERD
+  - "friend_pottery_sherd"
+Items.HEART_POTTERY_SHERD:
+  - Items.HEART_POTTERY_SHERD
+  - "heart_pottery_sherd"
+Items.HEARTBREAK_POTTERY_SHERD:
+  - Items.HEARTBREAK_POTTERY_SHERD
+  - "heartbreak_pottery_sherd"
+Items.HOWL_POTTERY_SHERD:
+  - Items.HOWL_POTTERY_SHERD
+  - "howl_pottery_sherd"
+Items.MINER_POTTERY_SHERD:
+  - Items.MINER_POTTERY_SHERD
+  - "miner_pottery_sherd"
+Items.MOURNER_POTTERY_SHERD:
+  - Items.MOURNER_POTTERY_SHERD
+  - "mourner_pottery_sherd"
+Items.PLENTY_POTTERY_SHERD:
+  - Items.PLENTY_POTTERY_SHERD
+  - "plenty_pottery_sherd"
+Items.PRIZE_POTTERY_SHERD:
+  - Items.PRIZE_POTTERY_SHERD
+  - "prize_pottery_sherd"
+Items.SHEAF_POTTERY_SHERD:
+  - Items.SHEAF_POTTERY_SHERD
+  - "sheaf_pottery_sherd"
+Items.SHELTER_POTTERY_SHERD:
+  - Items.SHELTER_POTTERY_SHERD
+  - "shelter_pottery_sherd"
+Items.SKULL_POTTERY_SHERD:
+  - Items.SKULL_POTTERY_SHERD
+  - "skull_pottery_sherd"
+Items.SNORT_POTTERY_SHERD:
+  - Items.SNORT_POTTERY_SHERD
+  - "snort_pottery_sherd"
+Items.ARMADILLO_SCUTE:
+  - Items.ARMADILLO_SCUTE
+  - "armadillo_scute"
+Items.ARMADILLO_SPAWN_EGG:
+  - Items.ARMADILLO_SPAWN_EGG
+  - "armadillo_spawn_egg"
+Items.WOLF_ARMOR:
+  - Items.WOLF_ARMOR
+  - "wolf_armor"
+Items.TRIAL_KEY:
+  - Items.TRIAL_KEY
+  - "trial_key"
+Items.OMINOUS_TRIAL_KEY:
+  - Items.OMINOUS_TRIAL_KEY
+  - "ominous_trial_key"
+Items.OMINOUS_BOTTLE:
+  - Items.OMINOUS_BOTTLE
+  - "ominous_bottle"
+Items.BREEZE_ROD:
+  - Items.BREEZE_ROD
+  - "breeze_rod"

--- a/plugins/generator-1.21.4/datapack-1.21.4/mappings/blocksitems.yaml
+++ b/plugins/generator-1.21.4/datapack-1.21.4/mappings/blocksitems.yaml
@@ -4491,6 +4491,12 @@ Items.THING_BANNER_PATTERN:
 Items.GLOBE_BANNER_PATTERN:
   - Items.GLOBE_BANNER_PATTERN
   - "globe_banner_pattern"
+Items.FIELD_MASONED_BANNER_PATTERN:
+  - Items.FIELD_MASONED_BANNER_PATTERN
+  - "field_masoned_banner_pattern"
+Items.BORDURE_INDENTED_BANNER_PATTERN:
+  - Items.BORDURE_INDENTED_BANNER_PATTERN
+  - "bordure_indented_banner_pattern"
 Items.SWEET_BERRIES:
   - Items.SWEET_BERRIES
   - "sweet_berries"
@@ -4620,6 +4626,54 @@ Items.AMETHYST_SHARD:
 Items.BUNDLE:
   - Items.BUNDLE
   - "bundle"
+Items.WHITE_BUNDLE:
+  - Items.WHITE_BUNDLE
+  - "white_bundle"
+Items.ORANGE_BUNDLE:
+  - Items.ORANGE_BUNDLE
+  - "orange_bundle"
+Items.MAGENTA_BUNDLE:
+  - Items.MAGENTA_BUNDLE
+  - "magenta_bundle"
+Items.LIGHT_BLUE_BUNDLE:
+  - Items.LIGHT_BLUE_BUNDLE
+  - "light_blue_bundle"
+Items.YELLOW_BUNDLE:
+  - Items.YELLOW_BUNDLE
+  - "yellow_bundle"
+Items.LIME_BUNDLE:
+  - Items.LIME_BUNDLE
+  - "lime_bundle"
+Items.PINK_BUNDLE:
+  - Items.PINK_BUNDLE
+  - "pink_bundle"
+Items.GRAY_BUNDLE:
+  - Items.GRAY_BUNDLE
+  - "gray_bundle"
+Items.LIGHT_GRAY_BUNDLE:
+  - Items.LIGHT_GRAY_BUNDLE
+  - "light_gray_bundle"
+Items.CYAN_BUNDLE:
+  - Items.CYAN_BUNDLE
+  - "cyan_bundle"
+Items.PURPLE_BUNDLE:
+  - Items.PURPLE_BUNDLE
+  - "purple_bundle"
+Items.BLUE_BUNDLE:
+  - Items.BLUE_BUNDLE
+  - "blue_bundle"
+Items.BROWN_BUNDLE:
+  - Items.BROWN_BUNDLE
+  - "brown_bundle"
+Items.GREEN_BUNDLE:
+  - Items.GREEN_BUNDLE
+  - "green_bundle"
+Items.RED_BUNDLE:
+  - Items.RED_BUNDLE
+  - "red_bundle"
+Items.BLACK_BUNDLE:
+  - Items.BLACK_BUNDLE
+  - "black_bundle"
 Items.RAW_IRON:
   - Items.RAW_IRON
   - "raw_iron"

--- a/plugins/generator-1.21.4/datapack-1.21.4/mappings/blocksitems.yaml
+++ b/plugins/generator-1.21.4/datapack-1.21.4/mappings/blocksitems.yaml
@@ -79,6 +79,9 @@ Blocks.PLANKS#4:
 Blocks.PLANKS#5:
   - Blocks.DARK_OAK_PLANKS
   - "dark_oak_planks"
+Blocks.PALE_OAK_PLANKS:
+  - Blocks.PALE_OAK_PLANKS
+  - "pale_oak_planks"
 Blocks.MANGROVE_PLANKS:
   - Blocks.MANGROVE_PLANKS
   - "mangrove_planks"
@@ -112,6 +115,9 @@ Blocks.SAPLING#4:
 Blocks.SAPLING#5:
   - Blocks.DARK_OAK_SAPLING
   - "dark_oak_sapling"
+Blocks.PALE_OAK_SAPLING:
+  - Blocks.PALE_OAK_SAPLING
+  - "pale_oak_sapling"
 Blocks.MANGROVE_PROPAGULE:
   - Blocks.MANGROVE_PROPAGULE
   - "mangrove_propagule"
@@ -277,6 +283,9 @@ Blocks.LOG2#0:
 Blocks.LOG2#1:
   - Blocks.DARK_OAK_LOG
   - "dark_oak_log"
+Blocks.PALE_OAK_LOG:
+  - Blocks.PALE_OAK_LOG
+  - "pale_oak_log"
 Blocks.MANGROVE_LOG:
   - Blocks.MANGROVE_LOG
   - "mangrove_log"
@@ -310,6 +319,9 @@ Blocks.LEAVES2#0:
 Blocks.LEAVES2#1:
   - Blocks.DARK_OAK_LEAVES
   - "dark_oak_leaves"
+Blocks.PALE_OAK_LEAVES:
+  - Blocks.PALE_OAK_LEAVES
+  - "pale_oak_leaves"
 Blocks.AZALEA_LEAVES:
   - Blocks.AZALEA_LEAVES
   - "azalea_leaves"
@@ -445,6 +457,12 @@ Blocks.RED_FLOWER#8:
 Blocks.TORCHFLOWER:
   - Blocks.TORCHFLOWER
   - "torchflower"
+Blocks.OPEN_EYEBLOSSOM:
+  - Blocks.OPEN_EYEBLOSSOM
+  - "open_eyeblossom"
+Blocks.CLOSED_EYEBLOSSOM:
+  - Blocks.CLOSED_EYEBLOSSOM
+  - "closed_eyeblossom"
 Blocks.PINK_PETALS:
   - Blocks.PINK_PETALS
   - "pink_petals"
@@ -505,6 +523,9 @@ Blocks.FIRE:
 Blocks.MOB_SPAWNER:
   - Blocks.SPAWNER
   - "spawner"
+Blocks.CREAKING_HEART:
+  - Blocks.CREAKING_HEART
+  - "creaking_heart"
 Blocks.OAK_STAIRS:
   - Blocks.OAK_STAIRS
   - "oak_stairs"
@@ -523,6 +544,9 @@ Blocks.ACACIA_STAIRS:
 Blocks.DARK_OAK_STAIRS:
   - Blocks.DARK_OAK_STAIRS
   - "dark_oak_stairs"
+Blocks.PALE_OAK_STAIRS:
+  - Blocks.PALE_OAK_STAIRS
+  - "pale_oak_stairs"
 Blocks.MANGROVE_STAIRS:
   - Blocks.MANGROVE_STAIRS
   - "mangrove_stairs"
@@ -604,6 +628,9 @@ Blocks.ACACIA_DOOR:
 Blocks.DARK_OAK_DOOR:
   - Blocks.DARK_OAK_DOOR
   - "dark_oak_door"
+Blocks.PALE_OAK_DOOR:
+  - Blocks.PALE_OAK_DOOR
+  - "pale_oak_door"
 Blocks.MANGROVE_DOOR:
   - Blocks.MANGROVE_DOOR
   - "mangrove_door"
@@ -820,6 +847,9 @@ Blocks.ACACIA_FENCE:
 Blocks.DARK_OAK_FENCE:
   - Blocks.DARK_OAK_FENCE
   - "dark_oak_fence"
+Blocks.PALE_OAK_FENCE:
+  - Blocks.PALE_OAK_FENCE
+  - "pale_oak_fence"
 Blocks.MANGROVE_FENCE:
   - Blocks.MANGROVE_FENCE
   - "mangrove_fence"
@@ -847,6 +877,9 @@ Blocks.ACACIA_FENCE_GATE:
 Blocks.DARK_OAK_FENCE_GATE:
   - Blocks.DARK_OAK_FENCE_GATE
   - "dark_oak_fence_gate"
+Blocks.PALE_OAK_FENCE_GATE:
+  - Blocks.PALE_OAK_FENCE_GATE
+  - "pale_oak_fence_gate"
 Blocks.MANGROVE_FENCE_GATE:
   - Blocks.MANGROVE_FENCE_GATE
   - "mangrove_fence_gate"
@@ -928,6 +961,27 @@ Blocks.GLOW_LICHEN:
 Blocks.WATERLILY:
   - Blocks.LILY_PAD
   - "lily_pad"
+Blocks.RESIN_CLUMP:
+  - Blocks.RESIN_CLUMP
+  - "resin_clump"
+Blocks.RESIN_BLOCK:
+  - Blocks.RESIN_BLOCK
+  - "resin_block"
+Blocks.RESIN_BRICKS:
+  - Blocks.RESIN_BRICKS
+  - "resin_bricks"
+Blocks.RESIN_BRICK_STAIRS:
+  - Blocks.RESIN_BRICK_STAIRS
+  - "resin_brick_stairs"
+Blocks.RESIN_BRICK_SLAB:
+  - Blocks.RESIN_BRICK_SLAB
+  - "resin_brick_slab"
+Blocks.RESIN_BRICK_WALL:
+  - Blocks.RESIN_BRICK_WALL
+  - "resin_brick_wall"
+Blocks.CHISELED_RESIN_BRICKS:
+  - Blocks.CHISELED_RESIN_BRICKS
+  - "chiseled_resin_bricks"
 Blocks.ENCHANTING_TABLE:
   - Blocks.ENCHANTING_TABLE
   - "enchanting_table"
@@ -1033,6 +1087,9 @@ Blocks.WOODEN_SLAB#4:
 Blocks.WOODEN_SLAB#5:
   - Blocks.DARK_OAK_SLAB
   - "dark_oak_slab"
+Blocks.PALE_OAK_SLAB:
+  - Blocks.PALE_OAK_SLAB
+  - "pale_oak_slab"
 Blocks.MANGROVE_SLAB:
   - Blocks.MANGROVE_SLAB
   - "mangrove_slab"
@@ -1682,6 +1739,9 @@ Blocks.STRIPPED_ACACIA_LOG:
 Blocks.STRIPPED_DARK_OAK_LOG:
   - Blocks.STRIPPED_DARK_OAK_LOG
   - "stripped_dark_oak_log"
+Blocks.STRIPPED_PALE_OAK_LOG:
+  - Blocks.STRIPPED_PALE_OAK_LOG
+  - "stripped_pale_oak_log"
 Blocks.STRIPPED_OAK_LOG:
   - Blocks.STRIPPED_OAK_LOG
   - "stripped_oak_log"
@@ -1712,6 +1772,9 @@ Blocks.ACACIA_WOOD:
 Blocks.DARK_OAK_WOOD:
   - Blocks.DARK_OAK_WOOD
   - "dark_oak_wood"
+Blocks.PALE_OAK_WOOD:
+  - Blocks.PALE_OAK_WOOD
+  - "pale_oak_wood"
 Blocks.MANGROVE_WOOD:
   - Blocks.MANGROVE_WOOD
   - "mangrove_wood"
@@ -1736,6 +1799,9 @@ Blocks.STRIPPED_ACACIA_WOOD:
 Blocks.STRIPPED_DARK_OAK_WOOD:
   - Blocks.STRIPPED_DARK_OAK_WOOD
   - "stripped_dark_oak_wood"
+Blocks.STRIPPED_PALE_OAK_WOOD:
+  - Blocks.STRIPPED_PALE_OAK_WOOD
+  - "stripped_pale_oak_wood"
 Blocks.STRIPPED_MANGROVE_WOOD:
   - Blocks.STRIPPED_MANGROVE_WOOD
   - "stripped_mangrove_wood"
@@ -1820,6 +1886,9 @@ Blocks.JUNGLE_SIGN:
 Blocks.DARK_OAK_SIGN:
   - Blocks.DARK_OAK_SIGN
   - "dark_oak_sign"
+Blocks.PALE_OAK_SIGN:
+  - Blocks.PALE_OAK_SIGN
+  - "pale_oak_sign"
 Blocks.MANGROVE_SIGN:
   - Blocks.MANGROVE_SIGN
   - "mangrove_sign"
@@ -1844,6 +1913,9 @@ Blocks.JUNGLE_WALL_SIGN:
 Blocks.DARK_OAK_WALL_SIGN:
   - Blocks.DARK_OAK_WALL_SIGN
   - "dark_oak_wall_sign"
+Blocks.PALE_OAK_WALL_SIGN:
+  - Blocks.PALE_OAK_WALL_SIGN
+  - "pale_oak_wall_sign"
 Blocks.MANGROVE_WALL_SIGN:
   - Blocks.MANGROVE_WALL_SIGN
   - "mangrove_wall_sign"
@@ -1871,6 +1943,9 @@ Blocks.JUNGLE_HANGING_SIGN:
 Blocks.DARK_OAK_HANGING_SIGN:
   - Blocks.DARK_OAK_HANGING_SIGN
   - "dark_oak_hanging_sign"
+Blocks.PALE_OAK_HANGING_SIGN:
+  - Blocks.PALE_OAK_HANGING_SIGN
+  - "pale_oak_hanging_sign"
 Blocks.CRIMSON_HANGING_SIGN:
   - Blocks.CRIMSON_HANGING_SIGN
   - "crimson_hanging_sign"
@@ -1904,6 +1979,9 @@ Blocks.JUNGLE_WALL_HANGING_SIGN:
 Blocks.DARK_OAK_WALL_HANGING_SIGN:
   - Blocks.DARK_OAK_WALL_HANGING_SIGN
   - "dark_oak_wall_hanging_sign"
+Blocks.PALE_OAK_WALL_HANGING_SIGN:
+  - Blocks.PALE_OAK_WALL_HANGING_SIGN
+  - "pale_oak_wall_hanging_sign"
 Blocks.CRIMSON_WALL_HANGING_SIGN:
   - Blocks.CRIMSON_WALL_HANGING_SIGN
   - "crimson_wall_hanging_sign"
@@ -1934,6 +2012,9 @@ Blocks.ACACIA_PRESSURE_PLATE:
 Blocks.DARK_OAK_PRESSURE_PLATE:
   - Blocks.DARK_OAK_PRESSURE_PLATE
   - "dark_oak_pressure_plate"
+Blocks.PALE_OAK_PRESSURE_PLATE:
+  - Blocks.PALE_OAK_PRESSURE_PLATE
+  - "pale_oak_pressure_plate"
 Blocks.MANGROVE_PRESSURE_PLATE:
   - Blocks.MANGROVE_PRESSURE_PLATE
   - "mangrove_pressure_plate"
@@ -1964,6 +2045,9 @@ Blocks.ACACIA_TRAPDOOR:
 Blocks.DARK_OAK_TRAPDOOR:
   - Blocks.DARK_OAK_TRAPDOOR
   - "dark_oak_trapdoor"
+Blocks.PALE_OAK_TRAPDOOR:
+  - Blocks.PALE_OAK_TRAPDOOR
+  - "pale_oak_trapdoor"
 Blocks.MANGROVE_TRAPDOOR:
   - Blocks.MANGROVE_TRAPDOOR
   - "mangrove_trapdoor"
@@ -2000,6 +2084,9 @@ Blocks.POTTED_ACACIA_SAPLING:
 Blocks.POTTED_DARK_OAK_SAPLING:
   - Blocks.POTTED_DARK_OAK_SAPLING
   - "potted_dark_oak_sapling"
+Blocks.POTTED_PALE_OAK_SAPLING:
+  - Blocks.POTTED_PALE_OAK_SAPLING
+  - "potted_pale_oak_sapling"
 Blocks.POTTED_FERN:
   - Blocks.POTTED_FERN
   - "potted_fern"
@@ -2069,6 +2156,9 @@ Blocks.ACACIA_BUTTON:
 Blocks.DARK_OAK_BUTTON:
   - Blocks.DARK_OAK_BUTTON
   - "dark_oak_button"
+Blocks.PALE_OAK_BUTTON:
+  - Blocks.PALE_OAK_BUTTON
+  - "pale_oak_button"
 Blocks.MANGROVE_BUTTON:
   - Blocks.MANGROVE_BUTTON
   - "mangrove_button"
@@ -3144,6 +3234,15 @@ Blocks.MOSS_CARPET:
 Blocks.MOSS_BLOCK:
   - Blocks.MOSS_BLOCK
   - "moss_block"
+Blocks.PALE_MOSS_CARPET:
+  - Blocks.PALE_MOSS_CARPET
+  - "pale_moss_carpet"
+Blocks.PALE_HANGING_MOSS:
+  - Blocks.PALE_HANGING_MOSS
+  - "pale_hanging_moss"
+Blocks.PALE_MOSS_BLOCK:
+  - Blocks.PALE_MOSS_BLOCK
+  - "pale_moss_block"
 Blocks.BIG_DRIPLEAF:
   - Blocks.BIG_DRIPLEAF
   - "big_dripleaf"
@@ -3279,6 +3378,12 @@ Blocks.POTTED_CHERRY_SAPLING:
 Blocks.POTTED_TORCHFLOWER:
   - Blocks.POTTED_TORCHFLOWER
   - "potted_torchflower"
+Blocks.POTTED_OPEN_EYEBLOSSOM:
+  - Blocks.POTTED_OPEN_EYEBLOSSOM
+  - "potted_open_eyeblossom"
+Blocks.POTTED_CLOSED_EYEBLOSSOM:
+  - Blocks.POTTED_CLOSED_EYEBLOSSOM
+  - "potted_closed_eyeblossom"
 Blocks.DECORATED_POT:
   - Blocks.DECORATED_POT
   - "decorated_pot"
@@ -3690,6 +3795,9 @@ Items.ACACIA_DOOR:
 Items.DARK_OAK_DOOR:
   - Items.DARK_OAK_DOOR
   - "dark_oak_door"
+Items.PALE_OAK_DOOR:
+  - Items.PALE_OAK_DOOR
+  - "pale_oak_door"
 Items.MANGROVE_DOOR:
   - Items.MANGROVE_DOOR
   - "mangrove_door"
@@ -3780,6 +3888,9 @@ Items.ACACIA_BOAT:
 Items.DARK_OAK_BOAT:
   - Items.DARK_OAK_BOAT
   - "dark_oak_boat"
+Items.PALE_OAK_BOAT:
+  - Items.PALE_OAK_BOAT
+  - "pale_oak_boat"
 Items.MANGROVE_BOAT:
   - Items.MANGROVE_BOAT
   - "mangrove_boat"
@@ -3807,6 +3918,9 @@ Items.ACACIA_CHEST_BOAT:
 Items.DARK_OAK_CHEST_BOAT:
   - Items.DARK_OAK_CHEST_BOAT
   - "dark_oak_chest_boat"
+Items.PALE_OAK_CHEST_BOAT:
+  - Items.PALE_OAK_CHEST_BOAT
+  - "pale_oak_chest_boat"
 Items.MANGROVE_CHEST_BOAT:
   - Items.MANGROVE_CHEST_BOAT
   - "mangrove_chest_boat"
@@ -3897,6 +4011,9 @@ Items.BRICK:
 Items.NETHERBRICK:
   - Items.NETHER_BRICK
   - "nether_brick"
+Items.RESIN_BRICK:
+  - Items.RESIN_BRICK
+  - "resin_brick"
 Items.CLAY_BALL:
   - Items.CLAY_BALL
   - "clay_ball"
@@ -4293,6 +4410,9 @@ Items.ACACIA_SIGN:
 Items.DARK_OAK_SIGN:
   - Items.DARK_OAK_SIGN
   - "dark_oak_sign"
+Items.PALE_OAK_SIGN:
+  - Items.PALE_OAK_SIGN
+  - "pale_oak_sign"
 Items.MANGROVE_SIGN:
   - Items.MANGROVE_SIGN
   - "mangrove_sign"
@@ -4320,6 +4440,9 @@ Items.ACACIA_HANGING_SIGN:
 Items.DARK_OAK_HANGING_SIGN:
   - Items.DARK_OAK_HANGING_SIGN
   - "dark_oak_hanging_sign"
+Items.PALE_OAK_HANGING_SIGN:
+  - Items.PALE_OAK_HANGING_SIGN
+  - "pale_oak_hanging_sign"
 Items.CRIMSON_HANGING_SIGN:
   - Items.CRIMSON_HANGING_SIGN
   - "crimson_hanging_sign"
@@ -4866,3 +4989,6 @@ Items.OMINOUS_BOTTLE:
 Items.BREEZE_ROD:
   - Items.BREEZE_ROD
   - "breeze_rod"
+Items.CREAKING_SPAWN_EGG:
+  - Items.CREAKING_SPAWN_EGG
+  - "creaking_spawn_egg"

--- a/plugins/mcreator-core/datalists/blocksitems.yaml
+++ b/plugins/mcreator-core/datalists/blocksitems.yaml
@@ -435,6 +435,21 @@
   type: block
   texture: MOSS_CARPET
 
+- Blocks.PALE_MOSS_BLOCK:
+  readable_name: "Pale Moss Block"
+  type: block
+  texture: PALE_MOSS_BLOCK
+
+- Blocks.PALE_MOSS_CARPET:
+  readable_name: "Pale Moss Carpet"
+  type: block
+  texture: PALE_MOSS_CARPET
+
+- Blocks.PALE_HANGING_MOSS:
+  readable_name: "Pale Hanging Moss"
+  type: block
+  texture: PALE_HANGING_MOSS
+
 - Blocks.PLANKS:
   readable_name: "Any Planks"
   type: block
@@ -470,6 +485,11 @@
   readable_name: "Dark Oak Planks"
   type: block
   texture: PLANKS#5
+
+- Blocks.PALE_OAK_PLANKS:
+  readable_name: "Pale Oak Planks"
+  type: block
+  texture: PALE_OAK_PLANKS
 
 - Blocks.CRIMSON_PLANKS:
   readable_name: "Crimson Planks"
@@ -536,6 +556,11 @@
   readable_name: "Dark Oak Sapling"
   type: block
   texture: SAPLING#5
+
+- Blocks.PALE_OAK_SAPLING:
+  readable_name: "Pale Oak Sapling"
+  type: block
+  texture: PALE_OAK_SAPLING
 
 - Blocks.MANGROVE_PROPAGULE:
   readable_name: "Mangrove Propagule"
@@ -1176,6 +1201,11 @@
   type: block
   texture: LOG2#1
 
+- Blocks.PALE_OAK_LOG:
+  readable_name: "Pale Oak Log"
+  type: block
+  texture: PALE_OAK_LOG
+
 - Blocks.WARPED_STEM:
   readable_name: "Warped Stem"
   type: block
@@ -1241,6 +1271,11 @@
   type: block
   texture: STRIPPED_DARK_OAK_LOG
 
+- Blocks.STRIPPED_PALE_OAK_LOG:
+  readable_name: "Stripped Pale Oak Log"
+  type: block
+  texture: STRIPPED_PALE_OAK_LOG
+
 - Blocks.STRIPPED_WARPED_STEM:
   readable_name: "Stripped Warped Stem"
   type: block
@@ -1296,6 +1331,11 @@
   type: block
   texture: DARK_OAK_WOOD
 
+- Blocks.PALE_OAK_WOOD:
+  readable_name: "Pale Oak Wood"
+  type: block
+  texture: PALE_OAK_WOOD
+
 - Blocks.WARPED_HYPHAE:
   readable_name: "Warped Hyphae"
   type: block
@@ -1345,6 +1385,11 @@
   readable_name: "Stripped Dark Oak Wood"
   type: block
   texture: STRIPPED_DARK_OAK_WOOD
+
+- Blocks.STRIPPED_PALE_OAK_WOOD:
+  readable_name: "Stripped Pale Oak Wood"
+  type: block
+  texture: STRIPPED_PALE_OAK_WOOD
 
 - Blocks.STRIPPED_WARPED_HYPHAE:
   readable_name: "Stripped Warped Hyphae"
@@ -1407,6 +1452,11 @@
   readable_name: "Dark Oak Leaves"
   type: block
   texture: LEAVES2#1
+
+- Blocks.PALE_OAK_LEAVES:
+  readable_name: "Pale Oak Leaves"
+  type: block
+  texture: PALE_OAK_LEAVES
 
 - Blocks.MANGROVE_LEAVES:
   readable_name: "Mangrove Leaves"
@@ -1810,6 +1860,16 @@
   type: block
   texture: TORCHFLOWER
 
+- Blocks.OPEN_EYEBLOSSOM:
+  readable_name: "Open Eyeblossom"
+  type: block
+  texture: OPEN_EYEBLOSSOM
+
+- Blocks.CLOSED_EYEBLOSSOM:
+  readable_name: "Closed Eyeblossom"
+  type: block
+  texture: CLOSED_EYEBLOSSOM
+
 - Blocks.PINK_PETALS:
   readable_name: "Pink Petals"
   type: block
@@ -2077,6 +2137,11 @@
   type: block
   texture: MOB_SPAWNER
 
+- Blocks.CREAKING_HEART:
+  readable_name: "Creaking Heart"
+  type: block
+  texture: CREAKING_HEART
+
 - Blocks.OAK_STAIRS:
   readable_name: "Oak Stairs"
   type: block
@@ -2106,6 +2171,11 @@
   readable_name: "Dark Oak Stairs"
   type: block
   texture: DARK_OAK_STAIRS
+
+- Blocks.PALE_OAK_STAIRS:
+  readable_name: "Pale Oak Stairs"
+  type: block
+  texture: PALE_OAK_STAIRS
 
 - Blocks.CRIMSON_STAIRS:
   readable_name: "Crimson Stairs"
@@ -2232,6 +2302,11 @@
   type: block
   texture: STANDING_DARK_OAK_SIGN
 
+- Blocks.PALE_OAK_SIGN:
+  readable_name: "Pale Oak Sign"
+  type: block
+  texture: STANDING_PALE_OAK_SIGN
+
 - Blocks.CRIMSON_SIGN:
   readable_name: "Crimson Sign"
   type: block
@@ -2286,6 +2361,11 @@
   readable_name: "Dark Oak Wall Sign"
   type: block_without_item
   texture: DARK_OAK_WALL_SIGN
+
+- Blocks.PALE_OAK_WALL_SIGN:
+  readable_name: "Pale Oak Wall Sign"
+  type: block_without_item
+  texture: PALE_OAK_WALL_SIGN
 
 - Blocks.CRIMSON_WALL_SIGN:
   readable_name: "Crimson Wall Sign"
@@ -2342,6 +2422,11 @@
   type: block
   texture: DARK_OAK_HANGING_SIGN
 
+- Blocks.PALE_OAK_HANGING_SIGN:
+  readable_name: "Pale Oak Hanging Sign"
+  type: block
+  texture: PALE_OAK_HANGING_SIGN
+
 - Blocks.CRIMSON_HANGING_SIGN:
   readable_name: "Crimson Hanging Sign"
   type: block
@@ -2397,6 +2482,11 @@
   type: block_without_item
   texture: DARK_OAK_WALL_HANGING_SIGN
 
+- Blocks.PALE_OAK_WALL_HANGING_SIGN:
+  readable_name: "Pale Oak Wall Hanging Sign"
+  type: block_without_item
+  texture: PALE_OAK_WALL_HANGING_SIGN
+
 - Blocks.CRIMSON_WALL_HANGING_SIGN:
   readable_name: "Crimson Wall Hanging Sign"
   type: block_without_item
@@ -2451,6 +2541,11 @@
   readable_name: "Dark Oak Door"
   type: block
   texture: DARK_OAK_DOOR
+
+- Blocks.PALE_OAK_DOOR:
+  readable_name: "Pale Oak Door"
+  type: block
+  texture: PALE_OAK_DOOR
 
 - Blocks.CRIMSON_DOOR:
   readable_name: "Crimson Door"
@@ -2551,6 +2646,11 @@
   readable_name: "Dark Oak Trapdoor"
   type: block
   texture: DARK_OAK_TRAPDOOR
+
+- Blocks.PALE_OAK_TRAPDOOR:
+  readable_name: "Pale Oak Trapdoor"
+  type: block
+  texture: PALE_OAK_TRAPDOOR
 
 - Blocks.CRIMSON_TRAPDOOR:
   readable_name: "Crimson Trapdoor"
@@ -2752,6 +2852,11 @@
   type: block
   texture: DARK_OAK_BUTTON
 
+- Blocks.PALE_OAK_BUTTON:
+  readable_name: "Pale Oak Button"
+  type: block
+  texture: PALE_OAK_BUTTON
+
 - Blocks.CRIMSON_BUTTON:
   readable_name: "Crimson Button"
   type: block
@@ -2806,6 +2911,11 @@
   readable_name: "Dark Oak Pressure Plate"
   type: block
   texture: DARK_OAK_PRESSURE_PLATE
+
+- Blocks.PALE_OAK_PRESSURE_PLATE:
+  readable_name: "Pale Oak Pressure Plate"
+  type: block
+  texture: PALE_OAK_PRESSURE_PLATE
 
 - Blocks.CRIMSON_PRESSURE_PLATE:
   readable_name: "Crimson Pressure Plate"
@@ -3084,6 +3194,11 @@
   type: block
   texture: DARK_OAK_FENCE
 
+- Blocks.PALE_OAK_FENCE:
+  readable_name: "Pale Oak Fence"
+  type: block
+  texture: PALE_OAK_FENCE
+
 - Blocks.CRIMSON_FENCE:
   readable_name: "Crimson Fence"
   type: block
@@ -3138,6 +3253,11 @@
   readable_name: "Dark Oak Fence Gate"
   type: block
   texture: DARK_OAK_FENCE_GATE
+
+- Blocks.PALE_OAK_FENCE_GATE:
+  readable_name: "Pale Oak Fence Gate"
+  type: block
+  texture: PALE_OAK_FENCE_GATE
 
 - Blocks.CRIMSON_FENCE_GATE:
   readable_name: "Crimson Fence Gate"
@@ -3375,6 +3495,41 @@
   type: block
   texture: WATERLILY
 
+- Blocks.RESIN_CLUMP:
+  readable_name: "Resin Clump"
+  type: block
+  texture: RESIN_CLUMP
+
+- Blocks.RESIN_BLOCK:
+  readable_name: "Block of Resin"
+  type: block
+  texture: RESIN_BLOCK
+
+- Blocks.RESIN_BRICKS:
+  readable_name: "Resin Bricks"
+  type: block
+  texture: RESIN_BRICKS
+
+- Blocks.RESIN_BRICK_STAIRS:
+  readable_name: "Resin Brick Stairs"
+  type: block
+  texture: RESIN_BRICK_STAIRS
+
+- Blocks.RESIN_BRICK_SLAB:
+  readable_name: "Resin Brick Slab"
+  type: block
+  texture: RESIN_BRICK_SLAB
+
+- Blocks.RESIN_BRICK_WALL:
+  readable_name: "Resin Brick Wall"
+  type: block
+  texture: RESIN_BRICK_WALL
+
+- Blocks.CHISELED_RESIN_BRICKS:
+  readable_name: "Chiseled Resin Bricks"
+  type: block
+  texture: CHISELED_RESIN_BRICKS
+
 - Blocks.ENCHANTING_TABLE:
   readable_name: "Enchanting Table"
   type: block
@@ -3571,6 +3726,11 @@
   type: block
   texture: WOODEN_SLAB#5
 
+- Blocks.PALE_OAK_SLAB:
+  readable_name: "Pale Oak Slab"
+  type: block
+  texture: PALE_OAK_SLAB
+
 - Blocks.CRIMSON_SLAB:
   readable_name: "Crimson Slab"
   type: block
@@ -3741,6 +3901,11 @@
   type: block_without_item
   texture: POTTED_DARK_OAK_SAPLING
 
+- Blocks.POTTED_PALE_OAK_SAPLING:
+  readable_name: "Potted Pale Oak Sapling"
+  type: block_without_item
+  texture: POTTED_PALE_OAK_SAPLING
+
 - Blocks.POTTED_MANGROVE_PROPAGULE:
   readable_name: "Potted Mangrove Propagule"
   type: block_without_item
@@ -3880,6 +4045,16 @@
   readable_name: "Potted Torchflower"
   type: block_without_item
   texture: POTTED_TORCHFLOWER
+
+- Blocks.POTTED_OPEN_EYEBLOSSOM:
+  readable_name: "Potted Open Eyeblossom"
+  type: block_without_item
+  texture: POTTED_OPEN_EYEBLOSSOM
+
+- Blocks.POTTED_CLOSED_EYEBLOSSOM:
+  readable_name: "Potted Closed Eyeblossom"
+  type: block_without_item
+  texture: POTTED_CLOSED_EYEBLOSSOM
 
 - Blocks.DECORATED_POT:
   readable_name: "Decorated Pot"
@@ -6490,6 +6665,11 @@
   type: item
   texture: DARK_OAK_SIGN
 
+- Items.PALE_OAK_SIGN:
+  readable_name: "Pale Oak Sign"
+  type: item
+  texture: PALE_OAK_SIGN
+
 - Items.CRIMSON_SIGN:
   readable_name: "Crimson Sign"
   type: item
@@ -6545,6 +6725,11 @@
   type: item
   texture: DARK_OAK_HANGING_SIGN_ITEM
 
+- Items.PALE_OAK_HANGING_SIGN:
+  readable_name: "Pale Oak Hanging Sign"
+  type: item
+  texture: PALE_OAK_HANGING_SIGN
+
 - Items.CRIMSON_HANGING_SIGN:
   readable_name: "Crimson Hanging Sign"
   type: item
@@ -6599,6 +6784,11 @@
   readable_name: "Dark Oak Door"
   type: item
   texture: DARK_OAK_DOOR
+
+- Items.PALE_OAK_DOOR:
+  readable_name: "Pale Oak Door"
+  type: item
+  texture: PALE_OAK_DOOR
 
 - Items.IRON_DOOR:
   readable_name: "Iron Door"
@@ -6745,6 +6935,11 @@
   type: item
   texture: DARK_OAK_BOAT
 
+- Items.PALE_OAK_BOAT:
+  readable_name: "Pale Oak Boat"
+  type: item
+  texture: PALE_OAK_BOAT
+
 - Items.MANGROVE_BOAT:
   readable_name: "Mangrove Boat"
   type: item
@@ -6789,6 +6984,11 @@
   readable_name: "Dark Oak Boat with Chest"
   type: item
   texture: DARK_OAK_CHEST_BOAT
+
+- Items.PALE_OAK_CHEST_BOAT:
+  readable_name: "Pale Oak Boat with Chest"
+  type: item
+  texture: PALE_OAK_CHEST_BOAT
 
 - Items.MANGROVE_CHEST_BOAT:
   readable_name: "Mangrove Boat with Chest"
@@ -6960,6 +7160,11 @@
   readable_name: "Nether Brick"
   type: item
   texture: NETHERBRICK
+
+- Items.RESIN_BRICK:
+  readable_name: "Resin Brick"
+  type: item
+  texture: RESIN_BRICK
 
 - Items.CLAY_BALL:
   readable_name: "Clay"
@@ -7767,6 +7972,11 @@
   readable_name: "Armadillo Spawn Egg"
   type: item
   texture: ARMADILLO_SPAWN_EGG
+
+- Items.CREAKING_SPAWN_EGG:
+  readable_name: "Creaking Spawn Egg"
+  type: item
+  texture: CREAKING_SPAWN_EGG
 
 - Items.EXPERIENCE_BOTTLE:
   readable_name: "Bottle o' Enchanting"

--- a/plugins/mcreator-core/datalists/blocksitems.yaml
+++ b/plugins/mcreator-core/datalists/blocksitems.yaml
@@ -5849,6 +5849,86 @@
   type: item
   texture: BUNDLE
 
+- Items.WHITE_BUNDLE:
+  readable_name: "White Bundle"
+  type: item
+  texture: WHITE_BUNDLE
+
+- Items.ORANGE_BUNDLE:
+  readable_name: "Orange Bundle"
+  type: item
+  texture: ORANGE_BUNDLE
+
+- Items.MAGENTA_BUNDLE:
+  readable_name: "Magenta Bundle"
+  type: item
+  texture: MAGENTA_BUNDLE
+
+- Items.LIGHT_BLUE_BUNDLE:
+  readable_name: "Light Blue Bundle"
+  type: item
+  texture: LIGHT_BLUE_BUNDLE
+
+- Items.YELLOW_BUNDLE:
+  readable_name: "Yellow Bundle"
+  type: item
+  texture: YELLOW_BUNDLE
+
+- Items.LIME_BUNDLE:
+  readable_name: "Lime Bundle"
+  type: item
+  texture: LIME_BUNDLE
+
+- Items.PINK_BUNDLE:
+  readable_name: "Pink Bundle"
+  type: item
+  texture: PINK_BUNDLE
+
+- Items.GRAY_BUNDLE:
+  readable_name: "Gray Bundle"
+  type: item
+  texture: GRAY_BUNDLE
+
+- Items.LIGHT_GRAY_BUNDLE:
+  readable_name: "Light Gray Bundle"
+  type: item
+  texture: LIGHT_GRAY_BUNDLE
+
+- Items.CYAN_BUNDLE:
+  readable_name: "Cyan Bundle"
+  type: item
+  texture: CYAN_BUNDLE
+
+- Items.PURPLE_BUNDLE:
+  readable_name: "Purple Bundle"
+  type: item
+  texture: PURPLE_BUNDLE
+
+- Items.BLUE_BUNDLE:
+  readable_name: "Blue Bundle"
+  type: item
+  texture: BLUE_BUNDLE
+
+- Items.BROWN_BUNDLE:
+  readable_name: "Brown Bundle"
+  type: item
+  texture: BROWN_BUNDLE
+
+- Items.GREEN_BUNDLE:
+  readable_name: "Green Bundle"
+  type: item
+  texture: GREEN_BUNDLE
+
+- Items.RED_BUNDLE:
+  readable_name: "Red Bundle"
+  type: item
+  texture: RED_BUNDLE
+
+- Items.BLACK_BUNDLE:
+  readable_name: "Black Bundle"
+  type: item
+  texture: BLACK_BUNDLE
+
 - Items.MAP:
   readable_name: "Empty Map"
   type: item
@@ -5865,38 +5945,32 @@
   texture: BRUSH
 
 - Items.FLOWER_BANNER_PATTERN:
-  readable_name: "Banner Pattern"
-  description: "Flower"
+  readable_name: "Flower Charge Banner Pattern"
   type: item
   texture: FLOWER_BANNER_PATTERN
 
 - Items.CREEPER_BANNER_PATTERN:
-  readable_name: "Banner Pattern"
-  description: "Creeper"
+  readable_name: "Creeper Charge Banner Pattern"
   type: item
   texture: CREEPER_BANNER_PATTERN
 
 - Items.SKULL_BANNER_PATTERN:
-  readable_name: "Banner Pattern"
-  description: "Skull"
+  readable_name: "Skull Charge Banner Pattern"
   type: item
   texture: SKULL_BANNER_PATTERN
 
 - Items.THING_BANNER_PATTERN:
-  readable_name: "Banner Pattern"
-  description: "Thing"
+  readable_name: "Thing Banner Pattern"
   type: item
   texture: THING_BANNER_PATTERN
 
 - Items.GLOBE_BANNER_PATTERN:
-  readable_name: "Banner Pattern"
-  description: "Globe"
+  readable_name: "Globe Banner Pattern"
   type: item
   texture: GLOBE_BANNER_PATTERN
 
 - Items.PIGLIN_BANNER_PATTERN:
-  readable_name: "Banner Pattern"
-  description: "Snout"
+  readable_name: "Snout Banner Pattern"
   type: item
   texture: PIGLIN_BANNER_PATTERN
 
@@ -5909,6 +5983,16 @@
   readable_name: "Guster Banner Pattern"
   type: item
   texture: GUSTER_BANNER_PATTERN
+
+- Items.FIELD_MASONED_BANNER_PATTERN:
+  readable_name: "Field Masoned Banner Pattern"
+  type: item
+  texture: FIELD_MASONED_BANNER_PATTERN
+
+- Items.BORDURE_INDENTED_BANNER_PATTERN:
+  readable_name: "Bordure Indented Banner Pattern"
+  type: item
+  texture: BORDURE_INDENTED_BANNER_PATTERN
 
 - Items.TOTEM_OF_UNDYING:
   readable_name: "Totem of Undying"


### PR DESCRIPTION
This PR ports the blocks/items datalist to 1.21.4 (no changes to old items).

This also changes the readable name of some banner patterns to match the in-game name.