### PR TITLE
New additional options to workspace creation menu

### DIFF
--- a/src/main/java/net/mcreator/ui/dialogs/workspace/AddonWorkspacePanel.java
+++ b/src/main/java/net/mcreator/ui/dialogs/workspace/AddonWorkspacePanel.java
@@ -34,6 +34,12 @@ public class AddonWorkspacePanel extends AbstractWorkspacePanel {
 
 		addFormElement(new JEmptyBox(20, 20));
 
+		JLabel requiredModInfosLabel = new JLabel("Required add-on infos");
+		requiredModInfosLabel.setFont(new Font("Sans-Serif", Font.BOLD, 18));
+		addFormElement(PanelUtils.westAndEastElement(requiredModInfosLabel, new JEmptyBox(0, 0)));
+
+		addFormElement(new JEmptyBox(15, 15));
+
 		addFormElement(PanelUtils.westAndEastElement(L10N.label("dialog.new_workspace.addon.display_name"),
 				workspaceDialogPanel.modName));
 
@@ -51,6 +57,28 @@ public class AddonWorkspacePanel extends AbstractWorkspacePanel {
 
 		addFormElement(PanelUtils.westAndEastElement(L10N.label("dialog.new_workspace.addon.folder"),
 				PanelUtils.centerAndEastElement(workspaceFolder, selectWorkspaceFolder, 0, 0)));
+
+		addFormElement(new JEmptyBox(10, 10));
+
+		JLabel additionalModInfosLabel = new JLabel("Additional add-on infos");
+		additionalModInfosLabel.setFont(new Font("Sans-Serif", Font.BOLD, 18));
+
+		addFormElement(PanelUtils.westAndEastElement(additionalModInfosLabel, new JEmptyBox(0, 0)));
+
+		addFormElement(new JEmptyBox(15, 15));
+
+		addFormElement(PanelUtils.westAndEastElement(L10N.label("dialog.workspace_settings.author"),
+				workspaceDialogPanel.author));
+
+		addFormElement(new JEmptyBox(10, 10));
+
+		addFormElement(PanelUtils.westAndEastElement(L10N.label("dialog.workspace_settings.description"),
+				workspaceDialogPanel.description));
+
+		addFormElement(new JEmptyBox(5, 5));
+
+		addFormElement(PanelUtils.westAndEastElement(L10N.label("dialog.workspace_settings.license"),
+				workspaceDialogPanel.license));
 
 		addNotice(UIRES.get("18px.warning"), "dialog.new_workspace.addon.notice1");
 		addNotice(UIRES.get("18px.info"), "dialog.new_workspace.addon.notice2");

--- a/src/main/java/net/mcreator/ui/dialogs/workspace/AddonWorkspacePanel.java
+++ b/src/main/java/net/mcreator/ui/dialogs/workspace/AddonWorkspacePanel.java
@@ -75,7 +75,7 @@ public class AddonWorkspacePanel extends AbstractWorkspacePanel {
 		addFormElement(PanelUtils.westAndEastElement(L10N.label("dialog.workspace_settings.description"),
 				workspaceDialogPanel.description));
 
-		addFormElement(new JEmptyBox(5, 5));
+		addFormElement(new JEmptyBox(10, 10));
 
 		addFormElement(PanelUtils.westAndEastElement(L10N.label("dialog.workspace_settings.license"),
 				workspaceDialogPanel.license));

--- a/src/main/java/net/mcreator/ui/dialogs/workspace/DatapackWorkspacePanel.java
+++ b/src/main/java/net/mcreator/ui/dialogs/workspace/DatapackWorkspacePanel.java
@@ -75,7 +75,7 @@ public class DatapackWorkspacePanel extends AbstractWorkspacePanel {
 		addFormElement(PanelUtils.westAndEastElement(L10N.label("dialog.workspace_settings.description"),
 				workspaceDialogPanel.description));
 
-		addFormElement(new JEmptyBox(5, 5));
+		addFormElement(new JEmptyBox(10, 10));
 
 		addFormElement(PanelUtils.westAndEastElement(L10N.label("dialog.workspace_settings.license"),
 				workspaceDialogPanel.license));

--- a/src/main/java/net/mcreator/ui/dialogs/workspace/DatapackWorkspacePanel.java
+++ b/src/main/java/net/mcreator/ui/dialogs/workspace/DatapackWorkspacePanel.java
@@ -34,6 +34,12 @@ public class DatapackWorkspacePanel extends AbstractWorkspacePanel {
 
 		addFormElement(new JEmptyBox(20, 20));
 
+		JLabel requiredModInfosLabel = new JLabel("Required datapack infos");
+		requiredModInfosLabel.setFont(new Font("Sans-Serif", Font.BOLD, 18));
+		addFormElement(PanelUtils.westAndEastElement(requiredModInfosLabel, new JEmptyBox(0, 0)));
+
+		addFormElement(new JEmptyBox(15, 15));
+
 		addFormElement(PanelUtils.westAndEastElement(L10N.label("dialog.new_workspace.datapack.display_name"),
 				workspaceDialogPanel.modName));
 
@@ -51,6 +57,28 @@ public class DatapackWorkspacePanel extends AbstractWorkspacePanel {
 
 		addFormElement(PanelUtils.westAndEastElement(L10N.label("dialog.new_workspace.datapack.folder"),
 				PanelUtils.centerAndEastElement(workspaceFolder, selectWorkspaceFolder, 0, 0)));
+
+		addFormElement(new JEmptyBox(10, 10));
+
+		JLabel additionalModInfosLabel = new JLabel("Additional datapack infos");
+		additionalModInfosLabel.setFont(new Font("Sans-Serif", Font.BOLD, 18));
+
+		addFormElement(PanelUtils.westAndEastElement(additionalModInfosLabel, new JEmptyBox(0, 0)));
+
+		addFormElement(new JEmptyBox(15, 15));
+
+		addFormElement(PanelUtils.westAndEastElement(L10N.label("dialog.workspace_settings.author"),
+				workspaceDialogPanel.author));
+
+		addFormElement(new JEmptyBox(10, 10));
+
+		addFormElement(PanelUtils.westAndEastElement(L10N.label("dialog.workspace_settings.description"),
+				workspaceDialogPanel.description));
+
+		addFormElement(new JEmptyBox(5, 5));
+
+		addFormElement(PanelUtils.westAndEastElement(L10N.label("dialog.workspace_settings.license"),
+				workspaceDialogPanel.license));
 
 		addNotice(UIRES.get("18px.info"), "dialog.new_workspace.datapack.notice");
 

--- a/src/main/java/net/mcreator/ui/dialogs/workspace/FabricWorkspacePanel.java
+++ b/src/main/java/net/mcreator/ui/dialogs/workspace/FabricWorkspacePanel.java
@@ -79,7 +79,7 @@ public class FabricWorkspacePanel extends AbstractWorkspacePanel {
 		addFormElement(PanelUtils.westAndEastElement(L10N.label("dialog.workspace_settings.description"),
 				workspaceDialogPanel.description));
 
-		addFormElement(new JEmptyBox(5, 5));
+		addFormElement(new JEmptyBox(10, 10));
 
 		addFormElement(PanelUtils.westAndEastElement(L10N.label("dialog.workspace_settings.license"),
 				workspaceDialogPanel.license));

--- a/src/main/java/net/mcreator/ui/dialogs/workspace/FabricWorkspacePanel.java
+++ b/src/main/java/net/mcreator/ui/dialogs/workspace/FabricWorkspacePanel.java
@@ -34,6 +34,12 @@ public class FabricWorkspacePanel extends AbstractWorkspacePanel {
 
 		addFormElement(new JEmptyBox(20, 20));
 
+		JLabel requiredModInfosLabel = new JLabel("Required mod infos");
+		requiredModInfosLabel.setFont(new Font("Sans-Serif", Font.BOLD, 18));
+		addFormElement(PanelUtils.westAndEastElement(requiredModInfosLabel, new JEmptyBox(0, 0)));
+
+		addFormElement(new JEmptyBox(15, 15));
+
 		addFormElement(PanelUtils.westAndEastElement(L10N.label("dialog.new_workspace.fabric.display_name"),
 				workspaceDialogPanel.modName));
 
@@ -51,10 +57,32 @@ public class FabricWorkspacePanel extends AbstractWorkspacePanel {
 		addFormElement(PanelUtils.westAndEastElement(L10N.label("dialog.new_workspace.fabric.package"),
 				workspaceDialogPanel.packageName));
 
-		addFormElement(new JEmptyBox(30, 30));
+		addFormElement(new JEmptyBox(10, 10));
 
 		addFormElement(PanelUtils.westAndEastElement(L10N.label("dialog.new_workspace.fabric.folder"),
 				PanelUtils.centerAndEastElement(workspaceFolder, selectWorkspaceFolder, 0, 0)));
+
+		addFormElement(new JEmptyBox(10, 10));
+
+		JLabel additionalModInfosLabel = new JLabel("Additional mod infos");
+		additionalModInfosLabel.setFont(new Font("Sans-Serif", Font.BOLD, 18));
+
+		addFormElement(PanelUtils.westAndEastElement(additionalModInfosLabel, new JEmptyBox(0, 0)));
+
+		addFormElement(new JEmptyBox(15, 15));
+
+		addFormElement(PanelUtils.westAndEastElement(L10N.label("dialog.workspace_settings.author"),
+				workspaceDialogPanel.author));
+
+		addFormElement(new JEmptyBox(10, 10));
+
+		addFormElement(PanelUtils.westAndEastElement(L10N.label("dialog.workspace_settings.description"),
+				workspaceDialogPanel.description));
+
+		addFormElement(new JEmptyBox(5, 5));
+
+		addFormElement(PanelUtils.westAndEastElement(L10N.label("dialog.workspace_settings.license"),
+				workspaceDialogPanel.license));
 
 		addNotice(UIRES.get("18px.info"), "dialog.new_workspace.fabric.notice");
 

--- a/src/main/java/net/mcreator/ui/dialogs/workspace/ForgeWorkspacePanel.java
+++ b/src/main/java/net/mcreator/ui/dialogs/workspace/ForgeWorkspacePanel.java
@@ -24,6 +24,7 @@ import net.mcreator.ui.component.util.PanelUtils;
 import net.mcreator.ui.init.L10N;
 import net.mcreator.ui.init.UIRES;
 
+import javax.swing.*;
 import java.awt.*;
 
 public class ForgeWorkspacePanel extends AbstractWorkspacePanel {
@@ -32,6 +33,12 @@ public class ForgeWorkspacePanel extends AbstractWorkspacePanel {
 		super(parent, GeneratorFlavor.FORGE);
 
 		addFormElement(new JEmptyBox(20, 20));
+
+		JLabel requiredModInfosLabel = new JLabel("Required mod infos");
+		requiredModInfosLabel.setFont(new Font("Sans-Serif", Font.BOLD, 18));
+		addFormElement(PanelUtils.westAndEastElement(requiredModInfosLabel, new JEmptyBox(0, 0)));
+
+		addFormElement(new JEmptyBox(15, 15));
 
 		addFormElement(PanelUtils.westAndEastElement(L10N.label("dialog.new_workspace.forge.display_name"),
 				workspaceDialogPanel.modName));
@@ -51,10 +58,32 @@ public class ForgeWorkspacePanel extends AbstractWorkspacePanel {
 		addFormElement(PanelUtils.westAndEastElement(L10N.label("dialog.new_workspace.forge.package"),
 				workspaceDialogPanel.packageName));
 
-		addFormElement(new JEmptyBox(30, 30));
+		addFormElement(new JEmptyBox(10, 10));
 
 		addFormElement(PanelUtils.westAndEastElement(L10N.label("dialog.new_workspace.forge.folder"),
 				PanelUtils.centerAndEastElement(workspaceFolder, selectWorkspaceFolder, 0, 0)));
+
+		addFormElement(new JEmptyBox(10, 10));
+
+		JLabel additionalModInfosLabel = new JLabel("Additional mod infos");
+		additionalModInfosLabel.setFont(new Font("Sans-Serif", Font.BOLD, 18));
+
+		addFormElement(PanelUtils.westAndEastElement(additionalModInfosLabel, new JEmptyBox(0, 0)));
+
+		addFormElement(new JEmptyBox(15, 15));
+
+		addFormElement(PanelUtils.westAndEastElement(L10N.label("dialog.workspace_settings.author"),
+				workspaceDialogPanel.author));
+
+		addFormElement(new JEmptyBox(10, 10));
+
+		addFormElement(PanelUtils.westAndEastElement(L10N.label("dialog.workspace_settings.description"),
+				workspaceDialogPanel.description));
+
+		addFormElement(new JEmptyBox(5, 5));
+
+		addFormElement(PanelUtils.westAndEastElement(L10N.label("dialog.workspace_settings.license"),
+				workspaceDialogPanel.license));
 
 		addNotice(UIRES.get("18px.info"), "dialog.new_workspace.forge.notice");
 

--- a/src/main/java/net/mcreator/ui/dialogs/workspace/ForgeWorkspacePanel.java
+++ b/src/main/java/net/mcreator/ui/dialogs/workspace/ForgeWorkspacePanel.java
@@ -80,7 +80,7 @@ public class ForgeWorkspacePanel extends AbstractWorkspacePanel {
 		addFormElement(PanelUtils.westAndEastElement(L10N.label("dialog.workspace_settings.description"),
 				workspaceDialogPanel.description));
 
-		addFormElement(new JEmptyBox(5, 5));
+		addFormElement(new JEmptyBox(10, 10));
 
 		addFormElement(PanelUtils.westAndEastElement(L10N.label("dialog.workspace_settings.license"),
 				workspaceDialogPanel.license));

--- a/src/main/java/net/mcreator/ui/dialogs/workspace/NeoForgeWorkspacePanel.java
+++ b/src/main/java/net/mcreator/ui/dialogs/workspace/NeoForgeWorkspacePanel.java
@@ -35,6 +35,12 @@ public class NeoForgeWorkspacePanel extends AbstractWorkspacePanel {
 
 		addFormElement(new JEmptyBox(20, 20));
 
+		JLabel requiredModInfosLabel = new JLabel("Required mod infos");
+		requiredModInfosLabel.setFont(new Font("Sans-Serif", Font.BOLD, 18));
+		addFormElement(PanelUtils.westAndEastElement(requiredModInfosLabel, new JEmptyBox(0, 0)));
+
+		addFormElement(new JEmptyBox(15, 15));
+
 		addFormElement(PanelUtils.westAndEastElement(L10N.label("dialog.new_workspace.neoforge.display_name"),
 				workspaceDialogPanel.modName));
 
@@ -53,10 +59,32 @@ public class NeoForgeWorkspacePanel extends AbstractWorkspacePanel {
 		addFormElement(PanelUtils.westAndEastElement(L10N.label("dialog.new_workspace.neoforge.package"),
 				workspaceDialogPanel.packageName));
 
-		addFormElement(new JEmptyBox(30, 30));
+		addFormElement(new JEmptyBox(10, 10));
 
 		addFormElement(PanelUtils.westAndEastElement(L10N.label("dialog.new_workspace.neoforge.folder"),
-				PanelUtils.centerAndEastElement(workspaceFolder, selectWorkspaceFolder, 0, 0)));
+				PanelUtils.westAndEastElement(workspaceFolder, selectWorkspaceFolder)));
+
+		addFormElement(new JEmptyBox(10, 10));
+
+		JLabel additionalModInfosLabel = new JLabel("Additional mod infos");
+		additionalModInfosLabel.setFont(new Font("Sans-Serif", Font.BOLD, 18));
+
+		addFormElement(PanelUtils.westAndEastElement(additionalModInfosLabel, new JEmptyBox(0, 0)));
+
+		addFormElement(new JEmptyBox(15, 15));
+
+		addFormElement(PanelUtils.westAndEastElement(L10N.label("dialog.workspace_settings.author"),
+				workspaceDialogPanel.author));
+
+		addFormElement(new JEmptyBox(10, 10));
+
+		addFormElement(PanelUtils.westAndEastElement(L10N.label("dialog.workspace_settings.description"),
+				workspaceDialogPanel.description));
+
+		addFormElement(new JEmptyBox(5, 5));
+
+		addFormElement(PanelUtils.westAndEastElement(L10N.label("dialog.workspace_settings.license"),
+				workspaceDialogPanel.license));
 
 		addNotice(UIRES.get("18px.info"), "dialog.new_workspace.neoforge.notice");
 

--- a/src/main/java/net/mcreator/ui/dialogs/workspace/NeoForgeWorkspacePanel.java
+++ b/src/main/java/net/mcreator/ui/dialogs/workspace/NeoForgeWorkspacePanel.java
@@ -81,7 +81,7 @@ public class NeoForgeWorkspacePanel extends AbstractWorkspacePanel {
 		addFormElement(PanelUtils.westAndEastElement(L10N.label("dialog.workspace_settings.description"),
 				workspaceDialogPanel.description));
 
-		addFormElement(new JEmptyBox(5, 5));
+		addFormElement(new JEmptyBox(10, 10));
 
 		addFormElement(PanelUtils.westAndEastElement(L10N.label("dialog.workspace_settings.license"),
 				workspaceDialogPanel.license));

--- a/src/main/java/net/mcreator/ui/dialogs/workspace/NewWorkspaceDialog.java
+++ b/src/main/java/net/mcreator/ui/dialogs/workspace/NewWorkspaceDialog.java
@@ -75,7 +75,9 @@ public class NewWorkspaceDialog extends MCreatorDialog {
 
 	public NewWorkspaceDialog(Window w) {
 		super(w, null, true);
-
+		setPreferredSize(new Dimension(825, 650));
+		revalidate();
+		repaint();
 		AbstractWorkspacePanel neoforgeWorkspacePanel = new NeoForgeWorkspacePanel(this);
 		AbstractWorkspacePanel fabricWorkspacePanel = new FabricWorkspacePanel(this);
 		AbstractWorkspacePanel forgeWorkspacePanel = new ForgeWorkspacePanel(this);

--- a/src/main/java/net/mcreator/ui/dialogs/workspace/QuiltWorkspacePanel.java
+++ b/src/main/java/net/mcreator/ui/dialogs/workspace/QuiltWorkspacePanel.java
@@ -80,7 +80,7 @@ public class QuiltWorkspacePanel extends AbstractWorkspacePanel {
 		addFormElement(PanelUtils.westAndEastElement(L10N.label("dialog.workspace_settings.description"),
 				workspaceDialogPanel.description));
 
-		addFormElement(new JEmptyBox(5, 5));
+		addFormElement(new JEmptyBox(10, 10));
 
 		addFormElement(PanelUtils.westAndEastElement(L10N.label("dialog.workspace_settings.license"),
 				workspaceDialogPanel.license));

--- a/src/main/java/net/mcreator/ui/dialogs/workspace/QuiltWorkspacePanel.java
+++ b/src/main/java/net/mcreator/ui/dialogs/workspace/QuiltWorkspacePanel.java
@@ -35,6 +35,12 @@ public class QuiltWorkspacePanel extends AbstractWorkspacePanel {
 
 		addFormElement(new JEmptyBox(20, 20));
 
+		JLabel requiredModInfosLabel = new JLabel("Required mod infos");
+		requiredModInfosLabel.setFont(new Font("Sans-Serif", Font.BOLD, 18));
+		addFormElement(PanelUtils.westAndEastElement(requiredModInfosLabel, new JEmptyBox(0, 0)));
+
+		addFormElement(new JEmptyBox(15, 15));
+
 		addFormElement(PanelUtils.westAndEastElement(L10N.label("dialog.new_workspace.quilt.display_name"),
 				workspaceDialogPanel.modName));
 
@@ -52,10 +58,32 @@ public class QuiltWorkspacePanel extends AbstractWorkspacePanel {
 		addFormElement(PanelUtils.westAndEastElement(L10N.label("dialog.new_workspace.quilt.package"),
 				workspaceDialogPanel.packageName));
 
-		addFormElement(new JEmptyBox(30, 30));
+		addFormElement(new JEmptyBox(10, 10));
 
 		addFormElement(PanelUtils.westAndEastElement(L10N.label("dialog.new_workspace.quilt.folder"),
 				PanelUtils.centerAndEastElement(workspaceFolder, selectWorkspaceFolder, 0, 0)));
+
+		addFormElement(new JEmptyBox(10, 10));
+
+		JLabel additionalModInfosLabel = new JLabel("Additional mod infos");
+		additionalModInfosLabel.setFont(new Font("Sans-Serif", Font.BOLD, 18));
+
+		addFormElement(PanelUtils.westAndEastElement(additionalModInfosLabel, new JEmptyBox(0, 0)));
+
+		addFormElement(new JEmptyBox(15, 15));
+
+		addFormElement(PanelUtils.westAndEastElement(L10N.label("dialog.workspace_settings.author"),
+				workspaceDialogPanel.author));
+
+		addFormElement(new JEmptyBox(10, 10));
+
+		addFormElement(PanelUtils.westAndEastElement(L10N.label("dialog.workspace_settings.description"),
+				workspaceDialogPanel.description));
+
+		addFormElement(new JEmptyBox(5, 5));
+
+		addFormElement(PanelUtils.westAndEastElement(L10N.label("dialog.workspace_settings.license"),
+				workspaceDialogPanel.license));
 
 		addNotice(UIRES.get("18px.info"), "dialog.new_workspace.quilt.notice");
 

--- a/src/main/java/net/mcreator/ui/dialogs/workspace/ResourcepackWorkspacePanel.java
+++ b/src/main/java/net/mcreator/ui/dialogs/workspace/ResourcepackWorkspacePanel.java
@@ -36,6 +36,12 @@ public class ResourcepackWorkspacePanel extends AbstractWorkspacePanel {
 
 		addFormElement(new JEmptyBox(20, 20));
 
+		JLabel requiredModInfosLabel = new JLabel("Required resourcepack infos");
+		requiredModInfosLabel.setFont(new Font("Sans-Serif", Font.BOLD, 18));
+		addFormElement(PanelUtils.westAndEastElement(requiredModInfosLabel, new JEmptyBox(0, 0)));
+
+		addFormElement(new JEmptyBox(15, 15));
+
 		addFormElement(PanelUtils.westAndEastElement(L10N.label("dialog.new_workspace.resourcepack.display_name"),
 				workspaceDialogPanel.modName));
 
@@ -53,6 +59,28 @@ public class ResourcepackWorkspacePanel extends AbstractWorkspacePanel {
 
 		addFormElement(PanelUtils.westAndEastElement(L10N.label("dialog.new_workspace.resourcepack.folder"),
 				PanelUtils.centerAndEastElement(workspaceFolder, selectWorkspaceFolder, 0, 0)));
+
+		addFormElement(new JEmptyBox(10, 10));
+
+		JLabel additionalModInfosLabel = new JLabel("Additional resourcepack infos");
+		additionalModInfosLabel.setFont(new Font("Sans-Serif", Font.BOLD, 18));
+
+		addFormElement(PanelUtils.westAndEastElement(additionalModInfosLabel, new JEmptyBox(0, 0)));
+
+		addFormElement(new JEmptyBox(15, 15));
+
+		addFormElement(PanelUtils.westAndEastElement(L10N.label("dialog.workspace_settings.author"),
+				workspaceDialogPanel.author));
+
+		addFormElement(new JEmptyBox(10, 10));
+
+		addFormElement(PanelUtils.westAndEastElement(L10N.label("dialog.workspace_settings.description"),
+				workspaceDialogPanel.description));
+
+		addFormElement(new JEmptyBox(5, 5));
+
+		addFormElement(PanelUtils.westAndEastElement(L10N.label("dialog.workspace_settings.license"),
+				workspaceDialogPanel.license));
 
 		addNotice(UIRES.get("18px.info"), "dialog.new_workspace.resourcepack.notice");
 

--- a/src/main/java/net/mcreator/ui/dialogs/workspace/ResourcepackWorkspacePanel.java
+++ b/src/main/java/net/mcreator/ui/dialogs/workspace/ResourcepackWorkspacePanel.java
@@ -77,7 +77,7 @@ public class ResourcepackWorkspacePanel extends AbstractWorkspacePanel {
 		addFormElement(PanelUtils.westAndEastElement(L10N.label("dialog.workspace_settings.description"),
 				workspaceDialogPanel.description));
 
-		addFormElement(new JEmptyBox(5, 5));
+		addFormElement(new JEmptyBox(10, 10));
 
 		addFormElement(PanelUtils.westAndEastElement(L10N.label("dialog.workspace_settings.license"),
 				workspaceDialogPanel.license));


### PR DESCRIPTION
- Added new options to the workspace creation menu to allow the user to directly set the author name, the description and the license on the creation screen, for every modloader (Forge, NeoForge, Fabric, Quilt, Datapacks, Resourcepacks, and Add-ons)

<img width="1011" height="798" alt="options" src="https://github.com/user-attachments/assets/457c9684-f263-4784-bb69-848928d02aba" />

If you have any questions or suggestions, I’d be happy to respond. This feature took several hours to implement and has been tested across all supported types, except for Quilt because there was no generator available for this version.