### PR TITLE
Add the tool item type to the itemtypes datalist

### DIFF
--- a/plugins/generator-1.21.1/neoforge-1.21.1/mappings/itemtypes.yaml
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/mappings/itemtypes.yaml
@@ -16,3 +16,4 @@ Potion: Potion
 Shield: Shield
 SpawnEgg: SpawnEgg
 Trident: Trident
+Tool: Tiered

--- a/plugins/generator-1.21.8/neoforge-1.21.8/mappings/itemtypes.yaml
+++ b/plugins/generator-1.21.8/neoforge-1.21.8/mappings/itemtypes.yaml
@@ -2,6 +2,7 @@ _default: ""
 Sword: CUSTOM
 Pickaxe: CUSTOM
 Armor: CUSTOM
+Tool: CUSTOM
 Axe: Axe
 Shovel: Shovel
 Hoe: Hoe

--- a/plugins/generator-1.21.8/neoforge-1.21.8/procedures/item_istype.java.ftl
+++ b/plugins/generator-1.21.8/neoforge-1.21.8/procedures/item_istype.java.ftl
@@ -5,6 +5,8 @@
 (${mappedMCItemToItemStackCode(input$item)}.is(ItemTags.PICKAXES))
 <#elseif field$item_type == "Armor">
 (${mappedMCItemToItemStackCode(input$item)}.has(DataComponents.EQUIPPABLE))
+<#elseif field$item_type == "Tool">
+(${mappedMCItemToItemStackCode(input$item)}.has(DataComponents.TOOL))
 <#else>
 (${mappedMCItemToItem(input$item)} instanceof ${generator.map(field$item_type, "itemtypes")}Item)
 </#if>

--- a/plugins/mcreator-core/datalists/itemtypes.yaml
+++ b/plugins/mcreator-core/datalists/itemtypes.yaml
@@ -15,3 +15,4 @@
 - Shield
 - SpawnEgg
 - Trident
+- Tool


### PR DESCRIPTION
In this PR I add the tool item type to the itemtypes datalist which allows one to check if an item is any type of tool. In 1.21.1, it checks the common TieredItem class all tools extend, and in 1.21.8 it checks if it has the TOOL data component.
<img width="851" height="615" alt="image" src="https://github.com/user-attachments/assets/0c497ef4-f80f-4a14-8c20-a8e88c076746" />
