### PR TITLE
Add null checks to block/plant item textures

### DIFF
--- a/src/main/java/net/mcreator/element/types/Block.java
+++ b/src/main/java/net/mcreator/element/types/Block.java
@@ -327,7 +327,7 @@ import java.util.stream.Collectors;
 	}
 
 	@Override public BufferedImage generateModElementPicture() {
-		if ((hasBlockItem && !itemTexture.isEmpty()) || (renderType() == 4)) {
+		if ((hasBlockItem && itemTexture != null && !itemTexture.isEmpty()) || (renderType() == 4)) {
 			return ImageUtils.resizeAndCrop(itemTexture.getImage(TextureType.ITEM), 32);
 		} else if (renderType() == 10) {
 			return (BufferedImage) MinecraftImageGenerator.Preview.generateBlockIcon(getTextureWithFallback(textureTop),

--- a/src/main/java/net/mcreator/element/types/Plant.java
+++ b/src/main/java/net/mcreator/element/types/Plant.java
@@ -218,7 +218,7 @@ import java.util.stream.Collectors;
 	}
 
 	@Override public BufferedImage generateModElementPicture() {
-		if (hasBlockItem && !itemTexture.isEmpty()) {
+		if (hasBlockItem && itemTexture != null && !itemTexture.isEmpty()) {
 			return ImageUtils.resizeAndCrop(itemTexture.getImage(TextureType.ITEM), 32);
 		}
 		return ImageUtils.resizeAndCrop(texture.getImage(TextureType.BLOCK), 32);


### PR DESCRIPTION
Fixes an issue found in #5825
