### PR TITLE
Fix file watcher hanging UI in some cases

### DIFF
--- a/src/main/java/net/mcreator/ui/minecraft/recourcepack/ResourcePackEditor.java
+++ b/src/main/java/net/mcreator/ui/minecraft/recourcepack/ResourcePackEditor.java
@@ -270,18 +270,19 @@ public class ResourcePackEditor extends JPanel implements IReloadableFilterable 
 
 		// Register event handler for texture changes
 		FileWatcher fileWatcher = mcreator.getGenerator().getFileWatcher();
-		fileWatcher.addListener((watchKey1, kind, file) -> {
-			if (file.getName().endsWith(".png") || file.getName().endsWith(".PNG")) {
-				// flush cache for this image
-				SwingUtilities.invokeLater(() -> {
+		fileWatcher.addListener(changedFiles -> SwingUtilities.invokeLater(() -> {
+			for (FileWatcher.FileChange change : changedFiles) {
+				File file = change.file();
+				if (file.getName().endsWith(".png") && file.isFile()) {
+					// flush cache for this image
 					try {
 						new ImageIcon(file.getAbsolutePath()).getImage().flush();
-						reloadElements();
 					} catch (Exception ignored) {
 					}
-				});
+				}
 			}
-		});
+			reloadElements();
+		}));
 	}
 
 	private void deleteMetadataIfApplicable(Workspace workspace, File file) {

--- a/src/main/java/net/mcreator/ui/workspace/resources/WorkspacePanelTextures.java
+++ b/src/main/java/net/mcreator/ui/workspace/resources/WorkspacePanelTextures.java
@@ -168,18 +168,19 @@ public class WorkspacePanelTextures extends JPanel implements IReloadableFiltera
 
 		// Register event handler for texture changes
 		FileWatcher fileWatcher = workspacePanel.getMCreator().getGenerator().getFileWatcher();
-		fileWatcher.addListener((watchKey1, kind, file) -> {
-			if (file.getName().endsWith(".png") || file.getName().endsWith(".PNG")) {
-				// flush cache for this image
-				SwingUtilities.invokeLater(() -> {
+		fileWatcher.addListener(changedFiles -> SwingUtilities.invokeLater(() -> {
+			for (FileWatcher.FileChange change : changedFiles) {
+				File file = change.file();
+				if (file.getName().endsWith(".png") && file.isFile()) {
+					// flush cache for this image
 					try {
 						new ImageIcon(file.getAbsolutePath()).getImage().flush();
-						reloadElements();
 					} catch (Exception ignored) {
 					}
-				});
+				}
 			}
-		});
+			reloadElements();
+		}));
 	}
 
 	public void attachGeneratorFileWatcher() {

--- a/src/test/java/net/mcreator/integration/generator/GeneratorsTest.java
+++ b/src/test/java/net/mcreator/integration/generator/GeneratorsTest.java
@@ -125,7 +125,7 @@ import static org.junit.jupiter.api.Assertions.*;
 						// Attach dummy file watcher to also test its operation
 						workspace.get().getGenerator().getFileWatcher()
 								.watchFolder(GeneratorUtils.getResourceRoot(workspace.get(), generatorConfiguration));
-						workspace.get().getGenerator().getFileWatcher().addListener((watchKey, kind, file) -> {
+						workspace.get().getGenerator().getFileWatcher().addListener(changedFiles -> {
 						});
 					}));
 


### PR DESCRIPTION
Fixes file watcher hanging UI in some cases by throttling how often events fire and grouping them during those periods.

Additionally, adds mechanism to disable file watching during FS intensive tasks such as code regeneration.