### PR TITLE
Wood pack maker improvements

### DIFF
--- a/src/main/java/net/mcreator/ui/dialogs/tools/PackMakerToolUtils.java
+++ b/src/main/java/net/mcreator/ui/dialogs/tools/PackMakerToolUtils.java
@@ -20,8 +20,10 @@
 package net.mcreator.ui.dialogs.tools;
 
 import net.mcreator.element.GeneratableElement;
+import net.mcreator.minecraft.TagType;
 import net.mcreator.workspace.Workspace;
 import net.mcreator.workspace.elements.FolderElement;
+import net.mcreator.workspace.elements.TagElement;
 
 public class PackMakerToolUtils {
 
@@ -43,6 +45,16 @@ public class PackMakerToolUtils {
 			workspace.getWorkspace().addModElement(generatableElement.getModElement());
 			workspace.getGenerator().generateElement(generatableElement);
 			workspace.getModElementManager().storeModElement(generatableElement);
+		}
+	}
+
+	public static void addTagEntries(Workspace workspace, TagType tagType, String tagName, String... entries) {
+		TagElement tag = new TagElement(tagType, tagName);
+		if (!workspace.getTagElements().containsKey(tag)) {
+			workspace.addTagElement(tag);
+		}
+		for (String entry : entries) {
+			workspace.getTagElements().get(tag).add(entry);
 		}
 	}
 

--- a/src/main/java/net/mcreator/ui/dialogs/tools/WoodPackMakerTool.java
+++ b/src/main/java/net/mcreator/ui/dialogs/tools/WoodPackMakerTool.java
@@ -158,24 +158,6 @@ public class WoodPackMakerTool {
 				.getTextureFile(RegistryNameFixer.fix(leavesTextureName), TextureType.BLOCK));
 
 		// we use Block GUI to get default values for the block element (kinda hacky!)
-		Block woodBlock = (Block) ModElementType.BLOCK.getModElementGUI(mcreator,
-				new ModElement(workspace, name + "Wood", ModElementType.BLOCK), false).getElementFromGUI();
-		woodBlock.name = name + " Wood";
-		woodBlock.texture = new TextureHolder(workspace, woodTextureName);
-		woodBlock.renderType = 11; // single texture
-		woodBlock.customModelName = "Single texture";
-		woodBlock.soundOnStep = new StepSound(workspace, "WOOD");
-		woodBlock.hardness = 2.0 * factor;
-		woodBlock.resistance = 2.0 * Math.pow(factor, 0.8);
-		woodBlock.destroyTool = "axe";
-		woodBlock.noteBlockInstrument = "BASS";
-		woodBlock.ignitedByLava = true;
-		woodBlock.flammability = (int) Math.round(5 * factor);
-		woodBlock.rotationMode = 5; // log rotation
-		woodBlock.creativeTabs = List.of(new TabEntry(workspace, "BUILDING_BLOCKS"));
-		PackMakerToolUtils.addGeneratableElementToWorkspace(workspace, folder, woodBlock);
-
-		// we use Block GUI to get default values for the block element (kinda hacky!)
 		Block logBlock = (Block) ModElementType.BLOCK.getModElementGUI(mcreator,
 				new ModElement(workspace, name + "Log", ModElementType.BLOCK), false).getElementFromGUI();
 		logBlock.name = name + " Log";
@@ -197,6 +179,24 @@ public class WoodPackMakerTool {
 		logBlock.rotationMode = 5; // log rotation
 		logBlock.creativeTabs = List.of(new TabEntry(workspace, "BUILDING_BLOCKS"));
 		PackMakerToolUtils.addGeneratableElementToWorkspace(workspace, folder, logBlock);
+
+		// we use Block GUI to get default values for the block element (kinda hacky!)
+		Block woodBlock = (Block) ModElementType.BLOCK.getModElementGUI(mcreator,
+				new ModElement(workspace, name + "Wood", ModElementType.BLOCK), false).getElementFromGUI();
+		woodBlock.name = name + " Wood";
+		woodBlock.texture = new TextureHolder(workspace, woodTextureName);
+		woodBlock.renderType = 11; // single texture
+		woodBlock.customModelName = "Single texture";
+		woodBlock.soundOnStep = new StepSound(workspace, "WOOD");
+		woodBlock.hardness = 2.0 * factor;
+		woodBlock.resistance = 2.0 * Math.pow(factor, 0.8);
+		woodBlock.destroyTool = "axe";
+		woodBlock.noteBlockInstrument = "BASS";
+		woodBlock.ignitedByLava = true;
+		woodBlock.flammability = (int) Math.round(5 * factor);
+		woodBlock.rotationMode = 5; // log rotation
+		woodBlock.creativeTabs = List.of(new TabEntry(workspace, "BUILDING_BLOCKS"));
+		PackMakerToolUtils.addGeneratableElementToWorkspace(workspace, folder, woodBlock);
 
 		// we use Block GUI to get default values for the block element (kinda hacky!)
 		Block planksBlock = (Block) ModElementType.BLOCK.getModElementGUI(mcreator,

--- a/src/main/java/net/mcreator/ui/dialogs/tools/WoodPackMakerTool.java
+++ b/src/main/java/net/mcreator/ui/dialogs/tools/WoodPackMakerTool.java
@@ -113,9 +113,9 @@ public class WoodPackMakerTool {
 
 		if (!PackMakerToolUtils.checkIfNamesAvailable(workspace, name + "Wood", name + "Log", name + "Planks",
 				name + "Leaves", name + "Stairs", name + "Slab", name + "Fence", name + "FenceGate",
-				name + "PressurePlate", name + "Button", name + "WoodRecipe", name + "PlanksLogRecipe",
-				name + "PlanksWoodRecipe", name + "StairsRecipe", name + "SlabRecipe", name + "FenceRecipe",
-				name + "FenceGateRecipe", name + "PressurePlateRecipe", name + "ButtonRecipe", name + "StickRecipe"))
+				name + "PressurePlate", name + "Button", name + "WoodRecipe", name + "PlanksRecipe",
+				name + "StairsRecipe", name + "SlabRecipe", name + "FenceRecipe", name + "FenceGateRecipe",
+				name + "PressurePlateRecipe", name + "ButtonRecipe"))
 			return;
 
 		// select folder the mod pack should be in
@@ -348,44 +348,35 @@ public class WoodPackMakerTool {
 				new ModElement(workspace, name + "WoodRecipe", ModElementType.RECIPE), false).getElementFromGUI();
 		woodRecipe.craftingBookCategory = "BUILDING";
 		woodRecipe.group = "bark";
-		woodRecipe.recipeSlots[0] = new MItemBlock(workspace, "CUSTOM:" + logBlock.getModElement().getName());
-		woodRecipe.recipeSlots[1] = new MItemBlock(workspace, "CUSTOM:" + logBlock.getModElement().getName());
-		woodRecipe.recipeSlots[3] = new MItemBlock(workspace, "CUSTOM:" + logBlock.getModElement().getName());
-		woodRecipe.recipeSlots[4] = new MItemBlock(workspace, "CUSTOM:" + logBlock.getModElement().getName());
-		woodRecipe.recipeReturnStack = new MItemBlock(workspace, "CUSTOM:" + name + "Wood");
+		woodRecipe.recipeSlots[0] = new MItemBlock(workspace, logEntry);
+		woodRecipe.recipeSlots[1] = new MItemBlock(workspace, logEntry);
+		woodRecipe.recipeSlots[3] = new MItemBlock(workspace, logEntry);
+		woodRecipe.recipeSlots[4] = new MItemBlock(workspace, logEntry);
+		woodRecipe.recipeReturnStack = new MItemBlock(workspace, woodEntry);
 		woodRecipe.recipeRetstackSize = 3;
 		PackMakerToolUtils.addGeneratableElementToWorkspace(workspace, folder, woodRecipe);
 
 		Recipe planksLogRecipe = (Recipe) ModElementType.RECIPE.getModElementGUI(mcreator,
-				new ModElement(workspace, name + "PlanksLogRecipe", ModElementType.RECIPE), false).getElementFromGUI();
+				new ModElement(workspace, name + "PlanksRecipe", ModElementType.RECIPE), false).getElementFromGUI();
 		planksLogRecipe.craftingBookCategory = "BUILDING";
 		planksLogRecipe.group = "planks";
-		planksLogRecipe.recipeSlots[4] = new MItemBlock(workspace, "CUSTOM:" + logBlock.getModElement().getName());
-		planksLogRecipe.recipeReturnStack = new MItemBlock(workspace, "CUSTOM:" + name + "Planks");
+		planksLogRecipe.recipeSlots[4] = new MItemBlock(workspace,
+				"TAG:" + workspace.getWorkspaceSettings().getModID() + ":" + registryName + "_logs");
+		planksLogRecipe.recipeReturnStack = new MItemBlock(workspace, planksEntry);
 		planksLogRecipe.recipeShapeless = true;
 		planksLogRecipe.recipeRetstackSize = 4;
 		PackMakerToolUtils.addGeneratableElementToWorkspace(workspace, folder, planksLogRecipe);
-
-		Recipe planksWoodRecipe = (Recipe) ModElementType.RECIPE.getModElementGUI(mcreator,
-				new ModElement(workspace, name + "PlanksWoodRecipe", ModElementType.RECIPE), false).getElementFromGUI();
-		planksWoodRecipe.craftingBookCategory = "BUILDING";
-		planksWoodRecipe.group = "planks";
-		planksWoodRecipe.recipeSlots[4] = new MItemBlock(workspace, "CUSTOM:" + woodBlock.getModElement().getName());
-		planksWoodRecipe.recipeReturnStack = new MItemBlock(workspace, "CUSTOM:" + name + "Planks");
-		planksWoodRecipe.recipeShapeless = true;
-		planksWoodRecipe.recipeRetstackSize = 4;
-		PackMakerToolUtils.addGeneratableElementToWorkspace(workspace, folder, planksWoodRecipe);
 
 		Recipe stairsRecipe = (Recipe) ModElementType.RECIPE.getModElementGUI(mcreator,
 				new ModElement(workspace, name + "StairsRecipe", ModElementType.RECIPE), false).getElementFromGUI();
 		stairsRecipe.craftingBookCategory = "BUILDING";
 		stairsRecipe.group = "wooden_stairs";
-		stairsRecipe.recipeSlots[0] = new MItemBlock(workspace, "CUSTOM:" + planksBlock.getModElement().getName());
-		stairsRecipe.recipeSlots[3] = new MItemBlock(workspace, "CUSTOM:" + planksBlock.getModElement().getName());
-		stairsRecipe.recipeSlots[4] = new MItemBlock(workspace, "CUSTOM:" + planksBlock.getModElement().getName());
-		stairsRecipe.recipeSlots[6] = new MItemBlock(workspace, "CUSTOM:" + planksBlock.getModElement().getName());
-		stairsRecipe.recipeSlots[7] = new MItemBlock(workspace, "CUSTOM:" + planksBlock.getModElement().getName());
-		stairsRecipe.recipeSlots[8] = new MItemBlock(workspace, "CUSTOM:" + planksBlock.getModElement().getName());
+		stairsRecipe.recipeSlots[0] = new MItemBlock(workspace, planksEntry);
+		stairsRecipe.recipeSlots[3] = new MItemBlock(workspace, planksEntry);
+		stairsRecipe.recipeSlots[4] = new MItemBlock(workspace, planksEntry);
+		stairsRecipe.recipeSlots[6] = new MItemBlock(workspace, planksEntry);
+		stairsRecipe.recipeSlots[7] = new MItemBlock(workspace, planksEntry);
+		stairsRecipe.recipeSlots[8] = new MItemBlock(workspace, planksEntry);
 		stairsRecipe.recipeReturnStack = new MItemBlock(workspace, "CUSTOM:" + name + "Stairs");
 		stairsRecipe.recipeRetstackSize = 4;
 		PackMakerToolUtils.addGeneratableElementToWorkspace(workspace, folder, stairsRecipe);
@@ -394,9 +385,9 @@ public class WoodPackMakerTool {
 				new ModElement(workspace, name + "SlabRecipe", ModElementType.RECIPE), false).getElementFromGUI();
 		slabRecipe.craftingBookCategory = "BUILDING";
 		slabRecipe.group = "wooden_slab";
-		slabRecipe.recipeSlots[6] = new MItemBlock(workspace, "CUSTOM:" + planksBlock.getModElement().getName());
-		slabRecipe.recipeSlots[7] = new MItemBlock(workspace, "CUSTOM:" + planksBlock.getModElement().getName());
-		slabRecipe.recipeSlots[8] = new MItemBlock(workspace, "CUSTOM:" + planksBlock.getModElement().getName());
+		slabRecipe.recipeSlots[6] = new MItemBlock(workspace, planksEntry);
+		slabRecipe.recipeSlots[7] = new MItemBlock(workspace, planksEntry);
+		slabRecipe.recipeSlots[8] = new MItemBlock(workspace, planksEntry);
 		slabRecipe.recipeReturnStack = new MItemBlock(workspace, "CUSTOM:" + name + "Slab");
 		slabRecipe.recipeRetstackSize = 6;
 		PackMakerToolUtils.addGeneratableElementToWorkspace(workspace, folder, slabRecipe);
@@ -404,12 +395,12 @@ public class WoodPackMakerTool {
 		Recipe fenceRecipe = (Recipe) ModElementType.RECIPE.getModElementGUI(mcreator,
 				new ModElement(workspace, name + "FenceRecipe", ModElementType.RECIPE), false).getElementFromGUI();
 		fenceRecipe.group = "wooden_fence";
-		fenceRecipe.recipeSlots[3] = new MItemBlock(workspace, "CUSTOM:" + planksBlock.getModElement().getName());
+		fenceRecipe.recipeSlots[3] = new MItemBlock(workspace, planksEntry);
 		fenceRecipe.recipeSlots[4] = new MItemBlock(workspace, "Items.STICK");
-		fenceRecipe.recipeSlots[5] = new MItemBlock(workspace, "CUSTOM:" + planksBlock.getModElement().getName());
-		fenceRecipe.recipeSlots[6] = new MItemBlock(workspace, "CUSTOM:" + planksBlock.getModElement().getName());
+		fenceRecipe.recipeSlots[5] = new MItemBlock(workspace, planksEntry);
+		fenceRecipe.recipeSlots[6] = new MItemBlock(workspace, planksEntry);
 		fenceRecipe.recipeSlots[7] = new MItemBlock(workspace, "Items.STICK");
-		fenceRecipe.recipeSlots[8] = new MItemBlock(workspace, "CUSTOM:" + planksBlock.getModElement().getName());
+		fenceRecipe.recipeSlots[8] = new MItemBlock(workspace, planksEntry);
 		fenceRecipe.recipeReturnStack = new MItemBlock(workspace, "CUSTOM:" + name + "Fence");
 		fenceRecipe.recipeRetstackSize = 3;
 		PackMakerToolUtils.addGeneratableElementToWorkspace(workspace, folder, fenceRecipe);
@@ -419,10 +410,10 @@ public class WoodPackMakerTool {
 		fenceGateRecipe.craftingBookCategory = "REDSTONE";
 		fenceGateRecipe.group = "wooden_fence_gate";
 		fenceGateRecipe.recipeSlots[3] = new MItemBlock(workspace, "Items.STICK");
-		fenceGateRecipe.recipeSlots[4] = new MItemBlock(workspace, "CUSTOM:" + planksBlock.getModElement().getName());
+		fenceGateRecipe.recipeSlots[4] = new MItemBlock(workspace, planksEntry);
 		fenceGateRecipe.recipeSlots[5] = new MItemBlock(workspace, "Items.STICK");
 		fenceGateRecipe.recipeSlots[6] = new MItemBlock(workspace, "Items.STICK");
-		fenceGateRecipe.recipeSlots[7] = new MItemBlock(workspace, "CUSTOM:" + planksBlock.getModElement().getName());
+		fenceGateRecipe.recipeSlots[7] = new MItemBlock(workspace, planksEntry);
 		fenceGateRecipe.recipeSlots[8] = new MItemBlock(workspace, "Items.STICK");
 		fenceGateRecipe.recipeReturnStack = new MItemBlock(workspace, "CUSTOM:" + name + "FenceGate");
 		fenceGateRecipe.recipeRetstackSize = 1;
@@ -433,10 +424,8 @@ public class WoodPackMakerTool {
 				.getElementFromGUI();
 		pressurePlateRecipe.craftingBookCategory = "REDSTONE";
 		pressurePlateRecipe.group = "wooden_pressure_plate";
-		pressurePlateRecipe.recipeSlots[6] = new MItemBlock(workspace,
-				"CUSTOM:" + planksBlock.getModElement().getName());
-		pressurePlateRecipe.recipeSlots[7] = new MItemBlock(workspace,
-				"CUSTOM:" + planksBlock.getModElement().getName());
+		pressurePlateRecipe.recipeSlots[6] = new MItemBlock(workspace, planksEntry);
+		pressurePlateRecipe.recipeSlots[7] = new MItemBlock(workspace, planksEntry);
 		pressurePlateRecipe.recipeReturnStack = new MItemBlock(workspace, "CUSTOM:" + name + "PressurePlate");
 		pressurePlateRecipe.recipeRetstackSize = 1;
 		PackMakerToolUtils.addGeneratableElementToWorkspace(workspace, folder, pressurePlateRecipe);
@@ -445,20 +434,11 @@ public class WoodPackMakerTool {
 				new ModElement(workspace, name + "ButtonRecipe", ModElementType.RECIPE), false).getElementFromGUI();
 		buttonRecipe.craftingBookCategory = "REDSTONE";
 		buttonRecipe.group = "wooden_button";
-		buttonRecipe.recipeSlots[4] = new MItemBlock(workspace, "CUSTOM:" + planksBlock.getModElement().getName());
+		buttonRecipe.recipeSlots[4] = new MItemBlock(workspace, planksEntry);
 		buttonRecipe.recipeShapeless = true;
 		buttonRecipe.recipeReturnStack = new MItemBlock(workspace, "CUSTOM:" + name + "Button");
 		buttonRecipe.recipeRetstackSize = 1;
 		PackMakerToolUtils.addGeneratableElementToWorkspace(workspace, folder, buttonRecipe);
-
-		Recipe stickRecipe = (Recipe) ModElementType.RECIPE.getModElementGUI(mcreator,
-				new ModElement(workspace, name + "StickRecipe", ModElementType.RECIPE), false).getElementFromGUI();
-		stickRecipe.group = "sticks";
-		stickRecipe.recipeSlots[0] = new MItemBlock(workspace, "CUSTOM:" + planksBlock.getModElement().getName());
-		stickRecipe.recipeSlots[3] = new MItemBlock(workspace, "CUSTOM:" + planksBlock.getModElement().getName());
-		stickRecipe.recipeReturnStack = new MItemBlock(workspace, "Items.STICK");
-		stickRecipe.recipeRetstackSize = 4;
-		PackMakerToolUtils.addGeneratableElementToWorkspace(workspace, folder, stickRecipe);
 	}
 
 	public static BasicAction getAction(ActionRegistry actionRegistry) {

--- a/src/main/java/net/mcreator/ui/dialogs/tools/WoodPackMakerTool.java
+++ b/src/main/java/net/mcreator/ui/dialogs/tools/WoodPackMakerTool.java
@@ -43,6 +43,7 @@ import net.mcreator.ui.validation.validators.ModElementNameValidator;
 import net.mcreator.ui.variants.modmaker.ModMaker;
 import net.mcreator.ui.workspace.resources.TextureType;
 import net.mcreator.util.ListUtils;
+import net.mcreator.util.StringUtils;
 import net.mcreator.util.image.ImageUtils;
 import net.mcreator.workspace.Workspace;
 import net.mcreator.workspace.elements.FolderElement;
@@ -52,7 +53,6 @@ import javax.swing.*;
 import java.awt.*;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Locale;
 
 public class WoodPackMakerTool {
 
@@ -110,6 +110,7 @@ public class WoodPackMakerTool {
 	private static void addWoodPackToWorkspace(MCreator mcreator, Workspace workspace, String name, Color color,
 			double factor) {
 		String registryName = RegistryNameFixer.fromCamelCase(name);
+		String readableName = StringUtils.machineToReadableName(name);
 
 		if (!PackMakerToolUtils.checkIfNamesAvailable(workspace, name + "Wood", name + "Log", name + "Planks",
 				name + "Leaves", name + "Stairs", name + "Slab", name + "Fence", name + "FenceGate",
@@ -128,39 +129,39 @@ public class WoodPackMakerTool {
 						"templates/textures/texturemaker/" + ListUtils.getRandomItem(
 								Arrays.asList("log_side_1", "log_side_2", "log_side_3", "log_side_4", "log_side_5")) + ".png")),
 				color, true);
-		String woodTextureName = (name + "_log_side").toLowerCase(Locale.ENGLISH);
+		String woodTextureName = registryName + "_log_side";
 		FileIO.writeImageToPNGFile(ImageUtils.toBufferedImage(wood.getImage()),
-				mcreator.getFolderManager().getTextureFile(RegistryNameFixer.fix(woodTextureName), TextureType.BLOCK));
+				mcreator.getFolderManager().getTextureFile(woodTextureName, TextureType.BLOCK));
 
 		//then we generate the missing log texture
 		ImageIcon log = ImageUtils.colorize(
 				ImageMakerTexturesCache.CACHE.get(new ResourcePointer("templates/textures/texturemaker/log_top.png")),
 				color, true);
-		String logTextureName = (name + "_log_top").toLowerCase(Locale.ENGLISH);
+		String logTextureName = registryName + "_log_top";
 		FileIO.writeImageToPNGFile(ImageUtils.toBufferedImage(log.getImage()),
-				mcreator.getFolderManager().getTextureFile(RegistryNameFixer.fix(logTextureName), TextureType.BLOCK));
+				mcreator.getFolderManager().getTextureFile(logTextureName, TextureType.BLOCK));
 
 		//then we generate the planks texture
 		ImageIcon planks = ImageUtils.colorize(ImageMakerTexturesCache.CACHE.get(new ResourcePointer(
 				"templates/textures/texturemaker/" + ListUtils.getRandomItem(Arrays.asList("planks_0", "planks_1"))
 						+ ".png")), color, true);
-		String planksTextureName = (name + "_planks").toLowerCase(Locale.ENGLISH);
+		String planksTextureName = registryName + "_planks";
 		FileIO.writeImageToPNGFile(ImageUtils.toBufferedImage(planks.getImage()), mcreator.getFolderManager()
-				.getTextureFile(RegistryNameFixer.fix(planksTextureName), TextureType.BLOCK));
+				.getTextureFile(planksTextureName, TextureType.BLOCK));
 
 		//then we generate the leaves texture
 		ImageIcon leaves = ImageUtils.colorize(ImageMakerTexturesCache.CACHE.get(new ResourcePointer(
 				"templates/textures/texturemaker/" + ListUtils.getRandomItem(
 						Arrays.asList("leaves_0", "leaves_1", "leaves_2", "leaves_3", "leaves_4", "leaves_5",
 								"leaves_new1", "leaves_new2", "leaves2")) + ".png")), color, true);
-		String leavesTextureName = (name + "_leaves").toLowerCase(Locale.ENGLISH);
+		String leavesTextureName = registryName + "_leaves";
 		FileIO.writeImageToPNGFile(ImageUtils.toBufferedImage(leaves.getImage()), mcreator.getFolderManager()
-				.getTextureFile(RegistryNameFixer.fix(leavesTextureName), TextureType.BLOCK));
+				.getTextureFile(leavesTextureName, TextureType.BLOCK));
 
 		// we use Block GUI to get default values for the block element (kinda hacky!)
 		Block logBlock = (Block) ModElementType.BLOCK.getModElementGUI(mcreator,
 				new ModElement(workspace, name + "Log", ModElementType.BLOCK), false).getElementFromGUI();
-		logBlock.name = name + " Log";
+		logBlock.name = readableName + " Log";
 		logBlock.texture = new TextureHolder(workspace, logTextureName);
 		logBlock.textureTop = new TextureHolder(workspace, logTextureName);
 		logBlock.textureBack = new TextureHolder(workspace, woodTextureName);
@@ -183,7 +184,7 @@ public class WoodPackMakerTool {
 		// we use Block GUI to get default values for the block element (kinda hacky!)
 		Block woodBlock = (Block) ModElementType.BLOCK.getModElementGUI(mcreator,
 				new ModElement(workspace, name + "Wood", ModElementType.BLOCK), false).getElementFromGUI();
-		woodBlock.name = name + " Wood";
+		woodBlock.name = readableName + " Wood";
 		woodBlock.texture = new TextureHolder(workspace, woodTextureName);
 		woodBlock.renderType = 11; // single texture
 		woodBlock.customModelName = "Single texture";
@@ -201,7 +202,7 @@ public class WoodPackMakerTool {
 		// we use Block GUI to get default values for the block element (kinda hacky!)
 		Block planksBlock = (Block) ModElementType.BLOCK.getModElementGUI(mcreator,
 				new ModElement(workspace, name + "Planks", ModElementType.BLOCK), false).getElementFromGUI();
-		planksBlock.name = name + " Planks";
+		planksBlock.name = readableName + " Planks";
 		planksBlock.texture = new TextureHolder(workspace, planksTextureName);
 		planksBlock.renderType = 11; // single texture
 		planksBlock.customModelName = "Single texture";
@@ -218,7 +219,7 @@ public class WoodPackMakerTool {
 		// we use Block GUI to get default values for the block element (kinda hacky!)
 		Block leavesBlock = (Block) ModElementType.BLOCK.getModElementGUI(mcreator,
 				new ModElement(workspace, name + "Leaves", ModElementType.BLOCK), false).getElementFromGUI();
-		leavesBlock.name = name + " Leaves";
+		leavesBlock.name = readableName + " Leaves";
 		leavesBlock.blockBase = "Leaves";
 		leavesBlock.texture = new TextureHolder(workspace, leavesTextureName);
 		leavesBlock.soundOnStep = new StepSound(workspace, "PLANT");
@@ -233,7 +234,7 @@ public class WoodPackMakerTool {
 		// we use Block GUI to get default values for the block element (kinda hacky!)
 		Block stairsBlock = (Block) ModElementType.BLOCK.getModElementGUI(mcreator,
 				new ModElement(workspace, name + "Stairs", ModElementType.BLOCK), false).getElementFromGUI();
-		stairsBlock.name = name + " Stairs";
+		stairsBlock.name = readableName + " Stairs";
 		stairsBlock.blockBase = "Stairs";
 		stairsBlock.texture = new TextureHolder(workspace, planksTextureName);
 		stairsBlock.textureTop = new TextureHolder(workspace, planksTextureName);
@@ -251,7 +252,7 @@ public class WoodPackMakerTool {
 		// we use Block GUI to get default values for the block element (kinda hacky!)
 		Block slabBlock = (Block) ModElementType.BLOCK.getModElementGUI(mcreator,
 				new ModElement(workspace, name + "Slab", ModElementType.BLOCK), false).getElementFromGUI();
-		slabBlock.name = name + " Slab";
+		slabBlock.name = readableName + " Slab";
 		slabBlock.blockBase = "Slab";
 		slabBlock.texture = new TextureHolder(workspace, planksTextureName);
 		slabBlock.textureTop = new TextureHolder(workspace, planksTextureName);
@@ -269,7 +270,7 @@ public class WoodPackMakerTool {
 		// we use Block GUI to get default values for the block element (kinda hacky!)
 		Block fenceBlock = (Block) ModElementType.BLOCK.getModElementGUI(mcreator,
 				new ModElement(workspace, name + "Fence", ModElementType.BLOCK), false).getElementFromGUI();
-		fenceBlock.name = name + " Fence";
+		fenceBlock.name = readableName + " Fence";
 		fenceBlock.blockBase = "Fence";
 		fenceBlock.texture = new TextureHolder(workspace, planksTextureName);
 		fenceBlock.soundOnStep = new StepSound(workspace, "WOOD");
@@ -285,7 +286,7 @@ public class WoodPackMakerTool {
 		// we use Block GUI to get default values for the block element (kinda hacky!)
 		Block fenceGateBlock = (Block) ModElementType.BLOCK.getModElementGUI(mcreator,
 				new ModElement(workspace, name + "FenceGate", ModElementType.BLOCK), false).getElementFromGUI();
-		fenceGateBlock.name = name + " Fence Gate";
+		fenceGateBlock.name = readableName + " Fence Gate";
 		fenceGateBlock.blockBase = "FenceGate";
 		fenceGateBlock.texture = new TextureHolder(workspace, planksTextureName);
 		fenceGateBlock.soundOnStep = new StepSound(workspace, "WOOD");
@@ -301,7 +302,7 @@ public class WoodPackMakerTool {
 		// we use Block GUI to get default values for the block element (kinda hacky!)
 		Block pressurePlateBlock = (Block) ModElementType.BLOCK.getModElementGUI(mcreator,
 				new ModElement(workspace, name + "PressurePlate", ModElementType.BLOCK), false).getElementFromGUI();
-		pressurePlateBlock.name = name + " Pressure Plate";
+		pressurePlateBlock.name = readableName + " Pressure Plate";
 		pressurePlateBlock.blockBase = "PressurePlate";
 		pressurePlateBlock.texture = new TextureHolder(workspace, planksTextureName);
 		pressurePlateBlock.soundOnStep = new StepSound(workspace, "WOOD");
@@ -317,7 +318,7 @@ public class WoodPackMakerTool {
 		// we use Block GUI to get default values for the block element (kinda hacky!)
 		Block buttonBlock = (Block) ModElementType.BLOCK.getModElementGUI(mcreator,
 				new ModElement(workspace, name + "Button", ModElementType.BLOCK), false).getElementFromGUI();
-		buttonBlock.name = name + " Button";
+		buttonBlock.name = readableName + " Button";
 		buttonBlock.blockBase = "Button";
 		buttonBlock.texture = new TextureHolder(workspace, planksTextureName);
 		buttonBlock.soundOnStep = new StepSound(workspace, "WOOD");

--- a/src/main/java/net/mcreator/ui/dialogs/tools/WoodPackMakerTool.java
+++ b/src/main/java/net/mcreator/ui/dialogs/tools/WoodPackMakerTool.java
@@ -27,6 +27,7 @@ import net.mcreator.generator.GeneratorStats;
 import net.mcreator.io.FileIO;
 import net.mcreator.io.ResourcePointer;
 import net.mcreator.minecraft.RegistryNameFixer;
+import net.mcreator.minecraft.TagType;
 import net.mcreator.ui.MCreator;
 import net.mcreator.ui.action.ActionRegistry;
 import net.mcreator.ui.action.BasicAction;
@@ -108,6 +109,8 @@ public class WoodPackMakerTool {
 
 	private static void addWoodPackToWorkspace(MCreator mcreator, Workspace workspace, String name, Color color,
 			double factor) {
+		String registryName = RegistryNameFixer.fromCamelCase(name);
+
 		if (!PackMakerToolUtils.checkIfNamesAvailable(workspace, name + "Wood", name + "Log", name + "Planks",
 				name + "Leaves", name + "Stairs", name + "Slab", name + "Fence", name + "FenceGate",
 				name + "PressurePlate", name + "Button", name + "WoodRecipe", name + "PlanksLogRecipe",
@@ -324,6 +327,21 @@ public class WoodPackMakerTool {
 		buttonBlock.flammability = (int) Math.round(5 * factor);
 		buttonBlock.creativeTabs = List.of(new TabEntry(workspace, "BUILDING_BLOCKS"));
 		PackMakerToolUtils.addGeneratableElementToWorkspace(workspace, folder, buttonBlock);
+
+		// Tags
+		String planksEntry = "CUSTOM:" + name + "Planks";
+		String logEntry = "CUSTOM:" + name + "Log";
+		String woodEntry = "CUSTOM:" + name + "Wood";
+		PackMakerToolUtils.addTagEntries(workspace, TagType.BLOCKS, "mod:" + registryName + "_logs", logEntry,
+				woodEntry);
+		PackMakerToolUtils.addTagEntries(workspace, TagType.BLOCKS, "minecraft:logs_that_burn",
+				"TAG:mod:" + registryName + "_logs");
+		PackMakerToolUtils.addTagEntries(workspace, TagType.BLOCKS, "minecraft:planks", planksEntry);
+		PackMakerToolUtils.addTagEntries(workspace, TagType.ITEMS, "mod:" + registryName + "_logs", logEntry,
+				woodEntry);
+		PackMakerToolUtils.addTagEntries(workspace, TagType.ITEMS, "minecraft:logs_that_burn",
+				"TAG:mod:" + registryName + "_logs");
+		PackMakerToolUtils.addTagEntries(workspace, TagType.ITEMS, "minecraft:planks", planksEntry);
 
 		//Recipes
 		Recipe woodRecipe = (Recipe) ModElementType.RECIPE.getModElementGUI(mcreator,


### PR DESCRIPTION
This PR contains some improvements for the wood pack maker tool:
- Logs and planks are now added to the correct tags (removing the need for some recipes)
- Improved texture and in-game names when using multiple words
- Log block is now generated before wood block to match vanilla ordering