### PR TITLE
Expose GUIComponent API

### DIFF
--- a/src/main/java/net/mcreator/element/parts/gui/GUIComponent.java
+++ b/src/main/java/net/mcreator/element/parts/gui/GUIComponent.java
@@ -65,7 +65,7 @@ import java.util.stream.Collectors;
 		uuid = UUID.randomUUID();
 	}
 
-	GUIComponent(int x, int y) {
+	public GUIComponent(int x, int y) {
 		this();
 		this.x = x;
 		this.y = y;


### PR DESCRIPTION
I am making a plugin for MCreator and saw that this API wasn't exposed for some reason, all this PR does is expose the GUIComponent API so that plugins can modify the overlay and gui builders.