### PR TITLE
Improvement for #5413

### DIFF
--- a/plugins/generator-1.21.1/neoforge-1.21.1/procedures/gui_set_text_textfield.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/procedures/gui_set_text_textfield.java.ftl
@@ -1,4 +1,4 @@
 <#if w.hasElementsOfType("gui")>
-if (${input$entity} instanceof Player _entity && _entity.containerMenu instanceof ${JavaModName}Menus.MenuAccessor _menu)
-	_menu.sendMenuStateUpdate(_entity.level(), 0, "${field$textfield}", ${input$text});
+if (${input$entity} instanceof Player _player && _player.containerMenu instanceof ${JavaModName}Menus.MenuAccessor _menu)
+	_menu.sendMenuStateUpdate(_player, 0, "${field$textfield}", ${input$text}, true);
 </#if>

--- a/plugins/generator-1.21.1/neoforge-1.21.1/procedures/gui_set_text_textfield.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/procedures/gui_set_text_textfield.java.ftl
@@ -1,4 +1,4 @@
 <#if w.hasElementsOfType("gui")>
 if (${input$entity} instanceof Player _entity && _entity.containerMenu instanceof ${JavaModName}Menus.MenuAccessor _menu)
-	_menu.sendMenuStateUpdate(_entity.level(), 0, "${field$textfield}", ${input$text}, true);
+	_menu.sendMenuStateUpdate(_entity.level(), 0, "${field$textfield}", ${input$text});
 </#if>

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/elementinits/menus.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/elementinits/menus.java.ftl
@@ -50,13 +50,9 @@ public class ${JavaModName}Menus {
 
 		Map<Integer, Slot> getSlots();
 
-		default void sendMenuStateUpdate(Level world, int elementType, String name, Object elementState) {
-			sendMenuStateUpdate(world, elementType, name, elementState, true);
-		}
-
-		default void sendMenuStateUpdate(Level world, int elementType, String name, Object elementState, boolean needClientUpdate) {
+		default void sendMenuStateUpdate(Player player, int elementType, String name, Object elementState, boolean needClientUpdate) {
 			getMenuState().put(elementType + ":" + name, elementState);
-			if (needClientUpdate && world.isClientSide && Minecraft.getInstance().screen instanceof ${JavaModName}Screens.ScreenAccessor accessor) {
+			if (needClientUpdate && player.level().isClientSide && Minecraft.getInstance().screen instanceof ${JavaModName}Screens.ScreenAccessor accessor) {
 				accessor.updateMenuState(elementType, name, elementState);
 			}
 		}

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/elementinits/menus.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/elementinits/menus.java.ftl
@@ -51,8 +51,12 @@ public class ${JavaModName}Menus {
 		Map<Integer, Slot> getSlots();
 
 		default void sendMenuStateUpdate(Level world, int elementType, String name, Object elementState) {
+			sendMenuStateUpdate(world, elementType, name, elementState, true);
+		}
+
+		default void sendMenuStateUpdate(Level world, int elementType, String name, Object elementState, boolean needClientUpdate) {
 			getMenuState().put(elementType + ":" + name, elementState);
-			if (world.isClientSide && Minecraft.getInstance().screen instanceof ${JavaModName}Screens.ScreenAccessor accessor) {
+			if (needClientUpdate && world.isClientSide && Minecraft.getInstance().screen instanceof ${JavaModName}Screens.ScreenAccessor accessor) {
 				accessor.updateMenuState(elementType, name, elementState);
 			}
 		}

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/elementinits/menus.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/elementinits/menus.java.ftl
@@ -50,10 +50,10 @@ public class ${JavaModName}Menus {
 
 		Map<Integer, Slot> getSlots();
 
-		default void sendMenuStateUpdate(Level world, int elementType, String name, Object elementState, boolean needClientUpdate) {
+		default void sendMenuStateUpdate(Level world, int elementType, String name, Object elementState) {
 			getMenuState().put(elementType + ":" + name, elementState);
-			if (needClientUpdate && world.isClientSide && Minecraft.getInstance().screen instanceof ${JavaModName}Screens.ScreenAccessor accessor) {
-				accessor.onMenuStateUpdate(elementType, name, elementState);
+			if (world.isClientSide && Minecraft.getInstance().screen instanceof ${JavaModName}Screens.ScreenAccessor accessor) {
+				accessor.updateMenuState(elementType, name, elementState);
 			}
 		}
 

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/elementinits/screens.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/elementinits/screens.java.ftl
@@ -48,7 +48,7 @@ package ${package}.init;
 	}
 
 	public interface ScreenAccessor {
-		void onMenuStateUpdate(int elementType, String name, Object elementState);
+		void updateMenuState(int elementType, String name, Object elementState);
 	}
 
 	<#if hasEntityModels>

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/gui/gui_window.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/gui/gui_window.java.ftl
@@ -226,7 +226,7 @@ public class ${name}Screen extends AbstractContainerScreen<${name}Menu> implemen
 			${component.getName()}.setMaxLength(8192);
 			${component.getName()}.setResponder(content -> {
 				if (!menuStateUpdateActive)
-					menu.sendMenuStateUpdate(world, 0, "${component.getName()}", content, false);
+					menu.sendMenuStateUpdate(entity, 0, "${component.getName()}", content, false);
 			});
 			<#if component.placeholder?has_content>
 			${component.getName()}.setHint(Component.translatable("gui.${modid}.${registryname}.${component.getName()}"));
@@ -285,13 +285,13 @@ public class ${name}Screen extends AbstractContainerScreen<${name}Menu> implemen
 				.pos(this.leftPos + ${component.gx(data.width)}, this.topPos + ${component.gy(data.height)})
 				.onValueChange((checkbox, value) -> {
 					if (!menuStateUpdateActive)
-						menu.sendMenuStateUpdate(world, 1, "${component.getName()}", value, false);
+						menu.sendMenuStateUpdate(entity, 1, "${component.getName()}", value, false);
 				})
 				<#if hasProcedure(component.isCheckedProcedure)>.selected(${component.getName()}Selected)</#if>
 				.build();
 			<#if hasProcedure(component.isCheckedProcedure)>
 				if (${component.getName()}Selected)
-					menu.sendMenuStateUpdate(world, 1, "${component.getName()}", true, false);
+					menu.sendMenuStateUpdate(entity, 1, "${component.getName()}", true, false);
 			</#if>
 
 			this.addRenderableWidget(${component.getName()});

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/gui/gui_window.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/gui/gui_window.java.ftl
@@ -39,9 +39,12 @@ package ${package}.client.gui;
 
 <#compress>
 public class ${name}Screen extends AbstractContainerScreen<${name}Menu> implements ${JavaModName}Screens.ScreenAccessor {
+
 	private final Level world;
 	private final int x, y, z;
 	private final Player entity;
+
+	private boolean menuStateUpdateActive = false;
 
 	<#list textFields as component>
 	EditBox ${component.getName()};

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/gui/gui_window.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/gui/gui_window.java.ftl
@@ -70,7 +70,9 @@ public class ${name}Screen extends AbstractContainerScreen<${name}Menu> implemen
 		this.imageHeight = ${data.height};
 	}
 
-	@Override public void onMenuStateUpdate(int elementType, String name, Object elementState) {
+	@Override public void updateMenuState(int elementType, String name, Object elementState) {
+		menuStateUpdateActive = true;
+
 		<#if textFields?has_content>
 		if (elementType == 0 && elementState instanceof String stringState) {
 			<#list textFields as component>
@@ -79,7 +81,10 @@ public class ${name}Screen extends AbstractContainerScreen<${name}Menu> implemen
 			</#list>
 		}
 		</#if>
-		<#-- onMenuStateUpdate is not implemented for checkboxes, as there is no procedure block to set checkbox state currently -->
+
+		<#-- updateMenuState is not implemented for checkboxes, as there is no procedure block to set checkbox state currently -->
+
+		menuStateUpdateActive = false;
 	}
 
 	<#if data.doesPauseGame>
@@ -216,7 +221,10 @@ public class ${name}Screen extends AbstractContainerScreen<${name}Menu> implemen
 			${component.getName()} = new EditBox(this.font, this.leftPos + ${component.gx(data.width) + 1}, this.topPos + ${component.gy(data.height) + 1},
 			${component.width - 2}, ${component.height - 2}, Component.translatable("gui.${modid}.${registryname}.${component.getName()}"));
 			${component.getName()}.setMaxLength(8192);
-			${component.getName()}.setResponder(content -> menu.sendMenuStateUpdate(world, 0, "${component.getName()}", content, false));
+			${component.getName()}.setResponder(content -> {
+				if (!menuStateUpdateActive)
+					menu.sendMenuStateUpdate(world, 0, "${component.getName()}", content);
+			});
 			<#if component.placeholder?has_content>
 			${component.getName()}.setHint(Component.translatable("gui.${modid}.${registryname}.${component.getName()}"));
 			</#if>
@@ -272,12 +280,15 @@ public class ${name}Screen extends AbstractContainerScreen<${name}Menu> implemen
 			<#if hasProcedure(component.isCheckedProcedure)>boolean ${component.getName()}Selected = <@procedureOBJToConditionCode component.isCheckedProcedure/>;</#if>
 			${component.getName()} = Checkbox.builder(Component.translatable("gui.${modid}.${registryname}.${component.getName()}"), this.font)
 				.pos(this.leftPos + ${component.gx(data.width)}, this.topPos + ${component.gy(data.height)})
-				.onValueChange((checkbox, value) -> menu.sendMenuStateUpdate(world, 1, "${component.getName()}", value, false))
+				.onValueChange((checkbox, value) -> {
+					if (!menuStateUpdateActive)
+						menu.sendMenuStateUpdate(world, 1, "${component.getName()}", value);
+				})
 				<#if hasProcedure(component.isCheckedProcedure)>.selected(${component.getName()}Selected)</#if>
 				.build();
 			<#if hasProcedure(component.isCheckedProcedure)>
 				if (${component.getName()}Selected)
-					menu.sendMenuStateUpdate(world, 1, "${component.getName()}", true, false);
+					menu.sendMenuStateUpdate(world, 1, "${component.getName()}", true);
 			</#if>
 
 			this.addRenderableWidget(${component.getName()});

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/gui/gui_window.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/gui/gui_window.java.ftl
@@ -226,7 +226,7 @@ public class ${name}Screen extends AbstractContainerScreen<${name}Menu> implemen
 			${component.getName()}.setMaxLength(8192);
 			${component.getName()}.setResponder(content -> {
 				if (!menuStateUpdateActive)
-					menu.sendMenuStateUpdate(world, 0, "${component.getName()}", content);
+					menu.sendMenuStateUpdate(world, 0, "${component.getName()}", content, false);
 			});
 			<#if component.placeholder?has_content>
 			${component.getName()}.setHint(Component.translatable("gui.${modid}.${registryname}.${component.getName()}"));
@@ -285,13 +285,13 @@ public class ${name}Screen extends AbstractContainerScreen<${name}Menu> implemen
 				.pos(this.leftPos + ${component.gx(data.width)}, this.topPos + ${component.gy(data.height)})
 				.onValueChange((checkbox, value) -> {
 					if (!menuStateUpdateActive)
-						menu.sendMenuStateUpdate(world, 1, "${component.getName()}", value);
+						menu.sendMenuStateUpdate(world, 1, "${component.getName()}", value, false);
 				})
 				<#if hasProcedure(component.isCheckedProcedure)>.selected(${component.getName()}Selected)</#if>
 				.build();
 			<#if hasProcedure(component.isCheckedProcedure)>
 				if (${component.getName()}Selected)
-					menu.sendMenuStateUpdate(world, 1, "${component.getName()}", true);
+					menu.sendMenuStateUpdate(world, 1, "${component.getName()}", true, false);
 			</#if>
 
 			this.addRenderableWidget(${component.getName()});

--- a/plugins/generator-1.21.4/neoforge-1.21.4/procedures/gui_set_text_textfield.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/procedures/gui_set_text_textfield.java.ftl
@@ -1,4 +1,4 @@
 <#if w.hasElementsOfType("gui")>
-if (${input$entity} instanceof Player _entity && _entity.containerMenu instanceof ${JavaModName}Menus.MenuAccessor _menu)
-	_menu.sendMenuStateUpdate(_entity.level(), 0, "${field$textfield}", ${input$text});
+if (${input$entity} instanceof Player _player && _player.containerMenu instanceof ${JavaModName}Menus.MenuAccessor _menu)
+	_menu.sendMenuStateUpdate(_player, 0, "${field$textfield}", ${input$text}, true);
 </#if>

--- a/plugins/generator-1.21.4/neoforge-1.21.4/procedures/gui_set_text_textfield.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/procedures/gui_set_text_textfield.java.ftl
@@ -1,4 +1,4 @@
 <#if w.hasElementsOfType("gui")>
 if (${input$entity} instanceof Player _entity && _entity.containerMenu instanceof ${JavaModName}Menus.MenuAccessor _menu)
-	_menu.sendMenuStateUpdate(_entity.level(), 0, "${field$textfield}", ${input$text}, true);
+	_menu.sendMenuStateUpdate(_entity.level(), 0, "${field$textfield}", ${input$text});
 </#if>

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/elementinits/menus.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/elementinits/menus.java.ftl
@@ -50,13 +50,9 @@ public class ${JavaModName}Menus {
 
 		Map<Integer, Slot> getSlots();
 
-		default void sendMenuStateUpdate(Level world, int elementType, String name, Object elementState) {
-			sendMenuStateUpdate(world, elementType, name, elementState, true);
-		}
-
-		default void sendMenuStateUpdate(Level world, int elementType, String name, Object elementState, boolean needClientUpdate) {
+		default void sendMenuStateUpdate(Player player, int elementType, String name, Object elementState, boolean needClientUpdate) {
 			getMenuState().put(elementType + ":" + name, elementState);
-			if (needClientUpdate && world.isClientSide && Minecraft.getInstance().screen instanceof ${JavaModName}Screens.ScreenAccessor accessor) {
+			if (needClientUpdate && player.level().isClientSide && Minecraft.getInstance().screen instanceof ${JavaModName}Screens.ScreenAccessor accessor) {
 				accessor.updateMenuState(elementType, name, elementState);
 			}
 		}

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/elementinits/menus.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/elementinits/menus.java.ftl
@@ -51,8 +51,12 @@ public class ${JavaModName}Menus {
 		Map<Integer, Slot> getSlots();
 
 		default void sendMenuStateUpdate(Level world, int elementType, String name, Object elementState) {
+			sendMenuStateUpdate(world, elementType, name, elementState, true);
+		}
+
+		default void sendMenuStateUpdate(Level world, int elementType, String name, Object elementState, boolean needClientUpdate) {
 			getMenuState().put(elementType + ":" + name, elementState);
-			if (world.isClientSide && Minecraft.getInstance().screen instanceof ${JavaModName}Screens.ScreenAccessor accessor) {
+			if (needClientUpdate && world.isClientSide && Minecraft.getInstance().screen instanceof ${JavaModName}Screens.ScreenAccessor accessor) {
 				accessor.updateMenuState(elementType, name, elementState);
 			}
 		}

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/elementinits/menus.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/elementinits/menus.java.ftl
@@ -50,10 +50,10 @@ public class ${JavaModName}Menus {
 
 		Map<Integer, Slot> getSlots();
 
-		default void sendMenuStateUpdate(Level world, int elementType, String name, Object elementState, boolean needClientUpdate) {
+		default void sendMenuStateUpdate(Level world, int elementType, String name, Object elementState) {
 			getMenuState().put(elementType + ":" + name, elementState);
-			if (needClientUpdate && world.isClientSide && Minecraft.getInstance().screen instanceof ${JavaModName}Screens.ScreenAccessor accessor) {
-				accessor.onMenuStateUpdate(elementType, name, elementState);
+			if (world.isClientSide && Minecraft.getInstance().screen instanceof ${JavaModName}Screens.ScreenAccessor accessor) {
+				accessor.updateMenuState(elementType, name, elementState);
 			}
 		}
 

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/elementinits/screens.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/elementinits/screens.java.ftl
@@ -48,7 +48,7 @@ package ${package}.init;
 	}
 
 	public interface ScreenAccessor {
-		void onMenuStateUpdate(int elementType, String name, Object elementState);
+		void updateMenuState(int elementType, String name, Object elementState);
 	}
 
 	<#if hasEntityModels>

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/gui/gui_window.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/gui/gui_window.java.ftl
@@ -44,6 +44,8 @@ public class ${name}Screen extends AbstractContainerScreen<${name}Menu> implemen
 	private final int x, y, z;
 	private final Player entity;
 
+	private boolean menuStateUpdateActive = false;
+
 	<#list textFields as component>
 	EditBox ${component.getName()};
 	</#list>
@@ -70,8 +72,6 @@ public class ${name}Screen extends AbstractContainerScreen<${name}Menu> implemen
 		this.imageWidth = ${data.width};
 		this.imageHeight = ${data.height};
 	}
-
-	private boolean menuStateUpdateActive = false;
 
 	@Override public void updateMenuState(int elementType, String name, Object elementState) {
 		menuStateUpdateActive = true;

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/gui/gui_window.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/gui/gui_window.java.ftl
@@ -225,7 +225,7 @@ public class ${name}Screen extends AbstractContainerScreen<${name}Menu> implemen
 			${component.getName()}.setMaxLength(8192);
 			${component.getName()}.setResponder(content -> {
 				if (!menuStateUpdateActive)
-					menu.sendMenuStateUpdate(world, 0, "${component.getName()}", content, false);
+					menu.sendMenuStateUpdate(entity, 0, "${component.getName()}", content, false);
 			});
 			<#if component.placeholder?has_content>
 			${component.getName()}.setHint(Component.translatable("gui.${modid}.${registryname}.${component.getName()}"));
@@ -284,13 +284,13 @@ public class ${name}Screen extends AbstractContainerScreen<${name}Menu> implemen
 				.pos(this.leftPos + ${component.gx(data.width)}, this.topPos + ${component.gy(data.height)})
 				.onValueChange((checkbox, value) -> {
 					if (!menuStateUpdateActive)
-						menu.sendMenuStateUpdate(world, 1, "${component.getName()}", value, false);
+						menu.sendMenuStateUpdate(entity, 1, "${component.getName()}", value, false);
 				})
 				<#if hasProcedure(component.isCheckedProcedure)>.selected(${component.getName()}Selected)</#if>
 				.build();
 			<#if hasProcedure(component.isCheckedProcedure)>
 				if (${component.getName()}Selected)
-					menu.sendMenuStateUpdate(world, 1, "${component.getName()}", true, false);
+					menu.sendMenuStateUpdate(entity, 1, "${component.getName()}", true, false);
 			</#if>
 
 			this.addRenderableWidget(${component.getName()});

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/gui/gui_window.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/gui/gui_window.java.ftl
@@ -71,7 +71,11 @@ public class ${name}Screen extends AbstractContainerScreen<${name}Menu> implemen
 		this.imageHeight = ${data.height};
 	}
 
-	@Override public void onMenuStateUpdate(int elementType, String name, Object elementState) {
+	private boolean menuStateUpdateActive = false;
+
+	@Override public void updateMenuState(int elementType, String name, Object elementState) {
+		menuStateUpdateActive = true;
+
 		<#if textFields?has_content>
 		if (elementType == 0 && elementState instanceof String stringState) {
 			<#list textFields as component>
@@ -80,7 +84,10 @@ public class ${name}Screen extends AbstractContainerScreen<${name}Menu> implemen
 			</#list>
 		}
 		</#if>
-		<#-- onMenuStateUpdate is not implemented for checkboxes, as there is no procedure block to set checkbox state currently -->
+
+		<#-- updateMenuState is not implemented for checkboxes, as there is no procedure block to set checkbox state currently -->
+
+		menuStateUpdateActive = false;
 	}
 
 	<#if data.doesPauseGame>
@@ -216,7 +223,10 @@ public class ${name}Screen extends AbstractContainerScreen<${name}Menu> implemen
 			${component.getName()} = new EditBox(this.font, this.leftPos + ${component.gx(data.width) + 1}, this.topPos + ${component.gy(data.height) + 1},
 			${component.width - 2}, ${component.height - 2}, Component.translatable("gui.${modid}.${registryname}.${component.getName()}"));
 			${component.getName()}.setMaxLength(8192);
-			${component.getName()}.setResponder(content -> menu.sendMenuStateUpdate(world, 0, "${component.getName()}", content, false));
+			${component.getName()}.setResponder(content -> {
+				if (!menuStateUpdateActive)
+					menu.sendMenuStateUpdate(world, 0, "${component.getName()}", content);
+			});
 			<#if component.placeholder?has_content>
 			${component.getName()}.setHint(Component.translatable("gui.${modid}.${registryname}.${component.getName()}"));
 			</#if>
@@ -272,12 +282,15 @@ public class ${name}Screen extends AbstractContainerScreen<${name}Menu> implemen
 			<#if hasProcedure(component.isCheckedProcedure)>boolean ${component.getName()}Selected = <@procedureOBJToConditionCode component.isCheckedProcedure/>;</#if>
 			${component.getName()} = Checkbox.builder(Component.translatable("gui.${modid}.${registryname}.${component.getName()}"), this.font)
 				.pos(this.leftPos + ${component.gx(data.width)}, this.topPos + ${component.gy(data.height)})
-				.onValueChange((checkbox, value) -> menu.sendMenuStateUpdate(world, 1, "${component.getName()}", value, false))
+				.onValueChange((checkbox, value) -> {
+					if (!menuStateUpdateActive)
+						menu.sendMenuStateUpdate(world, 1, "${component.getName()}", value);
+				})
 				<#if hasProcedure(component.isCheckedProcedure)>.selected(${component.getName()}Selected)</#if>
 				.build();
 			<#if hasProcedure(component.isCheckedProcedure)>
 				if (${component.getName()}Selected)
-					menu.sendMenuStateUpdate(world, 1, "${component.getName()}", true, false);
+					menu.sendMenuStateUpdate(world, 1, "${component.getName()}", true);
 			</#if>
 
 			this.addRenderableWidget(${component.getName()});

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/gui/gui_window.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/gui/gui_window.java.ftl
@@ -225,7 +225,7 @@ public class ${name}Screen extends AbstractContainerScreen<${name}Menu> implemen
 			${component.getName()}.setMaxLength(8192);
 			${component.getName()}.setResponder(content -> {
 				if (!menuStateUpdateActive)
-					menu.sendMenuStateUpdate(world, 0, "${component.getName()}", content);
+					menu.sendMenuStateUpdate(world, 0, "${component.getName()}", content, false);
 			});
 			<#if component.placeholder?has_content>
 			${component.getName()}.setHint(Component.translatable("gui.${modid}.${registryname}.${component.getName()}"));
@@ -284,13 +284,13 @@ public class ${name}Screen extends AbstractContainerScreen<${name}Menu> implemen
 				.pos(this.leftPos + ${component.gx(data.width)}, this.topPos + ${component.gy(data.height)})
 				.onValueChange((checkbox, value) -> {
 					if (!menuStateUpdateActive)
-						menu.sendMenuStateUpdate(world, 1, "${component.getName()}", value);
+						menu.sendMenuStateUpdate(world, 1, "${component.getName()}", value, false);
 				})
 				<#if hasProcedure(component.isCheckedProcedure)>.selected(${component.getName()}Selected)</#if>
 				.build();
 			<#if hasProcedure(component.isCheckedProcedure)>
 				if (${component.getName()}Selected)
-					menu.sendMenuStateUpdate(world, 1, "${component.getName()}", true);
+					menu.sendMenuStateUpdate(world, 1, "${component.getName()}", true, false);
 			</#if>
 
 			this.addRenderableWidget(${component.getName()});


### PR DESCRIPTION
Improvement for #5413

------

If we break-down the flow before this PR:

1. Set text procedure is ran server-side
2. Packet is sent to client-side
3. On client-side, sendMenuStateUpdate is called with needsClientUpdate on true
4. This in turn calls onMenuStateUpdate
5. Inside onMenuStateUpdate, setValue is called
6. This invokes responder, that calls sendMenuStateUpdate with needsClientUpdate on false
7. While this does not do another client update, update will be sent on the server with sync

Flow after this PR:

1. Set text procedure is ran server-side
2. Packet is sent to client-side
3. On client-side, sendMenuStateUpdate is called
4. This in turn calls onMenuStateUpdate
5. menuStateUpdateActive is set to true in onMenuStateUpdate
6. Inside onMenuStateUpdate, setValue is called
7. This invokes responder, but it does not call sendMenuStateUpdate because it knows non-user state update is in process

----

@151chit, please review