### PR TITLE
Prevent the creation of excessive amounts of model instances in armor models

### DIFF
--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/armor.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/armor.java.ftl
@@ -73,14 +73,11 @@ import net.minecraft.client.model.Model;
 	@SubscribeEvent public static void registerItemExtensions(RegisterClientExtensionsEvent event) {
 		<#if data.helmetModelName != "Default" && data.getHelmetModel()?? && data.enableHelmet>
 		event.registerItem(new IClientItemExtensions() {
-			private ${data.helmetModelName} model = null;
 			private HumanoidModel armorModel = null;
 			@Override @OnlyIn(Dist.CLIENT) public HumanoidModel getHumanoidArmorModel(LivingEntity living, ItemStack stack, EquipmentSlot slot, HumanoidModel defaultModel) {
-				if (model == null)
-					model = new ${data.helmetModelName}(Minecraft.getInstance().getEntityModels().bakeLayer(${data.helmetModelName}.LAYER_LOCATION));
 				if (armorModel == null) {
 					armorModel = new HumanoidModel(new ModelPart(Collections.emptyList(), Map.of(
-						"head", model.${data.helmetModelPart},
+						"head", new ${data.helmetModelName}(Minecraft.getInstance().getEntityModels().bakeLayer(${data.helmetModelName}.LAYER_LOCATION)).${data.helmetModelPart},
 						"hat", new ModelPart(Collections.emptyList(), Collections.emptyMap()),
 						"body", new ModelPart(Collections.emptyList(), Collections.emptyMap()),
 						"right_arm", new ModelPart(Collections.emptyList(), Collections.emptyMap()),
@@ -99,12 +96,10 @@ import net.minecraft.client.model.Model;
 
 		<#if data.bodyModelName != "Default" && data.getBodyModel()?? && data.enableBody>
 		event.registerItem(new IClientItemExtensions() {
-			private ${data.bodyModelName} model = null;
 			private HumanoidModel armorModel = null;
 			@Override @OnlyIn(Dist.CLIENT) public HumanoidModel getHumanoidArmorModel(LivingEntity living, ItemStack stack, EquipmentSlot slot, HumanoidModel defaultModel) {
-				if (model == null)
-					model = new ${data.bodyModelName}(Minecraft.getInstance().getEntityModels().bakeLayer(${data.bodyModelName}.LAYER_LOCATION));
 				if (armorModel == null) {
+					${data.bodyModelName} model = new ${data.bodyModelName}(Minecraft.getInstance().getEntityModels().bakeLayer(${data.bodyModelName}.LAYER_LOCATION));
 					armorModel = new HumanoidModel(new ModelPart(Collections.emptyList(), Map.of(
 						"body", model.${data.bodyModelPart},
 						"left_arm", model.${data.armsModelPartL},
@@ -125,12 +120,10 @@ import net.minecraft.client.model.Model;
 
 		<#if data.leggingsModelName != "Default" && data.getLeggingsModel()?? && data.enableLeggings>
 		event.registerItem(new IClientItemExtensions() {
-			private ${data.leggingsModelName} model = null;
 			private HumanoidModel armorModel = null;
 			@Override @OnlyIn(Dist.CLIENT) public HumanoidModel getHumanoidArmorModel(LivingEntity living, ItemStack stack, EquipmentSlot slot, HumanoidModel defaultModel) {
-				if (model == null)
-					model = new ${data.leggingsModelName}(Minecraft.getInstance().getEntityModels().bakeLayer(${data.leggingsModelName}.LAYER_LOCATION));
 				if (armorModel == null) {
+					${data.leggingsModelName} model = new ${data.leggingsModelName}(Minecraft.getInstance().getEntityModels().bakeLayer(${data.leggingsModelName}.LAYER_LOCATION));
 					armorModel = new HumanoidModel(new ModelPart(Collections.emptyList(), Map.of(
 						"left_leg", model.${data.leggingsModelPartL},
 						"right_leg", model.${data.leggingsModelPartR},
@@ -151,12 +144,10 @@ import net.minecraft.client.model.Model;
 
 		<#if data.bootsModelName != "Default" && data.getBootsModel()?? && data.enableBoots>
 		event.registerItem(new IClientItemExtensions() {
-			private ${data.bootsModelName} model = null;
 			private HumanoidModel armorModel = null;
 			@Override @OnlyIn(Dist.CLIENT) public HumanoidModel getHumanoidArmorModel(LivingEntity living, ItemStack stack, EquipmentSlot slot, HumanoidModel defaultModel) {
-				if (model == null)
-					model = new ${data.bootsModelName}(Minecraft.getInstance().getEntityModels().bakeLayer(${data.bootsModelName}.LAYER_LOCATION));
 				if (armorModel == null) {
+					${data.bootsModelName} model = new ${data.bootsModelName}(Minecraft.getInstance().getEntityModels().bakeLayer(${data.bootsModelName}.LAYER_LOCATION));
 					armorModel = new HumanoidModel(new ModelPart(Collections.emptyList(), Map.of(
 						"left_leg", model.${data.bootsModelPartL},
 						"right_leg", model.${data.bootsModelPartR},

--- a/plugins/generator-1.21.8/neoforge-1.21.8/templates/armor/armor_client.java.ftl
+++ b/plugins/generator-1.21.8/neoforge-1.21.8/templates/armor/armor_client.java.ftl
@@ -43,15 +43,12 @@ import net.minecraft.client.model.Model;
 		<#if data.enableHelmet>
 		event.registerItem(new IClientItemExtensions() {
 			<#if data.helmetModelName != "Default" && data.getHelmetModel()??>
-			private ${data.helmetModelName} model = null;
 			private HumanoidModel armorModel = null;
 			@Override public HumanoidModel getHumanoidArmorModel(ItemStack itemStack, EquipmentClientInfo.LayerType layerType, Model original) {
-				if (model == null)
-					model = new ${data.helmetModelName}(Minecraft.getInstance().getEntityModels().bakeLayer(${data.helmetModelName}.LAYER_LOCATION));
 				if (armorModel == null) {
 					armorModel = new HumanoidModel(new ModelPart(Collections.emptyList(), Map.of(
 						"head", new ModelPart(Collections.emptyList(), Map.of(
-							"head", model.${data.helmetModelPart},
+							"head", new ${data.helmetModelName}(Minecraft.getInstance().getEntityModels().bakeLayer(${data.helmetModelName}.LAYER_LOCATION)).${data.helmetModelPart},
 							"hat", new ModelPart(Collections.emptyList(), Collections.emptyMap())
 						)),
 						"body", new ModelPart(Collections.emptyList(), Collections.emptyMap()),
@@ -78,12 +75,10 @@ import net.minecraft.client.model.Model;
 		<#if data.enableBody>
 		event.registerItem(new IClientItemExtensions() {
 			<#if data.bodyModelName != "Default" && data.getBodyModel()??>
-			private ${data.bodyModelName} model = null;
 			private HumanoidModel armorModel = null;
 			@Override public HumanoidModel getHumanoidArmorModel(ItemStack itemStack, EquipmentClientInfo.LayerType layerType, Model original) {
-				if (model == null)
-					model = new ${data.bodyModelName}(Minecraft.getInstance().getEntityModels().bakeLayer(${data.bodyModelName}.LAYER_LOCATION));
 				if (armorModel == null) {
+					${data.bodyModelName} model = new ${data.bodyModelName}(Minecraft.getInstance().getEntityModels().bakeLayer(${data.bodyModelName}.LAYER_LOCATION));
 					armorModel = new HumanoidModel(new ModelPart(Collections.emptyList(), Map.of(
 						"body", model.${data.bodyModelPart},
 						"left_arm", model.${data.armsModelPartL},
@@ -112,12 +107,10 @@ import net.minecraft.client.model.Model;
 		<#if data.enableLeggings>
 		event.registerItem(new IClientItemExtensions() {
 			<#if data.leggingsModelName != "Default" && data.getLeggingsModel()??>
-			private ${data.leggingsModelName} model = null;
 			private HumanoidModel armorModel = null;
 			@Override public HumanoidModel getHumanoidArmorModel(ItemStack itemStack, EquipmentClientInfo.LayerType layerType, Model original) {
-				if (model == null)
-					model = new ${data.leggingsModelName}(Minecraft.getInstance().getEntityModels().bakeLayer(${data.leggingsModelName}.LAYER_LOCATION));
 				if (armorModel == null) {
+					${data.leggingsModelName} model = new ${data.leggingsModelName}(Minecraft.getInstance().getEntityModels().bakeLayer(${data.leggingsModelName}.LAYER_LOCATION));
 					armorModel = new HumanoidModel(new ModelPart(Collections.emptyList(), Map.of(
 						"left_leg", model.${data.leggingsModelPartL},
 						"right_leg", model.${data.leggingsModelPartR},
@@ -146,12 +139,10 @@ import net.minecraft.client.model.Model;
 		<#if data.enableBoots>
 		event.registerItem(new IClientItemExtensions() {
 			<#if data.bootsModelName != "Default" && data.getBootsModel()??>
-			private ${data.bootsModelName} model = null;
 			private HumanoidModel armorModel = null;
 			@Override public HumanoidModel getHumanoidArmorModel(ItemStack itemStack, EquipmentClientInfo.LayerType layerType, Model original) {
-				if (model == null)
-					model = new ${data.bootsModelName}(Minecraft.getInstance().getEntityModels().bakeLayer(${data.bootsModelName}.LAYER_LOCATION));
 				if (armorModel == null) {
+					${data.bootsModelName} model = new ${data.bootsModelName}(Minecraft.getInstance().getEntityModels().bakeLayer(${data.bootsModelName}.LAYER_LOCATION));
 					armorModel = new HumanoidModel(new ModelPart(Collections.emptyList(), Map.of(
 						"left_leg", model.${data.bootsModelPartL},
 						"right_leg", model.${data.bootsModelPartR},


### PR DESCRIPTION
In this PR, I prevent an excessive amount of model instances from being created when initializing armor models by reusing the same instance.

Before:
<img width="1146" height="363" alt="image" src="https://github.com/user-attachments/assets/1283d2ed-cc67-4acb-b025-55d0aaefb328" />

After:
<img width="1133" height="351" alt="image" src="https://github.com/user-attachments/assets/33e0b29c-0e47-4d32-9ee4-e09be665dcb6" />
