### PR TITLE
Fix item components not being applied for item arguments

### DIFF
--- a/plugins/generator-1.21.1/neoforge-1.21.1/procedures/get_command_parameter_itemstack.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/procedures/get_command_parameter_itemstack.java.ftl
@@ -1,1 +1,2 @@
-/*@ItemStack*/(ItemArgument.getItem(arguments, "${field$param}").getItem().getDefaultInstance())
+<@addTemplate file="utils/command/get_command_parameter_item.java.ftl"/>
+/*@ItemStack*/(commandParameterItemStack(arguments, "${field$param}"))

--- a/plugins/generator-1.21.1/neoforge-1.21.1/procedures/utils/command/get_command_parameter_item.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/procedures/utils/command/get_command_parameter_item.java.ftl
@@ -1,0 +1,9 @@
+private static ItemStack commandParameterItemStack(CommandContext<CommandSourceStack> arguments, String parameter) {
+	ItemInput input = ItemArgument.getItem(arguments, parameter);
+	try {
+		return input.createItemStack(1, false);
+	} catch (CommandSyntaxException e) {
+		e.printStackTrace();
+		return input.getItem().getDefaultInstance();
+	}
+}

--- a/plugins/generator-1.21.8/neoforge-1.21.8/procedures/get_command_parameter_itemstack.java.ftl
+++ b/plugins/generator-1.21.8/neoforge-1.21.8/procedures/get_command_parameter_itemstack.java.ftl
@@ -1,1 +1,2 @@
-/*@ItemStack*/(ItemArgument.getItem(arguments, "${field$param}").getItem().getDefaultInstance())
+<@addTemplate file="utils/command/get_command_parameter_item.java.ftl"/>
+/*@ItemStack*/(commandParameterItemStack(arguments, "${field$param}"))

--- a/plugins/generator-1.21.8/neoforge-1.21.8/procedures/utils/command/get_command_parameter_item.java.ftl
+++ b/plugins/generator-1.21.8/neoforge-1.21.8/procedures/utils/command/get_command_parameter_item.java.ftl
@@ -1,0 +1,9 @@
+private static ItemStack commandParameterItemStack(CommandContext<CommandSourceStack> arguments, String parameter) {
+	ItemInput input = ItemArgument.getItem(arguments, parameter);
+	try {
+		return input.createItemStack(1, false);
+	} catch (CommandSyntaxException e) {
+		e.printStackTrace();
+		return input.getItem().getDefaultInstance();
+	}
+}


### PR DESCRIPTION
This fixes this bug https://mcreator.net/forum/120401/item-components-custom-commands-arent-retained-20253