### PR TITLE
Add a procedure block to get an entity from a UUID

### DIFF
--- a/plugins/generator-1.21.1/neoforge-1.21.1/procedures/entity_get_from_uuid.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/procedures/entity_get_from_uuid.java.ftl
@@ -1,2 +1,2 @@
-<@addTemplate file="utils/entity/entity_parse_uuid.java.ftl"/>
-(world instanceof ServerLevel _level${cbi} ? _level${cbi}.getEntity(parseUUID(${input$uuid})) : null)
+<@addTemplate file="utils/entity/entity_from_uuid.java.ftl"/>
+(world instanceof ServerLevel _level${cbi} ? getEntityFromUUID(_level${cbi}, ${input$uuid}) : null)

--- a/plugins/generator-1.21.1/neoforge-1.21.1/procedures/utils/entity/entity_from_uuid.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/procedures/utils/entity/entity_from_uuid.java.ftl
@@ -1,0 +1,7 @@
+private static Entity getEntityFromUUID(ServerLevel level, String uuid) {
+    try {
+        return level.getEntity(UUID.fromString(uuid));
+    } catch (IllegalArgumentException e) {
+        return null;
+    }
+}

--- a/plugins/generator-1.21.1/neoforge-1.21.1/procedures/utils/entity/entity_parse_uuid.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/procedures/utils/entity/entity_parse_uuid.java.ftl
@@ -1,7 +1,0 @@
-private static UUID parseUUID(String uuid) {
-    try {
-        return UUID.fromString(uuid);
-    } catch (IllegalArgumentException e) {
-        return UUID.randomUUID();
-    }
-}

--- a/plugins/generator-1.21.8/neoforge-1.21.8/procedures/entity_get_from_uuid.java.ftl
+++ b/plugins/generator-1.21.8/neoforge-1.21.8/procedures/entity_get_from_uuid.java.ftl
@@ -1,2 +1,2 @@
-<@addTemplate file="utils/entity/entity_parse_uuid.java.ftl"/>
-(world instanceof ServerLevel _level${cbi} ? _level${cbi}.getEntity(parseUUID(${input$uuid})) : null)
+<@addTemplate file="utils/entity/entity_from_uuid.java.ftl"/>
+(world instanceof ServerLevel _level${cbi} ? getEntityFromUUID(_level${cbi}, ${input$uuid}) : null)

--- a/plugins/generator-1.21.8/neoforge-1.21.8/procedures/utils/entity/entity_from_uuid.java.ftl
+++ b/plugins/generator-1.21.8/neoforge-1.21.8/procedures/utils/entity/entity_from_uuid.java.ftl
@@ -1,0 +1,7 @@
+private static Entity getEntityFromUUID(ServerLevel level, String uuid) {
+    try {
+        return level.getEntity(UUID.fromString(uuid));
+    } catch (IllegalArgumentException e) {
+        return null;
+    }
+}

--- a/plugins/generator-1.21.8/neoforge-1.21.8/procedures/utils/entity/entity_parse_uuid.java.ftl
+++ b/plugins/generator-1.21.8/neoforge-1.21.8/procedures/utils/entity/entity_parse_uuid.java.ftl
@@ -1,7 +1,0 @@
-private static UUID parseUUID(String uuid) {
-    try {
-        return UUID.fromString(uuid);
-    } catch (IllegalArgumentException e) {
-        return UUID.randomUUID();
-    }
-}


### PR DESCRIPTION
In this PR, I add a procedure block to get an entity from its UUID on the server-side.

This is different from the ID procedure block in that UUIDs persist after the world is closed. IDs are assigned again every time the world opens.

<img width="583" height="91" alt="image" src="https://github.com/user-attachments/assets/5c28b744-c254-40f7-9148-12da74389150" />