### PR TITLE
Add Zelos renderer for Blockly

### DIFF
--- a/plugins/mcreator-localization/lang/texts.properties
+++ b/plugins/mcreator-localization/lang/texts.properties
@@ -1932,7 +1932,10 @@ preferences.backups.numberOfBackupsToStore.description=This number defines how m
 preferences.backups.backupOnVersionSwitch=Do a full backup when opening the workspace in a new version
 preferences.backups.backupOnVersionSwitch.description=If enabled, MCreator will do a full workspace backup before opening workspace folder in a new version
 preferences.blockly.blockRenderer=Blocks renderer
-preferences.blockly.blockRenderer.description=The renderer (display style) of the blocks in the Blockly editor
+preferences.blockly.blockRenderer.description=<html>The renderer (display style) of the blocks in the Blockly editor.<br>\
+  <ul><li>Geras is Blockly's original rendering engine.\
+  <li>Thrasos is Blockly's new, recommended, and more modern rendering engine.\
+  <li>Zelos is a rendering engine similar to Scratch 3.0.</ul>
 preferences.blockly.useSmartSort=Use smart procedure block sorting
 preferences.blockly.useSmartSort.description=When enabled, procedure blocks will be smart-sorted, otherwise they will be sorted alphabetically
 preferences.blockly.expandCategories=Expand toolbox categories

--- a/src/main/java/net/mcreator/preferences/data/BlocklySection.java
+++ b/src/main/java/net/mcreator/preferences/data/BlocklySection.java
@@ -43,7 +43,7 @@ public class BlocklySection extends PreferencesSection {
 	BlocklySection(String preferencesIdentifier) {
 		super(preferencesIdentifier);
 
-		blockRenderer = addEntry(new StringEntry("blockRenderer", "Thrasos", "Geras", "Thrasos"));
+		blockRenderer = addEntry(new StringEntry("blockRenderer", "Thrasos", "Geras", "Thrasos", "Zelos"));
 		colorSaturation = addEntry(new IntegerEntry("colorSaturation", 45, 30, 100));
 		colorValue = addEntry(new IntegerEntry("colorValue", 65, 30, 100));
 		useSmartSort = addEntry(new BooleanEntry("useSmartSort", true));


### PR DESCRIPTION
I was looking at Blockly's doc and I saw this new style, so I added it. I also added a small description for each style (based on [Blockly's doc](https://developers.google.com/blockly/guides/create-custom-blocks/renderers/overview)), so users can know and understand what those weird names are.