### PR TITLE
Sort generated files in "Edit code of element" dropdown list

### DIFF
--- a/src/main/java/net/mcreator/generator/GeneratorTemplate.java
+++ b/src/main/java/net/mcreator/generator/GeneratorTemplate.java
@@ -19,7 +19,7 @@
 package net.mcreator.generator;
 
 import net.mcreator.generator.template.TemplateExpressionParser;
-import net.mcreator.ui.MCreator;
+import net.mcreator.workspace.Workspace;
 
 import java.io.File;
 import java.util.HashMap;
@@ -102,8 +102,8 @@ public class GeneratorTemplate {
 				conditionData);
 	}
 
-	public String getPathInWorkspace(MCreator mcreator) {
-		return mcreator.getFolderManager().getPathInWorkspace(this.getFile());
+	public String getPathInWorkspace(Workspace workspace) {
+		return workspace.getFolderManager().getPathInWorkspace(this.getFile());
 	}
 
 	/**

--- a/src/main/java/net/mcreator/generator/GeneratorTemplate.java
+++ b/src/main/java/net/mcreator/generator/GeneratorTemplate.java
@@ -19,6 +19,7 @@
 package net.mcreator.generator;
 
 import net.mcreator.generator.template.TemplateExpressionParser;
+import net.mcreator.ui.MCreator;
 
 import java.io.File;
 import java.util.HashMap;
@@ -99,6 +100,10 @@ public class GeneratorTemplate {
 	public boolean shouldBeSkippedBasedOnCondition(Generator generator, Object conditionData) {
 		return TemplateExpressionParser.shouldSkipTemplateBasedOnCondition(generator, templateDefinition,
 				conditionData);
+	}
+
+	public String getPathInWorkspace(MCreator mcreator) {
+		return mcreator.getFolderManager().getPathInWorkspace(this.getFile());
 	}
 
 	/**

--- a/src/main/java/net/mcreator/ui/workspace/ModElementCodeDropdown.java
+++ b/src/main/java/net/mcreator/ui/workspace/ModElementCodeDropdown.java
@@ -102,7 +102,7 @@ class ModElementCodeDropdown extends JPopupMenu {
 	private JMenuItem modElementFileMenuItem(GeneratorTemplate template) {
 		JMenuItem item = new JMenuItem(
 				"<html>" + template.getFile().getName() + "<br><small color=#666666>" +
-						template.getPathInWorkspace(mcreator));
+						template.getPathInWorkspace(mcreator.getWorkspace()));
 		item.setIcon(FileIcons.getIconForFile(template.getFile()));
 		item.setBackground((Theme.current().getAltBackgroundColor()).darker());
 		item.setForeground(Theme.current().getForegroundColor());

--- a/src/main/java/net/mcreator/ui/workspace/ModElementCodeDropdown.java
+++ b/src/main/java/net/mcreator/ui/workspace/ModElementCodeDropdown.java
@@ -101,8 +101,8 @@ class ModElementCodeDropdown extends JPopupMenu {
 
 	private JMenuItem modElementFileMenuItem(GeneratorTemplate template) {
 		JMenuItem item = new JMenuItem(
-				"<html>" + template.getFile().getName() + "<br><small color=#666666>" + mcreator.getWorkspace()
-						.getFolderManager().getPathInWorkspace(template.getFile()));
+				"<html>" + template.getFile().getName() + "<br><small color=#666666>" +
+						template.getPathInWorkspace(mcreator));
 		item.setIcon(FileIcons.getIconForFile(template.getFile()));
 		item.setBackground((Theme.current().getAltBackgroundColor()).darker());
 		item.setForeground(Theme.current().getForegroundColor());

--- a/src/main/java/net/mcreator/ui/workspace/WorkspacePanel.java
+++ b/src/main/java/net/mcreator/ui/workspace/WorkspacePanel.java
@@ -1118,11 +1118,10 @@ import java.util.stream.Collectors;
 		}
 
 		if (modElementFiles.size() + modElementGlobalFiles.size() > 1)
-			new ModElementCodeDropdown(mcreator,
-					modElementFiles.stream().filter(e -> !(e instanceof ListTemplate)).sorted((o1, o2) ->
-							o1.getPathInWorkspace(mcreator).compareToIgnoreCase(o2.getPathInWorkspace(mcreator)))
-							.toList(), modElementGlobalFiles,
-					modElementListFiles).show(component, x, y);
+			new ModElementCodeDropdown(mcreator, modElementFiles.stream().filter(e -> !(e instanceof ListTemplate))
+					.sorted((o1, o2) -> o1.getPathInWorkspace(mcreator.getWorkspace())
+							.compareToIgnoreCase(o2.getPathInWorkspace(mcreator.getWorkspace()))).toList(),
+					modElementGlobalFiles, modElementListFiles).show(component, x, y);
 		else if (modElementFiles.size() == 1)
 			ProjectFileOpener.openCodeFile(mcreator, modElementFiles.getFirst().getFile());
 		else if (modElementGlobalFiles.size() == 1)

--- a/src/main/java/net/mcreator/ui/workspace/WorkspacePanel.java
+++ b/src/main/java/net/mcreator/ui/workspace/WorkspacePanel.java
@@ -1119,7 +1119,9 @@ import java.util.stream.Collectors;
 
 		if (modElementFiles.size() + modElementGlobalFiles.size() > 1)
 			new ModElementCodeDropdown(mcreator,
-					modElementFiles.stream().filter(e -> !(e instanceof ListTemplate)).toList(), modElementGlobalFiles,
+					modElementFiles.stream().filter(e -> !(e instanceof ListTemplate)).sorted((o1, o2) ->
+							o1.getPathInWorkspace(mcreator).compareToIgnoreCase(o2.getPathInWorkspace(mcreator)))
+							.toList(), modElementGlobalFiles,
 					modElementListFiles).show(component, x, y);
 		else if (modElementFiles.size() == 1)
 			ProjectFileOpener.openCodeFile(mcreator, modElementFiles.getFirst().getFile());


### PR DESCRIPTION
With this PR, generated files in the edit code dropdown are sorted alphabetically by file path, so that they appear in a consistent order.
 
For example, the json files for a block will always be ordered as blockstate -> itemstate -> block models -> item model -> loot table.
<img width="611" height="422" alt="sorted" src="https://github.com/user-attachments/assets/592222e2-5472-48bc-b19b-b733a23f4a56" />
