### PR TITLE
Improvements to code editor search/replace bars

### DIFF
--- a/plugins/mcreator-localization/lang/texts.properties
+++ b/plugins/mcreator-localization/lang/texts.properties
@@ -4057,3 +4057,7 @@ mcreator.resourcepack.tab.vanilla=Vanilla pack
 mcreator.resourcepack.tab.mod=Mod: {0}
 mcreator.resourcepack.delete_pack=<html>Are you sure you want to delete the selected pack?<br>\
   Deleting the pack will also remove all override files under its namespace!
+ide.search.regex=Regex
+ide.search.match_case=Match case
+ide.search.whole_words=Whole words
+ide.search.results={0} results

--- a/src/main/java/net/mcreator/ui/ide/ReplaceBar.java
+++ b/src/main/java/net/mcreator/ui/ide/ReplaceBar.java
@@ -39,9 +39,9 @@ public class ReplaceBar extends JPanel {
 	private final JTextField jtf1 = new JTextField(40);
 	private final JTextField jtf2 = new JTextField(40);
 
-	private final JCheckBox cb2 = new JCheckBox("Regex");
-	private final JCheckBox cb3 = new JCheckBox("Match case");
-	private final JCheckBox cb4 = new JCheckBox("Words");
+	private final JCheckBox cb2 = L10N.checkbox("ide.search.regex");
+	private final JCheckBox cb3 = L10N.checkbox("ide.search.match_case");
+	private final JCheckBox cb4 = L10N.checkbox("ide.search.whole_words");
 
 	private final RTextArea ra;
 	private final SearchContext context = new SearchContext();
@@ -178,7 +178,7 @@ public class ReplaceBar extends JPanel {
 
 		SearchResult marked = SearchEngine.markAll(ra, context);
 
-		matches.setText(marked.getMarkedCount() + " results");
+		matches.setText(L10N.t("ide.search.results", marked.getMarkedCount()));
 		if (marked.getMarkedCount() > 0) {
 			matches.setForeground(Theme.current().getAltForegroundColor());
 		} else {

--- a/src/main/java/net/mcreator/ui/ide/ReplaceBar.java
+++ b/src/main/java/net/mcreator/ui/ide/ReplaceBar.java
@@ -42,7 +42,6 @@ public class ReplaceBar extends JPanel {
 	private final JCheckBox cb2 = new JCheckBox("Regex");
 	private final JCheckBox cb3 = new JCheckBox("Match Case");
 	private final JCheckBox cb4 = new JCheckBox("Words");
-	private final JCheckBox cb5 = new JCheckBox("Selection");
 
 	private final RTextArea ra;
 	private final SearchContext context = new SearchContext();
@@ -83,7 +82,6 @@ public class ReplaceBar extends JPanel {
 		cb2.addActionListener(e -> updateSearch());
 		cb3.addActionListener(e -> updateSearch());
 		cb4.addActionListener(e -> updateSearch());
-		cb5.addActionListener(e -> updateSearch());
 
 		jtf2.addKeyListener(new KeyAdapter() {
 			@Override public void keyReleased(KeyEvent keyEvent) {
@@ -102,7 +100,6 @@ public class ReplaceBar extends JPanel {
 			context.setMatchCase(cb3.isSelected());
 			context.setRegularExpression(cb2.isSelected());
 			context.setWholeWord(cb4.isSelected());
-			context.setSearchSelectionOnly(cb5.isSelected());
 			SearchEngine.replace(ra, context);
 		});
 
@@ -112,7 +109,6 @@ public class ReplaceBar extends JPanel {
 			context.setMatchCase(cb3.isSelected());
 			context.setRegularExpression(cb2.isSelected());
 			context.setWholeWord(cb4.isSelected());
-			context.setSearchSelectionOnly(cb5.isSelected());
 			SearchEngine.replaceAll(ra, context);
 		});
 
@@ -129,20 +125,17 @@ public class ReplaceBar extends JPanel {
 		top.add(cb3);
 		top.add(cb2);
 		top.add(cb4);
-		top.add(cb5);
 		top.add(Box.createHorizontalStrut(10));
 		top.add(matches);
 		top.add(Box.createHorizontalGlue());
 
 		cb3.setOpaque(false);
 		cb2.setOpaque(false);
-		cb5.setOpaque(false);
 		cb4.setOpaque(false);
 
 		cb3.setForeground(new Color(0xE2E2E2));
 		cb2.setForeground(new Color(0xE2E2E2));
 		cb4.setForeground(new Color(0xE2E2E2));
-		cb5.setForeground(new Color(0xE2E2E2));
 
 		jtf1.setMaximumSize(jtf1.getPreferredSize());
 		jtf2.setMaximumSize(jtf1.getPreferredSize());
@@ -181,7 +174,6 @@ public class ReplaceBar extends JPanel {
 		context.setMatchCase(cb3.isSelected());
 		context.setRegularExpression(cb2.isSelected());
 		context.setWholeWord(cb4.isSelected());
-		context.setSearchSelectionOnly(cb5.isSelected());
 		context.setSearchWrap(true);
 
 		SearchResult marked = SearchEngine.markAll(ra, context);

--- a/src/main/java/net/mcreator/ui/ide/ReplaceBar.java
+++ b/src/main/java/net/mcreator/ui/ide/ReplaceBar.java
@@ -184,4 +184,8 @@ public class ReplaceBar extends JPanel {
 		});
 	}
 
+	public JTextField getSearchField() {
+		return jtf1;
+	}
+
 }

--- a/src/main/java/net/mcreator/ui/ide/ReplaceBar.java
+++ b/src/main/java/net/mcreator/ui/ide/ReplaceBar.java
@@ -40,7 +40,7 @@ public class ReplaceBar extends JPanel {
 	private final JTextField jtf2 = new JTextField(40);
 
 	private final JCheckBox cb2 = new JCheckBox("Regex");
-	private final JCheckBox cb3 = new JCheckBox("Match Case");
+	private final JCheckBox cb3 = new JCheckBox("Match case");
 	private final JCheckBox cb4 = new JCheckBox("Words");
 
 	private final RTextArea ra;

--- a/src/main/java/net/mcreator/ui/ide/ReplaceBar.java
+++ b/src/main/java/net/mcreator/ui/ide/ReplaceBar.java
@@ -44,13 +44,17 @@ public class ReplaceBar extends JPanel {
 	private final JCheckBox cb4 = new JCheckBox("Words");
 	private final JCheckBox cb5 = new JCheckBox("Selection");
 
+	private final RTextArea ra;
+	private final SearchContext context = new SearchContext();
+	private final JLabel matches = new JLabel();
+
 	ReplaceBar(RTextArea ra) {
 		super(new BorderLayout(0, 1));
+		this.ra = ra;
 
 		jtf1.putClientProperty(FlatClientProperties.TEXT_FIELD_SHOW_CLEAR_BUTTON, true);
 		jtf2.putClientProperty(FlatClientProperties.TEXT_FIELD_SHOW_CLEAR_BUTTON, true);
 
-		final JLabel matches = new JLabel();
 		matches.setForeground(Theme.current().getAltForegroundColor());
 
 		JToolBar top = new JToolBar();
@@ -66,22 +70,7 @@ public class ReplaceBar extends JPanel {
 		jtf1.addKeyListener(new KeyAdapter() {
 			@Override public void keyReleased(KeyEvent keyEvent) {
 				super.keyReleased(keyEvent);
-				SearchContext context = new SearchContext();
-				context.setSearchFor(jtf1.getText());
-				context.setMatchCase(cb3.isSelected());
-				context.setRegularExpression(cb2.isSelected());
-				context.setWholeWord(cb4.isSelected());
-				context.setSearchSelectionOnly(cb5.isSelected());
-				context.setSearchWrap(true);
-
-				SearchResult marked = SearchEngine.markAll(ra, context);
-
-				matches.setText(marked.getMarkedCount() + " results");
-				if (marked.getMarkedCount() > 0) {
-					matches.setForeground(Theme.current().getAltForegroundColor());
-				} else {
-					matches.setForeground(new Color(239, 96, 96));
-				}
+				updateSearch();
 
 				if (keyEvent.getKeyCode() == KeyEvent.VK_ENTER) {
 					SearchEngine.find(ra, context);
@@ -90,6 +79,11 @@ public class ReplaceBar extends JPanel {
 				}
 			}
 		});
+
+		cb2.addActionListener(e -> updateSearch());
+		cb3.addActionListener(e -> updateSearch());
+		cb4.addActionListener(e -> updateSearch());
+		cb5.addActionListener(e -> updateSearch());
 
 		jtf2.addKeyListener(new KeyAdapter() {
 			@Override public void keyReleased(KeyEvent keyEvent) {
@@ -103,7 +97,6 @@ public class ReplaceBar extends JPanel {
 		JButton replaceAll = L10N.button("action.replace_all");
 
 		replace.addActionListener(actionEvent -> {
-			SearchContext context = new SearchContext();
 			context.setSearchFor(jtf1.getText());
 			context.setReplaceWith(jtf2.getText());
 			context.setMatchCase(cb3.isSelected());
@@ -114,7 +107,6 @@ public class ReplaceBar extends JPanel {
 		});
 
 		replaceAll.addActionListener(actionEvent -> {
-			SearchContext context = new SearchContext();
 			context.setSearchFor(jtf1.getText());
 			context.setReplaceWith(jtf2.getText());
 			context.setMatchCase(cb3.isSelected());
@@ -182,6 +174,24 @@ public class ReplaceBar extends JPanel {
 				SearchEngine.markAll(ra, context);
 			}
 		});
+	}
+
+	private void updateSearch() {
+		context.setSearchFor(jtf1.getText());
+		context.setMatchCase(cb3.isSelected());
+		context.setRegularExpression(cb2.isSelected());
+		context.setWholeWord(cb4.isSelected());
+		context.setSearchSelectionOnly(cb5.isSelected());
+		context.setSearchWrap(true);
+
+		SearchResult marked = SearchEngine.markAll(ra, context);
+
+		matches.setText(marked.getMarkedCount() + " results");
+		if (marked.getMarkedCount() > 0) {
+			matches.setForeground(Theme.current().getAltForegroundColor());
+		} else {
+			matches.setForeground(new Color(239, 96, 96));
+		}
 	}
 
 	public JTextField getSearchField() {

--- a/src/main/java/net/mcreator/ui/ide/SearchBar.java
+++ b/src/main/java/net/mcreator/ui/ide/SearchBar.java
@@ -41,7 +41,6 @@ public class SearchBar extends JToolBar {
 	private final JCheckBox cb2 = new JCheckBox("Regex");
 	private final JCheckBox cb3 = new JCheckBox("Match Case");
 	private final JCheckBox cb4 = new JCheckBox("Words");
-	private final JCheckBox cb5 = new JCheckBox("Selection");
 
 	private final RTextArea ra;
 
@@ -82,7 +81,6 @@ public class SearchBar extends JToolBar {
 		cb2.addActionListener(e -> updateSearch());
 		cb3.addActionListener(e -> updateSearch());
 		cb4.addActionListener(e -> updateSearch());
-		cb5.addActionListener(e -> updateSearch());
 
 		setFloatable(false);
 		setBackground(Theme.current().getBackgroundColor());
@@ -92,7 +90,6 @@ public class SearchBar extends JToolBar {
 		add(cb3);
 		add(cb2);
 		add(cb4);
-		add(cb5);
 		add(Box.createHorizontalStrut(10));
 		add(matches);
 
@@ -130,7 +127,6 @@ public class SearchBar extends JToolBar {
 		context.setMatchCase(cb3.isSelected());
 		context.setRegularExpression(cb2.isSelected());
 		context.setWholeWord(cb4.isSelected());
-		context.setSearchSelectionOnly(cb5.isSelected());
 		context.setSearchWrap(true);
 
 		SearchResult marked = SearchEngine.markAll(ra, context);

--- a/src/main/java/net/mcreator/ui/ide/SearchBar.java
+++ b/src/main/java/net/mcreator/ui/ide/SearchBar.java
@@ -19,6 +19,7 @@
 package net.mcreator.ui.ide;
 
 import com.formdev.flatlaf.FlatClientProperties;
+import net.mcreator.ui.init.L10N;
 import net.mcreator.ui.init.UIRES;
 import net.mcreator.ui.laf.themes.Theme;
 import org.fife.ui.rtextarea.RTextArea;
@@ -38,9 +39,9 @@ import java.awt.event.KeyEvent;
 public class SearchBar extends JToolBar {
 
 	private final JTextField jtf1 = new JTextField(40);
-	private final JCheckBox cb2 = new JCheckBox("Regex");
-	private final JCheckBox cb3 = new JCheckBox("Match case");
-	private final JCheckBox cb4 = new JCheckBox("Words");
+	private final JCheckBox cb2 = L10N.checkbox("ide.search.regex");
+	private final JCheckBox cb3 = L10N.checkbox("ide.search.match_case");
+	private final JCheckBox cb4 = L10N.checkbox("ide.search.whole_words");
 
 	private final RTextArea ra;
 
@@ -131,7 +132,7 @@ public class SearchBar extends JToolBar {
 
 		SearchResult marked = SearchEngine.markAll(ra, context);
 
-		matches.setText(marked.getMarkedCount() + " results");
+		matches.setText(L10N.t("ide.search.results", marked.getMarkedCount()));
 		if (marked.getMarkedCount() > 0) {
 			matches.setForeground(Theme.current().getAltForegroundColor());
 		} else {

--- a/src/main/java/net/mcreator/ui/ide/SearchBar.java
+++ b/src/main/java/net/mcreator/ui/ide/SearchBar.java
@@ -39,7 +39,7 @@ public class SearchBar extends JToolBar {
 
 	private final JTextField jtf1 = new JTextField(40);
 	private final JCheckBox cb2 = new JCheckBox("Regex");
-	private final JCheckBox cb3 = new JCheckBox("Match Case");
+	private final JCheckBox cb3 = new JCheckBox("Match case");
 	private final JCheckBox cb4 = new JCheckBox("Words");
 
 	private final RTextArea ra;

--- a/src/main/java/net/mcreator/ui/ide/SearchBar.java
+++ b/src/main/java/net/mcreator/ui/ide/SearchBar.java
@@ -79,6 +79,11 @@ public class SearchBar extends JToolBar {
 			}
 		});
 
+		cb2.addActionListener(e -> updateSearch());
+		cb3.addActionListener(e -> updateSearch());
+		cb4.addActionListener(e -> updateSearch());
+		cb5.addActionListener(e -> updateSearch());
+
 		setFloatable(false);
 		setBackground(Theme.current().getBackgroundColor());
 

--- a/src/main/java/net/mcreator/ui/ide/action/ShowFindAction.java
+++ b/src/main/java/net/mcreator/ui/ide/action/ShowFindAction.java
@@ -33,6 +33,11 @@ public class ShowFindAction extends BasicAction {
 			if (pan instanceof CodeEditorView codeEditorView) {
 				codeEditorView.sed.setVisible(true);
 				codeEditorView.rep.setVisible(false);
+				String selectedText = codeEditorView.te.getSelectedText();
+				if (selectedText != null && !selectedText.isEmpty())
+					codeEditorView.sed.getSearchField().setText(selectedText);
+				codeEditorView.sed.getSearchField().selectAll();
+				codeEditorView.sed.getSearchField().requestFocusInWindow();
 				codeEditorView.disableJumpToMode();
 			}
 		});

--- a/src/main/java/net/mcreator/ui/ide/action/ShowReplaceAction.java
+++ b/src/main/java/net/mcreator/ui/ide/action/ShowReplaceAction.java
@@ -33,6 +33,11 @@ public class ShowReplaceAction extends BasicAction {
 			if (pan instanceof CodeEditorView codeEditorView) {
 				codeEditorView.sed.setVisible(false);
 				codeEditorView.rep.setVisible(true);
+				String selectedText = codeEditorView.te.getSelectedText();
+				if (selectedText != null && !selectedText.isEmpty())
+					codeEditorView.rep.getSearchField().setText(selectedText);
+				codeEditorView.rep.getSearchField().selectAll();
+				codeEditorView.rep.getSearchField().requestFocusInWindow();
 				codeEditorView.disableJumpToMode();
 			}
 		});


### PR DESCRIPTION
- Keyboard shortcut now always selects all the text in the search field. The search field is autofilled with any selected text in the code viewer (unless selection is empty)
- Checkboxes like "Match case" now update the search results when toggled