### PR TITLE
Fix block bases resetting some properties when editing element

### DIFF
--- a/src/main/java/net/mcreator/ui/modgui/BlockGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/BlockGUI.java
@@ -429,9 +429,11 @@ public class BlockGUI extends ModElementGUI<Block> {
 				renderType.setSelectedItem(singleTexture);
 				isWaterloggable.setSelected(false);
 				hasGravity.setSelected(false);
-				isNotColidable.setSelected(false);
-				reactionToPushing.setSelectedItem("NORMAL");
-				ignitedByLava.setSelected(false);
+				if (!isEditingMode()) {
+					isNotColidable.setSelected(false);
+					reactionToPushing.setSelectedItem("NORMAL");
+					ignitedByLava.setSelected(false);
+				}
 
 				String selectedBlockBase = blockBase.getSelectedItem();
 				switch (selectedBlockBase) {


### PR DESCRIPTION
This PR fixes a bug where editing a block with a block base always resets some properties (for example, block being not collidable)