### PR TITLE
Allow executing procedures with null dependencies

### DIFF
--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/procedure.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/procedure.java.ftl
@@ -34,6 +34,7 @@ package ${package}.procedures;
 import net.neoforged.bus.api.Event;
 
 <#assign nullableDependencies = []/>
+<#if !(data.skipDependencyNullCheck)>
 <#list dependencies as dependency>
 	<#if dependency.getRawType() != "number"
 		&& dependency.getRawType() != "world"
@@ -45,6 +46,7 @@ import net.neoforged.bus.api.Event;
 		<#assign nullableDependencies += [dependency.getName()]/>
 	</#if>
 </#list>
+</#if>
 
 <#compress>
 

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/procedure.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/procedure.java.ftl
@@ -35,17 +35,17 @@ import net.neoforged.bus.api.Event;
 
 <#assign nullableDependencies = []/>
 <#if !(data.skipDependencyNullCheck)>
-<#list dependencies as dependency>
-	<#if dependency.getRawType() != "number"
-		&& dependency.getRawType() != "world"
-		&& dependency.getRawType() != "itemstack"
-		&& dependency.getRawType() != "blockstate"
-		&& dependency.getRawType() != "actionresulttype"
-		&& dependency.getRawType() != "logic"
-		&& dependency.getRawType() != "cmdcontext">
-		<#assign nullableDependencies += [dependency.getName()]/>
-	</#if>
-</#list>
+	<#list dependencies as dependency>
+		<#if dependency.getRawType() != "number"
+			&& dependency.getRawType() != "world"
+			&& dependency.getRawType() != "itemstack"
+			&& dependency.getRawType() != "blockstate"
+			&& dependency.getRawType() != "actionresulttype"
+			&& dependency.getRawType() != "logic"
+			&& dependency.getRawType() != "cmdcontext">
+			<#assign nullableDependencies += [dependency.getName()]/>
+		</#if>
+	</#list>
 </#if>
 
 <#compress>

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/procedure.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/procedure.java.ftl
@@ -34,6 +34,7 @@ package ${package}.procedures;
 import net.neoforged.bus.api.Event;
 
 <#assign nullableDependencies = []/>
+<#if !(data.skipDependencyNullCheck)>
 <#list dependencies as dependency>
 	<#if dependency.getRawType() != "number"
 		&& dependency.getRawType() != "world"
@@ -45,6 +46,7 @@ import net.neoforged.bus.api.Event;
 		<#assign nullableDependencies += [dependency.getName()]/>
 	</#if>
 </#list>
+</#if>
 
 <#compress>
 

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/procedure.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/procedure.java.ftl
@@ -35,17 +35,17 @@ import net.neoforged.bus.api.Event;
 
 <#assign nullableDependencies = []/>
 <#if !(data.skipDependencyNullCheck)>
-<#list dependencies as dependency>
-	<#if dependency.getRawType() != "number"
-		&& dependency.getRawType() != "world"
-		&& dependency.getRawType() != "itemstack"
-		&& dependency.getRawType() != "blockstate"
-		&& dependency.getRawType() != "actionresulttype"
-		&& dependency.getRawType() != "logic"
-		&& dependency.getRawType() != "cmdcontext">
-		<#assign nullableDependencies += [dependency.getName()]/>
-	</#if>
-</#list>
+	<#list dependencies as dependency>
+		<#if dependency.getRawType() != "number"
+			&& dependency.getRawType() != "world"
+			&& dependency.getRawType() != "itemstack"
+			&& dependency.getRawType() != "blockstate"
+			&& dependency.getRawType() != "actionresulttype"
+			&& dependency.getRawType() != "logic"
+			&& dependency.getRawType() != "cmdcontext">
+			<#assign nullableDependencies += [dependency.getName()]/>
+		</#if>
+	</#list>
 </#if>
 
 <#compress>

--- a/plugins/mcreator-localization/help/default/procedure/skip_dependency_null_check.md
+++ b/plugins/mcreator-localization/help/default/procedure/skip_dependency_null_check.md
@@ -1,4 +1,5 @@
 If this option is enabled, the procedure will be executed even if one of the dependencies is null.
-Null checks should be inserted manually inside the procedure.
+Null checks should be inserted manually inside the procedure. This can be done using the null comparison procedure
+block, found in the "Advanced" tab.
 
-__Unchecked null values can crash the game__, so this option should be disabled in most cases.
+**Unchecked null values can crash the game**, so this option should be disabled in most cases.

--- a/plugins/mcreator-localization/help/default/procedure/skip_dependency_null_check.md
+++ b/plugins/mcreator-localization/help/default/procedure/skip_dependency_null_check.md
@@ -1,0 +1,4 @@
+If this option is enabled, the procedure will be executed even if one of the dependencies is null.
+Null checks should be inserted manually inside the procedure.
+
+__Unchecked null values can crash the game__, so this option should be disabled in most cases.

--- a/plugins/mcreator-localization/lang/texts.properties
+++ b/plugins/mcreator-localization/lang/texts.properties
@@ -2986,6 +2986,7 @@ elementgui.potion.amplifier=Amplifier:
 elementgui.potion.ambient=Ambient?
 elementgui.potion.show_particles=Show particles?
 elementgui.potion.error_potion_needs_display_name=Potion needs a display name
+elementgui.procedure.skip_dependency_null_check=<html>Skip null check for dependencies:<br><small>This option should be false in most cases
 elementgui.procedure.dependencies_added=<html><div style=''width: 110px; padding: 2px; background: #444444;''><span style=''background: yellow; color: black; font-wight: bold;''>&nbsp;&nbsp;!&nbsp;&nbsp;</span>&nbsp;New dependencies were added. Make sure to use the ones that the trigger you use provides.
 elementgui.procedure.dependencies_not_provided=<html><div style=''width: 110px; padding: 2px; background: #444444;''><span style=''background: red; color: white; font-wight: bold;''>&nbsp;X&nbsp;</span>&nbsp;You have selected external trigger that does not provide the following dependencies: {0}
 elementgui.procedure.cancelable_trigger=<html><div style=''width: 100px; font-size: 9px;''>Cancelable

--- a/plugins/mcreator-localization/lang/texts.properties
+++ b/plugins/mcreator-localization/lang/texts.properties
@@ -2986,6 +2986,7 @@ elementgui.potion.amplifier=Amplifier:
 elementgui.potion.ambient=Ambient?
 elementgui.potion.show_particles=Show particles?
 elementgui.potion.error_potion_needs_display_name=Potion needs a display name
+elementgui.procedure.additional_settings=Additional procedure settings
 elementgui.procedure.skip_dependency_null_check=<html>Skip null check for dependencies:<br><small>This option should be unchecked in most cases
 elementgui.procedure.dependencies_added=<html><div style=''width: 110px; padding: 2px; background: #444444;''><span style=''background: yellow; color: black; font-wight: bold;''>&nbsp;&nbsp;!&nbsp;&nbsp;</span>&nbsp;New dependencies were added. Make sure to use the ones that the trigger you use provides.
 elementgui.procedure.dependencies_not_provided=<html><div style=''width: 110px; padding: 2px; background: #444444;''><span style=''background: red; color: white; font-wight: bold;''>&nbsp;X&nbsp;</span>&nbsp;You have selected external trigger that does not provide the following dependencies: {0}

--- a/plugins/mcreator-localization/lang/texts.properties
+++ b/plugins/mcreator-localization/lang/texts.properties
@@ -2986,7 +2986,7 @@ elementgui.potion.amplifier=Amplifier:
 elementgui.potion.ambient=Ambient?
 elementgui.potion.show_particles=Show particles?
 elementgui.potion.error_potion_needs_display_name=Potion needs a display name
-elementgui.procedure.skip_dependency_null_check=<html>Skip null check for dependencies:<br><small>This option should be false in most cases
+elementgui.procedure.skip_dependency_null_check=<html>Skip null check for dependencies:<br><small>This option should be unchecked in most cases
 elementgui.procedure.dependencies_added=<html><div style=''width: 110px; padding: 2px; background: #444444;''><span style=''background: yellow; color: black; font-wight: bold;''>&nbsp;&nbsp;!&nbsp;&nbsp;</span>&nbsp;New dependencies were added. Make sure to use the ones that the trigger you use provides.
 elementgui.procedure.dependencies_not_provided=<html><div style=''width: 110px; padding: 2px; background: #444444;''><span style=''background: red; color: white; font-wight: bold;''>&nbsp;X&nbsp;</span>&nbsp;You have selected external trigger that does not provide the following dependencies: {0}
 elementgui.procedure.cancelable_trigger=<html><div style=''width: 100px; font-size: 9px;''>Cancelable

--- a/src/main/java/net/mcreator/element/types/Procedure.java
+++ b/src/main/java/net/mcreator/element/types/Procedure.java
@@ -49,6 +49,7 @@ public class Procedure extends GeneratableElement {
 	public static final String XML_BASE = "<xml xmlns=\"https://developers.google.com/blockly/xml\"><block type=\"event_trigger\" deletable=\"false\" x=\"40\" y=\"40\"><field name=\"trigger\">no_ext_trigger</field></block></xml>";
 
 	@BlocklyXML("procedures") public String procedurexml;
+	public boolean skipDependencyNullCheck;
 
 	private transient List<Dependency> dependencies = null;
 

--- a/src/main/java/net/mcreator/ui/modgui/ProcedureGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/ProcedureGUI.java
@@ -32,6 +32,7 @@ import net.mcreator.ui.blockly.*;
 import net.mcreator.ui.component.util.ComponentUtils;
 import net.mcreator.ui.component.util.PanelUtils;
 import net.mcreator.ui.dialogs.NewVariableDialog;
+import net.mcreator.ui.help.HelpUtils;
 import net.mcreator.ui.init.L10N;
 import net.mcreator.ui.init.UIRES;
 import net.mcreator.ui.laf.themes.Theme;
@@ -63,6 +64,7 @@ public class ProcedureGUI extends ModElementGUI<net.mcreator.element.types.Proce
 	private static final Logger LOG = LogManager.getLogger(ProcedureGUI.class);
 
 	private final JPanel pane5 = new JPanel(new BorderLayout(0, 0));
+	private final JPanel topPanel = new JPanel(new GridLayout(1, 2, 0, 2));
 
 	private BlocklyPanel blocklyPanel;
 
@@ -95,6 +97,8 @@ public class ProcedureGUI extends ModElementGUI<net.mcreator.element.types.Proce
 	private final JLabel sideTriggerLabel = new JLabel();
 
 	private final CompileNotesPanel compileNotesPanel = new CompileNotesPanel();
+
+	private final JCheckBox skipDependencyNullCheck = L10N.checkbox("elementgui.common.enable");
 
 	private final List<BlocklyChangedListener> blocklyChangedListeners = new ArrayList<>();
 
@@ -292,6 +296,13 @@ public class ProcedureGUI extends ModElementGUI<net.mcreator.element.types.Proce
 	}
 
 	@Override protected void initGUI() {
+		skipDependencyNullCheck.setOpaque(false);
+		topPanel.setOpaque(false);
+
+		topPanel.add(HelpUtils.wrapWithHelpButton(this.withEntry("procedure/skip_dependency_null_check"),
+				L10N.label("elementgui.procedure.skip_dependency_null_check")));
+		topPanel.add(skipDependencyNullCheck);
+
 		pane5.setOpaque(false);
 
 		localVarsList.setOpaque(false);
@@ -562,7 +573,8 @@ public class ProcedureGUI extends ModElementGUI<net.mcreator.element.types.Proce
 		blocklyEditorToolbar.setTemplateLibButtonWidth(168);
 		pane5.add("North", blocklyEditorToolbar);
 
-		addPage(PanelUtils.gridElements(1, 1, pane5), false).lazyValidate(() -> {
+		addPage(PanelUtils.gridElements(1, 1, PanelUtils.northAndCenterElement(
+				PanelUtils.join(FlowLayout.LEFT, topPanel), pane5)), false).lazyValidate(() -> {
 			if (hasDependencyErrors)
 				return new AggregatedValidationResult.FAIL(
 						L10N.t("elementgui.procedure.external_trigger_does_not_provide_all_dependencies"));
@@ -611,6 +623,7 @@ public class ProcedureGUI extends ModElementGUI<net.mcreator.element.types.Proce
 	}
 
 	@Override public void openInEditingMode(net.mcreator.element.types.Procedure procedure) {
+		skipDependencyNullCheck.setSelected(procedure.skipDependencyNullCheck);
 		blocklyPanel.addTaskToRunAfterLoaded(() -> {
 			blocklyPanel.setXML(procedure.procedurexml);
 
@@ -621,6 +634,7 @@ public class ProcedureGUI extends ModElementGUI<net.mcreator.element.types.Proce
 
 	@Override public net.mcreator.element.types.Procedure getElementFromGUI() {
 		net.mcreator.element.types.Procedure procedure = new net.mcreator.element.types.Procedure(modElement);
+		procedure.skipDependencyNullCheck = skipDependencyNullCheck.isSelected();
 		procedure.procedurexml = blocklyPanel.getXML();
 		return procedure;
 	}

--- a/src/main/java/net/mcreator/ui/modgui/ProcedureGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/ProcedureGUI.java
@@ -29,6 +29,7 @@ import net.mcreator.generator.template.TemplateGeneratorException;
 import net.mcreator.ui.MCreator;
 import net.mcreator.ui.MCreatorApplication;
 import net.mcreator.ui.blockly.*;
+import net.mcreator.ui.component.CollapsiblePanel;
 import net.mcreator.ui.component.util.ComponentUtils;
 import net.mcreator.ui.component.util.PanelUtils;
 import net.mcreator.ui.dialogs.NewVariableDialog;
@@ -64,7 +65,6 @@ public class ProcedureGUI extends ModElementGUI<net.mcreator.element.types.Proce
 	private static final Logger LOG = LogManager.getLogger(ProcedureGUI.class);
 
 	private final JPanel pane5 = new JPanel(new BorderLayout(0, 0));
-	private final JPanel topPanel = new JPanel(new GridLayout(1, 2, 0, 2));
 
 	private BlocklyPanel blocklyPanel;
 
@@ -297,11 +297,15 @@ public class ProcedureGUI extends ModElementGUI<net.mcreator.element.types.Proce
 
 	@Override protected void initGUI() {
 		skipDependencyNullCheck.setOpaque(false);
-		topPanel.setOpaque(false);
 
-		topPanel.add(HelpUtils.wrapWithHelpButton(this.withEntry("procedure/skip_dependency_null_check"),
+		JPanel skipDependencyWrapper = new JPanel(new GridLayout(1, 2, 0, 2));
+		skipDependencyWrapper.setOpaque(false);
+		skipDependencyWrapper.add(HelpUtils.wrapWithHelpButton(this.withEntry("procedure/skip_dependency_null_check"),
 				L10N.label("elementgui.procedure.skip_dependency_null_check")));
-		topPanel.add(skipDependencyNullCheck);
+		skipDependencyWrapper.add(skipDependencyNullCheck);
+
+		CollapsiblePanel procedureSettings = new CollapsiblePanel(L10N.t("elementgui.procedure.additional_settings"),
+				PanelUtils.join(FlowLayout.LEFT, 1, 1, skipDependencyWrapper));
 
 		pane5.setOpaque(false);
 
@@ -573,8 +577,8 @@ public class ProcedureGUI extends ModElementGUI<net.mcreator.element.types.Proce
 		blocklyEditorToolbar.setTemplateLibButtonWidth(168);
 		pane5.add("North", blocklyEditorToolbar);
 
-		addPage(PanelUtils.gridElements(1, 1, PanelUtils.northAndCenterElement(
-				PanelUtils.join(FlowLayout.LEFT, topPanel), pane5)), false).lazyValidate(() -> {
+		addPage(PanelUtils.gridElements(1, 1, PanelUtils.centerAndSouthElement(pane5, procedureSettings)), false)
+				.lazyValidate(() -> {
 			if (hasDependencyErrors)
 				return new AggregatedValidationResult.FAIL(
 						L10N.t("elementgui.procedure.external_trigger_does_not_provide_all_dependencies"));

--- a/src/test/java/net/mcreator/integration/TestWorkspaceDataProvider.java
+++ b/src/test/java/net/mcreator/integration/TestWorkspaceDataProvider.java
@@ -1808,6 +1808,7 @@ public class TestWorkspaceDataProvider {
 		} else if (ModElementType.PROCEDURE.equals(modElement.getType())) {
 			net.mcreator.element.types.Procedure procedure = new net.mcreator.element.types.Procedure(modElement);
 			procedure.procedurexml = net.mcreator.element.types.Procedure.XML_BASE;
+			procedure.skipDependencyNullCheck = _true;
 			return procedure;
 		} else if (ModElementType.DAMAGETYPE.equals(modElement.getType())) {
 			DamageType damageType = new DamageType(modElement);


### PR DESCRIPTION
This PR adds a checkbox to skip the initial null check for dependencies and execute the procedure anyway.

There are some instances where a dependency might be null (some projectile triggers, passing custom values to a procedure, etc.). Along with the null check procedure block, this gives more control over those situations.