### PR TITLE
[Bugfix] Player right-click global procedure triggers fired inconsistently in some cases

### DIFF
--- a/plugins/generator-1.21.1/neoforge-1.21.1/triggers/player_right_click_block.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/triggers/player_right_click_block.java.ftl
@@ -1,8 +1,7 @@
 <#include "procedures.java.ftl">
 @EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onRightClickBlock(PlayerInteractEvent.RightClickBlock event) {
-		if (event.getHand() != event.getEntity().getUsedItemHand())
-			return;
+		if (event.getHand() != InteractionHand.MAIN_HAND) return;
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
 				"x": "event.getPos().getX()",

--- a/plugins/generator-1.21.1/neoforge-1.21.1/triggers/player_right_click_block.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/triggers/player_right_click_block.java.ftl
@@ -1,6 +1,7 @@
 <#include "procedures.java.ftl">
 @EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onRightClickBlock(PlayerInteractEvent.RightClickBlock event) {
+		<#-- fix #5491, event is fired for both hands always, so we can filter by either -->
 		if (event.getHand() != InteractionHand.MAIN_HAND) return;
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {

--- a/plugins/generator-1.21.1/neoforge-1.21.1/triggers/player_right_click_empty_hand.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/triggers/player_right_click_empty_hand.java.ftl
@@ -10,6 +10,7 @@
 				"entity": "event.getEntity()"
 			}/>
 		</#compress></#assign>
+		<#-- fix #5491, event is fired for both hands always, so we can filter by either -->
 		if (event.getHand() != InteractionHand.MAIN_HAND) return;
 		PacketDistributor.sendToServer(new ${name}Message());
 		execute(${dependenciesCode});

--- a/plugins/generator-1.21.1/neoforge-1.21.1/triggers/player_right_click_empty_hand.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/triggers/player_right_click_empty_hand.java.ftl
@@ -10,8 +10,7 @@
 				"entity": "event.getEntity()"
 			}/>
 		</#compress></#assign>
-		if (event.getHand() != event.getEntity().getUsedItemHand())
-			return;
+		if (event.getHand() != InteractionHand.MAIN_HAND) return;
 		PacketDistributor.sendToServer(new ${name}Message());
 		execute(${dependenciesCode});
 	}

--- a/plugins/generator-1.21.1/neoforge-1.21.1/triggers/player_right_click_entity.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/triggers/player_right_click_entity.java.ftl
@@ -1,8 +1,7 @@
 <#include "procedures.java.ftl">
 @EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onRightClickEntity(PlayerInteractEvent.EntityInteract event) {
-		if (event.getHand() != event.getEntity().getUsedItemHand())
-			return;
+		if (event.getHand() != InteractionHand.MAIN_HAND) return;
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
 				"x": "event.getPos().getX()",

--- a/plugins/generator-1.21.1/neoforge-1.21.1/triggers/player_right_click_entity.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/triggers/player_right_click_entity.java.ftl
@@ -1,6 +1,7 @@
 <#include "procedures.java.ftl">
 @EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onRightClickEntity(PlayerInteractEvent.EntityInteract event) {
+		<#-- fix #5491, event is fired for both hands always, so we can filter by either -->
 		if (event.getHand() != InteractionHand.MAIN_HAND) return;
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {

--- a/plugins/generator-1.21.4/neoforge-1.21.4/triggers/player_right_click_block.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/triggers/player_right_click_block.java.ftl
@@ -1,8 +1,7 @@
 <#include "procedures.java.ftl">
 @EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onRightClickBlock(PlayerInteractEvent.RightClickBlock event) {
-		if (event.getHand() != event.getEntity().getUsedItemHand())
-			return;
+		if (event.getHand() != InteractionHand.MAIN_HAND) return;
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
 				"x": "event.getPos().getX()",

--- a/plugins/generator-1.21.4/neoforge-1.21.4/triggers/player_right_click_block.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/triggers/player_right_click_block.java.ftl
@@ -1,6 +1,7 @@
 <#include "procedures.java.ftl">
 @EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onRightClickBlock(PlayerInteractEvent.RightClickBlock event) {
+		<#-- fix #5491, event is fired for both hands always, so we can filter by either -->
 		if (event.getHand() != InteractionHand.MAIN_HAND) return;
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {

--- a/plugins/generator-1.21.4/neoforge-1.21.4/triggers/player_right_click_empty_hand.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/triggers/player_right_click_empty_hand.java.ftl
@@ -10,6 +10,7 @@
 				"entity": "event.getEntity()"
 			}/>
 		</#compress></#assign>
+		<#-- fix #5491, event is fired for both hands always, so we can filter by either -->
 		if (event.getHand() != InteractionHand.MAIN_HAND) return;
 		PacketDistributor.sendToServer(new ${name}Message());
 		execute(${dependenciesCode});

--- a/plugins/generator-1.21.4/neoforge-1.21.4/triggers/player_right_click_empty_hand.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/triggers/player_right_click_empty_hand.java.ftl
@@ -10,8 +10,7 @@
 				"entity": "event.getEntity()"
 			}/>
 		</#compress></#assign>
-		if (event.getHand() != event.getEntity().getUsedItemHand())
-			return;
+		if (event.getHand() != InteractionHand.MAIN_HAND) return;
 		PacketDistributor.sendToServer(new ${name}Message());
 		execute(${dependenciesCode});
 	}

--- a/plugins/generator-1.21.4/neoforge-1.21.4/triggers/player_right_click_entity.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/triggers/player_right_click_entity.java.ftl
@@ -1,8 +1,7 @@
 <#include "procedures.java.ftl">
 @EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onRightClickEntity(PlayerInteractEvent.EntityInteract event) {
-		if (event.getHand() != event.getEntity().getUsedItemHand())
-			return;
+		if (event.getHand() != InteractionHand.MAIN_HAND) return;
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {
 				"x": "event.getPos().getX()",

--- a/plugins/generator-1.21.4/neoforge-1.21.4/triggers/player_right_click_entity.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/triggers/player_right_click_entity.java.ftl
@@ -1,6 +1,7 @@
 <#include "procedures.java.ftl">
 @EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void onRightClickEntity(PlayerInteractEvent.EntityInteract event) {
+		<#-- fix #5491, event is fired for both hands always, so we can filter by either -->
 		if (event.getHand() != InteractionHand.MAIN_HAND) return;
 		<#assign dependenciesCode><#compress>
 			<@procedureDependenciesCode dependencies, {


### PR DESCRIPTION
Fix #5491

[Bugfix] Player right-click global procedure triggers fired inconsistently in some cases