### PR TITLE
[Feature Request] Template sections

### DIFF
--- a/plugins/generator-1.21.1/neoforge-1.21.1/procedures/entity_add_recipe.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/procedures/entity_add_recipe.java.ftl
@@ -1,2 +1,8 @@
 <#include "mcelements.ftl">
-if(${input$entity} instanceof ServerPlayer _serverPlayer) _serverPlayer.awardRecipesByKey(Collections.singletonList(${toResourceLocation(input$recipe)}));
+<@definePart type="head">
+if(${input$entity} instanceof ServerPlayer _serverPlayer) {
+</@definePart>
+	_serverPlayer.awardRecipesByKey(Collections.singletonList(${toResourceLocation(input$recipe)}));
+<@definePart type="tail">
+}
+</@definePart>

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/procedure.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/procedure.java.ftl
@@ -85,6 +85,7 @@ public class ${name}Procedure {
 		</#list>
 
 		${procedurecode}
+		${tail}
 	}
 
 	${extra_templates_code}

--- a/plugins/generator-1.21.4/neoforge-1.21.4/procedures/entity_add_recipe.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/procedures/entity_add_recipe.java.ftl
@@ -2,7 +2,7 @@
 <@definePart type="head">
 if(${input$entity} instanceof ServerPlayer _serverPlayer) {
 </@definePart>
+	_serverPlayer.awardRecipesByKey(Collections.singletonList(ResourceKey.create(Registries.RECIPE, ${toResourceLocation(input$recipe)})));
 <@definePart type="tail">
 }
 </@definePart>
-	_serverPlayer.awardRecipesByKey(Collections.singletonList(ResourceKey.create(Registries.RECIPE, ${toResourceLocation(input$recipe)})));

--- a/plugins/generator-1.21.4/neoforge-1.21.4/procedures/entity_add_recipe.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/procedures/entity_add_recipe.java.ftl
@@ -1,3 +1,8 @@
 <#include "mcelements.ftl">
-if(${input$entity} instanceof ServerPlayer _serverPlayer)
+<@definePart type="head">
+if(${input$entity} instanceof ServerPlayer _serverPlayer) {
+</@definePart>
+<@definePart type="tail">
+}
+</@definePart>
 	_serverPlayer.awardRecipesByKey(Collections.singletonList(ResourceKey.create(Registries.RECIPE, ${toResourceLocation(input$recipe)})));

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/procedure.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/procedure.java.ftl
@@ -85,6 +85,7 @@ public class ${name}Procedure {
 		</#list>
 
 		${procedurecode}
+		${tail}
 	}
 
 	${extra_templates_code}

--- a/src/main/java/net/mcreator/blockly/BlocklyToCode.java
+++ b/src/main/java/net/mcreator/blockly/BlocklyToCode.java
@@ -197,6 +197,12 @@ public abstract class BlocklyToCode implements IGeneratorProvider {
 					if (generator.getBlockType() == IBlockGenerator.BlockType.PROCEDURAL && Arrays.asList(
 							generator.getSupportedBlocks()).contains(type)) {
 						try {
+							//if the generator do not support the part feature, we will reset the tail and head
+							if (!generator.isSupportedHead()) {
+								this.append(this.getTail());
+								this.setHead("");
+								this.setTail("");
+							}
 							generator.generateBlock(this, block);
 						} catch (TemplateGeneratorException e) {
 							throw e;

--- a/src/main/java/net/mcreator/blockly/BlocklyToCode.java
+++ b/src/main/java/net/mcreator/blockly/BlocklyToCode.java
@@ -198,7 +198,7 @@ public abstract class BlocklyToCode implements IGeneratorProvider {
 							generator.getSupportedBlocks()).contains(type)) {
 						try {
 							//if the generator do not support the part feature, we will reset the tail and head
-							if (!generator.isSupportedHead()) {
+							if (!generator.isSupportedSection()) {
 								this.append(this.getTail());
 								this.setHead("");
 								this.setTail("");

--- a/src/main/java/net/mcreator/blockly/BlocklyToCode.java
+++ b/src/main/java/net/mcreator/blockly/BlocklyToCode.java
@@ -59,6 +59,8 @@ public abstract class BlocklyToCode implements IGeneratorProvider {
 
 	private final Set<String> usedBlocks = new HashSet<>();
 	private final Set<String> usedTemplates = new LinkedHashSet<>(), generatedTemplates = new HashSet<>();
+	private String head = "";
+	private String tail = "";
 
 	/**
 	 * @param workspace          <p>The {@link Workspace} executing the code</p>
@@ -340,4 +342,19 @@ public abstract class BlocklyToCode implements IGeneratorProvider {
 		return Collections.unmodifiableSet(usedBlocks);
 	}
 
+	public String getHead() {
+		return head;
+	}
+
+	public String getTail() {
+		return tail;
+	}
+
+	public void setHead(String head) {
+		this.head = head;
+	}
+
+	public void setTail(String tail) {
+		this.tail = tail;
+	}
 }

--- a/src/main/java/net/mcreator/blockly/IBlockGenerator.java
+++ b/src/main/java/net/mcreator/blockly/IBlockGenerator.java
@@ -29,7 +29,12 @@ public interface IBlockGenerator {
 
 	BlockType getBlockType();
 
-	default boolean isSupportedHead() {
+	/**
+	 * a method to know whether the generator change or define section.
+	 *
+	 * @return whether it will define the section
+	 */
+	default boolean isSupportedSection() {
 		return false;
 	}
 

--- a/src/main/java/net/mcreator/blockly/IBlockGenerator.java
+++ b/src/main/java/net/mcreator/blockly/IBlockGenerator.java
@@ -29,6 +29,10 @@ public interface IBlockGenerator {
 
 	BlockType getBlockType();
 
+	default boolean isSupportedHead() {
+		return false;
+	}
+
 	enum BlockType {
 		PROCEDURAL, OUTPUT
 	}

--- a/src/main/java/net/mcreator/blockly/PartLinker.java
+++ b/src/main/java/net/mcreator/blockly/PartLinker.java
@@ -1,0 +1,46 @@
+/*
+ * MCreator (https://mcreator.net/)
+ * Copyright (C) 2012-2020, Pylo
+ * Copyright (C) 2020-2025, Pylo, opensource contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package net.mcreator.blockly;
+
+import freemarker.core.Environment;
+import freemarker.template.*;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+public record PartLinker(AtomicReference<String> head, AtomicReference<String> tail) implements TemplateDirectiveModel {
+	@Override public void execute(Environment env, Map params, TemplateModel[] loopVars, TemplateDirectiveBody body)
+			throws TemplateException, IOException {
+		if (params.get("type") instanceof TemplateScalarModel templateScalarModel) {
+			if ("head".equals(templateScalarModel.getAsString())) {
+				var writer = new StringWriter();
+				body.render(writer);
+				head.set(writer.toString());
+			}
+			if ("tail".equals(templateScalarModel.getAsString())) {
+				var writer = new StringWriter();
+				body.render(writer);
+				tail.set(writer.toString());
+			}
+		}
+	}
+}

--- a/src/main/java/net/mcreator/blockly/PartLinker.java
+++ b/src/main/java/net/mcreator/blockly/PartLinker.java
@@ -41,6 +41,7 @@ public record PartLinker(AtomicReference<String> head, AtomicReference<String> t
 				body.render(writer);
 				tail.set(writer.toString());
 			}
+			//may be more.
 		}
 	}
 }

--- a/src/main/java/net/mcreator/blockly/PartLinker.java
+++ b/src/main/java/net/mcreator/blockly/PartLinker.java
@@ -25,23 +25,34 @@ import freemarker.template.*;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicReference;
 
-public record PartLinker(AtomicReference<String> head, AtomicReference<String> tail) implements TemplateDirectiveModel {
+public class PartLinker implements TemplateDirectiveModel {
+
+	private String newHead;
+	private String newTail;
+
 	@Override public void execute(Environment env, Map params, TemplateModel[] loopVars, TemplateDirectiveBody body)
 			throws TemplateException, IOException {
 		if (params.get("type") instanceof TemplateScalarModel templateScalarModel) {
 			if ("head".equals(templateScalarModel.getAsString())) {
 				var writer = new StringWriter();
 				body.render(writer);
-				head.set(writer.toString());
+				newHead = writer.toString();
 			}
 			if ("tail".equals(templateScalarModel.getAsString())) {
 				var writer = new StringWriter();
-				body.render(writer);
-				tail.set(writer.toString());
+				body.toString();
+				newTail = writer.toString();
 			}
-			//may be more.
+			//may be more
 		}
+	}
+
+	public String getNewHead() {
+		return newHead;
+	}
+
+	public String getNewTail() {
+		return newTail;
 	}
 }

--- a/src/main/java/net/mcreator/blockly/PartLinker.java
+++ b/src/main/java/net/mcreator/blockly/PartLinker.java
@@ -25,34 +25,22 @@ import freemarker.template.*;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 
-public class PartLinker implements TemplateDirectiveModel {
-
-	private String newHead;
-	private String newTail;
-
+public record PartLinker(AtomicReference<String> head, AtomicReference<String> tail) implements TemplateDirectiveModel {
 	@Override public void execute(Environment env, Map params, TemplateModel[] loopVars, TemplateDirectiveBody body)
 			throws TemplateException, IOException {
 		if (params.get("type") instanceof TemplateScalarModel templateScalarModel) {
 			if ("head".equals(templateScalarModel.getAsString())) {
 				var writer = new StringWriter();
 				body.render(writer);
-				newHead = writer.toString();
+				head.set(writer.toString());
 			}
 			if ("tail".equals(templateScalarModel.getAsString())) {
 				var writer = new StringWriter();
-				body.toString();
-				newTail = writer.toString();
+				body.render(writer);
+				tail.set(writer.toString());
 			}
-			//may be more
 		}
-	}
-
-	public String getNewHead() {
-		return newHead;
-	}
-
-	public String getNewTail() {
-		return newTail;
 	}
 }

--- a/src/main/java/net/mcreator/element/types/Procedure.java
+++ b/src/main/java/net/mcreator/element/types/Procedure.java
@@ -134,6 +134,7 @@ public class Procedure extends GeneratableElement {
 			additionalData.put("localvariables", blocklyToJava.getLocalVariables());
 			additionalData.put("procedureblocks", blocklyToJava.getUsedBlocks());
 			additionalData.put("extra_templates_code", blocklyToJava.getExtraTemplatesCode());
+			additionalData.put("tail", blocklyToJava.getTail().trim());
 
 			String triggerCode = "";
 			if (trigger != null) {

--- a/src/main/java/net/mcreator/generator/blockly/BlocklyBlockCodeGenerator.java
+++ b/src/main/java/net/mcreator/generator/blockly/BlocklyBlockCodeGenerator.java
@@ -443,6 +443,7 @@ public class BlocklyBlockCodeGenerator {
 		if (templateGenerator != null) {
 			dataModel.put("cbi", customBlockIndex);
 			dataModel.put("addTemplate", new ExtraTemplatesLinker(master));
+			//It could use the Map. But it is in future.
 			AtomicReference<String> head = new AtomicReference<>("");
 			AtomicReference<String> tail = new AtomicReference<>("");
 			dataModel.put("definePart", new PartLinker(head, tail));

--- a/src/main/java/net/mcreator/generator/blockly/BlocklyBlockCodeGenerator.java
+++ b/src/main/java/net/mcreator/generator/blockly/BlocklyBlockCodeGenerator.java
@@ -29,7 +29,6 @@ import org.w3c.dom.Element;
 
 import javax.annotation.Nullable;
 import java.util.*;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 public class BlocklyBlockCodeGenerator {
@@ -443,22 +442,21 @@ public class BlocklyBlockCodeGenerator {
 		if (templateGenerator != null) {
 			dataModel.put("cbi", customBlockIndex);
 			dataModel.put("addTemplate", new ExtraTemplatesLinker(master));
-			AtomicReference<String> head = new AtomicReference<>("");
-			AtomicReference<String> tail = new AtomicReference<>("");
-			dataModel.put("definePart", new PartLinker(head, tail));
+			var partLinker = new PartLinker();
+			dataModel.put("definePart", partLinker);
 
 			if (additionalData != null) {
 				dataModel.putAll(additionalData);
 			}
 
 			String code = templateGenerator.generateFromTemplate(type + "." + templateExtension + ".ftl", dataModel);
-			if (!Objects.equals(master.getHead(), head.get())) {
+			if (!Objects.equals(master.getHead(), partLinker.getNewHead())) {
 				//append the last tail
 				//a possible implementation is replace the // the start of head code // the end of head code
 				master.append(master.getTail());
-				master.setTail(tail.get());
-				master.append(head.get());
-				master.setHead(head.get());
+				master.setTail(partLinker.getNewTail());
+				master.append(partLinker.getNewHead());
+				master.setHead(partLinker.getNewHead());
 			}
 			master.append(code);
 		}

--- a/src/main/java/net/mcreator/generator/blockly/BlocklyBlockCodeGenerator.java
+++ b/src/main/java/net/mcreator/generator/blockly/BlocklyBlockCodeGenerator.java
@@ -28,10 +28,8 @@ import net.mcreator.util.XMLUtil;
 import org.w3c.dom.Element;
 
 import javax.annotation.Nullable;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 public class BlocklyBlockCodeGenerator {
@@ -445,13 +443,23 @@ public class BlocklyBlockCodeGenerator {
 		if (templateGenerator != null) {
 			dataModel.put("cbi", customBlockIndex);
 			dataModel.put("addTemplate", new ExtraTemplatesLinker(master));
+			AtomicReference<String> head = new AtomicReference<>("");
+			AtomicReference<String> tail = new AtomicReference<>("");
+			dataModel.put("definePart", new PartLinker(head, tail));
 
 			if (additionalData != null) {
 				dataModel.putAll(additionalData);
 			}
 
 			String code = templateGenerator.generateFromTemplate(type + "." + templateExtension + ".ftl", dataModel);
+			if (!Objects.equals(master.getHead(), head.get())) {
+				master.append(master.getTail());
+				master.setTail(tail.get());
+				master.append(head.get());
+				master.setHead(head.get());
+			}
 			master.append(code);
+			//reach the end
 		}
 
 		customBlockIndex++;

--- a/src/main/java/net/mcreator/generator/blockly/BlocklyBlockCodeGenerator.java
+++ b/src/main/java/net/mcreator/generator/blockly/BlocklyBlockCodeGenerator.java
@@ -453,13 +453,14 @@ public class BlocklyBlockCodeGenerator {
 
 			String code = templateGenerator.generateFromTemplate(type + "." + templateExtension + ".ftl", dataModel);
 			if (!Objects.equals(master.getHead(), head.get())) {
+				//append the last tail
+				//a possible implementation is replace the // the start of head code // the end of head code
 				master.append(master.getTail());
 				master.setTail(tail.get());
 				master.append(head.get());
 				master.setHead(head.get());
 			}
 			master.append(code);
-			//reach the end
 		}
 
 		customBlockIndex++;

--- a/src/main/java/net/mcreator/generator/blockly/OutputBlockCodeGenerator.java
+++ b/src/main/java/net/mcreator/generator/blockly/OutputBlockCodeGenerator.java
@@ -37,7 +37,7 @@ public record OutputBlockCodeGenerator(BlocklyBlockCodeGenerator blocklyBlockCod
 		return BlockType.OUTPUT;
 	}
 
-	@Override public boolean isSupportedHead() {
+	@Override public boolean isSupportedSection() {
 		return true;
 	}
 }

--- a/src/main/java/net/mcreator/generator/blockly/OutputBlockCodeGenerator.java
+++ b/src/main/java/net/mcreator/generator/blockly/OutputBlockCodeGenerator.java
@@ -36,4 +36,8 @@ public record OutputBlockCodeGenerator(BlocklyBlockCodeGenerator blocklyBlockCod
 	@Override public BlockType getBlockType() {
 		return BlockType.OUTPUT;
 	}
+
+	@Override public boolean isSupportedHead() {
+		return true;
+	}
 }

--- a/src/main/java/net/mcreator/generator/blockly/ProceduralBlockCodeGenerator.java
+++ b/src/main/java/net/mcreator/generator/blockly/ProceduralBlockCodeGenerator.java
@@ -38,7 +38,7 @@ public record ProceduralBlockCodeGenerator(BlocklyBlockCodeGenerator blocklyBloc
 		return BlockType.PROCEDURAL;
 	}
 
-	@Override public boolean isSupportedHead() {
+	@Override public boolean isSupportedSection() {
 		return true;
 	}
 }

--- a/src/main/java/net/mcreator/generator/blockly/ProceduralBlockCodeGenerator.java
+++ b/src/main/java/net/mcreator/generator/blockly/ProceduralBlockCodeGenerator.java
@@ -37,4 +37,8 @@ public record ProceduralBlockCodeGenerator(BlocklyBlockCodeGenerator blocklyBloc
 	@Override public BlockType getBlockType() {
 		return BlockType.PROCEDURAL;
 	}
+
+	@Override public boolean isSupportedHead() {
+		return true;
+	}
 }


### PR DESCRIPTION
In the PR, we introde a feature: template section

We split the template into three section: Head, Body, Tail

When the procedure hope to append to the last procedure, mcreator will check the head. If the head is equals, mcreator will not generate the head.

With this, we could generate a readable code: 

![image](https://github.com/user-attachments/assets/7fbc703c-0c42-41b7-978e-4bf10f68e3d6)

This may be a complex feature. So I make this PR as a feature request and hope that anyone could make a better solution.

There are some questions here:

1. the section is only used by the jsonprocedure. if we don't check the flag:
```
default boolean isSupportedSection() {
		return false;
	}
```
It could make code out of sort like below:

```
		if (entity instanceof ServerPlayer _serverPlayer) {
			_serverPlayer.awardRecipesByKey(Collections.singletonList(ResourceKey.create(Registries.RECIPE, ResourceLocation.parse("minecraft:stone_pickaxe"))));
			_serverPlayer.awardRecipesByKey(Collections.singletonList(ResourceKey.create(Registries.RECIPE, ResourceLocation.parse("minecraft:stone_pickaxe"))));
                        HelloworldoMod.LOGGER.info("helloworld");//this is a exception. because the tail is not set to "" and append to the above line.
		}
```

my solution is 
```
			//if the generator do not support the section feature, we will reset the tail and head
			if (!generator.isSupportedSection()) {
				this.append(this.getTail());
				this.setHead("");
				this.setTail("");
			}
```
