### PR TITLE
Splash screen text slisibility improvement and warning in workspaces

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,5 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Environment-dependent path to Maven home directory
+/mavenHomeManager.xml

--- a/.idea/MCreator-modification.iml
+++ b/.idea/MCreator-modification.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -58,7 +58,7 @@
   <component name="PWA">
     <option name="wasEnabledAtLeastOnce" value="true" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="mcreator_sdk21" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" project-jdk-name="mcreator_sdk21" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/out" />
   </component>
 </project>

--- a/src/main/java/net/mcreator/ui/SplashScreen.java
+++ b/src/main/java/net/mcreator/ui/SplashScreen.java
@@ -31,6 +31,7 @@ import java.awt.image.BaseMultiResolutionImage;
 public class SplashScreen extends JWindow {
 
 	private final ProgressBar initloadprogress = new ProgressBar();
+	int currentInitialLoadProgressValue = 0;
 	private final JLabel loadstate = new JLabel();
 
 	private final static int CORNER_RADIUS = 10;
@@ -51,10 +52,10 @@ public class SplashScreen extends JWindow {
 		imagePanel.add(pylo);
 
 		JLabel label = new JLabel(
-				"<html><p>MCreator is a Minecraft mod making toolkit developed by Pylo. Minecraft is a</p>"
-						+ "<p style='margin-top:-2'>registered trademark of Mojang. MCreator is not an official Minecraft product.</p>"
-						+ "<p style='margin-top:-2'>It is not approved by or associated with Mojang or Microsoft.</p>");
-		label.setFont(splashFont.deriveFont(10f));
+				"<html><p><strong>MCreator is a Minecraft mod making toolkit developed by Pylo. Minecraft is a</strong></p>"
+						+ "<p style='margin-top:-2'><strong>registered trademark of Mojang. MCreator is not an official Minecraft product.</strong></p>"
+						+ "<p style='margin-top:-2'><strong>It is not approved by or associated with Mojang or Microsoft.</strong></p>");
+		label.setFont(splashFont.deriveFont(10.0f));
 		label.setForeground(Color.white);
 		label.setBounds(shadowPadding + 30 + 10 - 4, shadowPadding + 330 - 10 - 10, 500, 45);
 		imagePanel.add(label);
@@ -82,10 +83,10 @@ public class SplashScreen extends JWindow {
 		initloadprogress.setForeground(Color.white);
 		initloadprogress.setMaximalValue(100);
 		initloadprogress.init();
-		initloadprogress.setBounds(shadowPadding + 30 + 10 - 4, shadowPadding + 283 - 10, 568, 3);
+		initloadprogress.setBounds(shadowPadding + 30 + 10 - 4, shadowPadding + 283 - 10, 568, 5);
 		imagePanel.add(initloadprogress);
 
-		loadstate.setFont(splashFont.deriveFont(12f));
+		loadstate.setFont(splashFont.deriveFont(13.0f));
 		loadstate.setForeground(Color.white);
 		loadstate.setBounds(shadowPadding + 30 + 10 - 4, shadowPadding + 283 - 39 - 10, 500, 45);
 		imagePanel.add(loadstate);
@@ -110,8 +111,22 @@ public class SplashScreen extends JWindow {
 
 	public void setProgress(int percentage, String message) {
 		SwingUtilities.invokeLater(() -> {
-			initloadprogress.setCurrentValue(percentage);
+
 			loadstate.setText(message);
+			new Thread(() -> {
+				loadstate.setText(message);
+				while (currentInitialLoadProgressValue < percentage) {
+					currentInitialLoadProgressValue++;
+					initloadprogress.setCurrentValue(currentInitialLoadProgressValue);
+					try {
+						Thread.sleep(5);
+					} catch (Exception e) {
+					}
+
+				}
+
+			}).start();
+
 		});
 	}
 

--- a/src/main/java/net/mcreator/ui/component/ProgressBar.java
+++ b/src/main/java/net/mcreator/ui/component/ProgressBar.java
@@ -32,9 +32,9 @@ public class ProgressBar extends JPanel {
 
 		g.setColor(Color.white);
 		if (curr >= 0 && wid == -1 && max != 0)
-			g.fillRect(0, 0, (int) (((double) getWidth() / ((double) max)) * (double) curr), getHeight());
+			g.fillRoundRect(0, 0, (int) (((double) getWidth() / ((double) max)) * (double) curr), getHeight(), 3, 3);
 		else if (max != 0 && curr >= 0)
-			g.fillRect(0, 0, wid, getHeight());
+			g.fillRoundRect(0, 0, wid, getHeight(), 3, 3);
 	}
 
 	public void setMaximalValue(int max) {

--- a/src/main/java/net/mcreator/ui/workspace/selector/WorkspaceSelector.java
+++ b/src/main/java/net/mcreator/ui/workspace/selector/WorkspaceSelector.java
@@ -253,8 +253,20 @@ public final class WorkspaceSelector extends JFrame implements DropTargetListene
 					removeRecentWorkspace(defaultListModel.elementAt(idx));
 					reloadRecents();
 				} else if (mouseEvent.getClickCount() == 2) {
-					workspaceOpenListener.workspaceOpened(recentsList.getSelectedValue().getPath());
-				}
+
+					// if the version is different, show the conform dialog
+					if (!recentsList.getSelectedValue().getMCRVersion().startsWith(Launcher.version.getMajorString())) {
+						int workspaceOpenConfirmResult = JOptionPane.showConfirmDialog(new JOptionPane(), "This workspace" +
+								" has been created or last used in a different or previous MCreator version. Opening it may break" +
+								" stuff if it has dependencies on plugins or components that have not been updated. Are you sure you" +
+								" want to continue?", "Open workspace", JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
+
+						if (workspaceOpenConfirmResult == JOptionPane.YES_OPTION)  {
+							workspaceOpenListener.workspaceOpened(recentsList.getSelectedValue().getPath());
+						}
+					} else {
+						workspaceOpenListener.workspaceOpened(recentsList.getSelectedValue().getPath());
+				}	}
 			}
 		});
 		recentsList.addKeyListener(new KeyAdapter() {


### PR DESCRIPTION
- Improved lisibility of the texts on the splash screen
- Progress bar a little bit bigger on the splash screen
- Warning appears when trying to open a workspace that has been last used in a different MCreator version

<img width="806" height="484" alt="SplashScreenshot" src="https://github.com/user-attachments/assets/6a7c97e3-3c52-4ac2-adc7-bbd0a1fe865c" />

<img width="642" height="204" alt="WarningScreenshot" src="https://github.com/user-attachments/assets/d2467728-d2fc-412e-80ce-4c9bc8dc8a03" />
