### PR TITLE
Recipe makers refactoring

### DIFF
--- a/src/main/java/net/mcreator/ui/minecraft/recipemakers/AbstractRecipeMaker.java
+++ b/src/main/java/net/mcreator/ui/minecraft/recipemakers/AbstractRecipeMaker.java
@@ -29,6 +29,10 @@ import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.io.File;
 
+/**
+ * Abstract class for recipe makers used in the Recipe element GUI. This class handles the background panel and the
+ * export button.
+ */
 public abstract class AbstractRecipeMaker extends JPanel {
 
 	protected final JButton export = new JButton(UIRES.get("18px.export"));
@@ -69,5 +73,9 @@ public abstract class AbstractRecipeMaker extends JPanel {
 		export.setEnabled(enabled);
 	}
 
+	/**
+	 * This method is called before and after the recipe is exported as a .png file.
+	 * @param exportedYet This parameter is false before the image is generated, true after.
+	 */
 	protected abstract void setupImageExport(boolean exportedYet);
 }

--- a/src/main/java/net/mcreator/ui/minecraft/recipemakers/AbstractRecipeMaker.java
+++ b/src/main/java/net/mcreator/ui/minecraft/recipemakers/AbstractRecipeMaker.java
@@ -1,0 +1,73 @@
+/*
+ * MCreator (https://mcreator.net/)
+ * Copyright (C) 2012-2020, Pylo
+ * Copyright (C) 2020-2025, Pylo, opensource contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package net.mcreator.ui.minecraft.recipemakers;
+
+import net.mcreator.io.FileIO;
+import net.mcreator.ui.component.ImagePanel;
+import net.mcreator.ui.dialogs.file.FileDialogs;
+import net.mcreator.ui.init.UIRES;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.File;
+
+public abstract class AbstractRecipeMaker extends JPanel {
+
+	protected final JButton export = new JButton(UIRES.get("18px.export"));
+	protected final ImagePanel imagePanel;
+
+	protected AbstractRecipeMaker(Image backgroundImage) {
+		imagePanel = new ImagePanel(backgroundImage);
+		imagePanel.fitToImage();
+		imagePanel.setLayout(null);
+
+		export.setContentAreaFilled(false);
+		export.setMargin(new Insets(0, 0, 0, 0));
+		export.setBounds(260, 13, 24, 24);
+		export.setFocusPainted(false);
+		export.setCursor(new Cursor(Cursor.HAND_CURSOR));
+		imagePanel.add(export);
+
+		export.addActionListener(event -> {
+			export.setVisible(false);
+			setCursor(new Cursor(Cursor.WAIT_CURSOR));
+			setupImageExport(false);
+			BufferedImage outputImage =
+					new BufferedImage(imagePanel.getWidth(), imagePanel.getHeight(), BufferedImage.TYPE_INT_ARGB);
+			imagePanel.paint(outputImage.getGraphics());
+			File file = FileDialogs.getSaveDialog(null, new String[] { ".png" });
+			if (file != null)
+				FileIO.writeImageToPNGFile(outputImage, file);
+			setCursor(new Cursor(Cursor.DEFAULT_CURSOR));
+			export.setVisible(true);
+			setupImageExport(true);
+		});
+
+		add(imagePanel);
+	}
+
+	@Override public void setEnabled(boolean enabled) {
+		super.setEnabled(enabled);
+		export.setEnabled(enabled);
+	}
+
+	protected abstract void setupImageExport(boolean exportedYet);
+}

--- a/src/main/java/net/mcreator/ui/minecraft/recipemakers/BlastFurnaceRecipeMaker.java
+++ b/src/main/java/net/mcreator/ui/minecraft/recipemakers/BlastFurnaceRecipeMaker.java
@@ -19,64 +19,30 @@
 package net.mcreator.ui.minecraft.recipemakers;
 
 import net.mcreator.element.parts.MItemBlock;
-import net.mcreator.io.FileIO;
 import net.mcreator.minecraft.MCItem;
 import net.mcreator.ui.MCreator;
-import net.mcreator.ui.component.ImagePanel;
-import net.mcreator.ui.dialogs.file.FileDialogs;
 import net.mcreator.ui.init.UIRES;
 import net.mcreator.ui.minecraft.MCItemHolder;
 
-import javax.swing.*;
 import java.awt.*;
-import java.awt.image.BufferedImage;
-import java.io.File;
 
-public class BlastFurnaceRecipeMaker extends JPanel {
+public class BlastFurnaceRecipeMaker extends AbstractRecipeMaker {
 
 	public final MCItemHolder cb1;
 	public final MCItemHolder cb2;
 
-	private final JButton export = new JButton(UIRES.get("18px.export"));
-
 	public BlastFurnaceRecipeMaker(MCreator mcreator, MCItem.ListProvider itemsWithTags, MCItem.ListProvider items) {
-		ImagePanel ip = new ImagePanel(UIRES.get("recipe.blast_furnace").getImage());
-
-		ip.fitToImage();
-		ip.setLayout(null);
+		super(UIRES.get("recipe.blast_furnace").getImage());
 
 		cb1 = new MCItemHolder(mcreator, itemsWithTags, true);
 		cb2 = new MCItemHolder(mcreator, items);
 
-		export.setContentAreaFilled(false);
-		export.setMargin(new Insets(0, 0, 0, 0));
-		export.setBounds(260, 13, 24, 24);
-		export.setFocusPainted(false);
-		export.setCursor(new Cursor(Cursor.HAND_CURSOR));
-		ip.add(export);
-		export.addActionListener(event -> {
-			export.setVisible(false);
-			cb1.setValidationShownFlag(false);
-			cb2.setValidationShownFlag(false);
-			setCursor(new Cursor(Cursor.WAIT_CURSOR));
-			BufferedImage im = new BufferedImage(ip.getWidth(), ip.getHeight(), BufferedImage.TYPE_INT_ARGB);
-			ip.paint(im.getGraphics());
-			File fi = FileDialogs.getSaveDialog(null, new String[] { ".png" });
-			if (fi != null)
-				FileIO.writeImageToPNGFile(im, fi);
-			setCursor(new Cursor(Cursor.DEFAULT_CURSOR));
-			export.setVisible(true);
-			cb1.setValidationShownFlag(true);
-			cb2.setValidationShownFlag(true);
-		});
-
 		cb1.setBounds(97, 30, 28, 28);
 		cb2.setBounds(200, 61, 28, 28);
 
-		ip.add(cb1);
-		ip.add(cb2);
+		imagePanel.add(cb1);
+		imagePanel.add(cb2);
 
-		add(ip);
 		setPreferredSize(new Dimension(306, 145));
 	}
 
@@ -92,7 +58,10 @@ public class BlastFurnaceRecipeMaker extends JPanel {
 		super.setEnabled(enabled);
 		cb1.setEnabled(enabled);
 		cb2.setEnabled(enabled);
-		export.setEnabled(enabled);
 	}
 
+	@Override protected void setupImageExport(boolean exportedYet) {
+		cb1.setValidationShownFlag(exportedYet);
+		cb2.setValidationShownFlag(exportedYet);
+	}
 }

--- a/src/main/java/net/mcreator/ui/minecraft/recipemakers/BrewingRecipeMaker.java
+++ b/src/main/java/net/mcreator/ui/minecraft/recipemakers/BrewingRecipeMaker.java
@@ -18,71 +18,35 @@
 
 package net.mcreator.ui.minecraft.recipemakers;
 
-import net.mcreator.io.FileIO;
 import net.mcreator.minecraft.MCItem;
 import net.mcreator.ui.MCreator;
-import net.mcreator.ui.component.ImagePanel;
-import net.mcreator.ui.dialogs.file.FileDialogs;
 import net.mcreator.ui.init.UIRES;
 import net.mcreator.ui.minecraft.MCItemHolder;
 
-import javax.swing.*;
 import java.awt.*;
-import java.awt.image.BufferedImage;
-import java.io.File;
 
-public class BrewingRecipeMaker extends JPanel {
+public class BrewingRecipeMaker extends AbstractRecipeMaker {
 
 	public final MCItemHolder cb1;
 	public final MCItemHolder cb2;
 	public final MCItemHolder cb3;
 
-	private final JButton export = new JButton(UIRES.get("18px.export"));
-
 	public BrewingRecipeMaker(MCreator mcreator, MCItem.ListProvider itemsWithTagsAndPotions,
 			MCItem.ListProvider itemsWithTags, MCItem.ListProvider itemsWithPotions) {
-		ImagePanel ip = new ImagePanel(UIRES.get("recipe.brewing").getImage());
-
-		ip.fitToImage();
-		ip.setLayout(null);
+		super(UIRES.get("recipe.brewing").getImage());
 
 		cb1 = new MCItemHolder(mcreator, itemsWithTagsAndPotions, true, true);
 		cb2 = new MCItemHolder(mcreator, itemsWithTags, true);
 		cb3 = new MCItemHolder(mcreator, itemsWithPotions, false, true);
 
-		export.setContentAreaFilled(false);
-		export.setMargin(new Insets(0, 0, 0, 0));
-		export.setBounds(260, 13, 24, 24);
-		export.setFocusPainted(false);
-		export.setCursor(new Cursor(Cursor.HAND_CURSOR));
-		ip.add(export);
-		export.addActionListener(event -> {
-			export.setVisible(false);
-			cb1.setValidationShownFlag(false);
-			cb2.setValidationShownFlag(false);
-			cb3.setValidationShownFlag(false);
-			setCursor(new Cursor(Cursor.WAIT_CURSOR));
-			BufferedImage im = new BufferedImage(ip.getWidth(), ip.getHeight(), BufferedImage.TYPE_INT_ARGB);
-			ip.paint(im.getGraphics());
-			File fi = FileDialogs.getSaveDialog(null, new String[] { ".png" });
-			if (fi != null)
-				FileIO.writeImageToPNGFile(im, fi);
-			setCursor(new Cursor(Cursor.DEFAULT_CURSOR));
-			export.setVisible(true);
-			cb1.setValidationShownFlag(true);
-			cb2.setValidationShownFlag(true);
-			cb3.setValidationShownFlag(true);
-		});
-
 		cb1.setBounds(65, 88, 28, 28);
 		cb2.setBounds(65, 26, 28, 28);
 		cb3.setBounds(210, 50, 41, 41);
 
-		ip.add(cb1);
-		ip.add(cb2);
-		ip.add(cb3);
+		imagePanel.add(cb1);
+		imagePanel.add(cb2);
+		imagePanel.add(cb3);
 
-		add(ip);
 		setPreferredSize(new Dimension(306, 145));
 	}
 
@@ -91,7 +55,12 @@ public class BrewingRecipeMaker extends JPanel {
 		cb1.setEnabled(enabled);
 		cb2.setEnabled(enabled);
 		cb3.setEnabled(enabled);
-		export.setEnabled(enabled);
+	}
+
+	@Override protected void setupImageExport(boolean exportedYet) {
+		cb1.setValidationShownFlag(exportedYet);
+		cb2.setValidationShownFlag(exportedYet);
+		cb3.setValidationShownFlag(exportedYet);
 	}
 
 }

--- a/src/main/java/net/mcreator/ui/minecraft/recipemakers/CampfireCookingRecipeMaker.java
+++ b/src/main/java/net/mcreator/ui/minecraft/recipemakers/CampfireCookingRecipeMaker.java
@@ -19,64 +19,30 @@
 package net.mcreator.ui.minecraft.recipemakers;
 
 import net.mcreator.element.parts.MItemBlock;
-import net.mcreator.io.FileIO;
 import net.mcreator.minecraft.MCItem;
 import net.mcreator.ui.MCreator;
-import net.mcreator.ui.component.ImagePanel;
-import net.mcreator.ui.dialogs.file.FileDialogs;
 import net.mcreator.ui.init.UIRES;
 import net.mcreator.ui.minecraft.MCItemHolder;
 
-import javax.swing.*;
 import java.awt.*;
-import java.awt.image.BufferedImage;
-import java.io.File;
 
-public class CampfireCookingRecipeMaker extends JPanel {
+public class CampfireCookingRecipeMaker extends AbstractRecipeMaker {
 
 	public final MCItemHolder cb1;
 	public final MCItemHolder cb2;
 
-	private final JButton export = new JButton(UIRES.get("18px.export"));
-
 	public CampfireCookingRecipeMaker(MCreator mcreator, MCItem.ListProvider itemsWithTags, MCItem.ListProvider items) {
-		ImagePanel ip = new ImagePanel(UIRES.get("recipe.campfire_cooking").getImage());
-
-		ip.fitToImage();
-		ip.setLayout(null);
+		super(UIRES.get("recipe.campfire_cooking").getImage());
 
 		cb1 = new MCItemHolder(mcreator, itemsWithTags, true);
 		cb2 = new MCItemHolder(mcreator, items);
 
-		export.setContentAreaFilled(false);
-		export.setMargin(new Insets(0, 0, 0, 0));
-		export.setBounds(260, 13, 24, 24);
-		export.setFocusPainted(false);
-		export.setCursor(new Cursor(Cursor.HAND_CURSOR));
-		ip.add(export);
-		export.addActionListener(event -> {
-			export.setVisible(false);
-			cb1.setValidationShownFlag(false);
-			cb2.setValidationShownFlag(false);
-			setCursor(new Cursor(Cursor.WAIT_CURSOR));
-			BufferedImage im = new BufferedImage(ip.getWidth(), ip.getHeight(), BufferedImage.TYPE_INT_ARGB);
-			ip.paint(im.getGraphics());
-			File fi = FileDialogs.getSaveDialog(null, new String[] { ".png" });
-			if (fi != null)
-				FileIO.writeImageToPNGFile(im, fi);
-			setCursor(new Cursor(Cursor.DEFAULT_CURSOR));
-			export.setVisible(true);
-			cb1.setValidationShownFlag(true);
-			cb2.setValidationShownFlag(true);
-		});
-
 		cb1.setBounds(97, 30, 28, 28);
 		cb2.setBounds(200, 61, 28, 28);
 
-		ip.add(cb1);
-		ip.add(cb2);
+		imagePanel.add(cb1);
+		imagePanel.add(cb2);
 
-		add(ip);
 		setPreferredSize(new Dimension(306, 145));
 	}
 
@@ -92,7 +58,10 @@ public class CampfireCookingRecipeMaker extends JPanel {
 		super.setEnabled(enabled);
 		cb1.setEnabled(enabled);
 		cb2.setEnabled(enabled);
-		export.setEnabled(enabled);
 	}
 
+	@Override protected void setupImageExport(boolean exportedYet) {
+		cb1.setValidationShownFlag(exportedYet);
+		cb2.setValidationShownFlag(exportedYet);
+	}
 }

--- a/src/main/java/net/mcreator/ui/minecraft/recipemakers/CraftingRecipeMaker.java
+++ b/src/main/java/net/mcreator/ui/minecraft/recipemakers/CraftingRecipeMaker.java
@@ -45,10 +45,6 @@ public class CraftingRecipeMaker extends AbstractRecipeMaker {
 	public CraftingRecipeMaker(MCreator mcreator, MCItem.ListProvider itemsWithTags, MCItem.ListProvider items) {
 		super(UIRES.get("recipe.crafting").getImage());
 
-		JLabel cb = new JLabel();
-		cb.setBackground(new Color(139, 139, 139));
-		cb.setHorizontalAlignment(SwingConstants.CENTER);
-
 		MouseAdapter cloneAdapter = new MouseAdapter() {
 			private static final int buttonsDownMask =
 					MouseEvent.BUTTON1_DOWN_MASK | MouseEvent.BUTTON2_DOWN_MASK | MouseEvent.BUTTON3_DOWN_MASK;
@@ -77,9 +73,7 @@ public class CraftingRecipeMaker extends AbstractRecipeMaker {
 
 		outputItem = new MCItemHolder(mcreator, items);
 		outputItem.setMargin(new Insets(0, 0, 0, 0));
-		outputItem.setBounds(212, 60, 28, 28);
-
-		cb.setBounds(205, 53, 40, 40);
+		outputItem.setBounds(210, 58, 28, 28);
 
 		sp = new JSpinner(new SpinnerNumberModel(1, 1, 64, 1));
 		sp.setBounds(210, 109, 42, 17);
@@ -99,7 +93,6 @@ public class CraftingRecipeMaker extends AbstractRecipeMaker {
 		shapeless.setBounds(156, 97, 23, 19);
 
 		imagePanel.add(shapeless);
-		imagePanel.add(cb);
 
 		setPreferredSize(new Dimension(300, 145));
 	}

--- a/src/main/java/net/mcreator/ui/minecraft/recipemakers/CraftingRecipeMaker.java
+++ b/src/main/java/net/mcreator/ui/minecraft/recipemakers/CraftingRecipeMaker.java
@@ -38,16 +38,8 @@ import java.io.File;
 public class CraftingRecipeMaker extends JPanel {
 
 	public final JSpinner sp;
-	public final MCItemHolder cb1;
-	public final MCItemHolder cb2;
-	public final MCItemHolder cb3;
-	public final MCItemHolder cb4;
-	public final MCItemHolder cb5;
-	public final MCItemHolder cb6;
-	public final MCItemHolder cb7;
-	public final MCItemHolder cb8;
-	public final MCItemHolder cb9;
-	public final MCItemHolder cb10;
+	public final MCItemHolder[] recipeSlots = new MCItemHolder[9];
+	public final MCItemHolder outputItem;
 
 	private final JLabel shapeless = new JLabel(UIRES.get("recipe.shapeless"));
 
@@ -63,16 +55,6 @@ public class CraftingRecipeMaker extends JPanel {
 		JLabel cb = new JLabel();
 		cb.setBackground(new Color(139, 139, 139));
 		cb.setHorizontalAlignment(SwingConstants.CENTER);
-
-		cb1 = new MCItemHolder(mcreator, itemsWithTags, true);
-		cb2 = new MCItemHolder(mcreator, itemsWithTags, true);
-		cb3 = new MCItemHolder(mcreator, itemsWithTags, true);
-		cb4 = new MCItemHolder(mcreator, itemsWithTags, true);
-		cb5 = new MCItemHolder(mcreator, itemsWithTags, true);
-		cb6 = new MCItemHolder(mcreator, itemsWithTags, true);
-		cb7 = new MCItemHolder(mcreator, itemsWithTags, true);
-		cb8 = new MCItemHolder(mcreator, itemsWithTags, true);
-		cb9 = new MCItemHolder(mcreator, itemsWithTags, true);
 
 		MouseAdapter cloneAdapter = new MouseAdapter() {
 			private static final int buttonsDownMask =
@@ -92,40 +74,17 @@ public class CraftingRecipeMaker extends JPanel {
 				}
 			}
 		};
-		cb1.addMouseListener(cloneAdapter);
-		cb2.addMouseListener(cloneAdapter);
-		cb3.addMouseListener(cloneAdapter);
-		cb4.addMouseListener(cloneAdapter);
-		cb5.addMouseListener(cloneAdapter);
-		cb6.addMouseListener(cloneAdapter);
-		cb7.addMouseListener(cloneAdapter);
-		cb8.addMouseListener(cloneAdapter);
-		cb9.addMouseListener(cloneAdapter);
 
-		cb10 = new MCItemHolder(mcreator, items);
+		for (int i = 0; i < 9; i++) {
+			recipeSlots[i] = new MCItemHolder(mcreator, itemsWithTags, true);
+			recipeSlots[i].addMouseListener(cloneAdapter);
+			recipeSlots[i].setMargin(new Insets(0, 0, 0, 0));
+			recipeSlots[i].setBounds(51 + 31 * (i % 3), 29 + 31 * (i / 3), 28, 28);
+		}
 
-		cb1.setMargin(new Insets(0, 0, 0, 0));
-		cb2.setMargin(new Insets(0, 0, 0, 0));
-		cb3.setMargin(new Insets(0, 0, 0, 0));
-		cb4.setMargin(new Insets(0, 0, 0, 0));
-		cb5.setMargin(new Insets(0, 0, 0, 0));
-		cb6.setMargin(new Insets(0, 0, 0, 0));
-		cb7.setMargin(new Insets(0, 0, 0, 0));
-		cb8.setMargin(new Insets(0, 0, 0, 0));
-		cb9.setMargin(new Insets(0, 0, 0, 0));
-
-		cb10.setMargin(new Insets(0, 0, 0, 0));
-
-		cb1.setBounds(51, 29, 28, 28);
-		cb2.setBounds(51, 60, 28, 28);
-		cb3.setBounds(51, 90, 28, 28);
-		cb4.setBounds(82, 29, 28, 28);
-		cb5.setBounds(82, 60, 28, 28);
-		cb6.setBounds(82, 90, 28, 28);
-		cb7.setBounds(112, 29, 28, 28);
-		cb8.setBounds(112, 60, 28, 28);
-		cb9.setBounds(112, 90, 28, 28);
-		cb10.setBounds(212, 60, 28, 28);
+		outputItem = new MCItemHolder(mcreator, items);
+		outputItem.setMargin(new Insets(0, 0, 0, 0));
+		outputItem.setBounds(212, 60, 28, 28);
 
 		cb.setBounds(205, 53, 40, 40);
 
@@ -143,16 +102,10 @@ public class CraftingRecipeMaker extends JPanel {
 		ip.add(export);
 		export.addActionListener(event -> {
 			export.setVisible(false);
-			cb1.setValidationShownFlag(false);
-			cb2.setValidationShownFlag(false);
-			cb3.setValidationShownFlag(false);
-			cb4.setValidationShownFlag(false);
-			cb5.setValidationShownFlag(false);
-			cb6.setValidationShownFlag(false);
-			cb7.setValidationShownFlag(false);
-			cb8.setValidationShownFlag(false);
-			cb9.setValidationShownFlag(false);
-			cb10.setValidationShownFlag(false);
+			for (int i = 0; i < 9; i++) {
+				recipeSlots[i].setValidationShownFlag(false);
+			}
+			outputItem.setValidationShownFlag(false);
 			sp.setVisible(false);
 			drop.setText(sp.getValue().toString());
 			drop.setVisible(true);
@@ -165,16 +118,10 @@ public class CraftingRecipeMaker extends JPanel {
 			setCursor(new Cursor(Cursor.DEFAULT_CURSOR));
 			export.setVisible(true);
 			drop.setVisible(false);
-			cb1.setValidationShownFlag(true);
-			cb2.setValidationShownFlag(true);
-			cb3.setValidationShownFlag(true);
-			cb4.setValidationShownFlag(true);
-			cb5.setValidationShownFlag(true);
-			cb6.setValidationShownFlag(true);
-			cb7.setValidationShownFlag(true);
-			cb8.setValidationShownFlag(true);
-			cb9.setValidationShownFlag(true);
-			cb10.setValidationShownFlag(true);
+			for (int i = 0; i < 9; i++) {
+				recipeSlots[i].setValidationShownFlag(true);
+			}
+			outputItem.setValidationShownFlag(true);
 			sp.setVisible(true);
 
 		});
@@ -184,17 +131,11 @@ public class CraftingRecipeMaker extends JPanel {
 		drop.setForeground(Color.white);
 		ip.add(ComponentUtils.deriveFont(drop, 16));
 
-		ip.add(cb1);
-		ip.add(cb2);
-		ip.add(cb3);
-		ip.add(cb4);
-		ip.add(cb5);
-		ip.add(cb6);
-		ip.add(cb7);
-		ip.add(cb8);
-		ip.add(cb9);
+		for (int i = 0; i < 9; i++) {
+			ip.add(recipeSlots[i]);
+		}
 
-		ip.add(cb10);
+		ip.add(outputItem);
 
 		shapeless.setVisible(false);
 		shapeless.setBounds(156, 97, 23, 19);
@@ -210,18 +151,20 @@ public class CraftingRecipeMaker extends JPanel {
 		this.shapeless.setVisible(shapeless);
 	}
 
+	public boolean hasInputItems() {
+		for (int i = 0; i < 9; i++) {
+			if (recipeSlots[i].containsItem())
+				return true;
+		}
+		return false;
+	}
+
 	@Override public void setEnabled(boolean enabled) {
 		super.setEnabled(enabled);
-		cb1.setEnabled(enabled);
-		cb2.setEnabled(enabled);
-		cb3.setEnabled(enabled);
-		cb4.setEnabled(enabled);
-		cb5.setEnabled(enabled);
-		cb6.setEnabled(enabled);
-		cb7.setEnabled(enabled);
-		cb8.setEnabled(enabled);
-		cb9.setEnabled(enabled);
-		cb10.setEnabled(enabled);
+		for (int i = 0; i < 9; i++) {
+			recipeSlots[i].setEnabled(enabled);
+		}
+		outputItem.setEnabled(enabled);
 		sp.setEnabled(enabled);
 		shapeless.setEnabled(enabled);
 		export.setEnabled(enabled);

--- a/src/main/java/net/mcreator/ui/minecraft/recipemakers/CraftingRecipeMaker.java
+++ b/src/main/java/net/mcreator/ui/minecraft/recipemakers/CraftingRecipeMaker.java
@@ -19,12 +19,9 @@
 package net.mcreator.ui.minecraft.recipemakers;
 
 import net.mcreator.element.parts.MItemBlock;
-import net.mcreator.io.FileIO;
 import net.mcreator.minecraft.MCItem;
 import net.mcreator.ui.MCreator;
-import net.mcreator.ui.component.ImagePanel;
 import net.mcreator.ui.component.util.ComponentUtils;
-import net.mcreator.ui.dialogs.file.FileDialogs;
 import net.mcreator.ui.init.UIRES;
 import net.mcreator.ui.minecraft.MCItemHolder;
 
@@ -32,10 +29,8 @@ import javax.swing.*;
 import java.awt.*;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
-import java.awt.image.BufferedImage;
-import java.io.File;
 
-public class CraftingRecipeMaker extends JPanel {
+public class CraftingRecipeMaker extends AbstractRecipeMaker {
 
 	public final JSpinner sp;
 	public final MCItemHolder[] recipeSlots = new MCItemHolder[9];
@@ -43,14 +38,12 @@ public class CraftingRecipeMaker extends JPanel {
 
 	private final JLabel shapeless = new JLabel(UIRES.get("recipe.shapeless"));
 
-	private final JButton export = new JButton(UIRES.get("18px.export"));
+	private final JLabel drop = new JLabel("1");
 
 	private MItemBlock lastItemBlock = null;
 
 	public CraftingRecipeMaker(MCreator mcreator, MCItem.ListProvider itemsWithTags, MCItem.ListProvider items) {
-		ImagePanel ip = new ImagePanel(UIRES.get("recipe.crafting").getImage());
-		ip.fitToImage();
-		ip.setLayout(null);
+		super(UIRES.get("recipe.crafting").getImage());
 
 		JLabel cb = new JLabel();
 		cb.setBackground(new Color(139, 139, 139));
@@ -90,60 +83,24 @@ public class CraftingRecipeMaker extends JPanel {
 
 		sp = new JSpinner(new SpinnerNumberModel(1, 1, 64, 1));
 		sp.setBounds(210, 109, 42, 17);
-		ip.add(sp);
-
-		JLabel drop = new JLabel("1");
-
-		export.setContentAreaFilled(false);
-		export.setMargin(new Insets(0, 0, 0, 0));
-		export.setBounds(260, 13, 24, 24);
-		export.setFocusPainted(false);
-		export.setCursor(new Cursor(Cursor.HAND_CURSOR));
-		ip.add(export);
-		export.addActionListener(event -> {
-			export.setVisible(false);
-			for (int i = 0; i < 9; i++) {
-				recipeSlots[i].setValidationShownFlag(false);
-			}
-			outputItem.setValidationShownFlag(false);
-			sp.setVisible(false);
-			drop.setText(sp.getValue().toString());
-			drop.setVisible(true);
-			setCursor(new Cursor(Cursor.WAIT_CURSOR));
-			BufferedImage im = new BufferedImage(ip.getWidth(), ip.getHeight(), BufferedImage.TYPE_INT_ARGB);
-			ip.paint(im.getGraphics());
-			File fl = FileDialogs.getSaveDialog(null, new String[] { ".png" });
-			if (fl != null)
-				FileIO.writeImageToPNGFile(im, fl);
-			setCursor(new Cursor(Cursor.DEFAULT_CURSOR));
-			export.setVisible(true);
-			drop.setVisible(false);
-			for (int i = 0; i < 9; i++) {
-				recipeSlots[i].setValidationShownFlag(true);
-			}
-			outputItem.setValidationShownFlag(true);
-			sp.setVisible(true);
-
-		});
+		imagePanel.add(sp);
 
 		drop.setBounds(212, 109, 38, 17);
 		drop.setVisible(false);
 		drop.setForeground(Color.white);
-		ip.add(ComponentUtils.deriveFont(drop, 16));
+		imagePanel.add(ComponentUtils.deriveFont(drop, 16));
 
 		for (int i = 0; i < 9; i++) {
-			ip.add(recipeSlots[i]);
+			imagePanel.add(recipeSlots[i]);
 		}
-
-		ip.add(outputItem);
+		imagePanel.add(outputItem);
 
 		shapeless.setVisible(false);
 		shapeless.setBounds(156, 97, 23, 19);
 
-		ip.add(shapeless);
-		ip.add(cb);
+		imagePanel.add(shapeless);
+		imagePanel.add(cb);
 
-		add(ip);
 		setPreferredSize(new Dimension(300, 145));
 	}
 
@@ -167,7 +124,15 @@ public class CraftingRecipeMaker extends JPanel {
 		outputItem.setEnabled(enabled);
 		sp.setEnabled(enabled);
 		shapeless.setEnabled(enabled);
-		export.setEnabled(enabled);
 	}
 
+	@Override protected void setupImageExport(boolean exportedYet) {
+		for (int i = 0; i < 9; i++) {
+			recipeSlots[i].setValidationShownFlag(exportedYet);
+		}
+		outputItem.setValidationShownFlag(exportedYet);
+		sp.setVisible(exportedYet);
+		drop.setText(sp.getValue().toString());
+		drop.setVisible(!exportedYet);
+	}
 }

--- a/src/main/java/net/mcreator/ui/minecraft/recipemakers/SmeltingRecipeMaker.java
+++ b/src/main/java/net/mcreator/ui/minecraft/recipemakers/SmeltingRecipeMaker.java
@@ -19,75 +19,30 @@
 package net.mcreator.ui.minecraft.recipemakers;
 
 import net.mcreator.element.parts.MItemBlock;
-import net.mcreator.io.FileIO;
 import net.mcreator.minecraft.MCItem;
 import net.mcreator.ui.MCreator;
-import net.mcreator.ui.component.ImagePanel;
-import net.mcreator.ui.component.util.ComponentUtils;
-import net.mcreator.ui.dialogs.file.FileDialogs;
 import net.mcreator.ui.init.UIRES;
 import net.mcreator.ui.minecraft.MCItemHolder;
 
-import javax.swing.*;
 import java.awt.*;
-import java.awt.image.BufferedImage;
-import java.io.File;
 
-public class SmeltingRecipeMaker extends JPanel {
+public class SmeltingRecipeMaker extends AbstractRecipeMaker {
 
 	public final MCItemHolder cb1;
 	public final MCItemHolder cb2;
 
-	private final JButton export = new JButton(UIRES.get("18px.export"));
-
 	public SmeltingRecipeMaker(MCreator mcreator, MCItem.ListProvider itemsWithTags, MCItem.ListProvider items) {
-		ImagePanel ip = new ImagePanel(UIRES.get("recipe.furnace").getImage());
-
-		ip.fitToImage();
-		ip.setLayout(null);
+		super(UIRES.get("recipe.furnace").getImage());
 
 		cb1 = new MCItemHolder(mcreator, itemsWithTags, true);
 		cb2 = new MCItemHolder(mcreator, items);
 
-		JLabel drop = new JLabel("1");
-
-		export.setContentAreaFilled(false);
-		export.setMargin(new Insets(0, 0, 0, 0));
-		export.setBounds(260, 13, 24, 24);
-		export.setFocusPainted(false);
-		export.setCursor(new Cursor(Cursor.HAND_CURSOR));
-		ip.add(export);
-		export.addActionListener(event -> {
-			export.setVisible(false);
-			cb1.setValidationShownFlag(false);
-			cb2.setValidationShownFlag(false);
-			drop.setVisible(true);
-			setCursor(new Cursor(Cursor.WAIT_CURSOR));
-			BufferedImage im = new BufferedImage(ip.getWidth(), ip.getHeight(), BufferedImage.TYPE_INT_ARGB);
-			ip.paint(im.getGraphics());
-			File fi = FileDialogs.getSaveDialog(null, new String[] { ".png" });
-			if (fi != null)
-				FileIO.writeImageToPNGFile(im, fi);
-			setCursor(new Cursor(Cursor.DEFAULT_CURSOR));
-			export.setVisible(true);
-			cb1.setValidationShownFlag(true);
-			cb2.setValidationShownFlag(true);
-			drop.setVisible(false);
-
-		});
-
-		drop.setBounds(203, 109, 38, 17);
-		drop.setVisible(false);
-		drop.setForeground(Color.white);
-		ip.add(ComponentUtils.deriveFont(drop, 16));
-
 		cb1.setBounds(97, 30, 28, 28);
 		cb2.setBounds(200, 61, 28, 28);
 
-		ip.add(cb1);
-		ip.add(cb2);
+		imagePanel.add(cb1);
+		imagePanel.add(cb2);
 
-		add(ip);
 		setPreferredSize(new Dimension(306, 145));
 	}
 
@@ -103,6 +58,10 @@ public class SmeltingRecipeMaker extends JPanel {
 		super.setEnabled(enabled);
 		cb1.setEnabled(enabled);
 		cb2.setEnabled(enabled);
-		export.setEnabled(enabled);
+	}
+
+	@Override protected void setupImageExport(boolean exportedYet) {
+		cb1.setValidationShownFlag(exportedYet);
+		cb2.setValidationShownFlag(exportedYet);
 	}
 }

--- a/src/main/java/net/mcreator/ui/minecraft/recipemakers/SmithingRecipeMaker.java
+++ b/src/main/java/net/mcreator/ui/minecraft/recipemakers/SmithingRecipeMaker.java
@@ -18,76 +18,38 @@
 
 package net.mcreator.ui.minecraft.recipemakers;
 
-import net.mcreator.io.FileIO;
 import net.mcreator.minecraft.MCItem;
 import net.mcreator.ui.MCreator;
-import net.mcreator.ui.component.ImagePanel;
-import net.mcreator.ui.dialogs.file.FileDialogs;
 import net.mcreator.ui.init.UIRES;
 import net.mcreator.ui.minecraft.MCItemHolder;
 
-import javax.swing.*;
 import java.awt.*;
-import java.awt.image.BufferedImage;
-import java.io.File;
 
-public class SmithingRecipeMaker extends JPanel {
+public class SmithingRecipeMaker extends AbstractRecipeMaker {
 
 	public final MCItemHolder cb4;
 	public final MCItemHolder cb1;
 	public final MCItemHolder cb2;
 	public final MCItemHolder cb3;
 
-	private final JButton export = new JButton(UIRES.get("18px.export"));
-
 	public SmithingRecipeMaker(MCreator mcreator, MCItem.ListProvider itemsWithTags, MCItem.ListProvider items) {
-		ImagePanel ip = new ImagePanel(UIRES.get("recipe.smithing").getImage());
-
-		ip.fitToImage();
-		ip.setLayout(null);
+		super(UIRES.get("recipe.smithing").getImage());
 
 		cb4 = new MCItemHolder(mcreator, itemsWithTags, true);
 		cb1 = new MCItemHolder(mcreator, itemsWithTags, true);
 		cb2 = new MCItemHolder(mcreator, itemsWithTags, true);
 		cb3 = new MCItemHolder(mcreator, items);
 
-		export.setContentAreaFilled(false);
-		export.setMargin(new Insets(0, 0, 0, 0));
-		export.setBounds(260, 13, 24, 24);
-		export.setFocusPainted(false);
-		export.setCursor(new Cursor(Cursor.HAND_CURSOR));
-		ip.add(export);
-		export.addActionListener(event -> {
-			export.setVisible(false);
-			cb4.setValidationShownFlag(false);
-			cb1.setValidationShownFlag(false);
-			cb2.setValidationShownFlag(false);
-			cb3.setValidationShownFlag(false);
-			setCursor(new Cursor(Cursor.WAIT_CURSOR));
-			BufferedImage im = new BufferedImage(ip.getWidth(), ip.getHeight(), BufferedImage.TYPE_INT_ARGB);
-			ip.paint(im.getGraphics());
-			File fi = FileDialogs.getSaveDialog(null, new String[] { ".png" });
-			if (fi != null)
-				FileIO.writeImageToPNGFile(im, fi);
-			setCursor(new Cursor(Cursor.DEFAULT_CURSOR));
-			export.setVisible(true);
-			cb4.setValidationShownFlag(true);
-			cb1.setValidationShownFlag(true);
-			cb2.setValidationShownFlag(true);
-			cb3.setValidationShownFlag(true);
-		});
-
 		cb4.setBounds(18, 60, 28, 28);
 		cb1.setBounds(85, 60, 28, 28);
 		cb2.setBounds(152, 60, 28, 28);
 		cb3.setBounds(246, 60, 28, 28);
 
-		ip.add(cb4);
-		ip.add(cb1);
-		ip.add(cb2);
-		ip.add(cb3);
+		imagePanel.add(cb4);
+		imagePanel.add(cb1);
+		imagePanel.add(cb2);
+		imagePanel.add(cb3);
 
-		add(ip);
 		setPreferredSize(new Dimension(306, 145));
 	}
 
@@ -97,6 +59,12 @@ public class SmithingRecipeMaker extends JPanel {
 		cb1.setEnabled(enabled);
 		cb2.setEnabled(enabled);
 		cb3.setEnabled(enabled);
-		export.setEnabled(enabled);
+	}
+
+	@Override protected void setupImageExport(boolean exportedYet) {
+		cb1.setValidationShownFlag(exportedYet);
+		cb2.setValidationShownFlag(exportedYet);
+		cb3.setValidationShownFlag(exportedYet);
+		cb4.setValidationShownFlag(exportedYet);
 	}
 }

--- a/src/main/java/net/mcreator/ui/minecraft/recipemakers/SmokerRecipeMaker.java
+++ b/src/main/java/net/mcreator/ui/minecraft/recipemakers/SmokerRecipeMaker.java
@@ -19,64 +19,30 @@
 package net.mcreator.ui.minecraft.recipemakers;
 
 import net.mcreator.element.parts.MItemBlock;
-import net.mcreator.io.FileIO;
 import net.mcreator.minecraft.MCItem;
 import net.mcreator.ui.MCreator;
-import net.mcreator.ui.component.ImagePanel;
-import net.mcreator.ui.dialogs.file.FileDialogs;
 import net.mcreator.ui.init.UIRES;
 import net.mcreator.ui.minecraft.MCItemHolder;
 
-import javax.swing.*;
 import java.awt.*;
-import java.awt.image.BufferedImage;
-import java.io.File;
 
-public class SmokerRecipeMaker extends JPanel {
+public class SmokerRecipeMaker extends AbstractRecipeMaker {
 
 	public final MCItemHolder cb1;
 	public final MCItemHolder cb2;
 
-	private final JButton export = new JButton(UIRES.get("18px.export"));
-
 	public SmokerRecipeMaker(MCreator mcreator, MCItem.ListProvider itemsWithTags, MCItem.ListProvider items) {
-		ImagePanel ip = new ImagePanel(UIRES.get("recipe.smoker").getImage());
-
-		ip.fitToImage();
-		ip.setLayout(null);
+		super(UIRES.get("recipe.smoker").getImage());
 
 		cb1 = new MCItemHolder(mcreator, itemsWithTags, true);
 		cb2 = new MCItemHolder(mcreator, items);
 
-		export.setContentAreaFilled(false);
-		export.setMargin(new Insets(0, 0, 0, 0));
-		export.setBounds(260, 13, 24, 24);
-		export.setFocusPainted(false);
-		export.setCursor(new Cursor(Cursor.HAND_CURSOR));
-		ip.add(export);
-		export.addActionListener(event -> {
-			export.setVisible(false);
-			cb1.setValidationShownFlag(false);
-			cb2.setValidationShownFlag(false);
-			setCursor(new Cursor(Cursor.WAIT_CURSOR));
-			BufferedImage im = new BufferedImage(ip.getWidth(), ip.getHeight(), BufferedImage.TYPE_INT_ARGB);
-			ip.paint(im.getGraphics());
-			File fi = FileDialogs.getSaveDialog(null, new String[] { ".png" });
-			if (fi != null)
-				FileIO.writeImageToPNGFile(im, fi);
-			setCursor(new Cursor(Cursor.DEFAULT_CURSOR));
-			export.setVisible(true);
-			cb1.setValidationShownFlag(true);
-			cb2.setValidationShownFlag(true);
-		});
-
 		cb1.setBounds(97, 30, 28, 28);
 		cb2.setBounds(200, 61, 28, 28);
 
-		ip.add(cb1);
-		ip.add(cb2);
+		imagePanel.add(cb1);
+		imagePanel.add(cb2);
 
-		add(ip);
 		setPreferredSize(new Dimension(306, 145));
 	}
 
@@ -92,6 +58,10 @@ public class SmokerRecipeMaker extends JPanel {
 		super.setEnabled(enabled);
 		cb1.setEnabled(enabled);
 		cb2.setEnabled(enabled);
-		export.setEnabled(enabled);
+	}
+
+	@Override protected void setupImageExport(boolean exportedYet) {
+		cb1.setValidationShownFlag(exportedYet);
+		cb2.setValidationShownFlag(exportedYet);
 	}
 }

--- a/src/main/java/net/mcreator/ui/minecraft/recipemakers/StoneCutterRecipeMaker.java
+++ b/src/main/java/net/mcreator/ui/minecraft/recipemakers/StoneCutterRecipeMaker.java
@@ -19,82 +19,43 @@
 package net.mcreator.ui.minecraft.recipemakers;
 
 import net.mcreator.element.parts.MItemBlock;
-import net.mcreator.io.FileIO;
 import net.mcreator.minecraft.MCItem;
 import net.mcreator.ui.MCreator;
-import net.mcreator.ui.component.ImagePanel;
 import net.mcreator.ui.component.util.ComponentUtils;
-import net.mcreator.ui.dialogs.file.FileDialogs;
 import net.mcreator.ui.init.UIRES;
 import net.mcreator.ui.minecraft.MCItemHolder;
 
 import javax.swing.*;
 import java.awt.*;
-import java.awt.image.BufferedImage;
-import java.io.File;
 
-public class StoneCutterRecipeMaker extends JPanel {
+public class StoneCutterRecipeMaker extends AbstractRecipeMaker {
 
 	public final JSpinner sp;
 	public final MCItemHolder cb1;
 	public final MCItemHolder cb2;
-
-	private final JButton export = new JButton(UIRES.get("18px.export"));
+	public final JLabel drop = new JLabel("1");
 
 	public StoneCutterRecipeMaker(MCreator mcreator, MCItem.ListProvider itemsWithTags, MCItem.ListProvider items) {
-		ImagePanel ip = new ImagePanel(UIRES.get("recipe.stonecutter").getImage());
-
-		ip.fitToImage();
-		ip.setLayout(null);
+		super(UIRES.get("recipe.stonecutter").getImage());
 
 		cb1 = new MCItemHolder(mcreator, itemsWithTags, true);
 		cb2 = new MCItemHolder(mcreator, items);
 
+		cb1.setBounds(97, 61, 28, 28);
+		cb2.setBounds(200, 61, 28, 28);
+
+		imagePanel.add(cb1);
+		imagePanel.add(cb2);
+
 		sp = new JSpinner(new SpinnerNumberModel(1, 1, 64, 1));
 		sp.setBounds(203, 109, 38, 17);
-		ip.add(sp);
-
-		JLabel drop = new JLabel("1");
-
-		export.setContentAreaFilled(false);
-		export.setMargin(new Insets(0, 0, 0, 0));
-		export.setBounds(260, 13, 24, 24);
-		export.setFocusPainted(false);
-		export.setCursor(new Cursor(Cursor.HAND_CURSOR));
-		ip.add(export);
-		export.addActionListener(event -> {
-			export.setVisible(false);
-			cb1.setValidationShownFlag(false);
-			cb2.setValidationShownFlag(false);
-			sp.setVisible(false);
-			drop.setText(sp.getValue().toString());
-			drop.setVisible(true);
-			setCursor(new Cursor(Cursor.WAIT_CURSOR));
-			BufferedImage im = new BufferedImage(ip.getWidth(), ip.getHeight(), BufferedImage.TYPE_INT_ARGB);
-			ip.paint(im.getGraphics());
-			File fi = FileDialogs.getSaveDialog(null, new String[] { ".png" });
-			if (fi != null)
-				FileIO.writeImageToPNGFile(im, fi);
-			setCursor(new Cursor(Cursor.DEFAULT_CURSOR));
-			export.setVisible(true);
-			cb1.setValidationShownFlag(true);
-			cb2.setValidationShownFlag(true);
-			sp.setVisible(true);
-			drop.setVisible(false);
-		});
+		imagePanel.add(sp);
 
 		drop.setBounds(203, 109, 38, 17);
 		drop.setVisible(false);
 		drop.setForeground(Color.white);
-		ip.add(ComponentUtils.deriveFont(drop, 16));
+		imagePanel.add(ComponentUtils.deriveFont(drop, 16));
 
-		cb1.setBounds(97, 61, 28, 28);
-		cb2.setBounds(200, 61, 28, 28);
-
-		ip.add(cb1);
-		ip.add(cb2);
-
-		add(ip);
 		setPreferredSize(new Dimension(306, 145));
 	}
 
@@ -111,7 +72,13 @@ public class StoneCutterRecipeMaker extends JPanel {
 		cb1.setEnabled(enabled);
 		cb2.setEnabled(enabled);
 		sp.setEnabled(enabled);
-		export.setEnabled(enabled);
 	}
 
+	@Override protected void setupImageExport(boolean exportedYet) {
+		cb1.setValidationShownFlag(exportedYet);
+		cb2.setValidationShownFlag(exportedYet);
+		sp.setVisible(exportedYet);
+		drop.setText(sp.getValue().toString());
+		drop.setVisible(!exportedYet);
+	}
 }

--- a/src/main/java/net/mcreator/ui/modgui/RecipeGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/RecipeGUI.java
@@ -264,13 +264,9 @@ public class RecipeGUI extends ModElementGUI<Recipe> {
 
 	@Override protected AggregatedValidationResult validatePage(int page) {
 		if ("Crafting".equals(recipeType.getSelectedItem())) {
-			if (!craftingRecipeMaker.cb10.containsItem()) {
+			if (!craftingRecipeMaker.outputItem.containsItem()) {
 				return new AggregatedValidationResult.FAIL(L10N.t("elementgui.recipe.error_crafting_no_result"));
-			} else if (!(craftingRecipeMaker.cb1.containsItem() || craftingRecipeMaker.cb2.containsItem()
-					|| craftingRecipeMaker.cb3.containsItem() || craftingRecipeMaker.cb4.containsItem()
-					|| craftingRecipeMaker.cb5.containsItem() || craftingRecipeMaker.cb6.containsItem()
-					|| craftingRecipeMaker.cb7.containsItem() || craftingRecipeMaker.cb8.containsItem()
-					|| craftingRecipeMaker.cb9.containsItem())) {
+			} else if (!craftingRecipeMaker.hasInputItems()) {
 				return new AggregatedValidationResult.FAIL(L10N.t("elementgui.recipe.error_crafting_no_ingredient"));
 			}
 		} else if ("Smelting".equals(recipeType.getSelectedItem())) {
@@ -331,16 +327,10 @@ public class RecipeGUI extends ModElementGUI<Recipe> {
 		switch (recipe.recipeType) {
 		case "Crafting" -> {
 			recipeShapeless.setSelected(recipe.recipeShapeless);
-			craftingRecipeMaker.cb1.setBlock(recipe.recipeSlots[0]);
-			craftingRecipeMaker.cb2.setBlock(recipe.recipeSlots[3]);
-			craftingRecipeMaker.cb3.setBlock(recipe.recipeSlots[6]);
-			craftingRecipeMaker.cb4.setBlock(recipe.recipeSlots[1]);
-			craftingRecipeMaker.cb5.setBlock(recipe.recipeSlots[4]);
-			craftingRecipeMaker.cb6.setBlock(recipe.recipeSlots[7]);
-			craftingRecipeMaker.cb7.setBlock(recipe.recipeSlots[2]);
-			craftingRecipeMaker.cb8.setBlock(recipe.recipeSlots[5]);
-			craftingRecipeMaker.cb9.setBlock(recipe.recipeSlots[8]);
-			craftingRecipeMaker.cb10.setBlock(recipe.recipeReturnStack);
+			for (int i = 0; i < 9; i++) {
+				craftingRecipeMaker.recipeSlots[i].setBlock(recipe.recipeSlots[i]);
+			}
+			craftingRecipeMaker.outputItem.setBlock(recipe.recipeReturnStack);
 			craftingRecipeMaker.sp.setValue(recipe.recipeRetstackSize);
 			craftingRecipeMaker.setShapeless(recipeShapeless.isSelected());
 		}
@@ -394,18 +384,12 @@ public class RecipeGUI extends ModElementGUI<Recipe> {
 		switch (recipe.recipeType) {
 		case "Crafting" -> {
 			MItemBlock[] recipeSlots = new MItemBlock[9];
-			recipeSlots[0] = craftingRecipeMaker.cb1.getBlock();
-			recipeSlots[3] = craftingRecipeMaker.cb2.getBlock();
-			recipeSlots[6] = craftingRecipeMaker.cb3.getBlock();
-			recipeSlots[1] = craftingRecipeMaker.cb4.getBlock();
-			recipeSlots[4] = craftingRecipeMaker.cb5.getBlock();
-			recipeSlots[7] = craftingRecipeMaker.cb6.getBlock();
-			recipeSlots[2] = craftingRecipeMaker.cb7.getBlock();
-			recipeSlots[5] = craftingRecipeMaker.cb8.getBlock();
-			recipeSlots[8] = craftingRecipeMaker.cb9.getBlock();
+			for (int i = 0; i < 9; i++) {
+				recipeSlots[i] = craftingRecipeMaker.recipeSlots[i].getBlock();
+			}
 			recipe.recipeRetstackSize = (int) craftingRecipeMaker.sp.getValue();
 			recipe.recipeShapeless = recipeShapeless.isSelected();
-			recipe.recipeReturnStack = craftingRecipeMaker.cb10.getBlock();
+			recipe.recipeReturnStack = craftingRecipeMaker.outputItem.getBlock();
 			recipe.recipeSlots = recipeSlots;
 		}
 		case "Smelting" -> {


### PR DESCRIPTION
- Added a common superclass for recipe makers, handling the background panel and the export button
- Crafting recipes input slots are now stored in a single array instead of 9 different fields. Indexes now match those of recipe element
- Removed unused labels from crafting and smelting recipes