### PR TITLE
Gradle 9 for MCreator build toolchain

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
     id "java"
     id "idea"
     id "de.undercouch.download" version "5.6.0"
-    id 'edu.sc.seis.launch4j' version '3.0.7'
+    id 'edu.sc.seis.launch4j' version '3.0.7' // TODO: needs to be updated as it currently fails with Gradle 9.0
     id 'org.jetbrains.gradle.plugin.idea-ext' version '1.2'
     id 'org.openjfx.javafxplugin' version '0.1.0'
 }
@@ -122,7 +122,7 @@ dependencies {
     implementation group: 'de.javagl', name: 'obj', version: '0.4.0'
     implementation group: 'com.univocity', name: 'univocity-parsers', version: '2.9.1'
     implementation group: 'org.slf4j', name: 'slf4j-nop', version: '2.0.17'
-    implementation group: 'org.gradle', name: 'gradle-tooling-api', version: '8.14.3'
+    implementation group: 'org.gradle', name: 'gradle-tooling-api', version: '9.0.0'
     implementation group: 'net.java.balloontip', name: 'balloontip', version: '1.2.4.1'
     implementation group: 'com.atlassian.commonmark', name: 'commonmark', version: '0.17.0'
     implementation group: 'com.atlassian.commonmark', name: 'commonmark-ext-autolink', version: '0.17.0'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Updates Gradle to version 9.

Currently blocked by:

* https://github.com/TheBoegl/gradle-launch4j/issues/188