### PR TITLE
Fix before entity is hurt global trigger using the Post event instead of the Pre event

### DIFF
--- a/plugins/generator-1.21.1/neoforge-1.21.1/triggers/entity_pre_hurt.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/triggers/entity_pre_hurt.java.ftl
@@ -1,6 +1,6 @@
 <#include "procedures.java.ftl">
 @EventBusSubscriber public class ${name}Procedure {
-	@SubscribeEvent public static void onEntityAttacked(LivingDamageEvent.Post event) {
+	@SubscribeEvent public static void onEntityAttacked(LivingDamageEvent.Pre event) {
 		if (event.getEntity() != null) {
 			<#assign dependenciesCode><#compress>
 				<@procedureDependenciesCode dependencies, {

--- a/plugins/generator-1.21.8/neoforge-1.21.8/triggers/entity_pre_hurt.java.ftl
+++ b/plugins/generator-1.21.8/neoforge-1.21.8/triggers/entity_pre_hurt.java.ftl
@@ -1,6 +1,6 @@
 <#include "procedures.java.ftl">
 @EventBusSubscriber public class ${name}Procedure {
-	@SubscribeEvent public static void onEntityAttacked(LivingDamageEvent.Post event) {
+	@SubscribeEvent public static void onEntityAttacked(LivingDamageEvent.Pre event) {
 		if (event.getEntity() != null) {
 			<#assign dependenciesCode><#compress>
 				<@procedureDependenciesCode dependencies, {


### PR DESCRIPTION
This fixes the before entity is hurt trigger running after the entity is hurt instead of before