### PR TITLE
Added a new chat message block with custom properties

### DIFF
--- a/plugins/generator-1.21.1/neoforge-1.21.1/procedures/world_send_chat_advanced.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/procedures/world_send_chat_advanced.java.ftl
@@ -1,0 +1,6 @@
+if (world instanceof ServerLevel _level)
+	_level.getServer().getCommands().performPrefixedCommand(
+	new CommandSourceStack(CommandSource.NULL, new Vec3(1, 1, 1), Vec2.ZERO,
+	_level, 4, "", Component.literal(""), _level.getServer(), null).withSuppressedOutput(), "tellraw @a {\"text\":${input$command?json_string}<#if field$color??>, \"color\": \"${field$color}\"</#if><#if (field$bold!"FALSE") == "TRUE">, \"bold\":true</#if><#if (field$italic!"FALSE") == "TRUE">, \"italic\":true</#if><#if (field$underlined!"FALSE") == "TRUE">, \"underlined\":true</#if>}"
+);
+

--- a/plugins/generator-1.21.8/neoforge-1.21.8/procedures/world_send_chat_advanced.java.ftl
+++ b/plugins/generator-1.21.8/neoforge-1.21.8/procedures/world_send_chat_advanced.java.ftl
@@ -1,0 +1,6 @@
+if (world instanceof ServerLevel _level)
+	_level.getServer().getCommands().performPrefixedCommand(
+	new CommandSourceStack(CommandSource.NULL, new Vec3(1, 1, 1), Vec2.ZERO,
+	_level, 4, "", Component.literal(""), _level.getServer(), null).withSuppressedOutput(), "tellraw @a {\"text\":${input$command?json_string}<#if field$color??>, \"color\": \"${field$color}\"</#if><#if (field$bold!"FALSE") == "TRUE">, \"bold\":true</#if><#if (field$italic!"FALSE") == "TRUE">, \"italic\":true</#if><#if (field$underlined!"FALSE") == "TRUE">, \"underlined\":true</#if>}"
+);
+

--- a/plugins/mcreator-core/procedures/world_send_chat_advanced.json
+++ b/plugins/mcreator-core/procedures/world_send_chat_advanced.json
@@ -1,0 +1,76 @@
+{
+  "args0": [
+    {
+      "type": "input_value",
+      "name": "command",
+      "check": "String"
+    },
+    {
+      "type": "field_dropdown",
+      "name": "color",
+      "options": [
+        ["white", "white"],
+        ["gray", "gray"],
+        ["dark_gray", "dark_gray"],
+        ["black", "black"],
+        ["red", "red"],
+        ["dark_red", "dark_red"],
+        ["blue", "blue"],
+        ["dark_blue", "dark_blue"],
+        ["green", "green"],
+        ["dark_green", "dark_green"],
+        ["yellow", "yellow"],
+        ["gold", "gold"]
+      ]
+    },
+    {
+      "type": "field_checkbox",
+      "name": "bold",
+      "checked": false
+    },
+    {
+      "type": "field_checkbox",
+      "name": "italic",
+      "checked": false
+    },
+    {
+      "type": "field_checkbox",
+      "name": "underlined",
+      "checked": false
+    },
+    {
+      "type": "field_image",
+      "src": "./res/server.png",
+      "width": 8,
+      "height": 24
+    }
+  ],
+  "inputsInline": true,
+  "previousStatement": null,
+  "nextStatement": null,
+  "colour": 35,
+  "mcreator": {
+    "toolbox_id": "worldmanagement",
+    "toolbox_init": [
+      "<value name=\"command\"><block type=\"text\"><field name=\"TEXT\">Message</field></block></value>",
+      "<value name=\"bold\"><block type=\"field_checkbox\"></block></value>",
+      "<value name=\"italic\"><block type=\"field_checkbox\"></block></value>",
+      "<value name=\"underlined\"><block type=\"field_checkbox\"></block></value>"
+    ],
+    "inputs": [
+      "command"
+    ],
+    "fields": [
+      "color",
+      "bold",
+      "italic",
+      "underlined"
+    ],
+    "dependencies": [
+      {
+        "name": "world",
+        "type": "world"
+      }
+    ]
+  }
+}

--- a/plugins/mcreator-localization/lang/texts.properties
+++ b/plugins/mcreator-localization/lang/texts.properties
@@ -1321,6 +1321,7 @@ blockly.block.world_make_portal=Place portal for dimension %4 if properly shaped
 blockly.block.world_place_feature=Try to place feature: %1 at x: %2 y: %3 z: %4 %5
 blockly.block.world_place_feature_with_result=Try to place feature: %1 at x: %2 y: %3 z: %4 and get placement success %5
 blockly.block.world_send_chat=Send to chat to all players: %1 %2
+blockly.block.world_send_chat_advanced=Send to chat to all players: %1 color %2 bold %3 italic %4 underlined %5 %6
 blockly.block.world_set_downfall=Enable rain if %1 otherwise, disable it
 blockly.block.world_spawn_falling_block=Spawn %1 as a falling block at x: %2 y: %3 z: %4 %5
 blockly.block.world_switch_world=Do %1 in server-side world %2


### PR DESCRIPTION
I added a new procedure block that allows sending chat messages with custom color and formatting (bold, italic, underlined) in a more intuitive way.

This simplifies the process compared to using the "Execute command" block with a `/tellraw @a` command.

<img width="842" height="86" alt="block" src="https://github.com/user-attachments/assets/fe46bde9-9f88-4815-9341-4a3cc23e64ba" />
