### PR TITLE
Directly pass uppercase registry name to template generators

### DIFF
--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/armor.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/armor.java.ftl
@@ -88,7 +88,7 @@ import net.minecraft.client.model.Model;
 				armorModel.young = living.isBaby();
 				return armorModel;
 			}
-		}, ${JavaModName}Items.${data.getModElement().getRegistryNameUpper()}_HELMET.get());
+		}, ${JavaModName}Items.${REGISTRYNAME}_HELMET.get());
 		</#if>
 
 		<#if data.bodyModelName != "Default" && data.getBodyModel()??>
@@ -108,7 +108,7 @@ import net.minecraft.client.model.Model;
 				armorModel.young = living.isBaby();
 				return armorModel;
 			}
-		}, ${JavaModName}Items.${data.getModElement().getRegistryNameUpper()}_CHESTPLATE.get());
+		}, ${JavaModName}Items.${REGISTRYNAME}_CHESTPLATE.get());
 		</#if>
 
 		<#if data.leggingsModelName != "Default" && data.getLeggingsModel()??>
@@ -128,7 +128,7 @@ import net.minecraft.client.model.Model;
 				armorModel.young = living.isBaby();
 				return armorModel;
 			}
-		}, ${JavaModName}Items.${data.getModElement().getRegistryNameUpper()}_LEGGINGS.get());
+		}, ${JavaModName}Items.${REGISTRYNAME}_LEGGINGS.get());
 		</#if>
 
 		<#if data.bootsModelName != "Default" && data.getBootsModel()??>
@@ -148,7 +148,7 @@ import net.minecraft.client.model.Model;
 				armorModel.young = living.isBaby();
 				return armorModel;
 			}
-		}, ${JavaModName}Items.${data.getModElement().getRegistryNameUpper()}_BOOTS.get());
+		}, ${JavaModName}Items.${REGISTRYNAME}_BOOTS.get());
 		</#if>
 	}
 	</#if>

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/block/block.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/block/block.java.ftl
@@ -689,7 +689,7 @@ public class ${name}Block extends
 						Minecraft.getInstance().level.getBiome(pos).value().getWaterFogColor() : 329011;
 					</#if>
 				</#if>
-			}, ${JavaModName}Blocks.${data.getModElement().getRegistryNameUpper()}.get());
+			}, ${JavaModName}Blocks.${REGISTRYNAME}.get());
 		}
 
 		<#if data.isItemTinted>
@@ -712,7 +712,7 @@ public class ${name}Block extends
 				<#else>
 					return 329011;
 				</#if>
-			}, ${JavaModName}Blocks.${data.getModElement().getRegistryNameUpper()}.get());
+			}, ${JavaModName}Blocks.${REGISTRYNAME}.get());
 		}
 		</#if>
 	</#if>

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/block/blockentity.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/block/blockentity.java.ftl
@@ -41,7 +41,7 @@ public class ${name}BlockEntity extends RandomizableContainerBlockEntity impleme
 	private final SidedInvWrapper handler = new SidedInvWrapper(this, null);
 
 	public ${name}BlockEntity(BlockPos position, BlockState state) {
-		super(${JavaModName}BlockEntities.${data.getModElement().getRegistryNameUpper()}.get(), position, state);
+		super(${JavaModName}BlockEntities.${REGISTRYNAME}.get(), position, state);
 	}
 
 	@Override public void loadAdditional(CompoundTag compound, HolderLookup.Provider lookupProvider) {

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/fluid/fluid.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/fluid/fluid.java.ftl
@@ -37,15 +37,15 @@ package ${package}.fluid;
 public abstract class ${name}Fluid extends BaseFlowingFluid {
 
 	public static final BaseFlowingFluid.Properties PROPERTIES = new BaseFlowingFluid.Properties(
-		() -> ${JavaModName}FluidTypes.${data.getModElement().getRegistryNameUpper()}_TYPE.get(),
-		() -> ${JavaModName}Fluids.${data.getModElement().getRegistryNameUpper()}.get(),
-		() -> ${JavaModName}Fluids.FLOWING_${data.getModElement().getRegistryNameUpper()}.get())
+		() -> ${JavaModName}FluidTypes.${REGISTRYNAME}_TYPE.get(),
+		() -> ${JavaModName}Fluids.${REGISTRYNAME}.get(),
+		() -> ${JavaModName}Fluids.FLOWING_${REGISTRYNAME}.get())
 		.explosionResistance(${data.resistance}f)
 		<#if data.flowRate != 5>.tickRate(${data.flowRate})</#if>
 		<#if data.levelDecrease != 1>.levelDecreasePerBlock(${data.levelDecrease})</#if>
 		<#if data.slopeFindDistance != 4>.slopeFindDistance(${data.slopeFindDistance})</#if>
-		<#if data.generateBucket>.bucket(() -> ${JavaModName}Items.${data.getModElement().getRegistryNameUpper()}_BUCKET.get())</#if>
-		.block(() -> (LiquidBlock) ${JavaModName}Blocks.${data.getModElement().getRegistryNameUpper()}.get());
+		<#if data.generateBucket>.bucket(() -> ${JavaModName}Items.${REGISTRYNAME}_BUCKET.get())</#if>
+		.block(() -> (LiquidBlock) ${JavaModName}Blocks.${REGISTRYNAME}.get());
 
 	private ${name}Fluid() {
 		super(PROPERTIES);

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/fluid/fluidblock.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/fluid/fluidblock.java.ftl
@@ -39,7 +39,7 @@ import net.minecraft.world.level.block.state.BlockBehaviour.Properties;
 <#compress>
 public class ${name}Block extends LiquidBlock {
 	public ${name}Block() {
-		super(${JavaModName}Fluids.${data.getModElement().getRegistryNameUpper()}.get(),
+		super(${JavaModName}Fluids.${REGISTRYNAME}.get(),
 			BlockBehaviour.Properties.of()
 			<#if generator.map(data.colorOnMap, "mapcolors") != "DEFAULT">
 			.mapColor(MapColor.${generator.map(data.colorOnMap, "mapcolors")})

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/fluid/fluidbucket.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/fluid/fluidbucket.java.ftl
@@ -38,7 +38,7 @@ import net.minecraft.network.chat.Component;
 public class ${name}Item extends BucketItem {
 
 	public ${name}Item() {
-		super(${JavaModName}Fluids.${data.getModElement().getRegistryNameUpper()}.get(),
+		super(${JavaModName}Fluids.${REGISTRYNAME}.get(),
 			new Item.Properties().craftRemainder(Items.BUCKET).stacksTo(1).rarity(Rarity.${data.rarity}));
 	}
 

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/fluid/fluidtype.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/fluid/fluidtype.java.ftl
@@ -158,6 +158,6 @@ package ${package}.fluid.types;
 					</#if> | 0xFF000000;
 				}
 				</#if>
-		}, ${JavaModName}FluidTypes.${data.getModElement().getRegistryNameUpper()}_TYPE.get());
+		}, ${JavaModName}FluidTypes.${REGISTRYNAME}_TYPE.get());
 	}
 }</#compress>

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/gui/gui_container.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/gui/gui_container.java.ftl
@@ -61,7 +61,7 @@ public class ${name}Menu extends AbstractContainerMenu implements Supplier<Map<I
 	private BlockEntity boundBlockEntity = null;
 
 	public ${name}Menu(int id, Inventory inv, FriendlyByteBuf extraData) {
-		super(${JavaModName}Menus.${data.getModElement().getRegistryNameUpper()}.get(), id);
+		super(${JavaModName}Menus.${REGISTRYNAME}.get(), id);
 
 		this.entity = inv.player;
 		this.world = inv.player.level();

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/item/item_container.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/item/item_container.java.ftl
@@ -35,7 +35,7 @@ package ${package}.item.inventory;
 @EventBusSubscriber(Dist.CLIENT) public class ${name}InventoryCapability extends ComponentItemHandler {
 
 	@SubscribeEvent @OnlyIn(Dist.CLIENT) public static void onItemDropped(ItemTossEvent event) {
-		if (event.getEntity().getItem().getItem() == ${JavaModName}Items.${data.getModElement().getRegistryNameUpper()}.get()) {
+		if (event.getEntity().getItem().getItem() == ${JavaModName}Items.${REGISTRYNAME}.get()) {
 			if (Minecraft.getInstance().screen instanceof ${data.guiBoundTo}Screen) {
 				Minecraft.getInstance().player.closeContainer();
 			}
@@ -51,7 +51,7 @@ package ${package}.item.inventory;
 	}
 
 	@Override public boolean isItemValid(int slot, @Nonnull ItemStack stack) {
-		return stack.getItem() != ${JavaModName}Items.${data.getModElement().getRegistryNameUpper()}.get();
+		return stack.getItem() != ${JavaModName}Items.${REGISTRYNAME}.get();
 	}
 
 	@Override public ItemStack getStackInSlot(int slot) {

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/livingentity/livingentity.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/livingentity/livingentity.java.ftl
@@ -53,7 +53,7 @@ public class ${name}Entity extends ${extendsClass} <#if data.ranged>implements R
 
 	<#if data.mobBehaviourType == "Raider">
 	public static final EnumProxy<Raid.RaiderType> RAIDER_TYPE = new EnumProxy<>(Raid.RaiderType.class,
-		${JavaModName}Entities.${data.getModElement().getRegistryNameUpper()}, new int[] {0, ${data.raidSpawnsCount[0]}, ${data.raidSpawnsCount[1]}, ${data.raidSpawnsCount[2]}, ${data.raidSpawnsCount[3]}, ${data.raidSpawnsCount[4]}, ${data.raidSpawnsCount[5]}, ${data.raidSpawnsCount[6]}}
+		${JavaModName}Entities.${REGISTRYNAME}, new int[] {0, ${data.raidSpawnsCount[0]}, ${data.raidSpawnsCount[1]}, ${data.raidSpawnsCount[2]}, ${data.raidSpawnsCount[3]}, ${data.raidSpawnsCount[4]}, ${data.raidSpawnsCount[5]}, ${data.raidSpawnsCount[6]}}
 	);
 	</#if>
 
@@ -664,7 +664,7 @@ public class ${name}Entity extends ${extendsClass} <#if data.ranged>implements R
 	    @Override public void performRangedAttack(LivingEntity target, float flval) {
 			<#if data.rangedItemType == "Default item">
 				<#if !data.rangedAttackItem.isEmpty()>
-				${name}EntityProjectile entityarrow = new ${name}EntityProjectile(${JavaModName}Entities.${data.getModElement().getRegistryNameUpper()}_PROJECTILE.get(), this, this.level());
+				${name}EntityProjectile entityarrow = new ${name}EntityProjectile(${JavaModName}Entities.${REGISTRYNAME}_PROJECTILE.get(), this, this.level());
 				<#else>
 				Arrow entityarrow = new Arrow(this.level(), this, new ItemStack(Items.ARROW), null);
 				</#if>
@@ -681,7 +681,7 @@ public class ${name}Entity extends ${extendsClass} <#if data.ranged>implements R
 
 	<#if data.breedable>
         @Override public AgeableMob getBreedOffspring(ServerLevel serverWorld, AgeableMob ageable) {
-			${name}Entity retval = ${JavaModName}Entities.${data.getModElement().getRegistryNameUpper()}.get().create(serverWorld);
+			${name}Entity retval = ${JavaModName}Entities.${REGISTRYNAME}.get().create(serverWorld);
 			retval.finalizeSpawn(serverWorld, serverWorld.getCurrentDifficultyAt(retval.blockPosition()), MobSpawnType.BREEDING, null);
 			return retval;
 		}
@@ -847,7 +847,7 @@ public class ${name}Entity extends ${extendsClass} <#if data.ranged>implements R
 	public static void init(RegisterSpawnPlacementsEvent event) {
 		<#if data.spawnThisMob>
 			<#if data.mobSpawningType == "creature">
-			event.register(${JavaModName}Entities.${data.getModElement().getRegistryNameUpper()}.get(),
+			event.register(${JavaModName}Entities.${REGISTRYNAME}.get(),
 					SpawnPlacementTypes.ON_GROUND, Heightmap.Types.MOTION_BLOCKING_NO_LEAVES,
 				<#if hasProcedure(data.spawningCondition)>
 					(entityType, world, reason, pos, random) -> {
@@ -864,7 +864,7 @@ public class ${name}Entity extends ${extendsClass} <#if data.ranged>implements R
 				RegisterSpawnPlacementsEvent.Operation.REPLACE
 			);
 			<#elseif data.mobSpawningType == "ambient" || data.mobSpawningType == "misc">
-			event.register(${JavaModName}Entities.${data.getModElement().getRegistryNameUpper()}.get(),
+			event.register(${JavaModName}Entities.${REGISTRYNAME}.get(),
 					SpawnPlacementTypes.NO_RESTRICTIONS, Heightmap.Types.MOTION_BLOCKING_NO_LEAVES,
 					<#if hasProcedure(data.spawningCondition)>
 					(entityType, world, reason, pos, random) -> {
@@ -879,7 +879,7 @@ public class ${name}Entity extends ${extendsClass} <#if data.ranged>implements R
 					RegisterSpawnPlacementsEvent.Operation.REPLACE
 			);
 			<#elseif data.mobSpawningType == "waterCreature" || data.mobSpawningType == "waterAmbient">
-			event.register(${JavaModName}Entities.${data.getModElement().getRegistryNameUpper()}.get(),
+			event.register(${JavaModName}Entities.${REGISTRYNAME}.get(),
 					SpawnPlacementTypes.IN_WATER, Heightmap.Types.MOTION_BLOCKING_NO_LEAVES,
 					<#if hasProcedure(data.spawningCondition)>
 					(entityType, world, reason, pos, random) -> {
@@ -896,7 +896,7 @@ public class ${name}Entity extends ${extendsClass} <#if data.ranged>implements R
 					RegisterSpawnPlacementsEvent.Operation.REPLACE
 			);
 			<#elseif data.mobSpawningType == "undergroundWaterCreature">
-			event.register(${JavaModName}Entities.${data.getModElement().getRegistryNameUpper()}.get(),
+			event.register(${JavaModName}Entities.${REGISTRYNAME}.get(),
 					SpawnPlacementTypes.IN_WATER, Heightmap.Types.MOTION_BLOCKING_NO_LEAVES,
 					<#if hasProcedure(data.spawningCondition)>
 					(entityType, world, reason, pos, random) -> {
@@ -915,7 +915,7 @@ public class ${name}Entity extends ${extendsClass} <#if data.ranged>implements R
 					RegisterSpawnPlacementsEvent.Operation.REPLACE
 			);
 			<#else>
-			event.register(${JavaModName}Entities.${data.getModElement().getRegistryNameUpper()}.get(),
+			event.register(${JavaModName}Entities.${REGISTRYNAME}.get(),
 					SpawnPlacementTypes.ON_GROUND, Heightmap.Types.MOTION_BLOCKING_NO_LEAVES,
 					<#if hasProcedure(data.spawningCondition)>
 					(entityType, world, reason, pos, random) -> {

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/plant/plant.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/plant/plant.java.ftl
@@ -417,12 +417,12 @@ public class ${name}Block extends ${getPlantClass(data.plantType)}Block
 
 <#macro toTreeGrower secondaryChance megaTree="" megaTree2="" tree="" tree2="" flowerTree="" flowerTree2="">
 	<#if (megaTree2?has_content || tree2?has_content || flowerTree2?has_content) && secondaryChance != 0>
-	new TreeGrower("${data.getModElement().getRegistryName()}", ${secondaryChance}f,
+	new TreeGrower("${registryname}", ${secondaryChance}f,
 		<@toOptionalTree megaTree/>, <@toOptionalTree megaTree2/>, <@toOptionalTree tree/>,
 		<@toOptionalTree tree2/>, <@toOptionalTree flowerTree/>, <@toOptionalTree flowerTree2/>
 	);
 	<#else>
-	new TreeGrower("${data.getModElement().getRegistryName()}", <@toOptionalTree megaTree/>, <@toOptionalTree tree/>, <@toOptionalTree flowerTree/>);
+	new TreeGrower("${registryname}", <@toOptionalTree megaTree/>, <@toOptionalTree tree/>, <@toOptionalTree flowerTree/>);
 	</#if>
 </#macro>
 

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/plant/plant.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/plant/plant.java.ftl
@@ -369,7 +369,7 @@ public class ${name}Block extends ${getPlantClass(data.plantType)}Block
 						Minecraft.getInstance().level.getBiome(pos).value().getWaterFogColor() : 329011;
 					</#if>
 				</#if>
-			}, ${JavaModName}Blocks.${data.getModElement().getRegistryNameUpper()}.get());
+			}, ${JavaModName}Blocks.${REGISTRYNAME}.get());
 		}
 
 		<#if data.isItemTinted>
@@ -392,7 +392,7 @@ public class ${name}Block extends ${getPlantClass(data.plantType)}Block
 				<#else>
 					return 329011;
 				</#if>
-			}, ${JavaModName}Blocks.${data.getModElement().getRegistryNameUpper()}.get());
+			}, ${JavaModName}Blocks.${REGISTRYNAME}.get());
 		}
 		</#if>
 	</#if>

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/plant/plantblockentity.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/plant/plantblockentity.java.ftl
@@ -34,7 +34,7 @@ package ${package}.block.entity;
 public class ${name}BlockEntity extends BlockEntity {
 
 	public ${name}BlockEntity(BlockPos pos, BlockState state) {
-		super(${JavaModName}BlockEntities.${data.getModElement().getRegistryNameUpper()}.get(), pos, state);
+		super(${JavaModName}BlockEntities.${REGISTRYNAME}.get(), pos, state);
 	}
 
 	@Override public ClientboundBlockEntityDataPacket getUpdatePacket() {

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/potioneffect.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/potioneffect.java.ftl
@@ -163,7 +163,7 @@ public class ${name}MobEffect extends <#if data.isInstant>Instantenous</#if>MobE
 				return false;
 			}
 			</#if>
-		}, ${JavaModName}MobEffects.${data.getModElement().getRegistryNameUpper()}.get());
+		}, ${JavaModName}MobEffects.${REGISTRYNAME}.get());
 	}
 	</#if>
 }

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/potioneffect.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/potioneffect.java.ftl
@@ -46,7 +46,7 @@ public class ${name}MobEffect extends <#if data.isInstant>Instantenous</#if>MobE
 		</#if>
 		<#list data.modifiers as modifier>
 		this.addAttributeModifier(${modifier.attribute},
-				ResourceLocation.fromNamespaceAndPath(${JavaModName}.MODID, "effect.${data.getModElement().getRegistryName()}_${modifier?index}"),
+				ResourceLocation.fromNamespaceAndPath(${JavaModName}.MODID, "effect.${registryname}_${modifier?index}"),
 				${modifier.amount}, AttributeModifier.Operation.${modifier.operation});
 		</#list>
 	}

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/projectile/projectile.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/projectile/projectile.java.ftl
@@ -178,7 +178,7 @@ public class ${name}Entity extends AbstractArrow implements ItemSupplier {
 	}
 
 	public static ${name}Entity shoot(Level world, LivingEntity entity, RandomSource random, float power, double damage, int knockback) {
-		${name}Entity entityarrow = new ${name}Entity(${JavaModName}Entities.${data.getModElement().getRegistryNameUpper()}.get(), entity, world, null);
+		${name}Entity entityarrow = new ${name}Entity(${JavaModName}Entities.${REGISTRYNAME}.get(), entity, world, null);
 		entityarrow.shoot(entity.getViewVector(1).x, entity.getViewVector(1).y, entity.getViewVector(1).z, power * 2, 0);
 		entityarrow.setSilent(true);
 		entityarrow.setCritArrow(${data.showParticles});
@@ -198,7 +198,7 @@ public class ${name}Entity extends AbstractArrow implements ItemSupplier {
 	}
 
 	public static ${name}Entity shoot(LivingEntity entity, LivingEntity target) {
-		${name}Entity entityarrow = new ${name}Entity(${JavaModName}Entities.${data.getModElement().getRegistryNameUpper()}.get(), entity, entity.level(), null);
+		${name}Entity entityarrow = new ${name}Entity(${JavaModName}Entities.${REGISTRYNAME}.get(), entity, entity.level(), null);
 		double dx = target.getX() - entity.getX();
 		double dy = target.getY() + target.getEyeHeight() - 1.1;
 		double dz = target.getZ() - entity.getZ();

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/tool.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/tool.java.ftl
@@ -114,7 +114,7 @@ public class ${name}Item extends ${data.toolType?replace("Spade", "Shovel")?repl
 
 	<#if (data.usageCount == 0) && (data.toolType == "Pickaxe" || data.toolType == "Axe" || data.toolType == "Sword" || data.toolType == "Spade" || data.toolType == "Hoe" || data.toolType == "MultiTool")>
 	@SubscribeEvent public static void handleToolDamage(ModifyDefaultComponentsEvent event) {
-		event.modify(${JavaModName}Items.${data.getModElement().getRegistryNameUpper()}.get(), builder -> builder.remove(DataComponents.MAX_DAMAGE));
+		event.modify(${JavaModName}Items.${REGISTRYNAME}.get(), builder -> builder.remove(DataComponents.MAX_DAMAGE));
 	}
 	</#if>
 

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/armor.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/armor.java.ftl
@@ -91,7 +91,7 @@ import net.minecraft.client.model.Model;
 				return ResourceLocation.parse("${modid}:textures/models/armor/${data.armorTextureFile}_layer_1.png");
 				</#if>
 			}
-		}, ${JavaModName}Items.${data.getModElement().getRegistryNameUpper()}_HELMET.get());
+		}, ${JavaModName}Items.${REGISTRYNAME}_HELMET.get());
 		</#if>
 
 		<#if data.enableBody>
@@ -118,7 +118,7 @@ import net.minecraft.client.model.Model;
 				return ResourceLocation.parse("${modid}:textures/models/armor/${data.armorTextureFile}_layer_1.png");
 				</#if>
 			}
-		}, ${JavaModName}Items.${data.getModElement().getRegistryNameUpper()}_CHESTPLATE.get());
+		}, ${JavaModName}Items.${REGISTRYNAME}_CHESTPLATE.get());
 		</#if>
 
 		<#if data.enableLeggings>
@@ -145,7 +145,7 @@ import net.minecraft.client.model.Model;
 				return ResourceLocation.parse("${modid}:textures/models/armor/${data.armorTextureFile}_layer_2.png");
 				</#if>
 			}
-		}, ${JavaModName}Items.${data.getModElement().getRegistryNameUpper()}_LEGGINGS.get());
+		}, ${JavaModName}Items.${REGISTRYNAME}_LEGGINGS.get());
 		</#if>
 
 		<#if data.enableBoots>
@@ -172,7 +172,7 @@ import net.minecraft.client.model.Model;
 				return ResourceLocation.parse("${modid}:textures/models/armor/${data.armorTextureFile}_layer_1.png");
 				</#if>
 			}
-		}, ${JavaModName}Items.${data.getModElement().getRegistryNameUpper()}_BOOTS.get());
+		}, ${JavaModName}Items.${REGISTRYNAME}_BOOTS.get());
 		</#if>
 	}
 

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/block/block.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/block/block.java.ftl
@@ -689,7 +689,7 @@ public class ${name}Block extends
 						Minecraft.getInstance().level.getBiome(pos).value().getWaterFogColor() : 329011;
 					</#if>
 				</#if>
-			}, ${JavaModName}Blocks.${data.getModElement().getRegistryNameUpper()}.get());
+			}, ${JavaModName}Blocks.${REGISTRYNAME}.get());
 		}
 	</#if>
 

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/block/blockentity.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/block/blockentity.java.ftl
@@ -41,7 +41,7 @@ public class ${name}BlockEntity extends RandomizableContainerBlockEntity impleme
 	private final SidedInvWrapper handler = new SidedInvWrapper(this, null);
 
 	public ${name}BlockEntity(BlockPos position, BlockState state) {
-		super(${JavaModName}BlockEntities.${data.getModElement().getRegistryNameUpper()}.get(), position, state);
+		super(${JavaModName}BlockEntities.${REGISTRYNAME}.get(), position, state);
 	}
 
 	@Override public void loadAdditional(CompoundTag compound, HolderLookup.Provider lookupProvider) {

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/fluid/fluid.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/fluid/fluid.java.ftl
@@ -37,15 +37,15 @@ package ${package}.fluid;
 public abstract class ${name}Fluid extends BaseFlowingFluid {
 
 	public static final BaseFlowingFluid.Properties PROPERTIES = new BaseFlowingFluid.Properties(
-		() -> ${JavaModName}FluidTypes.${data.getModElement().getRegistryNameUpper()}_TYPE.get(),
-		() -> ${JavaModName}Fluids.${data.getModElement().getRegistryNameUpper()}.get(),
-		() -> ${JavaModName}Fluids.FLOWING_${data.getModElement().getRegistryNameUpper()}.get())
+		() -> ${JavaModName}FluidTypes.${REGISTRYNAME}_TYPE.get(),
+		() -> ${JavaModName}Fluids.${REGISTRYNAME}.get(),
+		() -> ${JavaModName}Fluids.FLOWING_${REGISTRYNAME}.get())
 		.explosionResistance(${data.resistance}f)
 		<#if data.flowRate != 5>.tickRate(${data.flowRate})</#if>
 		<#if data.levelDecrease != 1>.levelDecreasePerBlock(${data.levelDecrease})</#if>
 		<#if data.slopeFindDistance != 4>.slopeFindDistance(${data.slopeFindDistance})</#if>
-		<#if data.generateBucket>.bucket(() -> ${JavaModName}Items.${data.getModElement().getRegistryNameUpper()}_BUCKET.get())</#if>
-		.block(() -> (LiquidBlock) ${JavaModName}Blocks.${data.getModElement().getRegistryNameUpper()}.get());
+		<#if data.generateBucket>.bucket(() -> ${JavaModName}Items.${REGISTRYNAME}_BUCKET.get())</#if>
+		.block(() -> (LiquidBlock) ${JavaModName}Blocks.${REGISTRYNAME}.get());
 
 	private ${name}Fluid() {
 		super(PROPERTIES);

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/fluid/fluidblock.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/fluid/fluidblock.java.ftl
@@ -39,7 +39,7 @@ import net.minecraft.world.level.block.state.BlockBehaviour.Properties;
 <#compress>
 public class ${name}Block extends LiquidBlock {
 	public ${name}Block(BlockBehaviour.Properties properties) {
-		super(${JavaModName}Fluids.${data.getModElement().getRegistryNameUpper()}.get(),
+		super(${JavaModName}Fluids.${REGISTRYNAME}.get(),
 			properties
 			<#if generator.map(data.colorOnMap, "mapcolors") != "DEFAULT">
 			.mapColor(MapColor.${generator.map(data.colorOnMap, "mapcolors")})

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/fluid/fluidbucket.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/fluid/fluidbucket.java.ftl
@@ -38,7 +38,7 @@ import net.minecraft.network.chat.Component;
 public class ${name}Item extends BucketItem {
 
 	public ${name}Item(Item.Properties properties) {
-		super(${JavaModName}Fluids.${data.getModElement().getRegistryNameUpper()}.get(),
+		super(${JavaModName}Fluids.${REGISTRYNAME}.get(),
 			properties.craftRemainder(Items.BUCKET).stacksTo(1).rarity(Rarity.${data.rarity}));
 	}
 

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/fluid/fluidtype.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/fluid/fluidtype.java.ftl
@@ -160,6 +160,6 @@ package ${package}.fluid.types;
 					</#if> | 0xFF000000;
 				}
 				</#if>
-		}, ${JavaModName}FluidTypes.${data.getModElement().getRegistryNameUpper()}_TYPE.get());
+		}, ${JavaModName}FluidTypes.${REGISTRYNAME}_TYPE.get());
 	}
 }</#compress>

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/gui/gui_container.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/gui/gui_container.java.ftl
@@ -61,7 +61,7 @@ public class ${name}Menu extends AbstractContainerMenu implements Supplier<Map<I
 	private BlockEntity boundBlockEntity = null;
 
 	public ${name}Menu(int id, Inventory inv, FriendlyByteBuf extraData) {
-		super(${JavaModName}Menus.${data.getModElement().getRegistryNameUpper()}.get(), id);
+		super(${JavaModName}Menus.${REGISTRYNAME}.get(), id);
 
 		this.entity = inv.player;
 		this.world = inv.player.level();

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/item/item_container.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/item/item_container.java.ftl
@@ -35,7 +35,7 @@ package ${package}.item.inventory;
 @EventBusSubscriber(Dist.CLIENT) public class ${name}InventoryCapability extends ComponentItemHandler {
 
 	@SubscribeEvent @OnlyIn(Dist.CLIENT) public static void onItemDropped(ItemTossEvent event) {
-		if (event.getEntity().getItem().getItem() == ${JavaModName}Items.${data.getModElement().getRegistryNameUpper()}.get()) {
+		if (event.getEntity().getItem().getItem() == ${JavaModName}Items.${REGISTRYNAME}.get()) {
 			if (Minecraft.getInstance().screen instanceof ${data.guiBoundTo}Screen) {
 				Minecraft.getInstance().player.closeContainer();
 			}
@@ -51,7 +51,7 @@ package ${package}.item.inventory;
 	}
 
 	@Override public boolean isItemValid(int slot, @Nonnull ItemStack stack) {
-		return stack.getItem() != ${JavaModName}Items.${data.getModElement().getRegistryNameUpper()}.get();
+		return stack.getItem() != ${JavaModName}Items.${REGISTRYNAME}.get();
 	}
 
 	@Override public ItemStack getStackInSlot(int slot) {

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/livingentity/livingentity.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/livingentity/livingentity.java.ftl
@@ -53,7 +53,7 @@ public class ${name}Entity extends ${extendsClass} <#if data.ranged>implements R
 
 	<#if data.mobBehaviourType == "Raider">
 	public static final EnumProxy<Raid.RaiderType> RAIDER_TYPE = new EnumProxy<>(Raid.RaiderType.class,
-		${JavaModName}Entities.${data.getModElement().getRegistryNameUpper()}, new int[] {0, ${data.raidSpawnsCount[0]}, ${data.raidSpawnsCount[1]}, ${data.raidSpawnsCount[2]}, ${data.raidSpawnsCount[3]}, ${data.raidSpawnsCount[4]}, ${data.raidSpawnsCount[5]}, ${data.raidSpawnsCount[6]}}
+		${JavaModName}Entities.${REGISTRYNAME}, new int[] {0, ${data.raidSpawnsCount[0]}, ${data.raidSpawnsCount[1]}, ${data.raidSpawnsCount[2]}, ${data.raidSpawnsCount[3]}, ${data.raidSpawnsCount[4]}, ${data.raidSpawnsCount[5]}, ${data.raidSpawnsCount[6]}}
 	);
 	</#if>
 
@@ -664,7 +664,7 @@ public class ${name}Entity extends ${extendsClass} <#if data.ranged>implements R
 	    @Override public void performRangedAttack(LivingEntity target, float flval) {
 			<#if data.rangedItemType == "Default item">
 				<#if !data.rangedAttackItem.isEmpty()>
-				${name}EntityProjectile entityarrow = new ${name}EntityProjectile(${JavaModName}Entities.${data.getModElement().getRegistryNameUpper()}_PROJECTILE.get(), this, this.level());
+				${name}EntityProjectile entityarrow = new ${name}EntityProjectile(${JavaModName}Entities.${REGISTRYNAME}_PROJECTILE.get(), this, this.level());
 				<#else>
 				Arrow entityarrow = new Arrow(this.level(), this, new ItemStack(Items.ARROW), null);
 				</#if>
@@ -681,7 +681,7 @@ public class ${name}Entity extends ${extendsClass} <#if data.ranged>implements R
 
 	<#if data.breedable>
         @Override public AgeableMob getBreedOffspring(ServerLevel serverWorld, AgeableMob ageable) {
-			${name}Entity retval = ${JavaModName}Entities.${data.getModElement().getRegistryNameUpper()}.get().create(serverWorld, EntitySpawnReason.BREEDING);
+			${name}Entity retval = ${JavaModName}Entities.${REGISTRYNAME}.get().create(serverWorld, EntitySpawnReason.BREEDING);
 			retval.finalizeSpawn(serverWorld, serverWorld.getCurrentDifficultyAt(retval.blockPosition()), EntitySpawnReason.BREEDING, null);
 			return retval;
 		}
@@ -847,7 +847,7 @@ public class ${name}Entity extends ${extendsClass} <#if data.ranged>implements R
 	public static void init(RegisterSpawnPlacementsEvent event) {
 		<#if data.spawnThisMob>
 			<#if data.mobSpawningType == "creature">
-			event.register(${JavaModName}Entities.${data.getModElement().getRegistryNameUpper()}.get(),
+			event.register(${JavaModName}Entities.${REGISTRYNAME}.get(),
 					SpawnPlacementTypes.ON_GROUND, Heightmap.Types.MOTION_BLOCKING_NO_LEAVES,
 				<#if hasProcedure(data.spawningCondition)>
 					(entityType, world, reason, pos, random) -> {
@@ -864,7 +864,7 @@ public class ${name}Entity extends ${extendsClass} <#if data.ranged>implements R
 				RegisterSpawnPlacementsEvent.Operation.REPLACE
 			);
 			<#elseif data.mobSpawningType == "ambient" || data.mobSpawningType == "misc">
-			event.register(${JavaModName}Entities.${data.getModElement().getRegistryNameUpper()}.get(),
+			event.register(${JavaModName}Entities.${REGISTRYNAME}.get(),
 					SpawnPlacementTypes.NO_RESTRICTIONS, Heightmap.Types.MOTION_BLOCKING_NO_LEAVES,
 					<#if hasProcedure(data.spawningCondition)>
 					(entityType, world, reason, pos, random) -> {
@@ -879,7 +879,7 @@ public class ${name}Entity extends ${extendsClass} <#if data.ranged>implements R
 					RegisterSpawnPlacementsEvent.Operation.REPLACE
 			);
 			<#elseif data.mobSpawningType == "waterCreature" || data.mobSpawningType == "waterAmbient">
-			event.register(${JavaModName}Entities.${data.getModElement().getRegistryNameUpper()}.get(),
+			event.register(${JavaModName}Entities.${REGISTRYNAME}.get(),
 					SpawnPlacementTypes.IN_WATER, Heightmap.Types.MOTION_BLOCKING_NO_LEAVES,
 					<#if hasProcedure(data.spawningCondition)>
 					(entityType, world, reason, pos, random) -> {
@@ -896,7 +896,7 @@ public class ${name}Entity extends ${extendsClass} <#if data.ranged>implements R
 					RegisterSpawnPlacementsEvent.Operation.REPLACE
 			);
 			<#elseif data.mobSpawningType == "undergroundWaterCreature">
-			event.register(${JavaModName}Entities.${data.getModElement().getRegistryNameUpper()}.get(),
+			event.register(${JavaModName}Entities.${REGISTRYNAME}.get(),
 					SpawnPlacementTypes.IN_WATER, Heightmap.Types.MOTION_BLOCKING_NO_LEAVES,
 					<#if hasProcedure(data.spawningCondition)>
 					(entityType, world, reason, pos, random) -> {
@@ -915,7 +915,7 @@ public class ${name}Entity extends ${extendsClass} <#if data.ranged>implements R
 					RegisterSpawnPlacementsEvent.Operation.REPLACE
 			);
 			<#else>
-			event.register(${JavaModName}Entities.${data.getModElement().getRegistryNameUpper()}.get(),
+			event.register(${JavaModName}Entities.${REGISTRYNAME}.get(),
 					SpawnPlacementTypes.ON_GROUND, Heightmap.Types.MOTION_BLOCKING_NO_LEAVES,
 					<#if hasProcedure(data.spawningCondition)>
 					(entityType, world, reason, pos, random) -> {

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/plant/plant.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/plant/plant.java.ftl
@@ -393,12 +393,12 @@ public class ${name}Block extends ${getPlantClass(data.plantType)}Block
 
 <#macro toTreeGrower secondaryChance megaTree="" megaTree2="" tree="" tree2="" flowerTree="" flowerTree2="">
 	<#if (megaTree2?has_content || tree2?has_content || flowerTree2?has_content) && secondaryChance != 0>
-	new TreeGrower("${data.getModElement().getRegistryName()}", ${secondaryChance}f,
+	new TreeGrower("${registryname}", ${secondaryChance}f,
 		<@toOptionalTree megaTree/>, <@toOptionalTree megaTree2/>, <@toOptionalTree tree/>,
 		<@toOptionalTree tree2/>, <@toOptionalTree flowerTree/>, <@toOptionalTree flowerTree2/>
 	);
 	<#else>
-	new TreeGrower("${data.getModElement().getRegistryName()}", <@toOptionalTree megaTree/>, <@toOptionalTree tree/>, <@toOptionalTree flowerTree/>);
+	new TreeGrower("${registryname}", <@toOptionalTree megaTree/>, <@toOptionalTree tree/>, <@toOptionalTree flowerTree/>);
 	</#if>
 </#macro>
 

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/plant/plant.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/plant/plant.java.ftl
@@ -369,7 +369,7 @@ public class ${name}Block extends ${getPlantClass(data.plantType)}Block
 						Minecraft.getInstance().level.getBiome(pos).value().getWaterFogColor() : 329011;
 					</#if>
 				</#if>
-			}, ${JavaModName}Blocks.${data.getModElement().getRegistryNameUpper()}.get());
+			}, ${JavaModName}Blocks.${REGISTRYNAME}.get());
 		}
 	</#if>
 }

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/plant/plantblockentity.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/plant/plantblockentity.java.ftl
@@ -34,7 +34,7 @@ package ${package}.block.entity;
 public class ${name}BlockEntity extends BlockEntity {
 
 	public ${name}BlockEntity(BlockPos pos, BlockState state) {
-		super(${JavaModName}BlockEntities.${data.getModElement().getRegistryNameUpper()}.get(), pos, state);
+		super(${JavaModName}BlockEntities.${REGISTRYNAME}.get(), pos, state);
 	}
 
 	@Override public ClientboundBlockEntityDataPacket getUpdatePacket() {

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/potioneffect.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/potioneffect.java.ftl
@@ -46,7 +46,7 @@ public class ${name}MobEffect extends <#if data.isInstant>Instantenous</#if>MobE
 		</#if>
 		<#list data.modifiers as modifier>
 		this.addAttributeModifier(${modifier.attribute},
-				ResourceLocation.fromNamespaceAndPath(${JavaModName}.MODID, "effect.${data.getModElement().getRegistryName()}_${modifier?index}"),
+				ResourceLocation.fromNamespaceAndPath(${JavaModName}.MODID, "effect.${registryname}_${modifier?index}"),
 				${modifier.amount}, AttributeModifier.Operation.${modifier.operation});
 		</#list>
 	}

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/potioneffect.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/potioneffect.java.ftl
@@ -149,7 +149,7 @@ public class ${name}MobEffect extends <#if data.isInstant>Instantenous</#if>MobE
 				return false;
 			}
 			</#if>
-		}, ${JavaModName}MobEffects.${data.getModElement().getRegistryNameUpper()}.get());
+		}, ${JavaModName}MobEffects.${REGISTRYNAME}.get());
 	}
 	</#if>
 
@@ -158,7 +158,7 @@ public class ${name}MobEffect extends <#if data.isInstant>Instantenous</#if>MobE
 		Consumable original = Items.HONEY_BOTTLE.components().get(DataComponents.CONSUMABLE);
 		if (original != null) {
 			List<ConsumeEffect> onConsumeEffects = new ArrayList<>(original.onConsumeEffects());
-			onConsumeEffects.add(new RemoveStatusEffectsConsumeEffect(${JavaModName}MobEffects.${data.getModElement().getRegistryNameUpper()}));
+			onConsumeEffects.add(new RemoveStatusEffectsConsumeEffect(${JavaModName}MobEffects.${REGISTRYNAME}));
 			Consumable replacementConsumable = new Consumable(original.consumeSeconds(), original.animation(), original.sound(), original.hasConsumeParticles(), onConsumeEffects);
 			event.modify(Items.HONEY_BOTTLE, builder -> builder.set(DataComponents.CONSUMABLE, replacementConsumable));
 		}

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/projectile/projectile.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/projectile/projectile.java.ftl
@@ -178,7 +178,7 @@ public class ${name}Entity extends AbstractArrow implements ItemSupplier {
 	}
 
 	public static ${name}Entity shoot(Level world, LivingEntity entity, RandomSource random, float power, double damage, int knockback) {
-		${name}Entity entityarrow = new ${name}Entity(${JavaModName}Entities.${data.getModElement().getRegistryNameUpper()}.get(), entity, world, null);
+		${name}Entity entityarrow = new ${name}Entity(${JavaModName}Entities.${REGISTRYNAME}.get(), entity, world, null);
 		entityarrow.shoot(entity.getViewVector(1).x, entity.getViewVector(1).y, entity.getViewVector(1).z, power * 2, 0);
 		entityarrow.setSilent(true);
 		entityarrow.setCritArrow(${data.showParticles});
@@ -199,7 +199,7 @@ public class ${name}Entity extends AbstractArrow implements ItemSupplier {
 	}
 
 	public static ${name}Entity shoot(LivingEntity entity, LivingEntity target) {
-		${name}Entity entityarrow = new ${name}Entity(${JavaModName}Entities.${data.getModElement().getRegistryNameUpper()}.get(), entity, entity.level(), null);
+		${name}Entity entityarrow = new ${name}Entity(${JavaModName}Entities.${REGISTRYNAME}.get(), entity, entity.level(), null);
 		double dx = target.getX() - entity.getX();
 		double dy = target.getY() + target.getEyeHeight() - 1.1;
 		double dz = target.getZ() - entity.getZ();

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/tool.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/tool.java.ftl
@@ -95,7 +95,7 @@ public class ${name}Item extends ${data.toolType?replace("Spade", "Shovel")?repl
 
 	<#if (data.usageCount == 0) && (data.toolType == "Pickaxe" || data.toolType == "Axe" || data.toolType == "Sword" || data.toolType == "Spade" || data.toolType == "Hoe" || data.toolType == "MultiTool")>
 	@SubscribeEvent public static void handleToolDamage(ModifyDefaultComponentsEvent event) {
-		event.modify(${JavaModName}Items.${data.getModElement().getRegistryNameUpper()}.get(), builder -> builder.remove(DataComponents.MAX_DAMAGE));
+		event.modify(${JavaModName}Items.${REGISTRYNAME}.get(), builder -> builder.remove(DataComponents.MAX_DAMAGE));
 	}
 	</#if>
 

--- a/src/main/java/net/mcreator/generator/template/TemplateGenerator.java
+++ b/src/main/java/net/mcreator/generator/template/TemplateGenerator.java
@@ -75,6 +75,7 @@ public class TemplateGenerator {
 
 		dataModel.put("data", element);
 		dataModel.put("registryname", element.getModElement().getRegistryName());
+		dataModel.put("REGISTRYNAME", element.getModElement().getRegistryNameUpper());
 		dataModel.put("name", element.getModElement().getName());
 
 		if (provider != null)
@@ -94,6 +95,7 @@ public class TemplateGenerator {
 		dataModel.put("itemindex", itemIndex);
 		dataModel.put("parent", element);
 		dataModel.put("registryname", element.getModElement().getRegistryName());
+		dataModel.put("REGISTRYNAME", element.getModElement().getRegistryNameUpper());
 		dataModel.put("name", element.getModElement().getName());
 
 		if (provider != null)

--- a/src/main/java/net/mcreator/ui/help/HelpLoader.java
+++ b/src/main/java/net/mcreator/ui/help/HelpLoader.java
@@ -109,6 +109,8 @@ public class HelpLoader {
 								dataModel.put("data", meHelpContext.getModElementFromGUI());
 								dataModel.put("registryname",
 										meHelpContext.getModElementFromGUI().getModElement().getRegistryName());
+								dataModel.put("REGISTRYNAME",
+										meHelpContext.getModElementFromGUI().getModElement().getRegistryNameUpper());
 								dataModel.put("name", meHelpContext.getModElementFromGUI().getModElement().getName());
 								dataModel.put("elementtype",
 										meHelpContext.getModElementFromGUI().getModElement().getType()


### PR DESCRIPTION
With this PR, templates can use `${REGISTRYNAME}` to query the uppercase registry name (similar to datalist mappings).

 This PR also fixes some templates using method calls instead of `${registryname}` directly