### PR TITLE
Procedure external trigger dependency check did not work in some cases

### DIFF
--- a/src/main/java/net/mcreator/ui/modgui/ProcedureGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/ProcedureGUI.java
@@ -192,7 +192,7 @@ public class ProcedureGUI extends ModElementGUI<net.mcreator.element.types.Proce
 					StringBuilder missingdeps = new StringBuilder();
 					boolean warn = false;
 					for (Dependency dependency : dependenciesArrayList) {
-						if (trigger.dependencies_provided != null && !trigger.dependencies_provided.contains(
+						if (trigger.dependencies_provided == null || !trigger.dependencies_provided.contains(
 								dependency)) {
 							warn = true;
 							missingdeps.append(" ").append(dependency.getName());


### PR DESCRIPTION
[Bugfix] Procedure external trigger dependency check did not work in some cases