### PR TITLE
[1.21.8] Disable leaves particles

### DIFF
--- a/plugins/generator-1.21.8/neoforge-1.21.8/templates/block/block.java.ftl
+++ b/plugins/generator-1.21.8/neoforge-1.21.8/templates/block/block.java.ftl
@@ -206,7 +206,7 @@ public class ${name}Block extends
 			<#if data.blockBase == "Stairs">
 				super(Blocks.AIR.defaultBlockState(), <@blockProperties/>);
 			<#elseif data.blockBase == "Leaves">
-				super(0.01f, <@blockProperties/>);
+				super(0f, <@blockProperties/>);
 			<#elseif data.blockBase == "PressurePlate" || data.blockBase == "TrapDoor" || data.blockBase == "Door">
 				super(BlockSetType.${data.blockSetType}, <@blockProperties/>);
 			<#elseif data.blockBase == "Button">


### PR DESCRIPTION
This PR makes it so leaves don't emit particles in 1.21.8 (saw a [reddit post](https://old.reddit.com/r/MCreator/comments/1om8dz1/custom_particles_for_leaves/) about untinted particles looking out of place). I do plan on adding proper particle settings later on.