### PR TITLE
Fix #5610 - Non-food items with eat or drink animation emitted eating sounds

### DIFF
--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/item/item.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/item/item.java.ftl
@@ -108,6 +108,16 @@ public class ${name}Item extends <#if data.hasBannerPatterns()>BannerPattern</#i
 	}
 	</#if>
 
+	<#if !data.isFood && data.animation == "eat">
+	@Override public SoundEvent getEatingSound() {
+		return SoundEvents.EMPTY;
+	}
+	<#elseif !data.isFood && data.animation == "drink">
+	@Override public SoundEvent getDrinkingSound() {
+		return SoundEvents.EMPTY;
+	}
+	</#if>
+
 	<#if data.stayInGridWhenCrafting>
 		@Override public boolean hasCraftingRemainingItem(ItemStack stack) {
 			return true;


### PR DESCRIPTION
Changelog:

* [Bugfix, NF 1.21.1] Non-food items with eat or drink animation emitted eating sounds