### PR TITLE
Add in-depth Java doc for preferences

### DIFF
--- a/src/main/java/net/mcreator/preferences/PreferencesManager.java
+++ b/src/main/java/net/mcreator/preferences/PreferencesManager.java
@@ -58,7 +58,7 @@ public class PreferencesManager {
 	public static PreferencesData PREFERENCES;
 
 	/**
-	 * <p>Init the system and load MCreator's preferences, so entries used inside the launcher can be get.</p>
+	 * <p>Init the system and load MCreator's preferences, so entries used inside the launcher can be obtained.</p>
 	 */
 	public static void init() {
 		PREFERENCES = new PreferencesData();
@@ -82,7 +82,7 @@ public class PreferencesManager {
 	}
 
 	/**
-	 * <p>Load all preferences registered under the provided {@param identifier}.</p>
+	 * <p>Load all preferences registered under the provided {@code identifier}.</p>
 	 *
 	 * @param identifier <p> The identifier used to get the preference file to load</p>
 	 */
@@ -185,6 +185,16 @@ public class PreferencesManager {
 		entries.forEach(PreferencesEntry::reset);
 	}
 
+	/**
+	 * <p>This method is a method used by the preferences system in order to register each {@link PreferencesEntry} added by a {@link PreferencesSection}.
+	 * It checks if the provided {@code identifier} already exists inside the system and then, proceed to either add the provided {@link PreferencesEntry} with {@code entry} to the existing {@code identifier}'s list of entries or create a new list linked tto this specific {@code identifier}.
+	 * This is the method allowing to add a {@link PreferencesEntry} to the loading and saving processes. However, the system already has the capacity to automatically register all {@link PreferencesEntry}, so this method should not be called somewhere else.</p>
+	 *
+	 * <p>For Java plugins: See {@link PreferencesSection#addEntry(PreferencesEntry)} and {@link PreferencesSection#addPluginEntry(String, PreferencesEntry)} to add custom entries.</p>
+	 *
+	 * @param identifier A unique {@link String} acting like a mod's id for this system.
+	 * @param entry The {@link PreferencesEntry} added via a {@link PreferencesSection}
+	 */
 	static <T, S extends PreferencesEntry<T>> void register(String identifier, S entry) {
 		if (PREFERENCES_REGISTRY.containsKey(identifier)) {
 			PREFERENCES_REGISTRY.get(identifier).add(entry);

--- a/src/main/java/net/mcreator/preferences/PreferencesSection.java
+++ b/src/main/java/net/mcreator/preferences/PreferencesSection.java
@@ -19,32 +19,101 @@
 
 package net.mcreator.preferences;
 
+import net.mcreator.preferences.data.PreferencesData;
+import net.mcreator.ui.dialogs.preferences.PreferencesDialog;
+
+/**
+ * <p>This class defines a section inside the {@link PreferencesDialog}. It groups all {@link PreferencesEntry} together both visually and innerly (when storing preferences).
+ * For examples on how to create a new {@link PreferencesSection} and declare new {@link PreferencesEntry} inside the class, see built-in sections {@link net.mcreator.preferences.data}.</p>
+ *
+ * <p>Java plugins need to initialize their section using {@link net.mcreator.plugin.events.ApplicationLoadedEvent}.
+ * Example:
+ *
+ * <pre>
+ *     {@code
+ *     public class MyPlugin extends JavaPlugin {
+ *
+ *         public MySection mySection;
+ *
+ *         public MyPlugin(Plugin plugin) {
+ *             addListener(ApplicationLoadedEvent.class, event -> {
+ *                 mySection = new MySection("myIdentifier");
+ *             });
+ *         }
+ *     }
+ *     }
+ * </pre></p>
+ */
 public abstract class PreferencesSection {
 
+	/**
+	 * <p>A unique {@link String} acting like a mod's id for this system. If you use this method with one of the built-in section (see {@link PreferencesData}), this parameter can <b><u>NOT</u></b> be {@code "core"} as the system use it for all built-in entries.</p>
+	 */
 	private final String preferencesIdentifier;
 
 	public PreferencesSection(String preferencesIdentifier) {
 		this.preferencesIdentifier = preferencesIdentifier;
 	}
 
+	/**
+	 * <p>This method allows adding a new {@link PreferencesEntry} to this {@link PreferencesSection}.
+	 * Contrary to {@link PreferencesSection#addPluginEntry(String, PreferencesEntry)}, this method does not allow to specify a custom {@code identifier},
+	 * meaning the system will use the one provided by this section ({@link PreferencesSection#preferencesIdentifier}).</p>
+	 *
+	 * <p>For Java plugins: Use this method <b><u>ONLY</u></b> when making a custom {@link PreferencesSection}.
+	 * Do <b><u>NOT</u></b> use with a built-in section (see {@link PreferencesData}).
+	 * Custom {@link PreferencesEntry} will be added to the {@code core} identifier group, leading to many problems for you and users.</p>
+	 *
+	 * @param entry The new {@link PreferencesEntry} to add to this section
+	 * @return The provided {@link PreferencesEntry} to register
+	 */
 	public final <T, S extends PreferencesEntry<T>> S addEntry(S entry) {
 		entry.setSection(this);
 		PreferencesManager.register(preferencesIdentifier, entry);
 		return entry;
 	}
 
+	/**
+	 * <p>This method allows adding a new {@link PreferencesEntry} to the {@link PreferencesSection}.
+	 * This method is designed so Java plugins can add a custom {@link PreferencesEntry} to an already existing {@link PreferencesSection} created by MCreator (see {@link PreferencesData}).
+	 * While this method will work in all types of cases, {@link #addPluginEntry(String, PreferencesEntry)} can be safely used when using a custom {@link PreferencesSection}}.</p>
+	 *
+	 * <p>Example of a Java plugin:
+	 * <pre>
+	 * {@code
+	 * public class MyPlugin extends JavaPlugin {
+	 *
+	 * 	public final BooleanEntry myEntry = new BooleanEntry("displayMCreator", true);
+	 *
+	 *	public MyPlugin(Plugin plugin) {
+	 * 		addListener(ApplicationLoadedEvent.class, event -> {
+	 * 			PreferencesManager.PREFERENCES.ui.addJavaEntry("myIdentifier", myEntry);
+	 * 		});
+	 * 	}
+	 *
+	 * }
+	 * }</pre></p>
+	 *
+	 * @param pluginPreferencesIdentifier A unique {@link String} acting like a mod's id for this system. If you use this method with one of the built-in section (see {@link PreferencesData}), this parameter can <b><u>NOT</u></b> be {@code "core"} as the system use it for all built-in entries.
+	 * @param entry The new {@link PreferencesEntry} to add to this section
+	 * @return The provided {@link PreferencesEntry} to register
+	 */
 	public final <T, S extends PreferencesEntry<T>> S addPluginEntry(String pluginPreferencesIdentifier, S entry) {
 		entry.setSection(this);
 		PreferencesManager.register(pluginPreferencesIdentifier, entry);
 		return entry;
 	}
 
+	/**
+	 *
+	 * @return True {@link PreferencesDialog} should display this {@link PreferencesSection}. Usually, this should always be true. This was implemented for {@link net.mcreator.preferences.data.HiddenSection}.
+	 */
 	public boolean isVisible() {
 		return true;
 	}
 
 	/**
-	 * @return Section key this preferences data collection belongs to
+	 * @return The registry name of this specific section. It is used, among other things, for the localization's key of the {@link PreferencesEntry} inside this section.
 	 */
 	public abstract String getSectionKey();
 


### PR DESCRIPTION
This adds many more explanations and documentation for the preference system, explaining important parts that were not covered by the original documentation, mainly destined for Java plugin developers.

~~This way, Nerdy can understand how easy it is to use this system.~~