### PR TITLE
Vector getters

### DIFF
--- a/plugins/generator-1.21.1/neoforge-1.21.1/procedures/entity_lookpos.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/procedures/entity_lookpos.java.ftl
@@ -1,0 +1,3 @@
+/*@int*/(${input$entity}.level().clip(new ClipContext(${input$entity}.getEyePosition(1f),${input$entity}.getEyePosition(1f)
+    .add(${input$entity}.getViewVector(1f).scale(${input$maxdistance})), ClipContext.Block.${field$block_mode!"OUTLINE"},
+    ClipContext.Fluid.${field$fluid_mode!"NONE"}, ${input$entity})).getBlockPos())

--- a/plugins/generator-1.21.8/neoforge-1.21.8/procedures/entity_lookpos.java.ftl
+++ b/plugins/generator-1.21.8/neoforge-1.21.8/procedures/entity_lookpos.java.ftl
@@ -1,0 +1,3 @@
+/*@int*/(${input$entity}.level().clip(new ClipContext(${input$entity}.getEyePosition(1f),${input$entity}.getEyePosition(1f)
+    .add(${input$entity}.getViewVector(1f).scale(${input$maxdistance})), ClipContext.Block.${field$block_mode!"OUTLINE"},
+    ClipContext.Fluid.${field$fluid_mode!"NONE"}, ${input$entity})).getBlockPos())

--- a/plugins/mcreator-core/procedures/entity_lookpos.json
+++ b/plugins/mcreator-core/procedures/entity_lookpos.json
@@ -1,0 +1,69 @@
+{
+  "args0": [
+    {
+      "type": "input_value",
+      "name": "maxdistance",
+      "check": "Number"
+    },
+    {
+      "type": "input_value",
+      "name": "entity",
+      "check": "Entity"
+    },
+    {
+      "type": "field_dropdown",
+      "name": "fluid_mode",
+      "options": [
+        [
+          "NONE",
+          "NONE"
+        ],
+        [
+          "SOURCE_ONLY",
+          "SOURCE_ONLY"
+        ],
+        [
+          "ANY",
+          "ANY"
+        ]
+      ]
+    },
+    {
+      "type": "field_dropdown",
+      "name": "block_mode",
+      "options": [
+        [
+          "OUTLINE",
+          "OUTLINE"
+        ],
+        [
+          "COLLIDER",
+          "COLLIDER"
+        ],
+        [
+          "VISUAL",
+          "VISUAL"
+        ]
+      ]
+    }
+  ],
+  "inputsInline": true,
+  "output": "Vector",
+  "colour": 270,
+  "mcreator": {
+    "group": "raytracing",
+    "toolbox_id": "entitydata",
+    "toolbox_init": [
+      "<value name=\"maxdistance\"><block type=\"math_number\"><field name=\"NUM\">5</field></block></value>",
+      "<value name=\"entity\"><block type=\"entity_from_deps\"></block></value>"
+    ],
+    "inputs": [
+      "maxdistance",
+      "entity"
+    ],
+    "fields": [
+      "fluid_mode",
+      "block_mode"
+    ]
+  }
+}

--- a/plugins/mcreator-localization/lang/texts.properties
+++ b/plugins/mcreator-localization/lang/texts.properties
@@ -1107,6 +1107,7 @@ blockly.block.entity_look_angle_y=Y value of look angle vector of %1
 blockly.block.entity_look_angle_z=Z value of look angle vector of %1
 blockly.block.entity_look_face=Block face %2 is looking at with raytrace distance %1 fluid mode %3 block mode %4
 blockly.block.entity_looking_at_block=Is %2 looking at a block with raytrace distance %1 fluid mode %3 block mode %4
+blockly.block.entity_lookpos=Look position of %2 with raytrace distance %1 fluid mode %3 block mode %4
 blockly.block.entity_lookpos_x=Look X position of %2 with raytrace distance %1 fluid mode %3 block mode %4
 blockly.block.entity_lookpos_y=Look Y position of %2 with raytrace distance %1 fluid mode %3 block mode %4
 blockly.block.entity_lookpos_z=Look Z position of %2 with raytrace distance %1 fluid mode %3 block mode %4


### PR DESCRIPTION
To improve performance and procedure clutter, I'll be adding the following procedure blocks that would return vectors:
- "Look position of [Entity] with raytrace distance [number]" (Done)
- "Get entity position"
- "Get entity look angle vector"
- "Get entity delta movement"


Please let me know what should be scrapped (and why) and what should be kept.