### PR TITLE
Other GUI listeners

### DIFF
--- a/src/main/java/net/mcreator/ui/modgui/BlockGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/BlockGUI.java
@@ -1579,9 +1579,9 @@ public class BlockGUI extends ModElementGUI<Block> {
 	}
 
 	private void refreshGUIProperties() {
-		boolean canSpawn = !guiBoundTo.isEmpty();
+		boolean isGuiBoundToEmpty = !guiBoundTo.isEmpty();
 
-		openGUIOnRightClick.setEnabled(canSpawn);
+		openGUIOnRightClick.setEnabled(isGuiBoundToEmpty);
 	}
 
 	@Override public void reloadDataLists() {

--- a/src/main/java/net/mcreator/ui/modgui/ItemGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/ItemGUI.java
@@ -675,10 +675,10 @@ public class ItemGUI extends ModElementGUI<Item> {
 	}
 
 	private void refreshGUIProperties() {
-		boolean canSpawn = !guiBoundTo.isEmpty();
+		boolean isGuiBoundToEmpty = !guiBoundTo.isEmpty();
 
-		inventorySize.setEnabled(canSpawn);
-		inventoryStackSize.setEnabled(canSpawn);
+		inventorySize.setEnabled(isGuiBoundToEmpty);
+		inventoryStackSize.setEnabled(isGuiBoundToEmpty);
 	}
 
 	@Override public void reloadDataLists() {

--- a/src/main/java/net/mcreator/ui/modgui/LivingEntityGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/LivingEntityGUI.java
@@ -998,10 +998,10 @@ public class LivingEntityGUI extends ModElementGUI<LivingEntity> implements IBlo
 	}
 
 	private void refreshGUIProperties() {
-		boolean canSpawn = !guiBoundTo.isEmpty();
+		boolean isGuiBoundToEmpty = !guiBoundTo.isEmpty();
 
-		inventorySize.setEnabled(canSpawn);
-		inventoryStackSize.setEnabled(canSpawn);
+		inventorySize.setEnabled(isGuiBoundToEmpty);
+		inventoryStackSize.setEnabled(isGuiBoundToEmpty);
 	}
 
 	private void refreshSpawnProperties() {


### PR DESCRIPTION
This PR adds 3 listeners and fixes an existing listener

ItemGUI (disable the 2 fields below if no gui is selected)

<img width="500" height="500" alt="image" src="https://github.com/user-attachments/assets/2c134c88-00e8-4c15-b6e3-e9e6950c866d" />

LivingEntityGUI (same)

<img width="500" height="500" alt="image" src="https://github.com/user-attachments/assets/f6389e27-4f60-45dc-9ae0-accdcf1a0e8f" />

BlockGUI

Now disable "Open bound GUI on right click" if no gui is selected

<img width="500" height="500" alt="image" src="https://github.com/user-attachments/assets/2cd4dddd-9b8b-4556-bd0f-0c58039c6732" />


