### PR TITLE
Fix #5841

### DIFF
--- a/src/main/java/net/mcreator/ui/action/impl/gradle/RunServerAction.java
+++ b/src/main/java/net/mcreator/ui/action/impl/gradle/RunServerAction.java
@@ -18,7 +18,6 @@
 
 package net.mcreator.ui.action.impl.gradle;
 
-import net.mcreator.gradle.GradleTaskFinishedListener;
 import net.mcreator.minecraft.MinecraftOptionsUtils;
 import net.mcreator.minecraft.ServerUtil;
 import net.mcreator.preferences.PreferencesManager;
@@ -86,10 +85,12 @@ public class RunServerAction extends GradleAction {
 											.getGradleTaskFor("run_client") != null) {
 										actionRegistry.getMCreator().getGradleConsole()
 												.exec(actionRegistry.getMCreator().getGeneratorConfiguration()
-														.getGradleTaskFor("run_client"));
+																.getGradleTaskFor("run_client"),
+														e -> actionRegistry.getMCreator().getGradleConsole()
+																.cancelTask());
 									}
 								}
-							}, (GradleTaskFinishedListener) null);
+							}, e -> actionRegistry.getMCreator().getGradleConsole().cancelTask());
 		} catch (Exception e) { // if something fails, we still need to free the gradle console
 			LOG.error("Failed to run server", e);
 			actionRegistry.getMCreator().getGradleConsole().markReady();


### PR DESCRIPTION
WHile testing for #5841, I noticed the scope of the problem was a bit larger. The main problem was the fact MCreator handled both run tasks (`run_client` and `run_server`) independently without stopping the second task when one ended. This was causing the Gradle console to always be free again even though one of the two tasks was still running, making possible the problem reported in the issue.

This PR simply fix the problem by canceling the other task when one is done. When the server is closed, the game is canceled, while when this is the client that is closed by the user, the server is canceled, making impossible to have the reported problem. No matter the case, both tasks will be finished/canceled.