### PR TITLE
Tooltips over GUI slots cause double tooltip to be shown

### DIFF
--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/gui/gui_window.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/gui/gui_window.java.ftl
@@ -36,6 +36,7 @@ package ${package}.client.gui;
 <#assign checkboxes = data.getComponentsOfType("Checkbox")>
 <#assign buttons = data.getComponentsOfType("Button")>
 <#assign imageButtons = data.getComponentsOfType("ImageButton")>
+<#assign tooltips = data.getComponentsOfType("Tooltip")>
 
 <#compress>
 public class ${name}Screen extends AbstractContainerScreen<${name}Menu> implements ${JavaModName}Screens.ScreenAccessor {
@@ -123,10 +124,10 @@ public class ${name}Screen extends AbstractContainerScreen<${name}Menu> implemen
 		</#list>
 		</#compress>
 
-		this.renderTooltip(guiGraphics, mouseX, mouseY);
-
-
-		<#list data.getComponentsOfType("Tooltip") as component>
+		<#if tooltips?has_content>
+		boolean customTooltipShown = false;
+		</#if>
+		<#list tooltips as component>
 			<#assign x = component.gx(data.width)>
 			<#assign y = component.gy(data.height)>
 			<#if hasProcedure(component.displayCondition)>
@@ -141,8 +142,14 @@ public class ${name}Screen extends AbstractContainerScreen<${name}Menu> implemen
 					<#else>
 						guiGraphics.renderTooltip(font, Component.translatable("gui.${modid}.${registryname}.${component.getName()}"), mouseX, mouseY);
 					</#if>
+					customTooltipShown = true;
 				}
 		</#list>
+
+		<#if tooltips?has_content>
+		if (!customTooltipShown)
+		</#if>
+		this.renderTooltip(guiGraphics, mouseX, mouseY);
 	}
 
 	@Override protected void renderBg(GuiGraphics guiGraphics, float partialTicks, int gx, int gy) {

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/gui/gui_window.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/gui/gui_window.java.ftl
@@ -36,6 +36,7 @@ package ${package}.client.gui;
 <#assign checkboxes = data.getComponentsOfType("Checkbox")>
 <#assign buttons = data.getComponentsOfType("Button")>
 <#assign imageButtons = data.getComponentsOfType("ImageButton")>
+<#assign tooltips = data.getComponentsOfType("Tooltip")>
 
 <#compress>
 public class ${name}Screen extends AbstractContainerScreen<${name}Menu> implements ${JavaModName}Screens.ScreenAccessor {
@@ -123,9 +124,10 @@ public class ${name}Screen extends AbstractContainerScreen<${name}Menu> implemen
 		</#list>
 		</#compress>
 
-		this.renderTooltip(guiGraphics, mouseX, mouseY);
-
-		<#list data.getComponentsOfType("Tooltip") as component>
+		<#if tooltips?has_content>
+		boolean customTooltipShown = false;
+		</#if>
+		<#list tooltips as component>
 			<#assign x = component.gx(data.width)>
 			<#assign y = component.gy(data.height)>
 			<#if hasProcedure(component.displayCondition)>
@@ -140,8 +142,14 @@ public class ${name}Screen extends AbstractContainerScreen<${name}Menu> implemen
 					<#else>
 						guiGraphics.renderTooltip(font, Component.translatable("gui.${modid}.${registryname}.${component.getName()}"), mouseX, mouseY);
 					</#if>
+					customTooltipShown = true;
 				}
 		</#list>
+
+		<#if tooltips?has_content>
+		if (!customTooltipShown)
+		</#if>
+		this.renderTooltip(guiGraphics, mouseX, mouseY);
 	}
 
 	@Override protected void renderBg(GuiGraphics guiGraphics, float partialTicks, int gx, int gy) {


### PR DESCRIPTION
Fix #5512 - Tooltips over GUI slots cause double tooltip to be shown - tries to fix this by not showing vanilla tooltips when custom ones are shown.

Changelog:

* [Bugfix] Custom tooltips over GUI slots caused both vanilla and custom tooltips to be shown one over another