### PR TITLE
Sign block base

### DIFF
--- a/plugins/generator-1.21.1/datapack-1.21.1/utils/mcitems.ftl
+++ b/plugins/generator-1.21.1/datapack-1.21.1/utils/mcitems.ftl
@@ -6,17 +6,21 @@
     </#if>
 </#function>
 
-<#function transformExtension mappedBlock>
+<#function handleExtension mappedBlock customelement>
     <#assign extension = mappedBlock?keep_after_last(".")?replace("body", "chestplate")?replace("legs", "leggings")>
-    <#return (extension?has_content)?then("_" + extension, "")>
+    <#if extension == "wall"> <#-- Special handling for wall variant of signs -->
+    	<#return "wall_" + customelement>
+    <#else>
+    	<#return (extension?has_content)?then(customelement + "_" + extension, customelement)>
+    </#if>
 </#function>
 
 <#function mappedMCItemToItemObjectJSON mappedBlock itemKey="item">
     <#if mappedBlock.getUnmappedValue().startsWith("CUSTOM:")>
         <#assign customelement = generator.getRegistryNameFromFullName(mappedBlock.getUnmappedValue())!""/>
         <#if customelement?has_content>
-            <#return "\"" + itemKey + "\": \"" + "${modid}:" + customelement
-            + transformExtension(mappedBlock)
+            <#return "\"" + itemKey + "\": \"" + "${modid}:"
+            + handleExtension(mappedBlock, customelement)
             + "\"">
         <#else>
             <#return "\"" + itemKey + "\": \"minecraft:air\"">
@@ -39,7 +43,7 @@
     <#if mappedBlock.getUnmappedValue().startsWith("CUSTOM:")>
         <#assign customelement = generator.getRegistryNameFromFullName(mappedBlock.getUnmappedValue())!""/>
         <#if customelement?has_content>
-            <#return "${modid}:" + customelement + transformExtension(mappedBlock)>
+            <#return "${modid}:" + handleExtension(mappedBlock, customelement)>
         <#else>
             <#return "minecraft:air">
         </#if>

--- a/plugins/generator-1.21.1/neoforge-1.21.1/block.definition.yaml
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/block.definition.yaml
@@ -501,19 +501,26 @@ localizationkeys:
 tags:
   - tag: BLOCKS:minecraft:mineable/pickaxe
     condition: "${data.destroyTool == 'pickaxe'}"
+    entryprovider: data.getProvidedBlocks()
   - tag: BLOCKS:minecraft:mineable/axe
     condition: "${data.destroyTool == 'axe'}"
+    entryprovider: data.getProvidedBlocks()
   - tag: BLOCKS:minecraft:mineable/shovel
     condition: "${data.destroyTool == 'shovel'}"
+    entryprovider: data.getProvidedBlocks()
   - tag: BLOCKS:minecraft:mineable/hoe
     condition: "${data.destroyTool == 'hoe'}"
+    entryprovider: data.getProvidedBlocks()
 
   - tag: BLOCKS:minecraft:needs_stone_tool
     condition: "${data.requiresCorrectTool && data.vanillaToolTier == 'STONE'}"
+    entryprovider: data.getProvidedBlocks()
   - tag: BLOCKS:minecraft:needs_iron_tool
     condition: "${data.requiresCorrectTool && data.vanillaToolTier == 'IRON'}"
+    entryprovider: data.getProvidedBlocks()
   - tag: BLOCKS:minecraft:needs_diamond_tool
     condition: "${data.requiresCorrectTool && data.vanillaToolTier == 'DIAMOND'}"
+    entryprovider: data.getProvidedBlocks()
 
   - tag: BLOCKS:minecraft:stairs
     condition: "${data.blockBase! == 'Stairs'}"
@@ -548,8 +555,10 @@ tags:
 
   - tag: BLOCKS:minecraft:replaceable
     condition: isReplaceable
+    entryprovider: data.getProvidedBlocks()
   - tag: BLOCKS:minecraft:climbable
     condition: isLadder
+    entryprovider: data.getProvidedBlocks()
 
   - tag: GAME_EVENTS:minecraft:@registryname_can_listen
     condition:

--- a/plugins/generator-1.21.1/neoforge-1.21.1/block.definition.yaml
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/block.definition.yaml
@@ -448,6 +448,35 @@ templates:
     variables: "model=button_inventory;txname=texture"
     name: "@MODASSETSROOT/models/block/@registryname_inventory.json"
 
+  # TX: Sign templates
+  - template: block/block.java.ftl # Wall sign class
+    condition: "blockBase %= Sign"
+    name: "@SRCROOT/@BASEPACKAGEPATH/block/Wall@NAMEBlock.java"
+    variables: "extends_class=WallSignBlock"
+  - template: json/block_item.json.ftl
+    condition:
+      - hasBlockItem
+      - "blockBase %= Sign"
+    writer: json
+    name: "@MODASSETSROOT/models/item/@registryname.json"
+  - template: json/block_states.json.ftl
+    condition: "blockBase %= Sign"
+    writer: json
+    name: "@MODASSETSROOT/blockstates/@registryname.json"
+  - template: json/block_states.json.ftl # Wall sign blockstates definition
+    condition: "blockBase %= Sign"
+    writer: json
+    name: "@MODASSETSROOT/blockstates/wall_@registryname.json"
+  - template: json/block_model_particle.json.ftl
+    condition: "blockBase %= Sign"
+    writer: json
+    name: "@MODASSETSROOT/models/block/@registryname.json"
+
+global_templates:
+  - template: elementinits/woodtypes.java.ftl
+    name: "@SRCROOT/@BASEPACKAGEPATH/init/@JavaModNameWoodTypes.java"
+    condition: "${w.getGElementsOfType('block')?filter(e -> e.isSign())?size != 0}"
+
 block_base_properties:
   Stairs: [facing, half, shape, waterlogged]
   Slab: [type, waterlogged]
@@ -461,6 +490,7 @@ block_base_properties:
   EndRod: [facing]
   PressurePlate: [powered]
   Button: [facing, face, powered]
+  Sign: [facing, rotation, waterlogged] # includes both standing sign and wall sign properties
 
 localizationkeys:
   - key: block.@modid.@registryname

--- a/plugins/generator-1.21.1/neoforge-1.21.1/block.definition.yaml
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/block.definition.yaml
@@ -552,6 +552,11 @@ tags:
     condition: "${(data.blockBase! == 'Button') && (data.blockSetType == 'OAK')}"
   - tag: BLOCKS:minecraft:buttons
     condition: "${(data.blockBase! == 'Button') && (data.blockSetType != 'OAK')}"
+  - tag: BLOCKS:minecraft:standing_signs
+    condition: "${(data.blockBase! == 'Sign')}"
+  - tag: BLOCKS:minecraft:wall_signs
+    condition: "${(data.blockBase! == 'Sign')}"
+    entry: "CUSTOM:@NAME.wall"
 
   - tag: BLOCKS:minecraft:replaceable
     condition: isReplaceable

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/block/block.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/block/block.java.ftl
@@ -201,6 +201,9 @@ public class <#if var_extends_class! == "WallSignBlock">Wall</#if>${name}Block e
 		<#if data.blockBase?has_content && data.blockBase == "Leaves">
 			.isSuffocating((bs, br, bp) -> false).isViewBlocking((bs, br, bp) -> false)
 		</#if>
+		<#if var_extends_class! == "WallSignBlock">
+			.dropsLike(${JavaModName}Blocks.${REGISTRYNAME}.get())
+		</#if>
 	</#macro>
 
 	public <#if var_extends_class! == "WallSignBlock">Wall</#if>${name}Block() {

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/block/block.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/block/block.java.ftl
@@ -45,11 +45,13 @@ package ${package}.block;
 import net.minecraft.world.level.block.state.BlockBehaviour.Properties;
 
 <#compress>
-public class ${name}Block extends
-	<#if data.hasGravity>
+public class <#if var_extends_class! == "WallSignBlock">Wall</#if>${name}Block extends
+	<#if var_extends_class??>
+		${var_extends_class}
+	<#elseif data.hasGravity>
 		FallingBlock
 	<#elseif data.blockBase?has_content>
-		${data.blockBase?replace("Stairs", "Stair")?replace("Pane", "IronBars")}Block
+		${data.blockBase?replace("Stairs", "Stair")?replace("Pane", "IronBars")?replace("Sign", "StandingSign")}Block
 	<#else>
 		Block
 	</#if>
@@ -189,7 +191,8 @@ public class ${name}Block extends
 				data.blockBase == "FenceGate" ||
 				data.blockBase == "PressurePlate" ||
 				data.blockBase == "Fence" ||
-				data.blockBase == "Wall")>
+				data.blockBase == "Wall" ||
+				data.blockBase == "Sign")>
 			.forceSolidOn()
 		</#if>
 		<#if data.blockBase?has_content && data.blockBase == "EndRod">
@@ -200,7 +203,7 @@ public class ${name}Block extends
 		</#if>
 	</#macro>
 
-	public ${name}Block() {
+	public <#if var_extends_class! == "WallSignBlock">Wall</#if>${name}Block() {
 		<#if data.blockBase?has_content>
 			<#if data.blockBase == "Stairs">
 				super(Blocks.AIR.defaultBlockState(), <@blockProperties/>);
@@ -210,6 +213,8 @@ public class ${name}Block extends
 				super(BlockSetType.${data.blockSetType}, <#if data.blockSetType == "OAK">30<#else>20</#if>, <@blockProperties/>);
 			<#elseif data.blockBase == "FenceGate">
 				super(WoodType.OAK, <@blockProperties/>);
+			<#elseif data.blockBase == "Sign">
+				super(${JavaModName}WoodTypes.${REGISTRYNAME}_WOOD_TYPE, <@blockProperties/>);
 			<#else>
 				super(<@blockProperties/>);
 			</#if>

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/elementinits/blocks.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/elementinits/blocks.java.ftl
@@ -38,6 +38,7 @@ package ${package}.init;
 
 <#assign hasTintedBlocks = false>
 <#assign hasTintedBlockItems = false>
+<#assign signs = w.getGElementsOfType("block")?filter(e -> e.isSign())>
 <#list blocks as block>
 	<#if block.getModElement().getTypeString() == "block">
 		<#if block.tintType != "No tint">
@@ -56,7 +57,7 @@ package ${package}.init;
 	</#if>
 </#list>
 
-public class ${JavaModName}Blocks {
+<#if signs?size != 0>@EventBusSubscriber </#if>public class ${JavaModName}Blocks {
 
 	public static final DeferredRegister.Blocks REGISTRY = DeferredRegister.createBlocks(${JavaModName}.MODID);
 
@@ -67,13 +68,17 @@ public class ${JavaModName}Blocks {
 		<#else>
 			public static final DeferredBlock<Block> ${block.getModElement().getRegistryNameUpper()} =
 				REGISTRY.register("${block.getModElement().getRegistryName()}", ${block.getModElement().getName()}Block::new);
+			<#if (block.getModElement().getTypeString() == "block") && (block.blockBase! == "Sign")>
+				public static final DeferredBlock<Block> WALL_${block.getModElement().getRegistryNameUpper()} =
+					REGISTRY.register("wall_${block.getModElement().getRegistryName()}", Wall${block.getModElement().getName()}Block::new);
+			</#if>
 		</#if>
 	</#list>
 
 	// Start of user code block custom blocks
 	// End of user code block custom blocks
 
-	<#if hasTintedBlocks || hasTintedBlockItems>
+	<#if hasTintedBlocks || hasTintedBlockItems || (signs?size != 0)>
 	@EventBusSubscriber(Dist.CLIENT) public static class BlocksClientSideHandler {
 		<#if hasTintedBlocks>
 		@SubscribeEvent public static void blockColorLoad(RegisterColorHandlersEvent.Block event) {
@@ -98,6 +103,22 @@ public class ${JavaModName}Blocks {
 			</#list>
 		}
 		</#if>
+
+		<#if signs?size != 0>
+		@SubscribeEvent public static void clientSetup(FMLClientSetupEvent event) {
+			<#list signs as block>
+				Sheets.addWoodType(${JavaModName}WoodTypes.${block.getModElement().getRegistryNameUpper()}_WOOD_TYPE);
+			</#list>
+		}
+		</#if>
+	}
+	</#if>
+
+	<#if signs?size != 0>
+	@SubscribeEvent public static void registerSigns(BlockEntityTypeAddBlocksEvent event) {
+		<#list signs as block>
+			event.modify(BlockEntityType.SIGN, ${block.getModElement().getRegistryNameUpper()}.get(), WALL_${block.getModElement().getRegistryNameUpper()}.get());
+		</#list>
 	}
 	</#if>
 

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/elementinits/items.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/elementinits/items.java.ftl
@@ -39,6 +39,7 @@ package ${package}.init;
 
 <#assign hasBlocks = false>
 <#assign hasDoubleBlocks = false>
+<#assign hasSigns = false>
 <#assign hasItemsWithProperties = w.getGElementsOfType("item")?filter(e -> e.customProperties?has_content)?size != 0
 	|| w.getGElementsOfType("tool")?filter(e -> e.toolType == "Shield")?size != 0>
 <#assign itemsWithInventory = w.getGElementsOfType("item")?filter(e -> e.hasInventory())>
@@ -83,6 +84,11 @@ public class ${JavaModName}Items {
 				<#assign hasDoubleBlocks = true>
 				public static final DeferredItem<Item> ${item.getModElement().getRegistryNameUpper()} =
 					doubleBlock(${JavaModName}Blocks.${item.getModElement().getRegistryNameUpper()}
+					<#if item.hasCustomItemProperties()>, <@blockItemProperties item/></#if>);
+			<#elseif (item.getModElement().getTypeString() == "block") && (item.blockBase! == "Sign")>
+				<#assign hasSigns = true>
+				public static final DeferredItem<Item> ${item.getModElement().getRegistryNameUpper()} =
+					signBlock(${JavaModName}Blocks.${item.getModElement().getRegistryNameUpper()}, ${JavaModName}Blocks.WALL_${item.getModElement().getRegistryNameUpper()}
 					<#if item.hasCustomItemProperties()>, <@blockItemProperties item/></#if>);
 			<#else>
 				<#assign hasBlocks = true>
@@ -130,6 +136,16 @@ public class ${JavaModName}Items {
 
 	private static DeferredItem<Item> doubleBlock(DeferredHolder<Block, Block> block, Item.Properties properties) {
 		return REGISTRY.register(block.getId().getPath(), () -> new DoubleHighBlockItem(block.get(), properties));
+	}
+	</#if>
+
+	<#if hasSigns>
+	private static DeferredItem<Item> signBlock(DeferredHolder<Block, Block> block, DeferredHolder<Block, Block> wallBlock) {
+		return signBlock(block, wallBlock, new Item.Properties());
+	}
+
+	private static DeferredItem<Item> signBlock(DeferredHolder<Block, Block> block, DeferredHolder<Block, Block> wallBlock, Item.Properties properties) {
+		return REGISTRY.register(block.getId().getPath(), () -> new SignItem(properties, block.get(), wallBlock.get()));
 	}
 	</#if>
 

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/elementinits/woodtypes.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/elementinits/woodtypes.java.ftl
@@ -1,0 +1,45 @@
+<#--
+ # MCreator (https://mcreator.net/)
+ # Copyright (C) 2012-2020, Pylo
+ # Copyright (C) 2020-2025, Pylo, opensource contributors
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # Additional permission for code generator templates (*.ftl files)
+ #
+ # As a special exception, you may create a larger work that contains part or
+ # all of the MCreator code generator templates (*.ftl files) and distribute
+ # that work under terms of your choice, so long as that work isn't itself a
+ # template for code generation. Alternatively, if you modify or redistribute
+ # the template itself, you may (at your option) remove this special exception,
+ # which will cause the template and the resulting code generator output files
+ # to be licensed under the GNU General Public License without this special
+ # exception.
+-->
+
+<#-- @formatter:off -->
+
+/*
+ *    MCreator note: This file will be REGENERATED on each build.
+ */
+
+package ${package}.init;
+
+public class ${JavaModName}WoodTypes {
+	<#compress>
+	<#list blocks?filter(e -> e.isSign()) as block>
+	public static final WoodType ${block.getModElement().getRegistryNameUpper()}_WOOD_TYPE = WoodType.register(new WoodType("${modid}:${block.getModElement().getRegistryName()}", BlockSetType.OAK));
+	</#list>
+	</#compress>
+}

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/json/block_model_particle.json.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/json/block_model_particle.json.ftl
@@ -1,0 +1,5 @@
+{
+    "textures": {
+      "particle": "${data.getParticleTexture().format("%s:block/%s")}"
+    }
+}

--- a/plugins/generator-1.21.1/neoforge-1.21.1/utils/mcitems.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/utils/mcitems.ftl
@@ -161,20 +161,24 @@
 
 <#function mappedElementToRegistryEntry mappedElement>
     <#return JavaModName + generator.isBlock(mappedElement)?then("Blocks", "Items") + "."
-    + generator.getRegistryNameFromFullName(mappedElement)?upper_case + transformExtension(mappedElement)?upper_case + ".get()">
+    + handleExtension(mappedElement, generator.getRegistryNameFromFullName(mappedElement))?upper_case + ".get()">
 </#function>
 
-<#function transformExtension mappedBlock>
+<#function handleExtension mappedBlock customelement>
     <#assign extension = mappedBlock?keep_after_last(".")?replace("body", "chestplate")?replace("legs", "leggings")>
-    <#return (extension?has_content)?then("_" + extension, "")>
+    <#if extension == "wall"> <#-- Special handling for wall variant of signs -->
+    	<#return "wall_" + customelement>
+    <#else>
+    	<#return (extension?has_content)?then(customelement + "_" + extension, customelement)>
+    </#if>
 </#function>
 
 <#function mappedMCItemToItemObjectJSON mappedBlock itemKey="item">
     <#if mappedBlock.getUnmappedValue().startsWith("CUSTOM:")>
         <#assign customelement = generator.getRegistryNameFromFullName(mappedBlock.getUnmappedValue())!""/>
         <#if customelement?has_content>
-            <#return "\"" + itemKey + "\": \"" + "${modid}:" + customelement
-            + transformExtension(mappedBlock)
+            <#return "\"" + itemKey + "\": \"" + "${modid}:"
+            + handleExtension(mappedBlock, customelement)
             + "\"">
         <#else>
             <#return "\"" + itemKey + "\": \"minecraft:air\"">
@@ -197,7 +201,7 @@
     <#if mappedBlock.getUnmappedValue().startsWith("CUSTOM:")>
         <#assign customelement = generator.getRegistryNameFromFullName(mappedBlock.getUnmappedValue())!""/>
         <#if customelement?has_content>
-            <#return "${modid}:" + customelement + transformExtension(mappedBlock)>
+            <#return "${modid}:" + handleExtension(mappedBlock, customelement)>
         <#else>
             <#return "minecraft:air">
         </#if>

--- a/plugins/generator-1.21.8/datapack-1.21.8/utils/mcitems.ftl
+++ b/plugins/generator-1.21.8/datapack-1.21.8/utils/mcitems.ftl
@@ -6,17 +6,21 @@
     </#if>
 </#function>
 
-<#function transformExtension mappedBlock>
+<#function handleExtension mappedBlock customelement>
     <#assign extension = mappedBlock?keep_after_last(".")?replace("body", "chestplate")?replace("legs", "leggings")>
-    <#return (extension?has_content)?then("_" + extension, "")>
+    <#if extension == "wall"> <#-- Special handling for wall variant of signs -->
+    	<#return "wall_" + customelement>
+    <#else>
+    	<#return (extension?has_content)?then(customelement + "_" + extension, customelement)>
+    </#if>
 </#function>
 
 <#function mappedMCItemToItemObjectJSON mappedBlock itemKey="item">
     <#if mappedBlock.getUnmappedValue().startsWith("CUSTOM:")>
         <#assign customelement = generator.getRegistryNameFromFullName(mappedBlock.getUnmappedValue())!""/>
         <#if customelement?has_content>
-            <#return "\"" + itemKey + "\": \"" + "${modid}:" + customelement
-            + transformExtension(mappedBlock)
+            <#return "\"" + itemKey + "\": \"" + "${modid}:"
+            + handleExtension(mappedBlock, customelement)
             + "\"">
         <#else>
             <#return "\"" + itemKey + "\": \"minecraft:air\"">
@@ -39,7 +43,7 @@
     <#if mappedBlock.getUnmappedValue().startsWith("CUSTOM:")>
         <#assign customelement = generator.getRegistryNameFromFullName(mappedBlock.getUnmappedValue())!""/>
         <#if customelement?has_content>
-            <#return "${modid}:" + customelement + transformExtension(mappedBlock)>
+            <#return "${modid}:" + handleExtension(mappedBlock, customelement)>
         <#else>
             <#return "minecraft:air">
         </#if>

--- a/plugins/generator-1.21.8/neoforge-1.21.8/block.definition.yaml
+++ b/plugins/generator-1.21.8/neoforge-1.21.8/block.definition.yaml
@@ -505,19 +505,26 @@ localizationkeys:
 tags:
   - tag: BLOCKS:minecraft:mineable/pickaxe
     condition: "${data.destroyTool == 'pickaxe'}"
+    entryprovider: data.getProvidedBlocks()
   - tag: BLOCKS:minecraft:mineable/axe
     condition: "${data.destroyTool == 'axe'}"
+    entryprovider: data.getProvidedBlocks()
   - tag: BLOCKS:minecraft:mineable/shovel
     condition: "${data.destroyTool == 'shovel'}"
+    entryprovider: data.getProvidedBlocks()
   - tag: BLOCKS:minecraft:mineable/hoe
     condition: "${data.destroyTool == 'hoe'}"
+    entryprovider: data.getProvidedBlocks()
 
   - tag: BLOCKS:minecraft:needs_stone_tool
     condition: "${data.requiresCorrectTool && data.vanillaToolTier == 'STONE'}"
+    entryprovider: data.getProvidedBlocks()
   - tag: BLOCKS:minecraft:needs_iron_tool
     condition: "${data.requiresCorrectTool && data.vanillaToolTier == 'IRON'}"
+    entryprovider: data.getProvidedBlocks()
   - tag: BLOCKS:minecraft:needs_diamond_tool
     condition: "${data.requiresCorrectTool && data.vanillaToolTier == 'DIAMOND'}"
+    entryprovider: data.getProvidedBlocks()
 
   - tag: BLOCKS:minecraft:stairs
     condition: "${data.blockBase! == 'Stairs'}"
@@ -552,8 +559,10 @@ tags:
 
   - tag: BLOCKS:minecraft:replaceable
     condition: isReplaceable
+    entryprovider: data.getProvidedBlocks()
   - tag: BLOCKS:minecraft:climbable
     condition: isLadder
+    entryprovider: data.getProvidedBlocks()
 
   - tag: GAME_EVENTS:minecraft:@registryname_can_listen
     condition:

--- a/plugins/generator-1.21.8/neoforge-1.21.8/block.definition.yaml
+++ b/plugins/generator-1.21.8/neoforge-1.21.8/block.definition.yaml
@@ -556,6 +556,11 @@ tags:
     condition: "${(data.blockBase! == 'Button') && (data.blockSetType == 'OAK')}"
   - tag: BLOCKS:minecraft:buttons
     condition: "${(data.blockBase! == 'Button') && (data.blockSetType != 'OAK')}"
+  - tag: BLOCKS:minecraft:standing_signs
+    condition: "${(data.blockBase! == 'Sign')}"
+  - tag: BLOCKS:minecraft:wall_signs
+    condition: "${(data.blockBase! == 'Sign')}"
+    entry: "CUSTOM:@NAME.wall"
 
   - tag: BLOCKS:minecraft:replaceable
     condition: isReplaceable

--- a/plugins/generator-1.21.8/neoforge-1.21.8/block.definition.yaml
+++ b/plugins/generator-1.21.8/neoforge-1.21.8/block.definition.yaml
@@ -452,6 +452,35 @@ templates:
     variables: "model=button_inventory;txname=texture"
     name: "@MODASSETSROOT/models/block/@registryname_inventory.json"
 
+  # TX: Sign templates
+  - template: block/block.java.ftl # Wall sign class
+    condition: "blockBase %= Sign"
+    name: "@SRCROOT/@BASEPACKAGEPATH/block/Wall@NAMEBlock.java"
+    variables: "extends_class=WallSignBlock"
+  - template: json/block_item.json.ftl
+    condition:
+      - hasBlockItem
+      - "blockBase %= Sign"
+    writer: json
+    name: "@MODASSETSROOT/models/item/@registryname.json"
+  - template: json/block_states.json.ftl
+    condition: "blockBase %= Sign"
+    writer: json
+    name: "@MODASSETSROOT/blockstates/@registryname.json"
+  - template: json/block_states.json.ftl # Wall sign blockstates definition
+    condition: "blockBase %= Sign"
+    writer: json
+    name: "@MODASSETSROOT/blockstates/wall_@registryname.json"
+  - template: json/block_model_particle.json.ftl
+    condition: "blockBase %= Sign"
+    writer: json
+    name: "@MODASSETSROOT/models/block/@registryname.json"
+
+global_templates:
+  - template: elementinits/woodtypes.java.ftl
+    name: "@SRCROOT/@BASEPACKAGEPATH/init/@JavaModNameWoodTypes.java"
+    condition: "${w.getGElementsOfType('block')?filter(e -> e.isSign())?size != 0}"
+
 block_base_properties:
   Stairs: [facing, half, shape, waterlogged]
   Slab: [type, waterlogged]
@@ -465,6 +494,7 @@ block_base_properties:
   EndRod: [facing]
   PressurePlate: [powered]
   Button: [facing, face, powered]
+  Sign: [facing, rotation, waterlogged] # includes both standing sign and wall sign properties
 
 localizationkeys:
   - key: item.@modid.@registryname

--- a/plugins/generator-1.21.8/neoforge-1.21.8/templates/block/block.java.ftl
+++ b/plugins/generator-1.21.8/neoforge-1.21.8/templates/block/block.java.ftl
@@ -42,11 +42,13 @@ package ${package}.block;
 import net.minecraft.world.level.block.state.BlockBehaviour.Properties;
 
 <#compress>
-public class ${name}Block extends
-	<#if data.hasGravity>
+public class <#if var_extends_class! == "WallSignBlock">Wall</#if>${name}Block extends
+	<#if var_extends_class??>
+		${var_extends_class}
+	<#elseif data.hasGravity>
 		FallingBlock
 	<#elseif data.blockBase?has_content>
-		${data.blockBase?replace("Stairs", "Stair")?replace("Pane", "IronBars")?replace("Leaves", "TintedParticleLeaves")}Block
+		${data.blockBase?replace("Stairs", "Stair")?replace("Pane", "IronBars")?replace("Leaves", "TintedParticleLeaves")?replace("Sign", "StandingSign")}Block
 	<#else>
 		Block
 	</#if>
@@ -190,7 +192,8 @@ public class ${name}Block extends
 				data.blockBase == "FenceGate" ||
 				data.blockBase == "PressurePlate" ||
 				data.blockBase == "Fence" ||
-				data.blockBase == "Wall")>
+				data.blockBase == "Wall" ||
+				data.blockBase == "Sign")>
 			.forceSolidOn()
 		</#if>
 		<#if data.blockBase?has_content && data.blockBase == "EndRod">
@@ -201,7 +204,7 @@ public class ${name}Block extends
 		</#if>
 	</#macro>
 
-	public ${name}Block(BlockBehaviour.Properties properties) {
+	public <#if var_extends_class! == "WallSignBlock">Wall</#if>${name}Block(BlockBehaviour.Properties properties) {
 		<#if data.blockBase?has_content>
 			<#if data.blockBase == "Stairs">
 				super(Blocks.AIR.defaultBlockState(), <@blockProperties/>);
@@ -213,6 +216,8 @@ public class ${name}Block extends
 				super(BlockSetType.${data.blockSetType}, <#if data.blockSetType == "OAK">30<#else>20</#if>, <@blockProperties/>);
 			<#elseif data.blockBase == "FenceGate">
 				super(WoodType.OAK, <@blockProperties/>);
+			<#elseif data.blockBase == "Sign">
+				super(${JavaModName}WoodTypes.${REGISTRYNAME}_WOOD_TYPE, <@blockProperties/>);
 			<#else>
 				super(<@blockProperties/>);
 			</#if>

--- a/plugins/generator-1.21.8/neoforge-1.21.8/templates/block/block.java.ftl
+++ b/plugins/generator-1.21.8/neoforge-1.21.8/templates/block/block.java.ftl
@@ -202,6 +202,9 @@ public class <#if var_extends_class! == "WallSignBlock">Wall</#if>${name}Block e
 		<#if data.blockBase?has_content && data.blockBase == "Leaves">
 			.isSuffocating((bs, br, bp) -> false).isViewBlocking((bs, br, bp) -> false)
 		</#if>
+		<#if var_extends_class! == "WallSignBlock">
+			.overrideLootTable(${JavaModName}Blocks.${REGISTRYNAME}.get().getLootTable()).overrideDescription(${JavaModName}Blocks.${REGISTRYNAME}.get().getDescriptionId())
+		</#if>
 	</#macro>
 
 	public <#if var_extends_class! == "WallSignBlock">Wall</#if>${name}Block(BlockBehaviour.Properties properties) {

--- a/plugins/generator-1.21.8/neoforge-1.21.8/templates/block/block.java.ftl
+++ b/plugins/generator-1.21.8/neoforge-1.21.8/templates/block/block.java.ftl
@@ -708,11 +708,11 @@ public class <#if var_extends_class! == "WallSignBlock">Wall</#if>${name}Block e
 		</#if>
 	</#list>
 
-	<#if data.hasSpecialInformation(w)>
-	public static class Item extends <#if data.isDoubleBlock()>DoubleHigh</#if>BlockItem {
+	<#if data.hasSpecialInformation(w) && !(var_extends_class??)> <#-- Do not generate item class for secondary block templates -->
+	public static class Item extends <#if data.isDoubleBlock()>DoubleHighBlock<#elseif data.isSign()>Sign<#else>Block</#if>Item {
 
 		public Item(Item.Properties properties) {
-			super(${JavaModName}Blocks.${REGISTRYNAME}.get(), properties);
+			super(${JavaModName}Blocks.${REGISTRYNAME}.get(), <#if data.isSign()>${JavaModName}Blocks.WALL_${REGISTRYNAME}.get(), </#if>properties);
 		}
 
 		<@addSpecialInformation data.specialInformation, "block." + modid + "." + registryname, true/>

--- a/plugins/generator-1.21.8/neoforge-1.21.8/templates/elementinits/items.java.ftl
+++ b/plugins/generator-1.21.8/neoforge-1.21.8/templates/elementinits/items.java.ftl
@@ -39,6 +39,7 @@ package ${package}.init;
 
 <#assign hasBlocks = false>
 <#assign hasDoubleBlocks = false>
+<#assign hasSigns = false>
 <#assign hasItemsWithCustomProperties = w.getGElementsOfType("item")?filter(e -> e.customProperties?has_content)?size != 0>
 <#assign hasItemsWithLeftHandedProperty = w.getGElementsOfType("item")?filter(e -> e.states
 	?filter(e -> e.stateMap.keySet()?filter(e -> e.getName() == "lefthanded")?size != 0)?size != 0)?size != 0>
@@ -95,6 +96,11 @@ public class ${JavaModName}Items {
 					public static final DeferredItem<Item> ${item.getModElement().getRegistryNameUpper()} =
 						doubleBlock(${JavaModName}Blocks.${item.getModElement().getRegistryNameUpper()}
 						<#if item.hasCustomItemProperties()>, <@blockItemProperties item/></#if>);
+				<#elseif (item.getModElement().getTypeString() == "block") && (item.blockBase! == "Sign")>
+					<#assign hasSigns = true>
+					public static final DeferredItem<Item> ${item.getModElement().getRegistryNameUpper()} =
+						signBlock(${JavaModName}Blocks.${item.getModElement().getRegistryNameUpper()}, ${JavaModName}Blocks.WALL_${item.getModElement().getRegistryNameUpper()}
+						<#if item.hasCustomItemProperties()>, <@blockItemProperties item/></#if>);
 				<#else>
 					<#assign hasBlocks = true>
 					public static final DeferredItem<Item> ${item.getModElement().getRegistryNameUpper()} =
@@ -132,6 +138,16 @@ public class ${JavaModName}Items {
 
 	private static DeferredItem<Item> doubleBlock(DeferredHolder<Block, Block> block, Item.Properties properties) {
 		return REGISTRY.registerItem(block.getId().getPath(), prop -> new DoubleHighBlockItem(block.get(), prop), properties);
+	}
+	</#if>
+
+	<#if hasSigns>
+	private static DeferredItem<Item> signBlock(DeferredHolder<Block, Block> block, DeferredHolder<Block, Block> wallBlock) {
+		return signBlock(block, wallBlock, new Item.Properties());
+	}
+
+	private static DeferredItem<Item> signBlock(DeferredHolder<Block, Block> block, DeferredHolder<Block, Block> wallBlock, Item.Properties properties) {
+		return REGISTRY.registerItem(block.getId().getPath(), prop -> new SignItem(block.get(), wallBlock.get(), prop), properties);
 	}
 	</#if>
 

--- a/plugins/generator-1.21.8/neoforge-1.21.8/templates/elementinits/woodtypes.java.ftl
+++ b/plugins/generator-1.21.8/neoforge-1.21.8/templates/elementinits/woodtypes.java.ftl
@@ -1,0 +1,45 @@
+<#--
+ # MCreator (https://mcreator.net/)
+ # Copyright (C) 2012-2020, Pylo
+ # Copyright (C) 2020-2025, Pylo, opensource contributors
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # Additional permission for code generator templates (*.ftl files)
+ #
+ # As a special exception, you may create a larger work that contains part or
+ # all of the MCreator code generator templates (*.ftl files) and distribute
+ # that work under terms of your choice, so long as that work isn't itself a
+ # template for code generation. Alternatively, if you modify or redistribute
+ # the template itself, you may (at your option) remove this special exception,
+ # which will cause the template and the resulting code generator output files
+ # to be licensed under the GNU General Public License without this special
+ # exception.
+-->
+
+<#-- @formatter:off -->
+
+/*
+ *    MCreator note: This file will be REGENERATED on each build.
+ */
+
+package ${package}.init;
+
+public class ${JavaModName}WoodTypes {
+	<#compress>
+	<#list blocks?filter(e -> e.isSign()) as block>
+	public static final WoodType ${block.getModElement().getRegistryNameUpper()}_WOOD_TYPE = WoodType.register(new WoodType("${modid}:${block.getModElement().getRegistryName()}", BlockSetType.OAK));
+	</#list>
+	</#compress>
+}

--- a/plugins/generator-1.21.8/neoforge-1.21.8/templates/json/block_model_particle.json.ftl
+++ b/plugins/generator-1.21.8/neoforge-1.21.8/templates/json/block_model_particle.json.ftl
@@ -1,0 +1,5 @@
+{
+    "textures": {
+      "particle": "${data.getParticleTexture().format("%s:block/%s")}"
+    }
+}

--- a/plugins/generator-1.21.8/neoforge-1.21.8/utils/mcitems.ftl
+++ b/plugins/generator-1.21.8/neoforge-1.21.8/utils/mcitems.ftl
@@ -161,20 +161,24 @@
 
 <#function mappedElementToRegistryEntry mappedElement>
     <#return JavaModName + generator.isBlock(mappedElement)?then("Blocks", "Items") + "."
-    + generator.getRegistryNameFromFullName(mappedElement)?upper_case + transformExtension(mappedElement)?upper_case + ".get()">
+    + handleExtension(mappedElement, generator.getRegistryNameFromFullName(mappedElement))?upper_case + ".get()">
 </#function>
 
-<#function transformExtension mappedBlock>
+<#function handleExtension mappedBlock customelement>
     <#assign extension = mappedBlock?keep_after_last(".")?replace("body", "chestplate")?replace("legs", "leggings")>
-    <#return (extension?has_content)?then("_" + extension, "")>
+    <#if extension == "wall"> <#-- Special handling for wall variant of signs -->
+    	<#return "wall_" + customelement>
+    <#else>
+    	<#return (extension?has_content)?then(customelement + "_" + extension, customelement)>
+    </#if>
 </#function>
 
 <#function mappedMCItemToItemObjectJSON mappedBlock itemKey="item">
     <#if mappedBlock.getUnmappedValue().startsWith("CUSTOM:")>
         <#assign customelement = generator.getRegistryNameFromFullName(mappedBlock.getUnmappedValue())!""/>
         <#if customelement?has_content>
-            <#return "\"" + itemKey + "\": \"" + "${modid}:" + customelement
-            + transformExtension(mappedBlock)
+            <#return "\"" + itemKey + "\": \"" + "${modid}:"
+            + handleExtension(mappedBlock, customelement)
             + "\"">
         <#else>
             <#return "\"" + itemKey + "\": \"minecraft:air\"">
@@ -197,7 +201,7 @@
     <#if mappedBlock.getUnmappedValue().startsWith("CUSTOM:")>
         <#assign customelement = generator.getRegistryNameFromFullName(mappedBlock.getUnmappedValue())!""/>
         <#if customelement?has_content>
-            <#return "${modid}:" + customelement + transformExtension(mappedBlock)>
+            <#return "${modid}:" + handleExtension(mappedBlock, customelement)>
         <#else>
             <#return "minecraft:air">
         </#if>

--- a/plugins/mcreator-localization/help/default/block/sign_entity_texture.md
+++ b/plugins/mcreator-localization/help/default/block/sign_entity_texture.md
@@ -1,0 +1,1 @@
+This is the texture used by signs to render in the world. Make sure the texture is compatible with the sign model.

--- a/plugins/mcreator-localization/lang/texts.properties
+++ b/plugins/mcreator-localization/lang/texts.properties
@@ -2404,6 +2404,7 @@ elementgui.block.block_set_type=<html>Block set type:<br><small>Determines prope
 elementgui.block.block_set_type.oak=Wood
 elementgui.block.block_set_type.stone=Stone
 elementgui.block.block_set_type.iron=Iron
+elementgui.block.sign_entity_texture=<html>Sign entity texture:<br><small>Used to render sign in world
 elementgui.block.item_texture=<html>Block item texture:<br><small>Optional texture for block in inventory and hand rendering
 elementgui.block.particle_texture=<html>Block particle texture:<br><small>Optional texture for block breaking particles
 elementgui.block.block_textures_and_model=Block textures and model

--- a/src/main/java/net/mcreator/element/types/Block.java
+++ b/src/main/java/net/mcreator/element/types/Block.java
@@ -371,6 +371,8 @@ import java.util.stream.Collectors;
 			return (BufferedImage) MinecraftImageGenerator.Preview.generatePressurePlateIcon(getMainTexture());
 		} else if (blockBase != null && blockBase.equals("Button")) {
 			return (BufferedImage) MinecraftImageGenerator.Preview.generateButtonIcon(getMainTexture());
+		} else if (blockBase != null && blockBase.equals("Sign")) {
+			return ImageUtils.resizeAndCrop(itemTexture.getImage(TextureType.ITEM), 32);
 		} else if (renderType() == 14) {
 			Image side = ImageUtils.drawOver(new ImageIcon(getTextureWithFallback(textureFront)),
 					new ImageIcon(getTextureWithFallback(textureLeft))).getImage();

--- a/src/main/java/net/mcreator/element/types/Block.java
+++ b/src/main/java/net/mcreator/element/types/Block.java
@@ -33,6 +33,7 @@ import net.mcreator.minecraft.MinecraftImageGenerator;
 import net.mcreator.ui.minecraft.states.PropertyDataWithValue;
 import net.mcreator.ui.workspace.resources.TextureType;
 import net.mcreator.util.image.ImageUtils;
+import net.mcreator.workspace.Workspace;
 import net.mcreator.workspace.elements.ModElement;
 import net.mcreator.workspace.references.ModElementReference;
 import net.mcreator.workspace.references.ResourceReference;
@@ -393,6 +394,13 @@ import java.util.stream.Collectors;
 			retval.add(new MCItem.Custom(this.getModElement(), "wall", "block", "Wall sign"));
 
 		return retval;
+	}
+
+	@Override public ImageIcon getIconForMCItem(Workspace workspace, String suffix) {
+		if (isSign() && "wall".equals(suffix)) {
+			return new ImageIcon(MinecraftImageGenerator.Preview.generateWallSignIcon(getMainTexture()));
+		}
+		return null;
 	}
 
 	@Override public List<MCItem> getCreativeTabItems() {

--- a/src/main/java/net/mcreator/element/types/Block.java
+++ b/src/main/java/net/mcreator/element/types/Block.java
@@ -27,6 +27,7 @@ import net.mcreator.element.parts.procedure.Procedure;
 import net.mcreator.element.parts.procedure.StringListProcedure;
 import net.mcreator.element.types.interfaces.*;
 import net.mcreator.generator.GeneratorFlavor;
+import net.mcreator.io.FileIO;
 import net.mcreator.minecraft.MCItem;
 import net.mcreator.minecraft.MinecraftImageGenerator;
 import net.mcreator.ui.minecraft.states.PropertyDataWithValue;
@@ -38,18 +39,23 @@ import net.mcreator.workspace.references.ResourceReference;
 import net.mcreator.workspace.references.TextureReference;
 import net.mcreator.workspace.resources.Model;
 import net.mcreator.workspace.resources.TexturedModel;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.swing.*;
 import java.awt.*;
 import java.awt.image.BufferedImage;
+import java.io.File;
 import java.util.*;
 import java.util.List;
 import java.util.stream.Collectors;
 
 @SuppressWarnings({ "unused", "NotNullFieldNotInitialized" }) public class Block extends GeneratableElement
 		implements IBlock, IItemWithModel, ITabContainedElement, ISpecialInfoHolder, IBlockWithBoundingBox {
+
+	private static final Logger LOG = LogManager.getLogger(Block.class);
 
 	@TextureReference(TextureType.BLOCK) public TextureHolder texture;
 	@TextureReference(TextureType.BLOCK) public TextureHolder textureTop;
@@ -71,6 +77,7 @@ import java.util.stream.Collectors;
 
 	public String blockBase;
 	public String blockSetType;
+	@TextureReference(TextureType.ENTITY) public TextureHolder signEntityTexture;
 
 	public String tintType;
 	public boolean isItemTinted;
@@ -247,6 +254,19 @@ import java.util.stream.Collectors;
 		this.animations = new ArrayList<>();
 	}
 
+	@Override public void finalizeModElementGeneration() {
+		if (isSign()) {
+			try {
+				File entityTextureLocation = new File(
+						getModElement().getFolderManager().getTexturesFolder(TextureType.OTHER),
+						"entity/signs/" + getModElement().getRegistryName() + ".png");
+				FileIO.copyFile(signEntityTexture.toFile(TextureType.ENTITY), entityTextureLocation);
+			} catch (Exception e) {
+				LOG.error("Failed to sign texture", e);
+			}
+		}
+	}
+
 	public int renderType() {
 		if (blockBase != null && !blockBase.isEmpty())
 			return -1;
@@ -267,6 +287,10 @@ import java.util.stream.Collectors;
 
 	@Override public boolean isDoubleBlock() {
 		return "Door".equals(blockBase);
+	}
+
+	public boolean isSign() {
+		return "Sign".equals(blockBase);
 	}
 
 	public boolean shouldOpenGUIOnRightClick() {

--- a/src/main/java/net/mcreator/element/types/Block.java
+++ b/src/main/java/net/mcreator/element/types/Block.java
@@ -28,6 +28,7 @@ import net.mcreator.element.parts.procedure.StringListProcedure;
 import net.mcreator.element.types.interfaces.*;
 import net.mcreator.generator.GeneratorFlavor;
 import net.mcreator.io.FileIO;
+import net.mcreator.minecraft.DataListEntry;
 import net.mcreator.minecraft.MCItem;
 import net.mcreator.minecraft.MinecraftImageGenerator;
 import net.mcreator.ui.minecraft.states.PropertyDataWithValue;
@@ -451,6 +452,10 @@ import java.util.stream.Collectors;
 			baseTypes.add(BaseType.BLOCKENTITY);
 
 		return baseTypes;
+	}
+
+	public Set<String> getProvidedBlocks() {
+		return providedMCItems().stream().map(DataListEntry::getName).collect(Collectors.toSet());
 	}
 
 	public Set<String> getVibrationalEvents() {

--- a/src/main/java/net/mcreator/element/types/Block.java
+++ b/src/main/java/net/mcreator/element/types/Block.java
@@ -392,7 +392,7 @@ import java.util.stream.Collectors;
 		retval.add(new MCItem.Custom(this.getModElement(), null, hasBlockItem ? "block" : "block_without_item"));
 
 		if (isSign()) // Provide sign wall block
-			retval.add(new MCItem.Custom(this.getModElement(), "wall", "block", "Wall sign"));
+			retval.add(new MCItem.Custom(this.getModElement(), "wall", "block_without_item", "Wall sign"));
 
 		return retval;
 	}

--- a/src/main/java/net/mcreator/element/types/Block.java
+++ b/src/main/java/net/mcreator/element/types/Block.java
@@ -386,11 +386,17 @@ import java.util.stream.Collectors;
 	}
 
 	@Override public List<MCItem> providedMCItems() {
-		return List.of(new MCItem.Custom(this.getModElement(), null, hasBlockItem ? "block" : "block_without_item"));
+		ArrayList<MCItem> retval = new ArrayList<>();
+		retval.add(new MCItem.Custom(this.getModElement(), null, hasBlockItem ? "block" : "block_without_item"));
+
+		if (isSign()) // Provide sign wall block
+			retval.add(new MCItem.Custom(this.getModElement(), "wall", "block", "Wall sign"));
+
+		return retval;
 	}
 
 	@Override public List<MCItem> getCreativeTabItems() {
-		return hasBlockItem ? providedMCItems() : Collections.emptyList();
+		return hasBlockItem ? List.of(new MCItem.Custom(this.getModElement(), null, "block")) : Collections.emptyList();
 	}
 
 	@Override public StringListProcedure getSpecialInfoProcedure() {

--- a/src/main/java/net/mcreator/minecraft/MinecraftImageGenerator.java
+++ b/src/main/java/net/mcreator/minecraft/MinecraftImageGenerator.java
@@ -1065,6 +1065,24 @@ public class MinecraftImageGenerator {
 		}
 
 		/**
+		 * <p>This method generates the block icon for wall signs.</p>
+		 *
+		 * @param texture <p>Block texture</p>
+		 * @return <p>Returns generated image.</p>
+		 */
+		public static Image generateWallSignIcon(Image texture) {
+			BufferedImage out = new BufferedImage(32, 32, BufferedImage.TYPE_INT_ARGB);
+			Graphics2D g2d = (Graphics2D) out.getGraphics();
+			g2d.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BILINEAR);
+			g2d.scale(1.6, 1.5);
+			g2d.translate(-6, -6);
+
+			g2d.drawImage(ImageUtils.generateCuboidImage(texture, 1, 12, 16, 8, 2, 0), null, null);
+			g2d.dispose();
+			return out;
+		}
+
+		/**
 		 * <p>This method generates the potion bottle icon for potions.</p>
 		 *
 		 * @param color <p>Color of the potion</p>

--- a/src/main/java/net/mcreator/ui/modgui/BlockGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/BlockGUI.java
@@ -422,6 +422,7 @@ public class BlockGUI extends ModElementGUI<Block> {
 			rotationMode.setEnabled(!hasBlockBase);
 			isWaterloggable.setEnabled(!hasBlockBase);
 			hasGravity.setEnabled(!hasBlockBase);
+			hasInventory.setEnabled(true);
 			isBonemealable.setEnabled(true);
 			transparencyType.setEnabled(true);
 			hasTransparency.setEnabled(true);
@@ -497,6 +498,8 @@ public class BlockGUI extends ModElementGUI<Block> {
 					}
 				}
 				case "Sign" -> {
+					hasInventory.setEnabled(false);
+					hasInventory.setSelected(false);
 					signPropertiesPanel.setVisible(true);
 					if (!isEditingMode()) {
 						lightOpacity.setValue(0);
@@ -518,6 +521,7 @@ public class BlockGUI extends ModElementGUI<Block> {
 			}
 
 			updateTextureOptions();
+			refreshFieldsTileEntity();
 			refreshBonemealProperties();
 		});
 
@@ -1469,7 +1473,7 @@ public class BlockGUI extends ModElementGUI<Block> {
 			hasInventory.setSelected(true);
 			hasInventory.setEnabled(false);
 			refreshFieldsTileEntity();
-		} else {
+		} else if (!"Sign".equals(blockBase.getSelectedItem())) {
 			hasInventory.setEnabled(true);
 		}
 

--- a/src/test/java/net/mcreator/integration/TestWorkspaceDataProvider.java
+++ b/src/test/java/net/mcreator/integration/TestWorkspaceDataProvider.java
@@ -2161,6 +2161,7 @@ public class TestWorkspaceDataProvider {
 		}
 		block.itemTexture = new TextureHolder(modElement.getWorkspace(), emptyLists ? "" : "itest");
 		block.particleTexture = new TextureHolder(modElement.getWorkspace(), emptyLists ? "" : "test7");
+		block.signEntityTexture = new TextureHolder(modElement.getWorkspace(), emptyLists ? "" : "entity_texture_0");
 		block.texture = new TextureHolder(modElement.getWorkspace(), "test");
 		block.textureTop = new TextureHolder(modElement.getWorkspace(), "test2");
 		block.textureLeft = new TextureHolder(modElement.getWorkspace(), "test3");


### PR DESCRIPTION
This PR adds support for a sign block base. Hanging signs will be added in a later PR.

Vanilla Minecraft uses `<wood>_sign` and `<wood>_wall_sign` for the block ids. To keep the IDs similar, wall sign variants will use `wall_<registryname>`.

<img width="854" height="480" alt="signs" src="https://github.com/user-attachments/assets/93865cee-d5c3-497b-b3bc-2de58e31c82c" />
