### PR TITLE
NeoForge versions bump

### DIFF
--- a/plugins/generator-1.21.1/datapack-1.21.1/generator.yaml
+++ b/plugins/generator-1.21.1/datapack-1.21.1/generator.yaml
@@ -1,6 +1,6 @@
 name: Data Pack for Java Edition @minecraft
 status: stable
-buildfileversion: 21.1.176
+buildfileversion: 21.1.190
 
 # gradle task definitions
 gradle:

--- a/plugins/generator-1.21.1/neoforge-1.21.1/generator.yaml
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/generator.yaml
@@ -1,6 +1,6 @@
 name: NeoForge for @minecraft (@buildfileversion)
 status: stable
-buildfileversion: 21.1.176
+buildfileversion: 21.1.190
 
 import:
   - datapack-1.21.1

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/armor.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/armor.java.ftl
@@ -38,7 +38,7 @@ package ${package}.item;
 import java.util.function.Consumer;
 import net.minecraft.client.model.Model;
 
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD) public abstract class ${name}Item extends ArmorItem {
+@EventBusSubscriber public abstract class ${name}Item extends ArmorItem {
 
 	public static Holder<ArmorMaterial> ARMOR_MATERIAL = null;
 

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/biome/tree_fruits_decorator.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/biome/tree_fruits_decorator.java.ftl
@@ -34,7 +34,7 @@
 
 package ${package}.world.features.treedecorators;
 
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD) public class ${name}FruitDecorator extends CocoaDecorator {
+@EventBusSubscriber public class ${name}FruitDecorator extends CocoaDecorator {
 
     public static MapCodec<${name}FruitDecorator> CODEC = MapCodec.unit(${name}FruitDecorator::new);
 

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/biome/tree_leave_decorator.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/biome/tree_leave_decorator.java.ftl
@@ -34,7 +34,7 @@
 
 package ${package}.world.features.treedecorators;
 
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD) public class ${name}LeaveDecorator extends LeaveVineDecorator {
+@EventBusSubscriber public class ${name}LeaveDecorator extends LeaveVineDecorator {
 
     public static MapCodec<${name}LeaveDecorator> CODEC = MapCodec.unit(${name}LeaveDecorator::new);
 

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/biome/tree_trunk_decorator.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/biome/tree_trunk_decorator.java.ftl
@@ -34,7 +34,7 @@
 
 package ${package}.world.features.treedecorators;
 
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD) public class ${name}TrunkDecorator extends TrunkVineDecorator {
+@EventBusSubscriber public class ${name}TrunkDecorator extends TrunkVineDecorator {
 
     public static MapCodec<${name}TrunkDecorator> CODEC = MapCodec.unit(${name}TrunkDecorator::new);
 

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/block/blockentity_renderer.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/block/blockentity_renderer.java.ftl
@@ -33,7 +33,7 @@
 
 package ${package}.client.renderer.block;
 
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD, value = Dist.CLIENT) public class ${name}Renderer implements BlockEntityRenderer<${name}BlockEntity> {
+@EventBusSubscriber(value = Dist.CLIENT) public class ${name}Renderer implements BlockEntityRenderer<${name}BlockEntity> {
 
 	private final CustomHierarchicalModel model;
 	private final ResourceLocation texture;

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/code.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/code.java.ftl
@@ -46,7 +46,7 @@
 
 package ${package};
 
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD)
+@EventBusSubscriber
 public class ${name} {
 
 	public ${name}() {

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/dimension/dimension.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/dimension/dimension.java.ftl
@@ -42,7 +42,7 @@ package ${package}.world.dimension;
 public class ${name}Dimension {
 
 	<#if data.useCustomEffects>
-	@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD, value = Dist.CLIENT) public static class ${name}SpecialEffectsHandler {
+	@EventBusSubscriber(value = Dist.CLIENT) public static class ${name}SpecialEffectsHandler {
 
 		@SubscribeEvent public static void registerDimensionSpecialEffects(RegisterDimensionSpecialEffectsEvent event) {
 			DimensionSpecialEffects customEffect = new DimensionSpecialEffects(

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/dimension/teleporter.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/dimension/teleporter.java.ftl
@@ -33,7 +33,7 @@
 
 package ${package}.world.teleporter;
 
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD) public class ${name}Teleporter {
+@EventBusSubscriber public class ${name}Teleporter {
 
 	public static Holder<PoiType> poi = null;
 

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/dispensebehaviour.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/dispensebehaviour.java.ftl
@@ -36,7 +36,7 @@
 package ${package}.item.extension;
 
 <#compress>
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD) public class ${name}ItemExtension {
+@EventBusSubscriber public class ${name}ItemExtension {
 	@SubscribeEvent public static void init(FMLCommonSetupEvent event) {
 		event.enqueueWork(() -> DispenserBlock.registerBehavior(${mappedMCItemToItem(data.item)}, new OptionalDispenseItemBehavior() {
 			public ItemStack execute(BlockSource blockSource, ItemStack stack) {

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/elementinits/attributes.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/elementinits/attributes.java.ftl
@@ -36,7 +36,7 @@
 
 package ${package}.init;
 
-@EventBusSubscriber (bus = EventBusSubscriber.Bus.MOD)
+@EventBusSubscriber
 public class ${JavaModName}Attributes {
 
 	public static final DeferredRegister<Attribute> REGISTRY = DeferredRegister.create(BuiltInRegistries.ATTRIBUTE, ${JavaModName}.MODID);

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/elementinits/blockentities.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/elementinits/blockentities.java.ftl
@@ -39,7 +39,7 @@ package ${package}.init;
 <#assign blockentitiesWithInventory = w.getGElementsOfType("block")?filter(e -> e.hasInventory)>
 
 <#if blockentitiesWithInventory?size != 0>
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD)
+@EventBusSubscriber
 </#if>
 public class ${JavaModName}BlockEntities {
 

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/elementinits/blocks.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/elementinits/blocks.java.ftl
@@ -74,7 +74,7 @@ public class ${JavaModName}Blocks {
 	// End of user code block custom blocks
 
 	<#if hasTintedBlocks || hasTintedBlockItems>
-	@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD, value = Dist.CLIENT) public static class BlocksClientSideHandler {
+	@EventBusSubscriber(value = Dist.CLIENT) public static class BlocksClientSideHandler {
 		<#if hasTintedBlocks>
 		@SubscribeEvent public static void blockColorLoad(RegisterColorHandlersEvent.Block event) {
 			<#list blocks as block>

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/elementinits/entities.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/elementinits/entities.java.ftl
@@ -40,7 +40,7 @@ package ${package}.init;
 <#assign entitiesWithInventory = w.getGElementsOfType("livingentity")?filter(e -> e.guiBoundTo?has_content)>
 
 <#if hasLivingEntities || entitiesWithInventory?size != 0>
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD)
+@EventBusSubscriber
 </#if>
 public class ${JavaModName}Entities {
 

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/elementinits/entityrenderers.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/elementinits/entityrenderers.java.ftl
@@ -36,7 +36,7 @@
 
 package ${package}.init;
 
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD, value = Dist.CLIENT) public class ${JavaModName}EntityRenderers {
+@EventBusSubscriber(value = Dist.CLIENT) public class ${JavaModName}EntityRenderers {
 
 	@SubscribeEvent public static void registerEntityRenderers(EntityRenderersEvent.RegisterRenderers event) {
 		<#list entities as entity>

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/elementinits/fluids.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/elementinits/fluids.java.ftl
@@ -47,7 +47,7 @@ public class ${JavaModName}Fluids {
 		REGISTRY.register("flowing_${fluid.getModElement().getRegistryName()}", () -> new ${fluid.getModElement().getName()}Fluid.Flowing());
 	</#list>
 
-	@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD, value = Dist.CLIENT) public static class FluidsClientSideHandler {
+	@EventBusSubscriber(value = Dist.CLIENT) public static class FluidsClientSideHandler {
 		@SubscribeEvent public static void clientSetup(FMLClientSetupEvent event) {
 			<#list fluids as fluid>
 			ItemBlockRenderTypes.setRenderLayer(${fluid.getModElement().getRegistryNameUpper()}.get(), RenderType.translucent());

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/elementinits/gamerules.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/elementinits/gamerules.java.ftl
@@ -36,7 +36,7 @@
 
 package ${package}.init;
 
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD)
+@EventBusSubscriber
 public class ${JavaModName}GameRules {
 
 	<#list gamerules as gamerule>

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/elementinits/items.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/elementinits/items.java.ftl
@@ -44,7 +44,7 @@ package ${package}.init;
 <#assign itemsWithInventory = w.getGElementsOfType("item")?filter(e -> e.hasInventory())>
 
 <#if itemsWithInventory?size != 0>
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD)
+@EventBusSubscriber
 </#if>
 public class ${JavaModName}Items {
 
@@ -134,7 +134,7 @@ public class ${JavaModName}Items {
 	</#if>
 
 	<#if hasItemsWithProperties>
-	@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD, value = Dist.CLIENT) public static class ItemsClientSideHandler {
+	@EventBusSubscriber(value = Dist.CLIENT) public static class ItemsClientSideHandler {
 		@SubscribeEvent @OnlyIn(Dist.CLIENT) public static void clientLoad(FMLClientSetupEvent event) {
 			event.enqueueWork(() -> {
 			<#compress>

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/elementinits/javamodels.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/elementinits/javamodels.java.ftl
@@ -36,7 +36,7 @@
 
 package ${package}.init;
 
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD, value = {Dist.CLIENT}) public class ${JavaModName}Models {
+@EventBusSubscriber(value = {Dist.CLIENT}) public class ${JavaModName}Models {
 
 	@SubscribeEvent public static void registerLayerDefinitions(EntityRenderersEvent.RegisterLayerDefinitions event) {
 		<#list javamodels as model>

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/elementinits/keybindings.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/elementinits/keybindings.java.ftl
@@ -38,7 +38,7 @@
 
 package ${package}.init;
 
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD, value = {Dist.CLIENT}) public class ${JavaModName}KeyMappings {
+@EventBusSubscriber(value = {Dist.CLIENT}) public class ${JavaModName}KeyMappings {
 
 	<#list keybinds as keybind>
 	public static final KeyMapping ${keybind.getModElement().getRegistryNameUpper()} = new KeyMapping(

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/elementinits/particles.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/elementinits/particles.java.ftl
@@ -36,7 +36,7 @@
 
 package ${package}.init;
 
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD, value = Dist.CLIENT) public class ${JavaModName}Particles {
+@EventBusSubscriber(value = Dist.CLIENT) public class ${JavaModName}Particles {
 
 	@SubscribeEvent public static void registerParticles(RegisterParticleProvidersEvent event) {
 		<#list particles as particle>

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/elementinits/screens.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/elementinits/screens.java.ftl
@@ -38,7 +38,7 @@ package ${package}.init;
 
 <#assign hasEntityModels = false>
 
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD, value = Dist.CLIENT) public class ${JavaModName}Screens {
+@EventBusSubscriber(value = Dist.CLIENT) public class ${JavaModName}Screens {
 
 	@SubscribeEvent public static void clientLoad(RegisterMenuScreensEvent event) {
 		<#list guis as gui>

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/elementinits/tabs.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/elementinits/tabs.java.ftl
@@ -43,7 +43,7 @@
 package ${package}.init;
 
 <#if vanillaTabs?has_content>
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD)
+@EventBusSubscriber
 </#if>
 <#compress>
 public class ${JavaModName}Tabs {

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/elementinits/villagerprofessions.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/elementinits/villagerprofessions.java.ftl
@@ -38,7 +38,7 @@
 
 package ${package}.init;
 
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD) public class ${JavaModName}VillagerProfessions {
+@EventBusSubscriber public class ${JavaModName}VillagerProfessions {
 
 	private static final Map<String, ProfessionPoiType> POI_TYPES = new HashMap<>();
 

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/fluid/fluidtype.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/fluid/fluidtype.java.ftl
@@ -34,7 +34,7 @@
 package ${package}.fluid.types;
 
 <#compress>
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD) public class ${name}FluidType extends FluidType {
+@EventBusSubscriber public class ${name}FluidType extends FluidType {
 	public ${name}FluidType() {
 		super(FluidType.Properties.create()
 			<#if data.type == "WATER">

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/gui/gui_msg_button.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/gui/gui_msg_button.java.ftl
@@ -33,7 +33,7 @@
 
 package ${package}.network;
 
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD) public record ${name}ButtonMessage(int buttonID, int x, int y, int z) implements CustomPacketPayload {
+@EventBusSubscriber public record ${name}ButtonMessage(int buttonID, int x, int y, int z) implements CustomPacketPayload {
 
 	public static final Type<${name}ButtonMessage> TYPE = new Type<>(ResourceLocation.fromNamespaceAndPath(${JavaModName}.MODID, "${registryname}_buttons"));
 

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/gui/gui_msg_menustate.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/gui/gui_msg_menustate.java.ftl
@@ -33,7 +33,7 @@
 
 package ${package}.network;
 
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD) public record MenuStateUpdateMessage(int elementType, String name, Object elementState) implements CustomPacketPayload {
+@EventBusSubscriber public record MenuStateUpdateMessage(int elementType, String name, Object elementState) implements CustomPacketPayload {
 
 	public static final Type<MenuStateUpdateMessage> TYPE = new Type<>(ResourceLocation.fromNamespaceAndPath(${JavaModName}.MODID, "guistate_update"));
 

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/gui/gui_msg_slot.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/gui/gui_msg_slot.java.ftl
@@ -33,7 +33,7 @@
 
 package ${package}.network;
 
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD) public record ${name}SlotMessage(int slotID, int x, int y, int z, int changeType, int meta) implements CustomPacketPayload {
+@EventBusSubscriber public record ${name}SlotMessage(int slotID, int x, int y, int z, int changeType, int meta) implements CustomPacketPayload {
 
 	public static final Type<${name}SlotMessage> TYPE = new Type<>(ResourceLocation.fromNamespaceAndPath(${JavaModName}.MODID, "${registryname}_slots"));
 

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/item/item.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/item/item.java.ftl
@@ -39,7 +39,7 @@ package ${package}.item;
 
 <#compress>
 <#if hasCustomJAVAModels>
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD)
+@EventBusSubscriber
 </#if>
 public class ${name}Item extends <#if data.hasBannerPatterns()>BannerPattern</#if>Item {
 	<#if data.hasBannerPatterns()>

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/keybind.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/keybind.java.ftl
@@ -35,7 +35,7 @@ package ${package}.network;
 
 import ${package}.${JavaModName};
 
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD) public record ${name}Message(int eventType, int pressedms) implements CustomPacketPayload {
+@EventBusSubscriber public record ${name}Message(int eventType, int pressedms) implements CustomPacketPayload {
 
 	public static final Type<${name}Message> TYPE = new Type<>(ResourceLocation.fromNamespaceAndPath(${JavaModName}.MODID, "key_${registryname}"));
 

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/modbase/variableslist.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/modbase/variableslist.java.ftl
@@ -5,7 +5,7 @@ import ${package}.${JavaModName};
 
 import net.minecraft.nbt.Tag;
 
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD) public class ${JavaModName}Variables {
+@EventBusSubscriber public class ${JavaModName}Variables {
 
 	public static final DeferredRegister<AttachmentType<?>> ATTACHMENT_TYPES = DeferredRegister.create(NeoForgeRegistries.Keys.ATTACHMENT_TYPES, ${JavaModName}.MODID);
 

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/potioneffect.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/potioneffect.java.ftl
@@ -35,7 +35,7 @@ package ${package}.potion;
 
 <#compress>
 <#if data.hasCustomRenderer()>
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD)
+@EventBusSubscriber
 </#if>
 public class ${name}MobEffect extends <#if data.isInstant>Instantenous</#if>MobEffect {
 

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/tool.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/tool.java.ftl
@@ -37,7 +37,7 @@ package ${package}.item;
 
 <#compress>
 <#if (data.usageCount == 0) && (data.toolType == "Pickaxe" || data.toolType == "Axe" || data.toolType == "Sword" || data.toolType == "Spade" || data.toolType == "Hoe" || data.toolType == "MultiTool")>
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD)
+@EventBusSubscriber
 </#if>
 <#if data.toolType == "Pickaxe" || data.toolType == "Axe" || data.toolType == "Sword" || data.toolType == "Spade"
 		|| data.toolType == "Hoe" || data.toolType == "Shears" || data.toolType == "Shield" || data.toolType == "MultiTool">

--- a/plugins/generator-1.21.1/neoforge-1.21.1/triggers/mod_clientload.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/triggers/mod_clientload.java.ftl
@@ -1,4 +1,4 @@
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD, value = {Dist.CLIENT}) public class ${name}Procedure {
+@EventBusSubscriber(value = {Dist.CLIENT}) public class ${name}Procedure {
 	@SubscribeEvent public static void init(FMLClientSetupEvent event) {
 		execute();
 	}

--- a/plugins/generator-1.21.1/neoforge-1.21.1/triggers/mod_load.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/triggers/mod_load.java.ftl
@@ -1,4 +1,4 @@
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD) public class ${name}Procedure {
+@EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void init(FMLCommonSetupEvent event) {
 		execute();
 	}

--- a/plugins/generator-1.21.1/neoforge-1.21.1/triggers/mod_serverload.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/triggers/mod_serverload.java.ftl
@@ -1,4 +1,4 @@
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD, value = {Dist.DEDICATED_SERVER}) public class ${name}Procedure {
+@EventBusSubscriber(value = {Dist.DEDICATED_SERVER}) public class ${name}Procedure {
 	@SubscribeEvent public static void init(FMLDedicatedServerSetupEvent event) {
 		execute();
 	}

--- a/plugins/generator-1.21.1/neoforge-1.21.1/triggers/player_left_click_air.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/triggers/player_left_click_air.java.ftl
@@ -14,7 +14,7 @@
 		execute(${dependenciesCode});
 	}
 
-	@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD)
+	@EventBusSubscriber
 	public record ${name}Message() implements CustomPacketPayload {
 		public static final Type<${name}Message> TYPE = new Type<>(ResourceLocation.fromNamespaceAndPath(${JavaModName}.MODID, "procedure_${registryname}"));
 

--- a/plugins/generator-1.21.1/neoforge-1.21.1/triggers/player_right_click_empty_hand.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/triggers/player_right_click_empty_hand.java.ftl
@@ -16,7 +16,7 @@
 		execute(${dependenciesCode});
 	}
 
-	@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD)
+	@EventBusSubscriber
 	public record ${name}Message() implements CustomPacketPayload {
 		public static final Type<${name}Message> TYPE = new Type<>(ResourceLocation.fromNamespaceAndPath(${JavaModName}.MODID, "procedure_${registryname}"));
 

--- a/plugins/generator-1.21.1/resourcepack-1.21.1/generator.yaml
+++ b/plugins/generator-1.21.1/resourcepack-1.21.1/generator.yaml
@@ -1,6 +1,6 @@
 name: Resource Pack for Java Edition @minecraft
 status: stable
-buildfileversion: 21.1.176
+buildfileversion: 21.1.190
 
 # gradle task definitions
 gradle:

--- a/plugins/generator-1.21.1/resourcepack-1.21.1/workspacebase/packloader/src/main/java/net/mcreator/packloader/PackLoaderMod.java
+++ b/plugins/generator-1.21.1/resourcepack-1.21.1/workspacebase/packloader/src/main/java/net/mcreator/packloader/PackLoaderMod.java
@@ -27,7 +27,7 @@ import java.util.List;
 	public PackLoaderMod(IEventBus modEventBus) {
 	}
 
-	@EventBusSubscriber(modid = MODID, bus = EventBusSubscriber.Bus.MOD, value = Dist.CLIENT)
+	@EventBusSubscriber(modid = MODID, value = Dist.CLIENT)
 	public static class ClientModEvents {
 		@SubscribeEvent public static void onClientSetup(FMLClientSetupEvent event) {
 			List<String> resourcePacks = new ArrayList<>();

--- a/plugins/generator-1.21.4/datapack-1.21.4/generator.yaml
+++ b/plugins/generator-1.21.4/datapack-1.21.4/generator.yaml
@@ -1,6 +1,6 @@
 name: Data Pack for Java Edition @minecraft
 status: stable
-buildfileversion: 21.4.137
+buildfileversion: 21.4.145
 
 # gradle task definitions
 gradle:

--- a/plugins/generator-1.21.4/neoforge-1.21.4/generator.yaml
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/generator.yaml
@@ -1,6 +1,6 @@
 name: NeoForge for @minecraft (@buildfileversion)
 status: stable
-buildfileversion: 21.4.137
+buildfileversion: 21.4.145
 
 import:
   - datapack-1.21.4

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/armor.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/armor.java.ftl
@@ -39,7 +39,7 @@ import java.util.Map;
 import java.util.function.Consumer;
 import net.minecraft.client.model.Model;
 
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD) public abstract class ${name}Item extends ArmorItem {
+@EventBusSubscriber public abstract class ${name}Item extends ArmorItem {
 
 	public static ArmorMaterial ARMOR_MATERIAL = new ArmorMaterial(
 		${data.maxDamage},

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/biome/tree_fruits_decorator.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/biome/tree_fruits_decorator.java.ftl
@@ -34,7 +34,7 @@
 
 package ${package}.world.features.treedecorators;
 
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD) public class ${name}FruitDecorator extends CocoaDecorator {
+@EventBusSubscriber public class ${name}FruitDecorator extends CocoaDecorator {
 
     public static MapCodec<${name}FruitDecorator> CODEC = MapCodec.unit(${name}FruitDecorator::new);
 

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/biome/tree_leave_decorator.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/biome/tree_leave_decorator.java.ftl
@@ -34,7 +34,7 @@
 
 package ${package}.world.features.treedecorators;
 
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD) public class ${name}LeaveDecorator extends LeaveVineDecorator {
+@EventBusSubscriber public class ${name}LeaveDecorator extends LeaveVineDecorator {
 
     public static MapCodec<${name}LeaveDecorator> CODEC = MapCodec.unit(${name}LeaveDecorator::new);
 

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/biome/tree_trunk_decorator.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/biome/tree_trunk_decorator.java.ftl
@@ -34,7 +34,7 @@
 
 package ${package}.world.features.treedecorators;
 
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD) public class ${name}TrunkDecorator extends TrunkVineDecorator {
+@EventBusSubscriber public class ${name}TrunkDecorator extends TrunkVineDecorator {
 
     public static MapCodec<${name}TrunkDecorator> CODEC = MapCodec.unit(${name}TrunkDecorator::new);
 

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/block/blockentity_renderer.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/block/blockentity_renderer.java.ftl
@@ -33,7 +33,7 @@
 
 package ${package}.client.renderer.block;
 
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD, value = Dist.CLIENT) public class ${name}Renderer implements BlockEntityRenderer<${name}BlockEntity> {
+@EventBusSubscriber(value = Dist.CLIENT) public class ${name}Renderer implements BlockEntityRenderer<${name}BlockEntity> {
 
 	private final CustomHierarchicalModel model;
 	private final ResourceLocation texture;

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/code.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/code.java.ftl
@@ -46,7 +46,7 @@
 
 package ${package};
 
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD)
+@EventBusSubscriber
 public class ${name} {
 
 	public ${name}() {

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/dimension/dimension.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/dimension/dimension.java.ftl
@@ -42,7 +42,7 @@ package ${package}.world.dimension;
 public class ${name}Dimension {
 
 	<#if data.useCustomEffects>
-	@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD, value = Dist.CLIENT) public static class ${name}SpecialEffectsHandler {
+	@EventBusSubscriber(value = Dist.CLIENT) public static class ${name}SpecialEffectsHandler {
 
 		@SubscribeEvent public static void registerDimensionSpecialEffects(RegisterDimensionSpecialEffectsEvent event) {
 			DimensionSpecialEffects customEffect = new DimensionSpecialEffects(

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/dimension/teleporter.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/dimension/teleporter.java.ftl
@@ -33,7 +33,7 @@
 
 package ${package}.world.teleporter;
 
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD) public class ${name}Teleporter {
+@EventBusSubscriber public class ${name}Teleporter {
 
 	public static Holder<PoiType> poi = null;
 

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/dispensebehaviour.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/dispensebehaviour.java.ftl
@@ -36,7 +36,7 @@
 package ${package}.item.extension;
 
 <#compress>
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD) public class ${name}ItemExtension {
+@EventBusSubscriber public class ${name}ItemExtension {
 	@SubscribeEvent public static void init(FMLCommonSetupEvent event) {
 		event.enqueueWork(() -> DispenserBlock.registerBehavior(${mappedMCItemToItem(data.item)}, new OptionalDispenseItemBehavior() {
 			public ItemStack execute(BlockSource blockSource, ItemStack stack) {

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/elementinits/attributes.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/elementinits/attributes.java.ftl
@@ -36,7 +36,7 @@
 
 package ${package}.init;
 
-@EventBusSubscriber (bus = EventBusSubscriber.Bus.MOD)
+@EventBusSubscriber
 public class ${JavaModName}Attributes {
 
 	public static final DeferredRegister<Attribute> REGISTRY = DeferredRegister.create(BuiltInRegistries.ATTRIBUTE, ${JavaModName}.MODID);

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/elementinits/blockentities.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/elementinits/blockentities.java.ftl
@@ -39,7 +39,7 @@ package ${package}.init;
 <#assign blockentitiesWithInventory = w.getGElementsOfType("block")?filter(e -> e.hasInventory)>
 
 <#if blockentitiesWithInventory?size != 0>
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD)
+@EventBusSubscriber
 </#if>
 public class ${JavaModName}BlockEntities {
 

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/elementinits/blocks.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/elementinits/blocks.java.ftl
@@ -71,7 +71,7 @@ public class ${JavaModName}Blocks {
 	}
 
 	<#if hasTintedBlocks>
-	@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD, value = Dist.CLIENT) public static class BlocksClientSideHandler {
+	@EventBusSubscriber(value = Dist.CLIENT) public static class BlocksClientSideHandler {
 		@SubscribeEvent public static void blockColorLoad(RegisterColorHandlersEvent.Block event) {
 			<#list blocks as block>
 				<#if block.getModElement().getTypeString() == "block" || block.getModElement().getTypeString() == "plant">

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/elementinits/entities.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/elementinits/entities.java.ftl
@@ -40,7 +40,7 @@ package ${package}.init;
 <#assign entitiesWithInventory = w.getGElementsOfType("livingentity")?filter(e -> e.guiBoundTo?has_content)>
 
 <#if hasLivingEntities || entitiesWithInventory?size != 0>
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD)
+@EventBusSubscriber
 </#if>
 public class ${JavaModName}Entities {
 

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/elementinits/entityrenderers.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/elementinits/entityrenderers.java.ftl
@@ -36,7 +36,7 @@
 
 package ${package}.init;
 
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD, value = Dist.CLIENT) public class ${JavaModName}EntityRenderers {
+@EventBusSubscriber(value = Dist.CLIENT) public class ${JavaModName}EntityRenderers {
 
 	@SubscribeEvent public static void registerEntityRenderers(EntityRenderersEvent.RegisterRenderers event) {
 		<#list entities as entity>

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/elementinits/fluids.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/elementinits/fluids.java.ftl
@@ -47,7 +47,7 @@ public class ${JavaModName}Fluids {
 		REGISTRY.register("flowing_${fluid.getModElement().getRegistryName()}", () -> new ${fluid.getModElement().getName()}Fluid.Flowing());
 	</#list>
 
-	@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD, value = Dist.CLIENT) public static class FluidsClientSideHandler {
+	@EventBusSubscriber(value = Dist.CLIENT) public static class FluidsClientSideHandler {
 		@SubscribeEvent public static void clientSetup(FMLClientSetupEvent event) {
 			<#list fluids as fluid>
 			ItemBlockRenderTypes.setRenderLayer(${fluid.getModElement().getRegistryNameUpper()}.get(), RenderType.translucent());

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/elementinits/gamerules.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/elementinits/gamerules.java.ftl
@@ -36,7 +36,7 @@
 
 package ${package}.init;
 
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD)
+@EventBusSubscriber
 public class ${JavaModName}GameRules {
 
 	<#list gamerules as gamerule>

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/elementinits/items.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/elementinits/items.java.ftl
@@ -45,7 +45,7 @@ package ${package}.init;
 <#assign itemsWithInventory = w.getGElementsOfType("item")?filter(e -> e.hasInventory())>
 
 <#if itemsWithInventory?size != 0>
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD)
+@EventBusSubscriber
 </#if>
 public class ${JavaModName}Items {
 
@@ -139,7 +139,7 @@ public class ${JavaModName}Items {
 	</#if>
 
 	<#if hasItemsWithCustomProperties || hasItemsWithLeftHandedProperty>
-	@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD, value = Dist.CLIENT) public static class ItemsClientSideHandler {
+	@EventBusSubscriber(value = Dist.CLIENT) public static class ItemsClientSideHandler {
 
 		<#if hasItemsWithCustomProperties>
 		@SubscribeEvent @OnlyIn(Dist.CLIENT) public static void registerItemModelProperties(RegisterRangeSelectItemModelPropertyEvent event) {

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/elementinits/javamodels.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/elementinits/javamodels.java.ftl
@@ -36,7 +36,7 @@
 
 package ${package}.init;
 
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD, value = {Dist.CLIENT}) public class ${JavaModName}Models {
+@EventBusSubscriber(value = {Dist.CLIENT}) public class ${JavaModName}Models {
 
 	@SubscribeEvent public static void registerLayerDefinitions(EntityRenderersEvent.RegisterLayerDefinitions event) {
 		<#list javamodels as model>

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/elementinits/keybindings.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/elementinits/keybindings.java.ftl
@@ -38,7 +38,7 @@
 
 package ${package}.init;
 
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD, value = {Dist.CLIENT}) public class ${JavaModName}KeyMappings {
+@EventBusSubscriber(value = {Dist.CLIENT}) public class ${JavaModName}KeyMappings {
 
 	<#list keybinds as keybind>
 	public static final KeyMapping ${keybind.getModElement().getRegistryNameUpper()} = new KeyMapping(

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/elementinits/particles.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/elementinits/particles.java.ftl
@@ -36,7 +36,7 @@
 
 package ${package}.init;
 
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD, value = Dist.CLIENT) public class ${JavaModName}Particles {
+@EventBusSubscriber(value = Dist.CLIENT) public class ${JavaModName}Particles {
 
 	@SubscribeEvent public static void registerParticles(RegisterParticleProvidersEvent event) {
 		<#list particles as particle>

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/elementinits/screens.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/elementinits/screens.java.ftl
@@ -38,7 +38,7 @@ package ${package}.init;
 
 <#assign hasEntityModels = false>
 
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD, value = Dist.CLIENT) public class ${JavaModName}Screens {
+@EventBusSubscriber(value = Dist.CLIENT) public class ${JavaModName}Screens {
 
 	@SubscribeEvent public static void clientLoad(RegisterMenuScreensEvent event) {
 		<#list guis as gui>

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/elementinits/tabs.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/elementinits/tabs.java.ftl
@@ -43,7 +43,7 @@
 package ${package}.init;
 
 <#if vanillaTabs?has_content>
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD)
+@EventBusSubscriber
 </#if>
 <#compress>
 public class ${JavaModName}Tabs {

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/elementinits/villagerprofessions.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/elementinits/villagerprofessions.java.ftl
@@ -38,7 +38,7 @@
 
 package ${package}.init;
 
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD) public class ${JavaModName}VillagerProfessions {
+@EventBusSubscriber public class ${JavaModName}VillagerProfessions {
 
 	private static final Map<String, ProfessionPoiType> POI_TYPES = new HashMap<>();
 

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/fluid/fluidtype.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/fluid/fluidtype.java.ftl
@@ -34,7 +34,7 @@
 package ${package}.fluid.types;
 
 <#compress>
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD) public class ${name}FluidType extends FluidType {
+@EventBusSubscriber public class ${name}FluidType extends FluidType {
 	public ${name}FluidType() {
 		super(FluidType.Properties.create()
 			<#if data.type == "WATER">

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/gui/gui_msg_button.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/gui/gui_msg_button.java.ftl
@@ -33,7 +33,7 @@
 
 package ${package}.network;
 
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD) public record ${name}ButtonMessage(int buttonID, int x, int y, int z) implements CustomPacketPayload {
+@EventBusSubscriber public record ${name}ButtonMessage(int buttonID, int x, int y, int z) implements CustomPacketPayload {
 
 	public static final Type<${name}ButtonMessage> TYPE = new Type<>(ResourceLocation.fromNamespaceAndPath(${JavaModName}.MODID, "${registryname}_buttons"));
 

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/gui/gui_msg_menustate.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/gui/gui_msg_menustate.java.ftl
@@ -33,7 +33,7 @@
 
 package ${package}.network;
 
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD) public record MenuStateUpdateMessage(int elementType, String name, Object elementState) implements CustomPacketPayload {
+@EventBusSubscriber public record MenuStateUpdateMessage(int elementType, String name, Object elementState) implements CustomPacketPayload {
 
 	public static final Type<MenuStateUpdateMessage> TYPE = new Type<>(ResourceLocation.fromNamespaceAndPath(${JavaModName}.MODID, "menustate_update"));
 

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/gui/gui_msg_slot.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/gui/gui_msg_slot.java.ftl
@@ -33,7 +33,7 @@
 
 package ${package}.network;
 
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD) public record ${name}SlotMessage(int slotID, int x, int y, int z, int changeType, int meta) implements CustomPacketPayload {
+@EventBusSubscriber public record ${name}SlotMessage(int slotID, int x, int y, int z, int changeType, int meta) implements CustomPacketPayload {
 
 	public static final Type<${name}SlotMessage> TYPE = new Type<>(ResourceLocation.fromNamespaceAndPath(${JavaModName}.MODID, "${registryname}_slots"));
 

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/item/item.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/item/item.java.ftl
@@ -37,7 +37,7 @@ package ${package}.item;
 
 <#compress>
 <#if data.hasCustomEatResultItem()>
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD)
+@EventBusSubscriber
 </#if>
 public class ${name}Item extends <#if data.hasBannerPatterns()>BannerPattern</#if>Item {
 

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/item/item_renderer.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/item/item_renderer.java.ftl
@@ -51,7 +51,7 @@ package ${package}.client.renderer.item;
 
 <#compress>
 @OnlyIn(Dist.CLIENT)
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD, value = Dist.CLIENT)
+@EventBusSubscriber(value = Dist.CLIENT)
 public class ${name}ItemRenderer implements NoDataSpecialModelRenderer {
 
 	@SubscribeEvent @OnlyIn(Dist.CLIENT) public static void registerItemRenderers(RegisterSpecialModelRendererEvent event) {

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/item/overrides_model.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/item/overrides_model.java.ftl
@@ -31,7 +31,7 @@
 <#-- @formatter:off -->
 package ${package}.client.renderer.item;
 
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD, value = Dist.CLIENT) public class LegacyOverrideSelectItemModel implements ItemModel {
+@EventBusSubscriber(value = Dist.CLIENT) public class LegacyOverrideSelectItemModel implements ItemModel {
 
     private final ModelOverride[] overrides;
     private final ItemModel[] models;

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/keybind.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/keybind.java.ftl
@@ -35,7 +35,7 @@ package ${package}.network;
 
 import ${package}.${JavaModName};
 
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD) public record ${name}Message(int eventType, int pressedms) implements CustomPacketPayload {
+@EventBusSubscriber public record ${name}Message(int eventType, int pressedms) implements CustomPacketPayload {
 
 	public static final Type<${name}Message> TYPE = new Type<>(ResourceLocation.fromNamespaceAndPath(${JavaModName}.MODID, "key_${registryname}"));
 

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/modbase/variableslist.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/modbase/variableslist.java.ftl
@@ -5,7 +5,7 @@ import ${package}.${JavaModName};
 
 import net.minecraft.nbt.Tag;
 
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD) public class ${JavaModName}Variables {
+@EventBusSubscriber public class ${JavaModName}Variables {
 
 	public static final DeferredRegister<AttachmentType<?>> ATTACHMENT_TYPES = DeferredRegister.create(NeoForgeRegistries.Keys.ATTACHMENT_TYPES, ${JavaModName}.MODID);
 

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/potioneffect.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/potioneffect.java.ftl
@@ -35,7 +35,7 @@ package ${package}.potion;
 
 <#compress>
 <#if data.hasCustomRenderer() || data.isCuredbyHoney>
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD)
+@EventBusSubscriber
 </#if>
 public class ${name}MobEffect extends <#if data.isInstant>Instantenous</#if>MobEffect {
 

--- a/plugins/generator-1.21.4/neoforge-1.21.4/templates/tool.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/templates/tool.java.ftl
@@ -37,7 +37,7 @@ package ${package}.item;
 
 <#compress>
 <#if (data.usageCount == 0) && (data.toolType == "Pickaxe" || data.toolType == "Axe" || data.toolType == "Sword" || data.toolType == "Spade" || data.toolType == "Hoe" || data.toolType == "MultiTool")>
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD)
+@EventBusSubscriber
 </#if>
 <#if data.toolType == "Pickaxe" || data.toolType == "Axe" || data.toolType == "Sword" || data.toolType == "Spade"
 		|| data.toolType == "Hoe" || data.toolType == "Shears" || data.toolType == "Shield" || data.toolType == "MultiTool">

--- a/plugins/generator-1.21.4/neoforge-1.21.4/triggers/mod_clientload.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/triggers/mod_clientload.java.ftl
@@ -1,4 +1,4 @@
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD, value = {Dist.CLIENT}) public class ${name}Procedure {
+@EventBusSubscriber(value = {Dist.CLIENT}) public class ${name}Procedure {
 	@SubscribeEvent public static void init(FMLClientSetupEvent event) {
 		execute();
 	}

--- a/plugins/generator-1.21.4/neoforge-1.21.4/triggers/mod_load.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/triggers/mod_load.java.ftl
@@ -1,4 +1,4 @@
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD) public class ${name}Procedure {
+@EventBusSubscriber public class ${name}Procedure {
 	@SubscribeEvent public static void init(FMLCommonSetupEvent event) {
 		execute();
 	}

--- a/plugins/generator-1.21.4/neoforge-1.21.4/triggers/mod_serverload.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/triggers/mod_serverload.java.ftl
@@ -1,4 +1,4 @@
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD, value = {Dist.DEDICATED_SERVER}) public class ${name}Procedure {
+@EventBusSubscriber(value = {Dist.DEDICATED_SERVER}) public class ${name}Procedure {
 	@SubscribeEvent public static void init(FMLDedicatedServerSetupEvent event) {
 		execute();
 	}

--- a/plugins/generator-1.21.4/neoforge-1.21.4/triggers/player_left_click_air.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/triggers/player_left_click_air.java.ftl
@@ -14,7 +14,7 @@
 		execute(${dependenciesCode});
 	}
 
-	@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD)
+	@EventBusSubscriber
 	public record ${name}Message() implements CustomPacketPayload {
 		public static final Type<${name}Message> TYPE = new Type<>(ResourceLocation.fromNamespaceAndPath(${JavaModName}.MODID, "procedure_${registryname}"));
 

--- a/plugins/generator-1.21.4/neoforge-1.21.4/triggers/player_right_click_empty_hand.java.ftl
+++ b/plugins/generator-1.21.4/neoforge-1.21.4/triggers/player_right_click_empty_hand.java.ftl
@@ -16,7 +16,7 @@
 		execute(${dependenciesCode});
 	}
 
-	@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD)
+	@EventBusSubscriber
 	public record ${name}Message() implements CustomPacketPayload {
 		public static final Type<${name}Message> TYPE = new Type<>(ResourceLocation.fromNamespaceAndPath(${JavaModName}.MODID, "procedure_${registryname}"));
 

--- a/plugins/generator-1.21.4/resourcepack-1.21.4/generator.yaml
+++ b/plugins/generator-1.21.4/resourcepack-1.21.4/generator.yaml
@@ -1,6 +1,6 @@
 name: Resource Pack for Java Edition @minecraft
 status: stable
-buildfileversion: 21.4.137
+buildfileversion: 21.4.145
 
 # gradle task definitions
 gradle:

--- a/plugins/generator-1.21.4/resourcepack-1.21.4/workspacebase/packloader/src/main/java/net/mcreator/packloader/PackLoaderMod.java
+++ b/plugins/generator-1.21.4/resourcepack-1.21.4/workspacebase/packloader/src/main/java/net/mcreator/packloader/PackLoaderMod.java
@@ -27,7 +27,7 @@ import java.util.List;
 	public PackLoaderMod(IEventBus modEventBus) {
 	}
 
-	@EventBusSubscriber(modid = MODID, bus = EventBusSubscriber.Bus.MOD, value = Dist.CLIENT)
+	@EventBusSubscriber(modid = MODID, value = Dist.CLIENT)
 	public static class ClientModEvents {
 		@SubscribeEvent public static void onClientSetup(FMLClientSetupEvent event) {
 			List<String> resourcePacks = new ArrayList<>();


### PR DESCRIPTION
1.21.1 -  21.1.176 -> 21.1.190
1.21.4 - 21.4.137 -> 21.4.145

Breaking changes:

Removed `bus` parameter in `@EventBusSubscriber` annotation

Changelog:

Updated generators to the latest version of NeoForge