### PR TITLE
Fix #5388 - Big projectile hitboxes not working with block collisions

### DIFF
--- a/src/test/java/net/mcreator/integration/TestWorkspaceDataProvider.java
+++ b/src/test/java/net/mcreator/integration/TestWorkspaceDataProvider.java
@@ -1234,8 +1234,13 @@ public class TestWorkspaceDataProvider {
 					getRandomMCItem(random, blocksAndItems).getName());
 			projectile.entityModel = "Default";
 			projectile.customModelTexture = "";
-			projectile.modelWidth = 0.4;
-			projectile.modelHeight = 1.3;
+			if (emptyLists) {
+				projectile.modelWidth = 4.4;
+				projectile.modelHeight = 5.3;
+			} else {
+				projectile.modelWidth = 0.3;
+				projectile.modelHeight = 0.2;
+			}
 			projectile.onHitsBlock = new Procedure("procedure1");
 			projectile.onHitsEntity = new Procedure("procedure2");
 			projectile.onHitsPlayer = new Procedure("procedure3");


### PR DESCRIPTION
Fix #5388

* [Bugfix] Big custom projectiles did not detect block collisions correctly