### PR TITLE
Make some GUIComponent fields public for plugins

### DIFF
--- a/src/main/java/net/mcreator/element/parts/gui/GUIComponent.java
+++ b/src/main/java/net/mcreator/element/parts/gui/GUIComponent.java
@@ -24,6 +24,7 @@ import net.mcreator.element.parts.procedure.RetvalProcedure;
 import net.mcreator.ui.init.L10N;
 import net.mcreator.ui.wysiwyg.WYSIWYG;
 import net.mcreator.ui.wysiwyg.WYSIWYGEditor;
+import net.mcreator.util.StringUtils;
 import net.mcreator.workspace.Workspace;
 
 import javax.annotation.Nonnull;
@@ -44,7 +45,7 @@ import java.util.stream.Collectors;
 	public boolean locked = false;
 	public transient UUID uuid;
 
-	public static final Map<String, Class<? extends GUIComponent>> typeMappings = new HashMap<>() {{
+	private static final Map<String, Class<? extends GUIComponent>> typeMappings = new HashMap<>() {{
 		put("tooltip", Tooltip.class); // weight -15
 		put("entitymodel", EntityModel.class); //weight -10
 		put("textfield", TextField.class); // weight 0
@@ -59,7 +60,7 @@ import java.util.stream.Collectors;
 		put("outputslot", OutputSlot.class); // weight 50
 	}};
 
-	public static final Map<Class<? extends GUIComponent>, String> typeMappingsReverse = typeMappings.entrySet()
+	private static final Map<Class<? extends GUIComponent>, String> typeMappingsReverse = typeMappings.entrySet()
 			.stream().collect(Collectors.toMap(Map.Entry::getValue, Map.Entry::getKey));
 
 	GUIComponent() {
@@ -134,6 +135,12 @@ import java.util.stream.Collectors;
 
 	@Override public String toString() {
 		return getName();
+	}
+
+	public static void registerCustomComponent(Class<? extends GUIComponent> type) {
+		String id = StringUtils.camelToSnake(type.getSimpleName()).toLowerCase();
+		typeMappings.put(id, type);
+		typeMappingsReverse.put(type, id);
 	}
 
 	public static class GSONAdapter implements JsonSerializer<GUIComponent>, JsonDeserializer<GUIComponent> {


### PR DESCRIPTION
Made the constructor of GUIComponent public so plugins can create their own GuiComponents

Also made typeMappings and typeMappingsReverse public so the new component can be registered for serialization/deserialization.