### PR TITLE
Fix #5915 - Buckets of custom fluids do not work with other mods in some cases

### DIFF
--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/elementinits/items.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/elementinits/items.java.ftl
@@ -47,7 +47,7 @@ package ${package}.init;
 <#assign chunks = items?chunk(2500)>
 <#assign has_chunks = chunks?size gt 1>
 
-<#if itemsWithInventory?size != 0>
+<#if itemsWithInventory?size != 0 || buckets?size != 0>
 @EventBusSubscriber
 </#if>
 public class ${JavaModName}Items {

--- a/plugins/generator-1.21.8/neoforge-1.21.8/templates/elementinits/items.java.ftl
+++ b/plugins/generator-1.21.8/neoforge-1.21.8/templates/elementinits/items.java.ftl
@@ -48,7 +48,7 @@ package ${package}.init;
 <#assign chunks = items?chunk(2500)>
 <#assign has_chunks = chunks?size gt 1>
 
-<#if itemsWithInventory?size != 0>
+<#if itemsWithInventory?size != 0 || buckets?size != 0>
 @EventBusSubscriber
 </#if>
 public class ${JavaModName}Items {


### PR DESCRIPTION
Changelog:

[Bugfix] Buckets of custom fluids did not work correctly with fluid tanks of other mods in some cases

Fix #5915