### PR TITLE
Fix #5334

### DIFF
--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/feature/structure_feature.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/feature/structure_feature.java.ftl
@@ -52,7 +52,7 @@ public class StructureFeature extends Feature<StructureFeatureConfiguration> {
 		StructureTemplate template = structureManager.getOrCreate(config.structure());
 		StructurePlaceSettings placeSettings = (new StructurePlaceSettings()).setRotation(rotation).setMirror(mirror).setRandom(random).setIgnoreEntities(false)
 				.addProcessor(new BlockIgnoreProcessor(config.ignoredBlocks().stream().map(Holder::value).toList()));
-		template.placeInWorld(worldGenLevel, placePos, placePos, placeSettings, random, 4);
+		template.placeInWorld(worldGenLevel, placePos, placePos, placeSettings, random, 2);
 		return true;
 	}
 }

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/feature/structure_feature.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/feature/structure_feature.java.ftl
@@ -52,7 +52,7 @@ public class StructureFeature extends Feature<StructureFeatureConfiguration> {
 		StructureTemplate template = structureManager.getOrCreate(config.structure());
 		StructurePlaceSettings placeSettings = (new StructurePlaceSettings()).setRotation(rotation).setMirror(mirror).setRandom(random).setIgnoreEntities(false)
 				.addProcessor(new BlockIgnoreProcessor(config.ignoredBlocks().stream().map(Holder::value).toList()));
-		template.placeInWorld(worldGenLevel, placePos, placePos, placeSettings, random, 4);
+		template.placeInWorld(worldGenLevel, placePos, placePos, placeSettings, random, 2);
 		return true;
 	}
 }


### PR DESCRIPTION
Changes so feature sends to client.

@AlsoSomeoneElse do we know what implications this does for the worldgen?

Technically we could check if `worldGenLevel instanceof WorldGenRegion` and use flag 4 in this case, otherwise flag 2