### PR TITLE
Fix resource location field not allowing namespaced initial values

### DIFF
--- a/plugins/mcreator-core/blockly/js/field_resourcelocation.js
+++ b/plugins/mcreator-core/blockly/js/field_resourcelocation.js
@@ -11,7 +11,8 @@ class FieldResourceLocation extends Blockly.FieldTextInput {
 
         const pathPattern = /^[a-z0-9_\-\.\/]+$/;
         const namespacedPattern = /^([a-z0-9_\-\.]+:)?[a-z0-9_\-\.\/]+$/;
-        const pattern = this.allowNamespace_ ? namespacedPattern : pathPattern;
+        // Allow namespaced values as initial values, as allowNamespace_ isn't assigned yet
+        const pattern = (this.allowNamespace_ ?? true) ? namespacedPattern : pathPattern;
 
         if (!pattern.test(newValue)) {
             return null;


### PR DESCRIPTION
This PR fixes a bug introduced in f050f502871aa755daad203c1787b763c9edcf3a, where resource location fields skip the initial text if it's namespaced. This can be seen with the "Block is in tag" feature ore rule test (which should contain `minecraft:dirt`):

<img width="573" height="243" alt="missing field" src="https://github.com/user-attachments/assets/d1075d04-6a52-4b75-8609-98835d4b5973" />
