### PR TITLE
Remove buttons from guistate dependency

### DIFF
--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/gui/gui_window.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/gui/gui_window.java.ftl
@@ -252,7 +252,6 @@ public class ${name}Screen extends AbstractContainerScreen<${name}Menu> {
 					</#if>
 			</#if>
 
-			guistate.put("button:${component.getName()}", ${component.getName()});
 			this.addRenderableWidget(${component.getName()});
 
 			<#assign btid +=1>
@@ -277,7 +276,6 @@ public class ${name}Screen extends AbstractContainerScreen<${name}Menu> {
 				}
 			};
 
-			guistate.put("button:${component.getName()}", ${component.getName()});
 			this.addRenderableWidget(${component.getName()});
 
 			<#assign btid +=1>

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/gui/gui_window.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/gui/gui_window.java.ftl
@@ -252,7 +252,6 @@ public class ${name}Screen extends AbstractContainerScreen<${name}Menu> {
 					</#if>
 			</#if>
 
-			guistate.put("button:${component.getName()}", ${component.getName()});
 			this.addRenderableWidget(${component.getName()});
 
 			<#assign btid +=1>
@@ -277,7 +276,6 @@ public class ${name}Screen extends AbstractContainerScreen<${name}Menu> {
 				}
 			};
 
-			guistate.put("button:${component.getName()}", ${component.getName()});
 			this.addRenderableWidget(${component.getName()});
 
 			<#assign btid +=1>


### PR DESCRIPTION
Remove buttons from guistate dependency as they don't hold any client-side-only information