### PR TITLE
Less redundant Blockly warnings

### DIFF
--- a/src/main/java/net/mcreator/generator/blockly/BlocklyBlockCodeGenerator.java
+++ b/src/main/java/net/mcreator/generator/blockly/BlocklyBlockCodeGenerator.java
@@ -417,8 +417,11 @@ public class BlocklyBlockCodeGenerator {
 		// add custom warnings if present
 		if (toolboxBlock.getWarnings() != null) {
 			for (String warning : toolboxBlock.getWarnings()) {
-				master.addCompileNote(new BlocklyCompileNote(BlocklyCompileNote.Type.WARNING,
-						L10N.t("blockly.warning." + warning, type)));
+				String message = L10N.t("blockly.warning." + warning, type);
+				// Do not add the same warning multiple times
+				if (master.getCompileNotes().stream().noneMatch(note -> note.message().equals(message))) {
+					master.addCompileNote(new BlocklyCompileNote(BlocklyCompileNote.Type.WARNING, message));
+				}
 			}
 		}
 


### PR DESCRIPTION
With this PR, custom block warnings (e.g. wait block, NBT procedures, lake feature) will appear at most once in the compile notes.