### PR TITLE
Automatically switch global variable scopes if updated variable type does not support the selected scope

### DIFF
--- a/src/main/java/net/mcreator/ui/workspace/WorkspacePanelVariables.java
+++ b/src/main/java/net/mcreator/ui/workspace/WorkspacePanelVariables.java
@@ -104,7 +104,7 @@ class WorkspacePanelVariables extends AbstractWorkspacePanel {
 								}
 							}
 							if (!scopeSupported) { // if the new type doesn't support the current scope, set it to the first supported one
-								elements.setValueAt(supportedScopes[0], row, 2);
+								super.setValueAt(supportedScopes[0], row, 2);
 							}
 
 							// Handle 3rd column - initial value


### PR DESCRIPTION
In this PR, I make it so if the global variable type is updated, but the selected variable scope is not supported by the new variable type, the scope is set to the first supported global variable scope of the new variable type.

Fixes #5945 