### PR TITLE
Improvement to extra Blockly templates

### DIFF
--- a/src/main/java/net/mcreator/blockly/BlocklyToCode.java
+++ b/src/main/java/net/mcreator/blockly/BlocklyToCode.java
@@ -18,8 +18,6 @@
 
 package net.mcreator.blockly;
 
-import freemarker.core.Environment;
-import freemarker.template.*;
 import net.mcreator.blockly.data.Dependency;
 import net.mcreator.blockly.data.DependencyProviderInput;
 import net.mcreator.blockly.data.StatementInput;
@@ -91,14 +89,16 @@ public abstract class BlocklyToCode implements IGeneratorProvider {
 
 	public final String getExtraTemplatesCode() throws TemplateGeneratorException {
 		StringBuilder code = new StringBuilder();
-		while (!usedTemplates.isEmpty() && templateGenerator != null) {
-			for (String template : usedTemplates.stream().toList()) {
-				generatedTemplates.add(template);
-				usedTemplates.remove(template);
-				Map<String, Object> dataModel = new HashMap<>();
-				dataModel.put("parent", parent);
-				dataModel.put("addTemplate", new ExtraTemplatesLinker(this));
-				code.append(templateGenerator.generateFromTemplate(template, dataModel));
+		if (templateGenerator != null) {
+			while (!usedTemplates.isEmpty()) {
+				for (String template : List.copyOf(usedTemplates)) {
+					generatedTemplates.add(template);
+					usedTemplates.remove(template);
+					Map<String, Object> dataModel = new HashMap<>();
+					dataModel.put("parent", parent);
+					dataModel.put("addTemplate", new ExtraTemplatesLinker(this));
+					code.append(templateGenerator.generateFromTemplate(template, dataModel));
+				}
 			}
 		}
 		return code.toString();
@@ -322,16 +322,6 @@ public abstract class BlocklyToCode implements IGeneratorProvider {
 	 */
 	public Collection<String> getUsedBlocks() {
 		return Collections.unmodifiableSet(usedBlocks);
-	}
-
-	private record ExtraTemplatesLinker(BlocklyToCode master) implements TemplateDirectiveModel {
-
-		@Override public void execute(Environment env, Map params, TemplateModel[] loopVars, TemplateDirectiveBody body)
-				throws TemplateModelException {
-			if (params.get("file") instanceof TemplateScalarModel template)
-				master.addTemplate(template.getAsString());
-		}
-
 	}
 
 }

--- a/src/main/java/net/mcreator/blockly/ExtraTemplatesLinker.java
+++ b/src/main/java/net/mcreator/blockly/ExtraTemplatesLinker.java
@@ -1,0 +1,35 @@
+/*
+ * MCreator (https://mcreator.net/)
+ * Copyright (C) 2012-2020, Pylo
+ * Copyright (C) 2020-2025, Pylo, opensource contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package net.mcreator.blockly;
+
+import freemarker.core.Environment;
+import freemarker.template.*;
+
+import java.util.Map;
+
+public record ExtraTemplatesLinker(BlocklyToCode master) implements TemplateDirectiveModel {
+
+	@Override public void execute(Environment env, Map params, TemplateModel[] loopVars, TemplateDirectiveBody body)
+			throws TemplateModelException {
+		if (params.get("file") instanceof TemplateScalarModel template)
+			master.addTemplate(template.getAsString());
+	}
+
+}

--- a/src/main/java/net/mcreator/generator/blockly/BlocklyBlockCodeGenerator.java
+++ b/src/main/java/net/mcreator/generator/blockly/BlocklyBlockCodeGenerator.java
@@ -18,12 +18,7 @@
 
 package net.mcreator.generator.blockly;
 
-import freemarker.core.Environment;
-import freemarker.template.*;
-import net.mcreator.blockly.BlocklyBlockUtil;
-import net.mcreator.blockly.BlocklyCompileNote;
-import net.mcreator.blockly.BlocklyToCode;
-import net.mcreator.blockly.IBlockGenerator;
+import net.mcreator.blockly.*;
 import net.mcreator.blockly.data.*;
 import net.mcreator.generator.mapping.MappableElement;
 import net.mcreator.generator.template.TemplateGenerator;
@@ -469,17 +464,6 @@ public class BlocklyBlockCodeGenerator {
 		return blocks_machine_names.computeIfAbsent(blockType,
 				key -> blocks.values().stream().filter(block -> block.getType() == key)
 						.map(ToolboxBlock::getMachineName).toArray(String[]::new));
-	}
-
-	private record ExtraTemplatesLinker(BlocklyToCode master) implements TemplateDirectiveModel {
-
-		@Override
-		public void execute(Environment env, Map params, TemplateModel[] loopVars, TemplateDirectiveBody body)
-				throws TemplateModelException {
-			if (params.get("file") instanceof TemplateScalarModel template)
-				master.addTemplate(template.getAsString());
-		}
-
 	}
 
 }


### PR DESCRIPTION
* Extra templates can now add other extra templates to further reduce duplicated code (this is probably needed by #5265);
* `BlocklyToCode` now filters added extra templates to not generate them more than once.