### PR TITLE
Optional tags support

### DIFF
--- a/plugins/generator-1.21.1/datapack-1.21.1/templates/tags.json.ftl
+++ b/plugins/generator-1.21.1/datapack-1.21.1/templates/tags.json.ftl
@@ -28,10 +28,8 @@
 
 <#macro tagEntry valueObject name>
 	<#assign value = valueObject.getUnmappedValue()>
-	<#-- make external entries and tag entries not using the minecraft namespace optional -->
-	<#if value?starts_with("EXTERNAL:") ||
-		(value?starts_with("TAG:") && !value?starts_with("TAG:minecraft:") && value?contains(":")) ||
-		(value?starts_with("#") && !value?starts_with("#minecraft:") && value?contains(":"))>
+	<#-- make external entries and tag entries optional -->
+	<#if value?starts_with("EXTERNAL:") || value?starts_with("TAG:") || value?starts_with("#")>
 		{
           "id": "${name}",
           "required": false

--- a/plugins/generator-1.21.1/datapack-1.21.1/templates/tags.json.ftl
+++ b/plugins/generator-1.21.1/datapack-1.21.1/templates/tags.json.ftl
@@ -4,24 +4,39 @@
     "values": [
       <#if type == "items" || type == "blocks">
           <#list w.normalizeTagElements(tag.resourcePath(), 1, elements) as value>
-            "${mappedMCItemToRegistryName(value, true)}"<#sep>,
+			<@tagEntry value mappedMCItemToRegistryName(value, true)/><#sep>,
           </#list>
       <#elseif type == "entities">
           <#list w.normalizeTagElements(tag.resourcePath(), 2, elements) as value>
-            "${value.getMappedValue(2)}"<#sep>,
+			<@tagEntry value value.getMappedValue(2)/><#sep>,
           </#list>
       <#elseif type == "biomes" || type == "structures" || type == "game_events">
           <#list w.normalizeTagElements(tag.resourcePath(), 0, elements) as value>
-            "${value}"<#sep>,
+			<@tagEntry value value/><#sep>,
           </#list>
       <#elseif type == "damage_types" || type == "enchantments">
           <#list w.normalizeTagElements(tag.resourcePath(), 1, elements) as value>
-            "${value.getMappedValue(1)}"<#sep>,
+			<@tagEntry value value.getMappedValue(1)/><#sep>,
           </#list>
       <#elseif type == "functions">
           <#list w.filterBrokenReferences(elements) as value>
-            "${generator.getResourceLocationForModElement(value)}"<#sep>,
+			<@tagEntry value generator.getResourceLocationForModElement(value)/><#sep>,
           </#list>
       </#if>
     ]
 }
+
+<#macro tagEntry valueObject name>
+	<#assign value = valueObject.getUnmappedValue()>
+	<#-- make external entries and tag entries not using the minecraft namespace optional -->
+	<#if value?starts_with("EXTERNAL:") ||
+		(value?starts_with("TAG:") && !value?starts_with("TAG:minecraft:") && value?contains(":")) ||
+		(value?starts_with("#") && !value?starts_with("#minecraft:") && value?contains(":"))>
+		{
+          "id": "${name}",
+          "required": false
+        }
+	<#else>
+		"${name}"
+	</#if>
+</#macro>

--- a/plugins/generator-1.21.4/datapack-1.21.4/templates/tags.json.ftl
+++ b/plugins/generator-1.21.4/datapack-1.21.4/templates/tags.json.ftl
@@ -28,10 +28,8 @@
 
 <#macro tagEntry valueObject name>
     <#assign value = valueObject.getUnmappedValue()>
-    <#-- make external entries and tag entries not using the minecraft namespace optional -->
-    <#if value?starts_with("EXTERNAL:") ||
-        (value?starts_with("TAG:") && !value?starts_with("TAG:minecraft:") && value?contains(":")) ||
-        (value?starts_with("#") && !value?starts_with("#minecraft:") && value?contains(":"))>
+    <#-- make external entries and tag entries optional -->
+    <#if value?starts_with("EXTERNAL:") || value?starts_with("TAG:") || value?starts_with("#")>
 		{
           "id": "${name}",
           "required": false

--- a/plugins/generator-1.21.4/datapack-1.21.4/templates/tags.json.ftl
+++ b/plugins/generator-1.21.4/datapack-1.21.4/templates/tags.json.ftl
@@ -4,24 +4,39 @@
     "values": [
       <#if type == "items" || type == "blocks">
           <#list w.normalizeTagElements(tag.resourcePath(), 1, elements) as value>
-            "${mappedMCItemToRegistryName(value, true)}"<#sep>,
+            <@tagEntry value mappedMCItemToRegistryName(value, true)/><#sep>,
           </#list>
       <#elseif type == "entities">
           <#list w.normalizeTagElements(tag.resourcePath(), 2, elements) as value>
-            "${value.getMappedValue(2)}"<#sep>,
+            <@tagEntry value value.getMappedValue(2)/><#sep>,
           </#list>
       <#elseif type == "biomes" || type == "structures" || type == "game_events">
           <#list w.normalizeTagElements(tag.resourcePath(), 0, elements) as value>
-            "${value}"<#sep>,
+            <@tagEntry value value/><#sep>,
           </#list>
       <#elseif type == "damage_types" || type == "enchantments">
           <#list w.normalizeTagElements(tag.resourcePath(), 1, elements) as value>
-            "${value.getMappedValue(1)}"<#sep>,
+            <@tagEntry value value.getMappedValue(1)/><#sep>,
           </#list>
       <#elseif type == "functions">
           <#list w.filterBrokenReferences(elements) as value>
-            "${generator.getResourceLocationForModElement(value)}"<#sep>,
+            <@tagEntry value generator.getResourceLocationForModElement(value)/><#sep>,
           </#list>
       </#if>
     ]
 }
+
+<#macro tagEntry valueObject name>
+    <#assign value = valueObject.getUnmappedValue()>
+    <#-- make external entries and tag entries not using the minecraft namespace optional -->
+    <#if value?starts_with("EXTERNAL:") ||
+        (value?starts_with("TAG:") && !value?starts_with("TAG:minecraft:") && value?contains(":")) ||
+        (value?starts_with("#") && !value?starts_with("#minecraft:") && value?contains(":"))>
+		{
+          "id": "${name}",
+          "required": false
+        }
+    <#else>
+		"${name}"
+    </#if>
+</#macro>

--- a/plugins/mcreator-localization/lang/texts.properties
+++ b/plugins/mcreator-localization/lang/texts.properties
@@ -639,9 +639,7 @@ itemlistfield.remove=Remove entry
 itemlistfield.removeall=Remove all entries
 itemlistfield.addtag=Add tag entry
 itemlistfield.addexternal.title=Add external entry
-itemlistfield.addexternal.message=<html>Enter the name of the external entry <b>including its namespace</b> (e.g. someothermod:modelement):<br><br>\
-    Make sure to declare dependency on the mod that adds this entry in the workspace settings.<br>\
-    <b>If the entry does not exist, the tag will fail to load in the game entirely!</b>
+itemlistfield.addexternal.message=<html>Enter the name of the external entry <b>including its namespace</b> (e.g. othermodnamespace:modelement):
 itemlistfield.addexternal.entry.error=Use other means of adding entries for vanilla entries and entries from your mod
 itemlistfield.addexternal.entry=Entry
 workspace.loading=Loading the workspace...

--- a/src/test/java/net/mcreator/integration/TestWorkspaceDataProvider.java
+++ b/src/test/java/net/mcreator/integration/TestWorkspaceDataProvider.java
@@ -335,20 +335,39 @@ public class TestWorkspaceDataProvider {
 			workspace.addTagElement(tag);
 			workspace.getTagElements().get(tag).add("minecraft:stone");
 			workspace.getTagElements().get(tag).add("~minecraft:dirt");
+			workspace.getTagElements().get(tag).add("EXTERNAL:externalmod:item");
+			if (workspace.getGeneratorStats().getModElementTypeCoverageInfo().get(ModElementType.ITEM)
+					== GeneratorStats.CoverageStatus.FULL) {
+				workspace.getTagElements().get(tag).add("CUSTOM:Exampleitem1");
+				workspace.getTagElements().get(tag).add("~CUSTOM:Exampleitem2");
+			}
 
 			tag = new TagElement(TagType.BLOCKS, "minecraft:test");
 			workspace.addTagElement(tag);
 			workspace.getTagElements().get(tag).add("minecraft:stone");
 			workspace.getTagElements().get(tag).add("~minecraft:dirt");
+			workspace.getTagElements().get(tag).add("EXTERNAL:externalmod:block");
+			if (workspace.getGeneratorStats().getModElementTypeCoverageInfo().get(ModElementType.BLOCK)
+					== GeneratorStats.CoverageStatus.FULL) {
+				workspace.getTagElements().get(tag).add("CUSTOM:Exampleblock1");
+				workspace.getTagElements().get(tag).add("~CUSTOM:Exampleblock2");
+			}
 
 			tag = new TagElement(TagType.ENTITIES, "minecraft:test");
 			workspace.addTagElement(tag);
 			workspace.getTagElements().get(tag).add("minecraft:creeper");
 			workspace.getTagElements().get(tag).add("~minecraft:zombie");
+			workspace.getTagElements().get(tag).add("EXTERNAL:externalmod:entity");
+			if (workspace.getGeneratorStats().getModElementTypeCoverageInfo().get(ModElementType.LIVINGENTITY)
+					== GeneratorStats.CoverageStatus.FULL) {
+				workspace.getTagElements().get(tag).add("CUSTOM:Examplelivingentity1");
+				workspace.getTagElements().get(tag).add("~CUSTOM:Examplelivingentity2");
+			}
 
 			tag = new TagElement(TagType.BIOMES, "minecraft:test");
 			workspace.addTagElement(tag);
 			workspace.getTagElements().get(tag).add("minecraft:plains");
+			workspace.getTagElements().get(tag).add("EXTERNAL:externalmod:biome");
 			if (workspace.getGeneratorStats().getModElementTypeCoverageInfo().get(ModElementType.BIOME)
 					== GeneratorStats.CoverageStatus.FULL) {
 				workspace.getTagElements().get(tag).add("~CUSTOM:Examplebiome1");
@@ -358,6 +377,7 @@ public class TestWorkspaceDataProvider {
 			workspace.addTagElement(tag);
 			workspace.getTagElements().get(tag).add("minecraft:stronghold");
 			workspace.getTagElements().get(tag).add("~minecraft:mineshaft");
+			workspace.getTagElements().get(tag).add("EXTERNAL:externalmod:structure");
 			if (workspace.getGeneratorStats().getModElementTypeCoverageInfo().get(ModElementType.STRUCTURE)
 					== GeneratorStats.CoverageStatus.FULL) {
 				workspace.getTagElements().get(tag).add("CUSTOM:Examplestructure1");
@@ -366,6 +386,7 @@ public class TestWorkspaceDataProvider {
 
 			tag = new TagElement(TagType.DAMAGE_TYPES, "minecraft:test");
 			workspace.addTagElement(tag);
+			workspace.getTagElements().get(tag).add("EXTERNAL:externalmod:damage_type");
 			if (workspace.getGeneratorStats().getModElementTypeCoverageInfo().get(ModElementType.DAMAGETYPE)
 					== GeneratorStats.CoverageStatus.FULL) {
 				workspace.getTagElements().get(tag).add("CUSTOM:Exampledamagetype1");
@@ -374,6 +395,7 @@ public class TestWorkspaceDataProvider {
 
 			tag = new TagElement(TagType.ENCHANTMENTS, "minecraft:test");
 			workspace.addTagElement(tag);
+			workspace.getTagElements().get(tag).add("EXTERNAL:externalmod:enchantment");
 			if (workspace.getGeneratorStats().getModElementTypeCoverageInfo().get(ModElementType.ENCHANTMENT)
 					== GeneratorStats.CoverageStatus.FULL) {
 				workspace.getTagElements().get(tag).add("CUSTOM:Exampleenchantment1");
@@ -382,6 +404,7 @@ public class TestWorkspaceDataProvider {
 
 			tag = new TagElement(TagType.GAME_EVENTS, "minecraft:test");
 			workspace.addTagElement(tag);
+			workspace.getTagElements().get(tag).add("EXTERNAL:externalmod:game_event");
 			workspace.getTagElements().get(tag).add("minecraft:block_attach");
 			workspace.getTagElements().get(tag).add("~minecraft:container_open");
 


### PR DESCRIPTION
This PR changes generators so external and tag entries of tags are marked as optional, widening compatibility and making optional mod extensions possible.

Changelog:

* External and tag entries in custom tags are now optional, making soft mod dependencies possible