### PR TITLE
Added option to make blocks/plants strippable

### DIFF
--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/block/block.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/block/block.java.ftl
@@ -481,6 +481,15 @@ public class ${name}Block extends
 	}
 	</#if>
 
+	<#if data.strippingResult?? && !data.strippingResult.isEmpty()>
+	@Override public BlockState getToolModifiedState(BlockState blockstate, UseOnContext context, ItemAbility itemAbility, boolean simulate) {
+		if (ItemAbilities.AXE_STRIP == itemAbility && context.getItemInHand().canPerformAction(itemAbility)) {
+			return ${mappedBlockToBlock(data.strippingResult)}.withPropertiesOf(blockstate);
+		}
+		return super.getToolModifiedState(blockstate, context, itemAbility, simulate);
+	}
+	</#if>
+
 	<#if data.creativePickItem?? && !data.creativePickItem.isEmpty()>
 	@Override public ItemStack getCloneItemStack(LevelReader level, BlockPos pos, BlockState state) {
 		return ${mappedMCItemToItemStackCode(data.creativePickItem, 1)};

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/plant/plant.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/plant/plant.java.ftl
@@ -186,6 +186,15 @@ public class ${name}Block extends ${getPlantClass(data.plantType)}Block
 	}
 	</#if>
 
+	<#if data.strippingResult?? && !data.strippingResult.isEmpty()>
+	@Override public BlockState getToolModifiedState(BlockState blockstate, UseOnContext context, ItemAbility itemAbility, boolean simulate) {
+		if (ItemAbilities.AXE_STRIP == itemAbility && context.getItemInHand().canPerformAction(itemAbility)) {
+			return ${mappedBlockToBlock(data.strippingResult)}.withPropertiesOf(blockstate);
+		}
+		return super.getToolModifiedState(blockstate, context, itemAbility, simulate);
+	}
+	</#if>
+
 	<#if data.creativePickItem?? && !data.creativePickItem.isEmpty()>
 	@Override public ItemStack getCloneItemStack(BlockState state, HitResult target, LevelReader world, BlockPos pos, Player player) {
 		return ${mappedMCItemToItemStackCode(data.creativePickItem, 1)};

--- a/plugins/generator-1.21.8/neoforge-1.21.8/templates/block/block.java.ftl
+++ b/plugins/generator-1.21.8/neoforge-1.21.8/templates/block/block.java.ftl
@@ -482,6 +482,15 @@ public class ${name}Block extends
 	}
 	</#if>
 
+	<#if data.strippingResult?? && !data.strippingResult.isEmpty()>
+	@Override public BlockState getToolModifiedState(BlockState blockstate, UseOnContext context, ItemAbility itemAbility, boolean simulate) {
+		if (ItemAbilities.AXE_STRIP == itemAbility && context.getItemInHand().canPerformAction(itemAbility)) {
+			return ${mappedBlockToBlock(data.strippingResult)}.withPropertiesOf(blockstate);
+		}
+		return super.getToolModifiedState(blockstate, context, itemAbility, simulate);
+	}
+	</#if>
+
 	<#if data.creativePickItem?? && !data.creativePickItem.isEmpty()>
 	@Override public ItemStack getCloneItemStack(LevelReader world, BlockPos pos, BlockState state, boolean includeData, Player entity) {
 		return ${mappedMCItemToItemStackCode(data.creativePickItem, 1)};

--- a/plugins/generator-1.21.8/neoforge-1.21.8/templates/plant/plant.java.ftl
+++ b/plugins/generator-1.21.8/neoforge-1.21.8/templates/plant/plant.java.ftl
@@ -184,6 +184,15 @@ public class ${name}Block extends ${getPlantClass(data.plantType)}Block
 	}
 	</#if>
 
+	<#if data.strippingResult?? && !data.strippingResult.isEmpty()>
+	@Override public BlockState getToolModifiedState(BlockState blockstate, UseOnContext context, ItemAbility itemAbility, boolean simulate) {
+		if (ItemAbilities.AXE_STRIP == itemAbility && context.getItemInHand().canPerformAction(itemAbility)) {
+			return ${mappedBlockToBlock(data.strippingResult)}.withPropertiesOf(blockstate);
+		}
+		return super.getToolModifiedState(blockstate, context, itemAbility, simulate);
+	}
+	</#if>
+
 	<#if data.creativePickItem?? && !data.creativePickItem.isEmpty()>
 	@Override public ItemStack getCloneItemStack(LevelReader world, BlockPos pos, BlockState state, boolean includeData, Player entity) {
 		return ${mappedMCItemToItemStackCode(data.creativePickItem, 1)};

--- a/plugins/mcreator-localization/help/default/block/stripping_result.md
+++ b/plugins/mcreator-localization/help/default/block/stripping_result.md
@@ -1,0 +1,1 @@
+This parameter controls what this block turns into when it's stripped with an axe.

--- a/plugins/mcreator-localization/lang/texts.properties
+++ b/plugins/mcreator-localization/lang/texts.properties
@@ -2485,6 +2485,7 @@ elementgui.block.enchantments_bonus=Enchantments power bonus:
 elementgui.block.ignited_by_lava=Can block be ignited by lava?
 elementgui.block.flammability=Block flammability:
 elementgui.block.push_reaction=Reaction to being pushed:
+elementgui.block.stripping_result=<html>Block can be stripped into:<br><small>Leave empty if block cannot be stripped
 elementgui.block.has_block_item=<html>Does block have an item form?<br><small>This option should be enabled in most cases
 elementgui.block.properties_block_item=Block item properties
 elementgui.block.properties_advanced_block=Advanced block properties

--- a/src/main/java/net/mcreator/element/types/Block.java
+++ b/src/main/java/net/mcreator/element/types/Block.java
@@ -123,6 +123,7 @@ import java.util.stream.Collectors;
 	public String offsetType;
 	public String aiPathNodeType;
 	public Color beaconColorModifier;
+	public MItemBlock strippingResult;
 
 	public boolean ignitedByLava;
 	public int flammability;

--- a/src/main/java/net/mcreator/element/types/Plant.java
+++ b/src/main/java/net/mcreator/element/types/Plant.java
@@ -109,6 +109,7 @@ import java.util.stream.Collectors;
 	public MItemBlock creativePickItem;
 	public String offsetType;
 	public String aiPathNodeType;
+	public MItemBlock strippingResult;
 
 	public boolean ignitedByLava;
 	public int flammability;

--- a/src/main/java/net/mcreator/ui/modgui/BlockGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/BlockGUI.java
@@ -169,6 +169,8 @@ public class BlockGUI extends ModElementGUI<Block> {
 
 	private final MCItemHolder customDrop = new MCItemHolder(mcreator, ElementUtil::loadBlocksAndItems);
 
+	private final MCItemHolder strippingResult = new MCItemHolder(mcreator, ElementUtil::loadBlocks);
+
 	private final JComboBox<String> generationShape = new JComboBox<>(new String[] { "UNIFORM", "TRIANGLE" });
 	private final JMinMaxSpinner generateHeight = new JMinMaxSpinner(0, 64, -2032, 2016, 1).allowEqualValues();
 	private final JSpinner frequencyPerChunks = new JSpinner(new SpinnerNumberModel(10, 1, 64, 1));
@@ -753,7 +755,7 @@ public class BlockGUI extends ModElementGUI<Block> {
 		JPanel selp3 = new JPanel(new GridLayout(8, 2, 0, 2));
 		JPanel soundProperties = new JPanel(new GridLayout(7, 2, 0, 2));
 
-		JPanel advancedProperties = new JPanel(new GridLayout(13, 2, 0, 2));
+		JPanel advancedProperties = new JPanel(new GridLayout(14, 2, 0, 2));
 
 		hasGravity.setOpaque(false);
 		tickRandomly.setOpaque(false);
@@ -959,6 +961,10 @@ public class BlockGUI extends ModElementGUI<Block> {
 		advancedProperties.add(HelpUtils.wrapWithHelpButton(this.withEntry("block/ai_path_node_type"),
 				L10N.label("elementgui.common.ai_path_node_type")));
 		advancedProperties.add(aiPathNodeType);
+
+		advancedProperties.add(HelpUtils.wrapWithHelpButton(this.withEntry("block/stripping_result"),
+				L10N.label("elementgui.block.stripping_result")));
+		advancedProperties.add(PanelUtils.centerInPanel(strippingResult));
 
 		JComponent advancedWithCondition = PanelUtils.northAndCenterElement(advancedProperties, placingCondition, 5, 2);
 
@@ -1732,6 +1738,7 @@ public class BlockGUI extends ModElementGUI<Block> {
 		slipperiness.setValue(block.slipperiness);
 		jumpFactor.setValue(block.jumpFactor);
 		speedFactor.setValue(block.speedFactor);
+		strippingResult.setBlock(block.strippingResult);
 
 		disableOffset.setSelected(block.disableOffset);
 		boundingBoxList.setEntries(block.boundingBoxes);
@@ -1899,6 +1906,7 @@ public class BlockGUI extends ModElementGUI<Block> {
 		block.slipperiness = (double) slipperiness.getValue();
 		block.speedFactor = (double) speedFactor.getValue();
 		block.jumpFactor = (double) jumpFactor.getValue();
+		block.strippingResult = strippingResult.getBlock();
 
 		block.sensitiveToVibration = sensitiveToVibration.isSelected();
 		block.vibrationSensitivityRadius = vibrationSensitivityRadius.getSelectedProcedure();

--- a/src/main/java/net/mcreator/ui/modgui/PlantGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/PlantGUI.java
@@ -155,6 +155,7 @@ public class PlantGUI extends ModElementGUI<Plant> {
 
 	private final JComboBox<String> offsetType = new JComboBox<>(new String[] { "XZ", "XYZ", "NONE" });
 	private final SearchableComboBox<String> aiPathNodeType = new SearchableComboBox<>();
+	private final MCItemHolder strippingResult = new MCItemHolder(mcreator, ElementUtil::loadBlocks);
 
 	private final JComboBox<String> tintType = new JComboBox<>(
 			new String[] { "No tint", "Grass", "Foliage", "Birch foliage", "Spruce foliage", "Default foliage", "Water",
@@ -661,7 +662,7 @@ public class PlantGUI extends ModElementGUI<Plant> {
 				PanelUtils.pullElementUp(PanelUtils.centerAndSouthElement(selp2, soundProperties)))));
 		pane3.setOpaque(false);
 
-		JPanel advancedProperties = new JPanel(new GridLayout(8, 2, 10, 2));
+		JPanel advancedProperties = new JPanel(new GridLayout(9, 2, 10, 2));
 		advancedProperties.setOpaque(false);
 
 		forceTicking.setOpaque(false);
@@ -691,6 +692,10 @@ public class PlantGUI extends ModElementGUI<Plant> {
 		advancedProperties.add(HelpUtils.wrapWithHelpButton(this.withEntry("block/ai_path_node_type"),
 				L10N.label("elementgui.common.ai_path_node_type")));
 		advancedProperties.add(aiPathNodeType);
+
+		advancedProperties.add(HelpUtils.wrapWithHelpButton(this.withEntry("block/stripping_result"),
+				L10N.label("elementgui.block.stripping_result")));
+		advancedProperties.add(PanelUtils.centerInPanel(strippingResult));
 
 		advancedProperties.add(
 				HelpUtils.wrapWithHelpButton(this.withEntry("plant/type"), L10N.label("elementgui.plant.type")));
@@ -1040,6 +1045,7 @@ public class PlantGUI extends ModElementGUI<Plant> {
 		colorOnMap.setSelectedItem(plant.colorOnMap);
 		offsetType.setSelectedItem(plant.offsetType);
 		aiPathNodeType.setSelectedItem(plant.aiPathNodeType);
+		strippingResult.setBlock(plant.strippingResult);
 		creativePickItem.setBlock(plant.creativePickItem);
 		ignitedByLava.setSelected(plant.ignitedByLava);
 		flammability.setValue(plant.flammability);
@@ -1156,6 +1162,7 @@ public class PlantGUI extends ModElementGUI<Plant> {
 		plant.colorOnMap = colorOnMap.getSelectedItem().toString();
 		plant.offsetType = (String) offsetType.getSelectedItem();
 		plant.aiPathNodeType = aiPathNodeType.getSelectedItem();
+		plant.strippingResult = strippingResult.getBlock();
 		plant.creativePickItem = creativePickItem.getBlock();
 		plant.ignitedByLava = ignitedByLava.isSelected();
 		plant.flammability = (int) flammability.getValue();

--- a/src/test/java/net/mcreator/integration/TestWorkspaceDataProvider.java
+++ b/src/test/java/net/mcreator/integration/TestWorkspaceDataProvider.java
@@ -1128,6 +1128,8 @@ public class TestWorkspaceDataProvider {
 			plant.colorOnMap = getRandomItem(random, ElementUtil.getDataListAsStringArray("mapcolors"));
 			plant.offsetType = getRandomString(random, Arrays.asList("NONE", "XZ", "XYZ"));
 			plant.aiPathNodeType = getRandomItem(random, ElementUtil.getDataListAsStringArray("pathnodetypes"));
+			plant.strippingResult = new MItemBlock(modElement.getWorkspace(),
+					getRandomMCItem(random, blocks).getName());
 			plant.unbreakable = _true;
 			plant.isCustomSoundType = !_true;
 			plant.soundOnStep = new StepSound(modElement.getWorkspace(),

--- a/src/test/java/net/mcreator/integration/TestWorkspaceDataProvider.java
+++ b/src/test/java/net/mcreator/integration/TestWorkspaceDataProvider.java
@@ -2039,6 +2039,7 @@ public class TestWorkspaceDataProvider {
 		block.slipperiness = 12.342;
 		block.speedFactor = 34.632;
 		block.jumpFactor = 17.732;
+		block.strippingResult = new MItemBlock(modElement.getWorkspace(), getRandomMCItem(random, blocks).getName());
 		block.blockSetType = getRandomItem(random, new String[] { "OAK", "STONE", "IRON" });
 		block.pottedPlant = new MItemBlock(modElement.getWorkspace(),
 				getRandomMCItem(random, blocksWithItemForm).getName());


### PR DESCRIPTION
This PR adds an option to make a block strippable by specifying the stripping result (in newer NeoForge versions, this is handled by a datamap).
Stripped log/wood will be added to the wood pack in a later PR