### PR TITLE
Fix duplicate titles of debug panel sections

### DIFF
--- a/src/main/java/net/mcreator/ui/debug/DebugPanel.java
+++ b/src/main/java/net/mcreator/ui/debug/DebugPanel.java
@@ -143,7 +143,7 @@ public class DebugPanel extends JPanel {
 		markersScroll.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
 		markersScroll.getViewport().setOpaque(false);
 
-		markersParent.setBorder(BorderFactory.createTitledBorder(L10N.t("debug.frames")));
+		markersParent.setBorder(BorderFactory.createTitledBorder(L10N.t("debug.markers")));
 		markersParent.setLayout(markersLayout);
 		markersParent.add(markersScroll, "markers");
 		markersParent.add(nomarkerwrap, "no_markers");


### PR DESCRIPTION
Fix markers section of debug panel being named the same as stack frames section.