### PR TITLE
Fix wrong entity scaling with baby models

### DIFF
--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/livingentity/livingentity_renderer.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/livingentity/livingentity_renderer.java.ftl
@@ -138,7 +138,7 @@ public class ${name}Renderer extends <#if humanoid>Humanoid</#if>MobRenderer<${n
 		</#list>
 	}
 
-	<#if data.mobModelName == "Villager" || (data.visualScale?? && (data.visualScale.getFixedValue() != 1 || hasProcedure(data.visualScale)))>
+	<#if data.mobModelName == "Villager" || data.breedable || (data.visualScale?? && (data.visualScale.getFixedValue() != 1 || hasProcedure(data.visualScale)))>
 	@Override protected void scale(${name}Entity entity, PoseStack poseStack, float f) {
 		<#if hasProcedure(data.visualScale)>
 			Level world = entity.level();
@@ -152,6 +152,9 @@ public class ${name}Renderer extends <#if humanoid>Humanoid</#if>MobRenderer<${n
 		</#if>
 		<#if data.mobModelName == "Villager">
 			poseStack.scale(0.9375f, 0.9375f, 0.9375f);
+		</#if>
+		<#if data.breedable>
+			poseStack.scale(entity.getAgeScale(), enity.getAgeScale(), entity.getAgeScale());
 		</#if>
 	}
 	</#if>

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/livingentity/livingentity_renderer.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/livingentity/livingentity_renderer.java.ftl
@@ -154,7 +154,8 @@ public class ${name}Renderer extends <#if humanoid>Humanoid</#if>MobRenderer<${n
 			poseStack.scale(0.9375f, 0.9375f, 0.9375f);
 		</#if>
 		<#if data.breedable>
-			poseStack.scale(entity.getAgeScale(), enity.getAgeScale(), entity.getAgeScale());
+			poseStack.scale(entity.getAgeScale(), entity.getAgeScale(), entity.getAgeScale());
+
 		</#if>
 	}
 	</#if>

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/livingentity/livingentity_renderer.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/livingentity/livingentity_renderer.java.ftl
@@ -113,6 +113,12 @@ package ${package}.client.renderer;
 <#compress>
 public class ${name}Renderer extends <#if humanoid>Humanoid</#if>MobRenderer<${name}Entity, ${renderState}, ${model}> {
 
+	<#-- This entity reference is shared for all entities as renderer only has one instance.
+	     This currently works, but is somewhat hacky. It works because all methods requiring it
+	     are called after extractRenderState where this entity is assigned to the current entity.
+	     On the other hand, vanilla code reuses state for all entities too, so it may be fine.
+	     If we need to change this, we can use RegisterRenderStateModifiersEvent and
+	     and IRenderStateExtension#setRenderData with custom ContextKey-->
 	private ${name}Entity entity = null;
 
 	public ${name}Renderer(EntityRendererProvider.Context context) {
@@ -180,7 +186,7 @@ public class ${name}Renderer extends <#if humanoid>Humanoid</#if>MobRenderer<${n
 		return ResourceLocation.parse("${modid}:textures/entities/${data.mobModelTexture}");
 	}
 
-	<#if data.mobModelName == "Villager" || (data.visualScale?? && (data.visualScale.getFixedValue() != 1 || hasProcedure(data.visualScale)))>
+	<#if data.mobModelName == "Villager" || data.breedable || (data.visualScale?? && (data.visualScale.getFixedValue() != 1 || hasProcedure(data.visualScale)))>
 	@Override protected void scale(${renderState} state, PoseStack poseStack) {
 		<#if hasProcedure(data.visualScale)>
 			Level world = entity.level();
@@ -194,6 +200,9 @@ public class ${name}Renderer extends <#if humanoid>Humanoid</#if>MobRenderer<${n
 		</#if>
 		<#if data.mobModelName == "Villager">
 			poseStack.scale(0.9375f, 0.9375f, 0.9375f);
+		</#if>
+		<#if data.breedable>
+			poseStack.scale(entity.getAgeScale(), entity.getAgeScale(), entity.getAgeScale());
 		</#if>
 	}
 	</#if>


### PR DESCRIPTION
Fix #5501

Changelog:

* [Bugfix] Custom animal baby entity models were not scaled proportionally with the bounding box

Release notes:

* Custom animal baby entity models are now scaled the same as the bounding box automatically. Any custom workarounds for this bug should be removed by the modder.

-----

Also adds FTL comment to 1.21.4 renderer for some clarification