### PR TITLE
Fix #5529 - With newer versions of NeoForge, hoppers ignored the take restriction of custom blocks with inventory

### DIFF
--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/block/blockentity.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/block/blockentity.java.ftl
@@ -39,8 +39,6 @@ public class ${name}BlockEntity extends RandomizableContainerBlockEntity impleme
 
 	private NonNullList<ItemStack> stacks = NonNullList.withSize(${data.inventorySize}, ItemStack.EMPTY);
 
-	private final SidedInvWrapper handler = new SidedInvWrapper(this, null);
-
 	<#if data.sensitiveToVibration>
 	private final VibrationSystem.Listener vibrationListener = new VibrationSystem.Listener(this);
 	private final VibrationSystem.User vibrationUser = new VibrationUser(this.getBlockPos());
@@ -195,10 +193,6 @@ public class ${name}BlockEntity extends RandomizableContainerBlockEntity impleme
 		</#if>
 	}
 	<#-- END: WorldlyContainer -->
-
-	public SidedInvWrapper getItemHandler() {
-		return handler;
-	}
 
 	<#if data.hasEnergyStorage>
 	private final EnergyStorage energyStorage = new EnergyStorage(${data.energyCapacity}, ${data.energyMaxReceive}, ${data.energyMaxExtract}, ${data.energyInitial}) {

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/elementinits/blockentities.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/elementinits/blockentities.java.ftl
@@ -62,7 +62,7 @@ public class ${JavaModName}BlockEntities {
 	<#compress>
 	@SubscribeEvent public static void registerCapabilities(RegisterCapabilitiesEvent event) {
 		<#list blockentitiesWithInventory as blockentity>
-			event.registerBlockEntity(Capabilities.ItemHandler.BLOCK, ${blockentity.getModElement().getRegistryNameUpper()}.get(), (blockEntity, side) -> blockEntity.getItemHandler());
+			event.registerBlockEntity(Capabilities.ItemHandler.BLOCK, ${blockentity.getModElement().getRegistryNameUpper()}.get(), SidedInvWrapper::new);
 			<#if blockentity.hasEnergyStorage>
 			event.registerBlockEntity(Capabilities.EnergyStorage.BLOCK, ${blockentity.getModElement().getRegistryNameUpper()}.get(), (blockEntity, side) -> blockEntity.getEnergyStorage());
 			</#if>

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/block/blockentity.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/block/blockentity.java.ftl
@@ -39,8 +39,6 @@ public class ${name}BlockEntity extends RandomizableContainerBlockEntity impleme
 
 	private NonNullList<ItemStack> stacks = NonNullList.withSize(${data.inventorySize}, ItemStack.EMPTY);
 
-	private final SidedInvWrapper handler = new SidedInvWrapper(this, null);
-
 	<#if data.sensitiveToVibration>
 	private final VibrationSystem.Listener vibrationListener = new VibrationSystem.Listener(this);
 	private final VibrationSystem.User vibrationUser = new VibrationUser(this.getBlockPos());
@@ -195,10 +193,6 @@ public class ${name}BlockEntity extends RandomizableContainerBlockEntity impleme
 		</#if>
 	}
 	<#-- END: WorldlyContainer -->
-
-	public SidedInvWrapper getItemHandler() {
-		return handler;
-	}
 
 	<#if data.hasEnergyStorage>
 	private final EnergyStorage energyStorage = new EnergyStorage(${data.energyCapacity}, ${data.energyMaxReceive}, ${data.energyMaxExtract}, ${data.energyInitial}) {

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/elementinits/blockentities.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/elementinits/blockentities.java.ftl
@@ -62,7 +62,7 @@ public class ${JavaModName}BlockEntities {
 	<#compress>
 	@SubscribeEvent public static void registerCapabilities(RegisterCapabilitiesEvent event) {
 		<#list blockentitiesWithInventory as blockentity>
-			event.registerBlockEntity(Capabilities.ItemHandler.BLOCK, ${blockentity.getModElement().getRegistryNameUpper()}.get(), (blockEntity, side) -> blockEntity.getItemHandler());
+			event.registerBlockEntity(Capabilities.ItemHandler.BLOCK, ${blockentity.getModElement().getRegistryNameUpper()}.get(), SidedInvWrapper::new);
 			<#if blockentity.hasEnergyStorage>
 			event.registerBlockEntity(Capabilities.EnergyStorage.BLOCK, ${blockentity.getModElement().getRegistryNameUpper()}.get(), (blockEntity, side) -> blockEntity.getEnergyStorage());
 			</#if>


### PR DESCRIPTION
[Bugfix] With newer versions of NeoForge, hoppers ignored the take restriction of custom blocks with inventory

Thanks to the NeoForge team for assistance at https://github.com/neoforged/NeoForge/issues/2307!

Fixes #5529