### PR TITLE
Sort Blockly compile notes by priority (errors first, then warnings)

### DIFF
--- a/src/main/java/net/mcreator/blockly/BlocklyCompileNote.java
+++ b/src/main/java/net/mcreator/blockly/BlocklyCompileNote.java
@@ -26,7 +26,7 @@ public record BlocklyCompileNote(Type type, String message) implements Comparabl
 
 	@Override public int compareTo(BlocklyCompileNote o) {
 		if (this.type() == o.type()) {
-			return this.message().compareTo(o.message());
+			return 0;
 		} else {
 			return this.type().priority > o.type().priority ? -1 : 1;
 		}

--- a/src/main/java/net/mcreator/blockly/BlocklyCompileNote.java
+++ b/src/main/java/net/mcreator/blockly/BlocklyCompileNote.java
@@ -18,14 +18,28 @@
 
 package net.mcreator.blockly;
 
-public record BlocklyCompileNote(Type type, String message) {
+public record BlocklyCompileNote(Type type, String message) implements Comparable<BlocklyCompileNote> {
 
 	@Override public String toString() {
 		return type.name() + ": " + message;
 	}
 
+	@Override public int compareTo(BlocklyCompileNote o) {
+		if (this.type() == o.type()) {
+			return this.message().compareTo(o.message());
+		} else {
+			return this.type().priority > o.type().priority ? -1 : 1;
+		}
+	}
+
 	public enum Type {
-		INFO, WARNING, ERROR
+		INFO(0), WARNING(1), ERROR(2);
+
+		private final int priority;
+
+		Type(int priority) {
+			this.priority = priority;
+		}
 	}
 
 }

--- a/src/main/java/net/mcreator/ui/blockly/CompileNotesPanel.java
+++ b/src/main/java/net/mcreator/ui/blockly/CompileNotesPanel.java
@@ -73,7 +73,7 @@ public class CompileNotesPanel extends JPanel {
 	public void updateCompileNotes(List<BlocklyCompileNote> compileNotesArrayList) {
 		synchronized (compileNotes) {
 			compileNotes.clear();
-			compileNotesArrayList.forEach(compileNotes::addElement);
+			compileNotesArrayList.stream().sorted().forEach(compileNotes::addElement);
 		}
 		compileNotesLabel.setText(L10N.t("blockly.compile_notes", compileNotesArrayList.size()));
 		everUpdated = true;


### PR DESCRIPTION
This PR makes it so that compile errors appear before warnings, regardless of how the blocks are ordered

<img width="1126" height="593" alt="sorted" src="https://github.com/user-attachments/assets/108b1763-4262-415e-a50b-02edc7eec105" />
