### PR TITLE
Magnitude procedure block (fixed commit issues)

### DIFF
--- a/plugins/generator-1.21.1/neoforge-1.21.1/procedures/vector_magnitude.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/procedures/vector_magnitude.java.ftl
@@ -1,0 +1,1 @@
+(${input$vector}.length())

--- a/plugins/generator-1.21.8/neoforge-1.21.8/procedures/vector_magnitude.java.ftl
+++ b/plugins/generator-1.21.8/neoforge-1.21.8/procedures/vector_magnitude.java.ftl
@@ -1,0 +1,1 @@
+(${input$vector}.length())

--- a/plugins/mcreator-core/procedures/vector_magnitude.json
+++ b/plugins/mcreator-core/procedures/vector_magnitude.json
@@ -1,0 +1,22 @@
+{
+  "args0": [
+    {
+      "type": "input_value",
+      "name": "vector",
+      "check": "Vector"
+    }
+  ],
+  "inputsInline": true,
+  "output": "Number",
+  "colour": "%{BKY_MATH_HUE}",
+  "mcreator": {
+    "group": "base",
+    "toolbox_id": "vector",
+    "toolbox_init": [
+      "~<value name=\"vector\"><block type=\"vector_new_vector\"><value name=\"x\"><block type=\"coord_x\"></block></value><value name=\"y\"><block type=\"coord_y\"></block></value><value name=\"z\"><block type=\"coord_z\"></block></value></block></value>"
+    ],
+    "inputs": [
+      "vector"
+    ]
+  }
+}

--- a/plugins/mcreator-localization/lang/texts.properties
+++ b/plugins/mcreator-localization/lang/texts.properties
@@ -1262,6 +1262,7 @@ blockly.block.logic_vector_compare=Is %1 the same vector as %2
 blockly.block.loot_table_foreach=For each item from loot table %1 as %2 %3 %4 do %5
 blockly.block.vector_distance=Get distance between %1 and %2
 blockly.block.vector_dual_ops=%1 %2 %3
+blockly.block.vector_magnitude=Get magnitude of %1
 blockly.block.vector_new_vector=Make vector with x: %1 y: %2 z: %3
 blockly.block.vector_normalize=Normalized vector of %1
 blockly.block.vector_number_scale=Scale vector %1 by %2 through %3


### PR DESCRIPTION
This is a remake of PR number #5770 due to issues it had with commits.

This PR will add a single procedure block that will return the magnitude/length of a vector, which is useful in some cases...
<img width="1254" height="402" alt="491326269-cb673618-986a-432c-8206-1cdf06b6c448" src="https://github.com/user-attachments/assets/ab0c27a5-47a5-4927-a438-004d1cbc096c" />
