### PR TITLE
Fix textures list wrap not working when resizing MCreator frame

### DIFF
--- a/src/main/java/net/mcreator/ui/component/ScrollablePanel.java
+++ b/src/main/java/net/mcreator/ui/component/ScrollablePanel.java
@@ -1,0 +1,46 @@
+/*
+ * MCreator (https://mcreator.net/)
+ * Copyright (C) 2012-2020, Pylo
+ * Copyright (C) 2020-2025, Pylo, opensource contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package net.mcreator.ui.component;
+
+import javax.swing.*;
+import java.awt.*;
+
+public class ScrollablePanel extends JPanel implements Scrollable {
+
+	@Override public Dimension getPreferredScrollableViewportSize() {
+		return getPreferredSize();
+	}
+
+	@Override public int getScrollableUnitIncrement(Rectangle visibleRect, int orientation, int direction) {
+		return 65;
+	}
+
+	@Override public int getScrollableBlockIncrement(Rectangle visibleRect, int orientation, int direction) {
+		return 65;
+	}
+
+	@Override public boolean getScrollableTracksViewportWidth() {
+		return true;
+	}
+
+	@Override public boolean getScrollableTracksViewportHeight() {
+		return false;
+	}
+}

--- a/src/main/java/net/mcreator/ui/workspace/resources/WorkspacePanelTextures.java
+++ b/src/main/java/net/mcreator/ui/workspace/resources/WorkspacePanelTextures.java
@@ -22,6 +22,7 @@ import net.mcreator.io.FileIO;
 import net.mcreator.io.FileWatcher;
 import net.mcreator.ui.component.JSelectableList;
 import net.mcreator.ui.component.ListGroup;
+import net.mcreator.ui.component.ScrollablePanel;
 import net.mcreator.ui.component.TransparentToolBar;
 import net.mcreator.ui.component.util.ComponentUtils;
 import net.mcreator.ui.component.util.ListUtil;
@@ -79,7 +80,7 @@ public class WorkspacePanelTextures extends JPanel implements IReloadableFiltera
 			}
 		};
 
-		JPanel respan = new JPanel(new GridBagLayout());
+		JPanel respan = new ScrollablePanel();
 		respan.setLayout(new BoxLayout(respan, BoxLayout.Y_AXIS));
 
 		Arrays.stream(TextureType.getSupportedTypes(workspacePanel.getMCreator().getWorkspace(), true))
@@ -98,7 +99,7 @@ public class WorkspacePanelTextures extends JPanel implements IReloadableFiltera
 		sp.setOpaque(false);
 		sp.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
 		sp.getViewport().setOpaque(false);
-		sp.getVerticalScrollBar().setUnitIncrement(20);
+		sp.getVerticalScrollBar().setUnitIncrement(65);
 		sp.setBorder(null);
 
 		add("Center", sp);


### PR DESCRIPTION
Changelog:

* [Bugfix] Workspace textures list did not wrap entries when resizing the MCreator frame

Original issue: https://mcreator.net/forum/118112/texture-files-icons-tiles-not-showing-all-images-when-mcreator-not-maximised