### PR TITLE
NF and MDG bump

### DIFF
--- a/plugins/generator-1.21.1/datapack-1.21.1/generator.yaml
+++ b/plugins/generator-1.21.1/datapack-1.21.1/generator.yaml
@@ -1,6 +1,6 @@
 name: Data Pack for Java Edition @minecraft
 status: stable
-buildfileversion: 21.1.190
+buildfileversion: 21.1.209
 
 # gradle task definitions
 gradle:

--- a/plugins/generator-1.21.1/datapack-1.21.1/workspacebase/packloader/build.gradle
+++ b/plugins/generator-1.21.1/datapack-1.21.1/workspacebase/packloader/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'eclipse'
-    id 'net.neoforged.moddev' version '2.0.107'
+    id 'net.neoforged.moddev' version '2.0.110'
 }
 
 version = '1.0'

--- a/plugins/generator-1.21.1/neoforge-1.21.1/generator.yaml
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/generator.yaml
@@ -1,6 +1,6 @@
 name: NeoForge for @minecraft (@buildfileversion)
 status: lts
-buildfileversion: 21.1.190
+buildfileversion: 21.1.209
 
 import:
   - datapack-1.21.1

--- a/plugins/generator-1.21.1/neoforge-1.21.1/workspacebase/build.gradle
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/workspacebase/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'eclipse'
-    id 'net.neoforged.moddev' version '2.0.107'
+    id 'net.neoforged.moddev' version '2.0.110'
 }
 
 version = '1.0'

--- a/plugins/generator-1.21.1/resourcepack-1.21.1/generator.yaml
+++ b/plugins/generator-1.21.1/resourcepack-1.21.1/generator.yaml
@@ -1,6 +1,6 @@
 name: Resource Pack for Java Edition @minecraft
 status: stable
-buildfileversion: 21.1.190
+buildfileversion: 21.1.209
 
 # gradle task definitions
 gradle:

--- a/plugins/generator-1.21.1/resourcepack-1.21.1/workspacebase/packloader/build.gradle
+++ b/plugins/generator-1.21.1/resourcepack-1.21.1/workspacebase/packloader/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'eclipse'
-    id 'net.neoforged.moddev' version '2.0.107'
+    id 'net.neoforged.moddev' version '2.0.110'
 }
 
 version = '1.0'

--- a/plugins/generator-1.21.8/datapack-1.21.8/generator.yaml
+++ b/plugins/generator-1.21.8/datapack-1.21.8/generator.yaml
@@ -1,6 +1,6 @@
 name: Data Pack for Java Edition @minecraft
 status: stable
-buildfileversion: 21.8.31
+buildfileversion: 21.8.47
 
 # gradle task definitions
 gradle:

--- a/plugins/generator-1.21.8/datapack-1.21.8/workspacebase/packloader/build.gradle
+++ b/plugins/generator-1.21.8/datapack-1.21.8/workspacebase/packloader/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'eclipse'
-    id 'net.neoforged.moddev' version '2.0.107'
+    id 'net.neoforged.moddev' version '2.0.110'
 }
 
 version = '1.0'

--- a/plugins/generator-1.21.8/neoforge-1.21.8/generator.yaml
+++ b/plugins/generator-1.21.8/neoforge-1.21.8/generator.yaml
@@ -1,6 +1,6 @@
 name: NeoForge for @minecraft (@buildfileversion)
 status: stable
-buildfileversion: 21.8.31
+buildfileversion: 21.8.47
 
 import:
   - datapack-1.21.8

--- a/plugins/generator-1.21.8/neoforge-1.21.8/workspacebase/build.gradle
+++ b/plugins/generator-1.21.8/neoforge-1.21.8/workspacebase/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'eclipse'
-    id 'net.neoforged.moddev' version '2.0.107'
+    id 'net.neoforged.moddev' version '2.0.110'
 }
 
 version = '1.0'

--- a/plugins/generator-1.21.8/resourcepack-1.21.8/generator.yaml
+++ b/plugins/generator-1.21.8/resourcepack-1.21.8/generator.yaml
@@ -1,6 +1,6 @@
 name: Resource Pack for Java Edition @minecraft
 status: stable
-buildfileversion: 21.8.31
+buildfileversion: 21.8.47
 
 # gradle task definitions
 gradle:

--- a/plugins/generator-1.21.8/resourcepack-1.21.8/workspacebase/packloader/build.gradle
+++ b/plugins/generator-1.21.8/resourcepack-1.21.8/workspacebase/packloader/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'eclipse'
-    id 'net.neoforged.moddev' version '2.0.107'
+    id 'net.neoforged.moddev' version '2.0.110'
 }
 
 version = '1.0'


### PR DESCRIPTION
Why update?

There are some bug fixes that might be worth considering when updating the generator (then we are still in eap):
MDG: Updated together with the others

Atm there is no branch for 1.21.8 yet which may mean it will no longer be updated

1.21.8:

Fix the bug that some blocks do not catch fire from lava when they should
Fix IGuiGraphicsExtension#drawScrollingString() rendering scrolling and static strings at different y levels 
Fix non-compostables being insertable through null side

1.21.1:

Fix non-compostables being insertable through null side
Fix issues with binding function keys on Mac systems