### PR TITLE
Add some block bases to the correct block tags

### DIFF
--- a/plugins/generator-1.21.1/neoforge-1.21.1/block.definition.yaml
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/block.definition.yaml
@@ -474,6 +474,24 @@ tags:
     condition: "${data.blockBase! == 'Wall'}"
   - tag: BLOCKS:minecraft:leaves
     condition: "${data.blockBase! == 'Leaves'}"
+  - tag: BLOCKS:minecraft:wooden_trapdoors
+    condition: "${(data.blockBase! == 'TrapDoor') && (data.blockSetType == 'OAK')}"
+  - tag: BLOCKS:minecraft:trapdoors
+    condition: "${(data.blockBase! == 'TrapDoor') && (data.blockSetType != 'OAK')}"
+  - tag: BLOCKS:minecraft:wooden_doors
+    condition: "${(data.blockBase! == 'Door') && (data.blockSetType == 'OAK')}"
+  - tag: BLOCKS:minecraft:doors
+    condition: "${(data.blockBase! == 'Door') && (data.blockSetType != 'OAK')}"
+  - tag: BLOCKS:minecraft:mob_interactable_doors
+    condition: "${(data.blockBase! == 'Door') && (data.blockSetType == 'STONE')}"
+  - tag: BLOCKS:minecraft:wooden_pressure_plates
+    condition: "${(data.blockBase! == 'PressurePlate') && (data.blockSetType == 'OAK')}"
+  - tag: BLOCKS:minecraft:pressure_plates
+    condition: "${(data.blockBase! == 'PressurePlate') && (data.blockSetType != 'OAK')}"
+  - tag: BLOCKS:minecraft:wooden_buttons
+    condition: "${(data.blockBase! == 'Button') && (data.blockSetType == 'OAK')}"
+  - tag: BLOCKS:minecraft:buttons
+    condition: "${(data.blockBase! == 'Button') && (data.blockSetType != 'OAK')}"
 
   - tag: BLOCKS:minecraft:replaceable
     condition: isReplaceable

--- a/plugins/generator-1.21.8/neoforge-1.21.8/block.definition.yaml
+++ b/plugins/generator-1.21.8/neoforge-1.21.8/block.definition.yaml
@@ -478,6 +478,24 @@ tags:
     condition: "${data.blockBase! == 'Wall'}"
   - tag: BLOCKS:minecraft:leaves
     condition: "${data.blockBase! == 'Leaves'}"
+  - tag: BLOCKS:minecraft:wooden_trapdoors
+    condition: "${(data.blockBase! == 'TrapDoor') && (data.blockSetType == 'OAK')}"
+  - tag: BLOCKS:minecraft:trapdoors
+    condition: "${(data.blockBase! == 'TrapDoor') && (data.blockSetType != 'OAK')}"
+  - tag: BLOCKS:minecraft:wooden_doors
+    condition: "${(data.blockBase! == 'Door') && (data.blockSetType == 'OAK')}"
+  - tag: BLOCKS:minecraft:doors
+    condition: "${(data.blockBase! == 'Door') && (data.blockSetType != 'OAK')}"
+  - tag: BLOCKS:minecraft:mob_interactable_doors
+    condition: "${(data.blockBase! == 'Door') && (data.blockSetType == 'STONE')}"
+  - tag: BLOCKS:minecraft:wooden_pressure_plates
+    condition: "${(data.blockBase! == 'PressurePlate') && (data.blockSetType == 'OAK')}"
+  - tag: BLOCKS:minecraft:pressure_plates
+    condition: "${(data.blockBase! == 'PressurePlate') && (data.blockSetType != 'OAK')}"
+  - tag: BLOCKS:minecraft:wooden_buttons
+    condition: "${(data.blockBase! == 'Button') && (data.blockSetType == 'OAK')}"
+  - tag: BLOCKS:minecraft:buttons
+    condition: "${(data.blockBase! == 'Button') && (data.blockSetType != 'OAK')}"
 
   - tag: BLOCKS:minecraft:replaceable
     condition: isReplaceable


### PR DESCRIPTION
With this PR, some block bases (door, trapdoor, button, pressure plate) are automatically added to the correct block tags