### PR TITLE
Add the global session variable scope to the entity variable

### DIFF
--- a/plugins/generator-1.21.1/neoforge-1.21.1/variables/entity.yaml
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/variables/entity.yaml
@@ -5,6 +5,6 @@ scopes:
     get: ${name}
     set: ${name} = ${opt.removeParentheses(value)};
   global_session:
-    init: public static ${var.getType().getJavaType(generator.getWorkspace())} ${var.getName()} = ${var.getType().getDefaultValue(generator.getWorkspace())};
+    init: public static ${var.getType().getJavaType(generator.getWorkspace())} ${var.getName()} = ${var.getValue()};
     get: ${JavaModName}Variables.${name}
     set: ${JavaModName}Variables.${name} = ${opt.removeParentheses(value)};

--- a/plugins/generator-1.21.8/neoforge-1.21.8/variables/entity.yaml
+++ b/plugins/generator-1.21.8/neoforge-1.21.8/variables/entity.yaml
@@ -5,6 +5,6 @@ scopes:
     get: ${name}
     set: ${name} = ${opt.removeParentheses(value)};
   global_session:
-    init: public static ${var.getType().getJavaType(generator.getWorkspace())} ${var.getName()} = ${var.getType().getDefaultValue(generator.getWorkspace())};
+    init: public static ${var.getType().getJavaType(generator.getWorkspace())} ${var.getName()} = ${var.getValue()};
     get: ${JavaModName}Variables.${name}
     set: ${JavaModName}Variables.${name} = ${opt.removeParentheses(value)};


### PR DESCRIPTION
In this PR I add the global session variable scope to the entity variable, since there is no downside to doing so. It allows you to store an entity as a public static variable, which can be useful in some cases. For example, storing a static entity instance for an entity model in GUIs to reuse instead of constantly making new instances.