### PR TITLE
Flower pot block base

### DIFF
--- a/plugins/generator-1.21.1/neoforge-1.21.1/block.definition.yaml
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/block.definition.yaml
@@ -33,7 +33,7 @@ templates:
   - template: json/block_item.json.ftl
     condition:
       - hasBlockItem
-      - "renderType() #?= 10,11,12,14,110,120,2,4"
+      - "renderType() #?= 10,11,12,14,15,110,120,150,2,4"
     writer: json
     name: "@MODASSETSROOT/models/item/@registryname.json"
   - template: json/block_item_cmodel.json.ftl
@@ -71,6 +71,11 @@ templates:
     writer: json
     name: "@MODASSETSROOT/models/block/@registryname.json"
   - template: json/block.json.ftl
+    condition: "renderType() #= 15"
+    writer: json
+    name: "@MODASSETSROOT/models/block/@registryname.json"
+    variables: "model=flower_pot_cross;txname=plant"
+  - template: json/block.json.ftl
     condition: "renderType() #= 110"
     writer: json
     variables: "model=leaves;txname=all"
@@ -80,6 +85,11 @@ templates:
     writer: json
     variables: "model=tinted_cross;txname=cross"
     name: "@MODASSETSROOT/models/block/@registryname.json"
+  - template: json/block.json.ftl
+    condition: "renderType() #= 150"
+    writer: json
+    name: "@MODASSETSROOT/models/block/@registryname.json"
+    variables: "model=tinted_flower_pot_cross;txname=plant"
   - template: json/block_cmodel.json.ftl
     condition: "renderType() #= 2"
     writer: json

--- a/plugins/generator-1.21.1/neoforge-1.21.1/block.definition.yaml
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/block.definition.yaml
@@ -507,6 +507,8 @@ tags:
     condition: "${data.blockBase! == 'Wall'}"
   - tag: BLOCKS:minecraft:leaves
     condition: "${data.blockBase! == 'Leaves'}"
+  - tag: BLOCKS:minecraft:flower_pots
+    condition: "${data.blockBase! == 'FlowerPot'}"
 
   - tag: BLOCKS:minecraft:replaceable
     condition: isReplaceable

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/block/block.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/block/block.java.ftl
@@ -210,6 +210,9 @@ public class ${name}Block extends
 				super(BlockSetType.${data.blockSetType}, <#if data.blockSetType == "OAK">30<#else>20</#if>, <@blockProperties/>);
 			<#elseif data.blockBase == "FenceGate">
 				super(WoodType.OAK, <@blockProperties/>);
+			<#elseif data.blockBase == "FlowerPot">
+				super(() -> (FlowerPotBlock) Blocks.FLOWER_POT, () -> ${mappedBlockToBlock(data.pottedPlant)}, <@blockProperties/>);
+				((FlowerPotBlock) Blocks.FLOWER_POT).addPlant(ResourceLocation.parse("${mappedMCItemToRegistryName(data.pottedPlant)}"), () -> this);
 			<#else>
 				super(<@blockProperties/>);
 			</#if>
@@ -482,7 +485,7 @@ public class ${name}Block extends
 	@Override public ItemStack getCloneItemStack(LevelReader level, BlockPos pos, BlockState state) {
 		return ${mappedMCItemToItemStackCode(data.creativePickItem, 1)};
 	}
-	<#elseif !data.hasBlockItem>
+	<#elseif !data.hasBlockItem && (data.blockBase! != "FlowerPot")>
 	@Override public ItemStack getCloneItemStack(LevelReader level, BlockPos pos, BlockState state) {
 		return ItemStack.EMPTY;
 	}

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/json/block_loot_table.json.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/json/block_loot_table.json.ftl
@@ -1,10 +1,28 @@
 <#include "../mcitems.ftl">
 <#assign defaultSlabDrops = data.getModElement().getTypeString() == "block" && data.blockBase?has_content && data.blockBase == "Slab" && !(data.customDrop?? && !data.customDrop.isEmpty())/>
+<#assign isFlowerPot = data.getModElement().getTypeString() == "block" && data.blockBase! == "FlowerPot">
 {
   "type": "minecraft:block",
   "random_sequence": "${modid}:blocks/${registryname}"
-  <#if data.hasDrops()>,
+  <#if data.hasDrops() || isFlowerPot>,
   "pools": [
+    <#if isFlowerPot>
+    {
+      "rolls": 1.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:flower_pot"
+        }
+      ]
+    }<#if data.dropAmount != 0>,</#if>
+    </#if>
+    <#if data.hasDrops()>
     {
       "rolls": 1.0,
       <#if data.dropAmount == 1 && !defaultSlabDrops>
@@ -17,7 +35,9 @@
       "entries": [
         {
           "type": "minecraft:item",
-          "name": <#if data.customDrop?? && !data.customDrop.isEmpty()>"${mappedMCItemToRegistryName(data.customDrop)}"<#else>"${modid}:${registryname}"</#if>
+          "name": <#if data.customDrop?? && !data.customDrop.isEmpty()>"${mappedMCItemToRegistryName(data.customDrop)}"
+            <#elseif isFlowerPot>"${mappedMCItemToRegistryName(data.pottedPlant)}"
+            <#else>"${modid}:${registryname}"</#if>
           <#if data.isDoubleBlock()>,
           "conditions": [
             {
@@ -62,6 +82,7 @@
         }
       ]
     }
+    </#if>
   ]
   </#if>
 }

--- a/plugins/generator-1.21.8/neoforge-1.21.8/block.definition.yaml
+++ b/plugins/generator-1.21.8/neoforge-1.21.8/block.definition.yaml
@@ -33,7 +33,7 @@ templates:
   - template: json/block_item.json.ftl
     condition:
       - hasBlockItem
-      - "renderType() #?= 10,11,12,14,110,120,2,4"
+      - "renderType() #?= 10,11,12,14,15,110,120,150,2,4"
     writer: json
     name: "@MODASSETSROOT/models/item/@registryname.json"
   - template: json/block_item_cmodel.json.ftl
@@ -75,6 +75,11 @@ templates:
     writer: json
     name: "@MODASSETSROOT/models/block/@registryname.json"
   - template: json/block.json.ftl
+    condition: "renderType() #= 15"
+    writer: json
+    name: "@MODASSETSROOT/models/block/@registryname.json"
+    variables: "model=flower_pot_cross;txname=plant"
+  - template: json/block.json.ftl
     condition: "renderType() #= 110"
     writer: json
     variables: "model=leaves;txname=all"
@@ -84,6 +89,11 @@ templates:
     writer: json
     variables: "model=tinted_cross;txname=cross"
     name: "@MODASSETSROOT/models/block/@registryname.json"
+  - template: json/block.json.ftl
+    condition: "renderType() #= 150"
+    writer: json
+    name: "@MODASSETSROOT/models/block/@registryname.json"
+    variables: "model=tinted_flower_pot_cross;txname=plant"
   - template: json/block_cmodel.json.ftl
     condition: "renderType() #= 2"
     writer: json

--- a/plugins/generator-1.21.8/neoforge-1.21.8/block.definition.yaml
+++ b/plugins/generator-1.21.8/neoforge-1.21.8/block.definition.yaml
@@ -511,6 +511,8 @@ tags:
     condition: "${data.blockBase! == 'Wall'}"
   - tag: BLOCKS:minecraft:leaves
     condition: "${data.blockBase! == 'Leaves'}"
+  - tag: BLOCKS:minecraft:flower_pots
+    condition: "${data.blockBase! == 'FlowerPot'}"
 
   - tag: BLOCKS:minecraft:replaceable
     condition: isReplaceable

--- a/plugins/generator-1.21.8/neoforge-1.21.8/templates/block/block.java.ftl
+++ b/plugins/generator-1.21.8/neoforge-1.21.8/templates/block/block.java.ftl
@@ -213,6 +213,9 @@ public class ${name}Block extends
 				super(BlockSetType.${data.blockSetType}, <#if data.blockSetType == "OAK">30<#else>20</#if>, <@blockProperties/>);
 			<#elseif data.blockBase == "FenceGate">
 				super(WoodType.OAK, <@blockProperties/>);
+			<#elseif data.blockBase == "FlowerPot">
+				super(() -> (FlowerPotBlock) Blocks.FLOWER_POT, () -> ${mappedBlockToBlock(data.pottedPlant)}, <@blockProperties/>);
+				((FlowerPotBlock) Blocks.FLOWER_POT).addPlant(ResourceLocation.parse("${mappedMCItemToRegistryName(data.pottedPlant)}"), () -> this);
 			<#else>
 				super(<@blockProperties/>);
 			</#if>
@@ -483,7 +486,7 @@ public class ${name}Block extends
 	@Override public ItemStack getCloneItemStack(LevelReader world, BlockPos pos, BlockState state, boolean includeData, Player entity) {
 		return ${mappedMCItemToItemStackCode(data.creativePickItem, 1)};
 	}
-	<#elseif !data.hasBlockItem>
+	<#elseif !data.hasBlockItem && (data.blockBase! != "FlowerPot")>
 	@Override public ItemStack getCloneItemStack(LevelReader world, BlockPos pos, BlockState state, boolean includeData, Player entity) {
 		return ItemStack.EMPTY;
 	}

--- a/plugins/generator-1.21.8/neoforge-1.21.8/templates/json/block_loot_table.json.ftl
+++ b/plugins/generator-1.21.8/neoforge-1.21.8/templates/json/block_loot_table.json.ftl
@@ -1,10 +1,28 @@
 <#include "../mcitems.ftl">
 <#assign defaultSlabDrops = data.getModElement().getTypeString() == "block" && data.blockBase?has_content && data.blockBase == "Slab" && !(data.customDrop?? && !data.customDrop.isEmpty())/>
+<#assign isFlowerPot = data.getModElement().getTypeString() == "block" && data.blockBase! == "FlowerPot">
 {
   "type": "minecraft:block",
   "random_sequence": "${modid}:blocks/${registryname}"
-  <#if data.hasDrops()>,
+  <#if data.hasDrops() || isFlowerPot>,
   "pools": [
+    <#if isFlowerPot>
+    {
+      "rolls": 1.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:flower_pot"
+        }
+      ]
+    }<#if data.dropAmount != 0>,</#if>
+    </#if>
+    <#if data.hasDrops()>
     {
       "rolls": 1.0,
       <#if data.dropAmount == 1 && !defaultSlabDrops>
@@ -19,6 +37,14 @@
           <#if data.customDrop?? && !data.customDrop.isEmpty()>
             <#assign dropItem = mappedMCItemToRegistryName(data.customDrop)>
             <#if data.customDrop.isAir() || dropItem == "minecraft:air">
+            "type": "minecraft:empty"
+            <#else>
+            "type": "minecraft:item",
+            "name": "${dropItem}"
+            </#if>
+          <#elseif isFlowerPot>
+            <#assign dropItem = mappedMCItemToRegistryName(data.pottedPlant)>
+            <#if data.pottedPlant.isAir() || dropItem == "minecraft:air">
             "type": "minecraft:empty"
             <#else>
             "type": "minecraft:item",
@@ -72,6 +98,7 @@
         }
       ]
     }
+    </#if>
   ]
   </#if>
 }

--- a/plugins/mcreator-localization/help/default/block/potted_plant.md
+++ b/plugins/mcreator-localization/help/default/block/potted_plant.md
@@ -1,0 +1,1 @@
+This parameter controls what block is inside the flower pot.

--- a/plugins/mcreator-localization/lang/texts.properties
+++ b/plugins/mcreator-localization/lang/texts.properties
@@ -2403,6 +2403,7 @@ elementgui.block.block_set_type=<html>Block set type:<br><small>Determines prope
 elementgui.block.block_set_type.oak=Wood
 elementgui.block.block_set_type.stone=Stone
 elementgui.block.block_set_type.iron=Iron
+elementgui.block.potted_plant=Potted plant:
 elementgui.block.item_texture=<html>Block item texture:<br><small>Optional texture for block in inventory and hand rendering
 elementgui.block.particle_texture=<html>Block particle texture:<br><small>Optional texture for block breaking particles
 elementgui.block.block_textures_and_model=Block textures and model

--- a/src/main/java/net/mcreator/element/types/Block.java
+++ b/src/main/java/net/mcreator/element/types/Block.java
@@ -71,6 +71,7 @@ import java.util.stream.Collectors;
 
 	public String blockBase;
 	public String blockSetType;
+	public MItemBlock pottedPlant;
 
 	public String tintType;
 	public boolean isItemTinted;
@@ -248,7 +249,7 @@ import java.util.stream.Collectors;
 	}
 
 	public int renderType() {
-		if (blockBase != null && !blockBase.isEmpty())
+		if (blockBase != null && !blockBase.isEmpty() && !blockBase.equals("FlowerPot"))
 			return -1;
 		return renderType;
 	}
@@ -288,7 +289,8 @@ import java.util.stream.Collectors;
 	@Override public boolean isFullCube() {
 		if ("Stairs".equals(blockBase) || "Slab".equals(blockBase) || "Fence".equals(blockBase) || "Wall".equals(
 				blockBase) || "TrapDoor".equals(blockBase) || "Door".equals(blockBase) || "FenceGate".equals(blockBase)
-				|| "EndRod".equals(blockBase) || "PressurePlate".equals(blockBase) || "Button".equals(blockBase))
+				|| "EndRod".equals(blockBase) || "PressurePlate".equals(blockBase) || "Button".equals(blockBase)
+				|| "FlowerPot".equals(blockBase))
 			return false;
 
 		return IBlockWithBoundingBox.super.isFullCube();

--- a/src/main/java/net/mcreator/element/types/Block.java
+++ b/src/main/java/net/mcreator/element/types/Block.java
@@ -283,7 +283,7 @@ import java.util.stream.Collectors;
 	}
 
 	public boolean hasDrops() {
-		return dropAmount > 0 && (hasBlockItem || hasCustomDrop());
+		return dropAmount > 0 && (hasBlockItem || hasCustomDrop() || "FlowerPot".equals(blockBase));
 	}
 
 	@Override public boolean isFullCube() {

--- a/src/main/java/net/mcreator/minecraft/ElementUtil.java
+++ b/src/main/java/net/mcreator/minecraft/ElementUtil.java
@@ -144,6 +144,23 @@ public class ElementUtil {
 	}
 
 	/**
+	 * Loads all blocks with an item form, without those that are wildcard elements to subtypes
+	 * (wood: oak wood, cherry wood, ...), so only oak wood, cherry wood, ... are loaded, without wildcard wood element
+	 *
+	 * @return All Blocks from both Minecraft and custom elements with or without metadata
+	 */
+	public static List<MCItem> loadBlocksWithItemForm(Workspace workspace) {
+		List<MCItem> elements = new ArrayList<>();
+		workspace.getModElements().forEach(modElement -> elements.addAll(modElement.getMCItems()));
+		elements.sort(MCItem.getComparator(workspace, elements)); // sort custom elements
+		elements.addAll(
+				DataListLoader.loadDataList("blocksitems").stream().map(e -> (MCItem) e).filter(MCItem::hasNoSubtypes)
+						.toList());
+		return elements.stream().filter(typeMatches("block")).filter(e -> e.isSupportedInWorkspace(workspace))
+				.collect(Collectors.toList());
+	}
+
+	/**
 	 * Loads all mod elements and all Minecraft blocks, including those that
 	 * are wildcard elements to subtypes (wood: oak wood, cherry wood, ...)
 	 *

--- a/src/main/java/net/mcreator/ui/modgui/BlockGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/BlockGUI.java
@@ -262,7 +262,7 @@ public class BlockGUI extends ModElementGUI<Block> {
 	private final ValidationGroup page3group = new ValidationGroup();
 
 	public static final List<String> blockBases = List.of("Stairs", "Slab", "Fence", "Wall", "Leaves", "TrapDoor",
-			"Pane", "Door", "FenceGate", "EndRod", "PressurePlate", "Button");
+			"Pane", "Door", "FenceGate", "EndRod", "PressurePlate", "Button", "FlowerPot");
 	private final SearchableComboBox<String> blockBase = new SearchableComboBox<>(
 			ListUtils.merge(List.of("Default basic block"), blockBases));
 	private final JComboBox<String> blockSetType = new TranslatedComboBox(
@@ -272,7 +272,9 @@ public class BlockGUI extends ModElementGUI<Block> {
 			Map.entry("IRON", "elementgui.block.block_set_type.iron")
 			//@formatter:on
 	);
+	private final MCItemHolder pottedPlant = new MCItemHolder(mcreator, ElementUtil::loadBlocks);
 	private JComponent blockSetTypePanel;
+	private JComponent flowerPotPanel;
 
 	private final JCheckBox ignitedByLava = L10N.checkbox("elementgui.common.enable");
 	private final JSpinner flammability = new JSpinner(new SpinnerNumberModel(0, 0, 1024, 1));
@@ -426,6 +428,12 @@ public class BlockGUI extends ModElementGUI<Block> {
 			hasTransparency.setEnabled(true);
 			connectedSides.setEnabled(true);
 			blockSetTypePanel.setVisible(false);
+			flowerPotPanel.setVisible(false);
+			// Re-enable block item if user switches from flower pot to any other block base option
+			if (!isEditingMode() && !hasBlockItem.isSelected()) {
+				hasBlockItem.setSelected(true);
+				updateBlockItemSettings();
+			}
 
 			if (hasBlockBase) {
 				rotationMode.setSelectedIndex(0);
@@ -493,6 +501,22 @@ public class BlockGUI extends ModElementGUI<Block> {
 						reactionToPushing.setSelectedItem("DESTROY");
 					}
 				}
+				case "FlowerPot" -> {
+					flowerPotPanel.setVisible(true);
+					renderType.setEnabled(true);
+					if (!isEditingMode()) {
+						renderType.setSelectedItem(pottedPlantModel);
+						hasBlockItem.setSelected(false);
+						updateBlockItemSettings();
+						lightOpacity.setValue(0);
+						hasTransparency.setSelected(true);
+						transparencyType.setSelectedItem("CUTOUT");
+						hardness.setValue(0d);
+						resistance.setValue(0d);
+						soundOnStep.setSelectedItem("STONE");
+						reactionToPushing.setSelectedItem("DESTROY");
+					}
+				}
 				default -> {
 					if (!isEditingMode()) {
 						lightOpacity.setValue(0);
@@ -547,7 +571,12 @@ public class BlockGUI extends ModElementGUI<Block> {
 				HelpUtils.wrapWithHelpButton(this.withEntry("block/block_set_type"),
 						L10N.label("elementgui.block.block_set_type")), blockSetType));
 
+		txblock4.add(flowerPotPanel = PanelUtils.gridElements(1, 2, 2, 2,
+				HelpUtils.wrapWithHelpButton(this.withEntry("block/potted_plant"),
+						L10N.label("elementgui.block.potted_plant")), PanelUtils.centerInPanel(pottedPlant)));
+
 		blockSetTypePanel.setVisible(false);
+		flowerPotPanel.setVisible(false);
 		plantsGrowOn.setOpaque(false);
 
 		textures = new BlockTexturesSelector(mcreator);
@@ -1639,6 +1668,7 @@ public class BlockGUI extends ModElementGUI<Block> {
 			blockBase.setSelectedItem(block.blockBase);
 		}
 		blockSetType.setSelectedItem(block.blockSetType);
+		pottedPlant.setBlock(block.pottedPlant);
 
 		plantsGrowOn.setSelected(block.plantsGrowOn);
 		hasInventory.setSelected(block.hasInventory);
@@ -1853,6 +1883,7 @@ public class BlockGUI extends ModElementGUI<Block> {
 		if (blockBase.getSelectedIndex() != 0)
 			block.blockBase = blockBase.getSelectedItem();
 		block.blockSetType = (String) blockSetType.getSelectedItem();
+		block.pottedPlant = pottedPlant.getBlock();
 
 		Model model = Objects.requireNonNull(renderType.getSelectedItem());
 		block.renderType = 10;

--- a/src/main/java/net/mcreator/ui/modgui/BlockGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/BlockGUI.java
@@ -273,7 +273,7 @@ public class BlockGUI extends ModElementGUI<Block> {
 			Map.entry("IRON", "elementgui.block.block_set_type.iron")
 			//@formatter:on
 	);
-	private final MCItemHolder pottedPlant = new MCItemHolder(mcreator, ElementUtil::loadBlocks);
+	private final MCItemHolder pottedPlant = new MCItemHolder(mcreator, ElementUtil::loadBlocksWithItemForm);
 	private JComponent blockSetTypePanel;
 	private JComponent flowerPotPanel;
 

--- a/src/main/java/net/mcreator/ui/modgui/BlockGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/BlockGUI.java
@@ -54,6 +54,7 @@ import net.mcreator.ui.procedure.NumberProcedureSelector;
 import net.mcreator.ui.procedure.ProcedureSelector;
 import net.mcreator.ui.procedure.StringListProcedureSelector;
 import net.mcreator.ui.validation.ValidationGroup;
+import net.mcreator.ui.validation.Validator;
 import net.mcreator.ui.validation.component.VTextField;
 import net.mcreator.ui.validation.validators.*;
 import net.mcreator.ui.workspace.resources.TextureType;
@@ -1351,6 +1352,7 @@ public class BlockGUI extends ModElementGUI<Block> {
 
 		page1group.addValidationElement(textures);
 		page1group.addValidationElement(itemTexture);
+		page1group.addValidationElement(pottedPlant);
 
 		itemTexture.setValidator(new TextureSelectionButtonValidator(itemTexture, () -> {
 			Model model = renderType.getSelectedItem();
@@ -1359,6 +1361,14 @@ public class BlockGUI extends ModElementGUI<Block> {
 
 		name.setValidator(new TextFieldValidator(name, L10N.t("elementgui.block.error_block_must_have_name")));
 		name.enableRealtimeValidation();
+
+		pottedPlant.setValidator(new MCItemHolderValidator(pottedPlant) {
+			@Override public ValidationResult validate() {
+				if (!"FlowerPot".equals(blockBase.getSelectedItem()))
+					return Validator.ValidationResult.PASSED;
+				return super.validate();
+			}
+		});
 
 		page3group.addValidationElement(name);
 

--- a/src/main/java/net/mcreator/ui/modgui/BlockGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/BlockGUI.java
@@ -230,8 +230,9 @@ public class BlockGUI extends ModElementGUI<Block> {
 	private final Model cross = new Model.BuiltInModel("Cross model");
 	private final Model crop = new Model.BuiltInModel("Crop model");
 	private final Model grassBlock = new Model.BuiltInModel("Grass block");
+	private final Model pottedPlantModel = new Model.BuiltInModel("Potted plant");
 	private final SearchableComboBox<Model> renderType = new SearchableComboBox<>(
-			new Model[] { normal, singleTexture, cross, crop, grassBlock });
+			new Model[] { normal, singleTexture, cross, crop, grassBlock, pottedPlantModel });
 
 	private JBlockPropertiesStatesList blockStates;
 	private final Map<?, ?> blockBaseProperties = Objects.requireNonNullElse(
@@ -1295,6 +1296,8 @@ public class BlockGUI extends ModElementGUI<Block> {
 				}
 				if (!isEditingMode() && selected.equals(grassBlock)) {
 					transparencyType.setSelectedItem("CUTOUT_MIPPED");
+				} else if (!isEditingMode() && selected.equals(pottedPlantModel)) {
+					transparencyType.setSelectedItem("CUTOUT");
 				}
 			}
 		});
@@ -1538,7 +1541,7 @@ public class BlockGUI extends ModElementGUI<Block> {
 		animations.reloadDataLists();
 
 		ComboBoxUtil.updateComboBoxContents(renderType,
-				ListUtils.merge(Arrays.asList(normal, singleTexture, cross, crop, grassBlock),
+				ListUtils.merge(Arrays.asList(normal, singleTexture, cross, crop, grassBlock, pottedPlantModel),
 						Model.getModelsWithTextureMaps(mcreator.getWorkspace()).stream()
 								.filter(el -> el.getType() == Model.Type.JSON || el.getType() == Model.Type.OBJ)
 								.collect(Collectors.toList()), Model.getJavaModels(mcreator.getWorkspace())));
@@ -1867,6 +1870,8 @@ public class BlockGUI extends ModElementGUI<Block> {
 			block.renderType = 13;
 		else if (model.equals(grassBlock))
 			block.renderType = 14;
+		else if (model.equals(pottedPlantModel))
+			block.renderType = "No tint".equals(tintType.getSelectedItem()) ? 15 : 150;
 		block.customModelName = model.getReadableName();
 
 		return block;

--- a/src/test/java/net/mcreator/integration/TestWorkspaceDataProvider.java
+++ b/src/test/java/net/mcreator/integration/TestWorkspaceDataProvider.java
@@ -1922,6 +1922,7 @@ public class TestWorkspaceDataProvider {
 		var blocksAndItems = ElementUtil.loadBlocksAndItems(modElement.getWorkspace());
 		var blocks = ElementUtil.loadBlocks(modElement.getWorkspace());
 		var blocksAndTags = ElementUtil.loadBlocksAndTags(modElement.getWorkspace());
+		var blocksWithItemForm = ElementUtil.loadBlocksWithItemForm(modElement.getWorkspace());
 		var biomes = ElementUtil.loadAllBiomes(modElement.getWorkspace());
 		var tabs = ElementUtil.loadAllTabs(modElement.getWorkspace()).stream()
 				.map(e -> new TabEntry(modElement.getWorkspace(), e)).toList();
@@ -2044,6 +2045,8 @@ public class TestWorkspaceDataProvider {
 		block.speedFactor = 34.632;
 		block.jumpFactor = 17.732;
 		block.blockSetType = getRandomItem(random, new String[] { "OAK", "STONE", "IRON" });
+		block.pottedPlant = new MItemBlock(modElement.getWorkspace(),
+				getRandomMCItem(random, blocksWithItemForm).getName());
 		block.tickRate = _true ? 0 : 24;
 		block.isCustomSoundType = !_true;
 		block.soundOnStep = new StepSound(modElement.getWorkspace(),


### PR DESCRIPTION
This PR adds a block base for potted plants.
Unlike other block bases, the block model isn't fixed. This allows for plants with custom potted model (similar to cactus, azalea etc.)

<img width="854" height="480" alt="potted plants" src="https://github.com/user-attachments/assets/5f688b27-ebbf-4a4d-bebd-d936a6c16568" />
