### PR TITLE
Fix crash with waterloggable double plants

### DIFF
--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/plant/plant.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/plant/plant.java.ftl
@@ -139,7 +139,8 @@ public class ${name}Block extends ${getPlantClass(data.plantType)}Block
 
 	@Override
 	public BlockState getStateForPlacement(BlockPlaceContext context) {
-		return super.getStateForPlacement(context).setValue(WATERLOGGED, context.getLevel().getFluidState(context.getClickedPos()).getType() == Fluids.WATER);
+		BlockState state = super.getStateForPlacement(context);
+		return state == null ? null : state.setValue(WATERLOGGED, context.getLevel().getFluidState(context.getClickedPos()).getType() == Fluids.WATER);
 	}
 
 	@Override public FluidState getFluidState(BlockState state) {

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/plant/plant.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/plant/plant.java.ftl
@@ -139,7 +139,8 @@ public class ${name}Block extends ${getPlantClass(data.plantType)}Block
 
 	@Override
 	public BlockState getStateForPlacement(BlockPlaceContext context) {
-		return super.getStateForPlacement(context).setValue(WATERLOGGED, context.getLevel().getFluidState(context.getClickedPos()).getType() == Fluids.WATER);
+		BlockState state = super.getStateForPlacement(context);
+		return state == null ? null : state.setValue(WATERLOGGED, context.getLevel().getFluidState(context.getClickedPos()).getType() == Fluids.WATER);
 	}
 
 	@Override public FluidState getFluidState(BlockState state) {


### PR DESCRIPTION
This PR fixes #5514 , which was caused by a missing null check when placing double plants in narrow spaces.