### PR TITLE
Add CanGlide option to armor items for Elytra like Gliding

### DIFF
--- a/plugins/generator-1.21.8/neoforge-1.21.8/templates/armor/armor.java.ftl
+++ b/plugins/generator-1.21.8/neoforge-1.21.8/templates/armor/armor.java.ftl
@@ -68,7 +68,7 @@ public abstract class ${name}Item extends Item {
 	public static class Helmet extends ${name}Item {
 
 		public Helmet(Item.Properties properties) {
-			super(properties<#if data.helmetImmuneToFire>.fireResistant()</#if>.humanoidArmor(ARMOR_MATERIAL, ArmorType.HELMET));
+			super(properties<#if data.helmetImmuneToFire>.fireResistant()</#if><#if data.helmetCanGlide>.component(DataComponents.GLIDER, Unit.INSTANCE)</#if>.humanoidArmor(ARMOR_MATERIAL, ArmorType.HELMET));
 		}
 
 		<@addSpecialInformation data.helmetSpecialInformation, "item." + modid + "." + registryname + "_helmet"/>
@@ -85,7 +85,7 @@ public abstract class ${name}Item extends Item {
 	public static class Chestplate extends ${name}Item {
 
 		public Chestplate(Item.Properties properties) {
-			super(properties<#if data.bodyImmuneToFire>.fireResistant()</#if>.humanoidArmor(ARMOR_MATERIAL, ArmorType.CHESTPLATE));
+			super(properties<#if data.bodyImmuneToFire>.fireResistant()</#if><#if data.bodyCanGlide>.component(DataComponents.GLIDER, Unit.INSTANCE)</#if>.humanoidArmor(ARMOR_MATERIAL, ArmorType.CHESTPLATE));
 		}
 
 		<@addSpecialInformation data.bodySpecialInformation, "item." + modid + "." + registryname + "_chestplate"/>
@@ -102,7 +102,7 @@ public abstract class ${name}Item extends Item {
 	public static class Leggings extends ${name}Item {
 
 		public Leggings(Item.Properties properties) {
-			super(properties<#if data.leggingsImmuneToFire>.fireResistant()</#if>.humanoidArmor(ARMOR_MATERIAL, ArmorType.LEGGINGS));
+			super(properties<#if data.leggingsImmuneToFire>.fireResistant()</#if><#if data.leggingsCanGlide>.component(DataComponents.GLIDER, Unit.INSTANCE)</#if>.humanoidArmor(ARMOR_MATERIAL, ArmorType.LEGGINGS));
 		}
 
 		<@addSpecialInformation data.leggingsSpecialInformation, "item." + modid + "." + registryname + "_leggings"/>
@@ -119,7 +119,7 @@ public abstract class ${name}Item extends Item {
 	public static class Boots extends ${name}Item {
 
 		public Boots(Item.Properties properties) {
-			super(properties<#if data.bootsImmuneToFire>.fireResistant()</#if>.humanoidArmor(ARMOR_MATERIAL, ArmorType.BOOTS));
+			super(properties<#if data.bootsImmuneToFire>.fireResistant()</#if><#if data.bootsCanGlide>.component(DataComponents.GLIDER, Unit.INSTANCE)</#if>.humanoidArmor(ARMOR_MATERIAL, ArmorType.BOOTS));
 		}
 
 		<@addSpecialInformation data.bootsSpecialInformation, "item." + modid + "." + registryname + "_boots"/>

--- a/plugins/mcreator-localization/help/default/item/can_glide.md
+++ b/plugins/mcreator-localization/help/default/item/can_glide.md
@@ -1,0 +1,1 @@
+This parameter controls if the item can make the player Glide, like an Elytra.

--- a/plugins/mcreator-localization/lang/texts.properties
+++ b/plugins/mcreator-localization/lang/texts.properties
@@ -2843,6 +2843,7 @@ elementgui.item.use_duration=<html>Item use duration:<br><small>Use non-negative
 elementgui.item.container_item_damage=<html>Damage item on crafting<br><small>Only available for damageable items
 elementgui.item.number_of_uses=<html>Item use count / durability (leave 0 to disable damage):<br><small>If you want to make a tool, create a tool instead
 elementgui.item.is_immune_to_fire=Is item immune to fire?
+elementgui.item.can_glide=Does item allow the user to glide?
 elementgui.item.is_piglin_currency=Is item a piglin currency?
 elementgui.item.recipe_remainder=<html>Recipe remainder<br><small>Leave empty to use current item.
 elementgui.item.damage_vs_entity=<html>Attack damage (check to enable):

--- a/src/main/java/net/mcreator/element/types/Armor.java
+++ b/src/main/java/net/mcreator/element/types/Armor.java
@@ -116,6 +116,11 @@ import java.util.stream.Collectors;
 	public boolean leggingsImmuneToFire;
 	public boolean bootsImmuneToFire;
 
+	public boolean helmetCanGlide;
+	public boolean bodyCanGlide;
+	public boolean leggingsCanGlide;
+	public boolean bootsCanGlide;
+
 	public LogicProcedure helmetGlowCondition;
 	public LogicProcedure bodyGlowCondition;
 	public LogicProcedure leggingsGlowCondition;

--- a/src/main/java/net/mcreator/ui/modgui/ArmorGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/ArmorGUI.java
@@ -160,6 +160,11 @@ public class ArmorGUI extends ModElementGUI<Armor> {
 	private final JCheckBox leggingsImmuneToFire = L10N.checkbox("elementgui.common.enable");
 	private final JCheckBox bootsImmuneToFire = L10N.checkbox("elementgui.common.enable");
 
+	private final JCheckBox helmetCanGlide = L10N.checkbox("elementgui.common.enable");
+	private final JCheckBox bodyCanGlide = L10N.checkbox("elementgui.common.enable");
+	private final JCheckBox leggingsCanGlide = L10N.checkbox("elementgui.common.enable");
+	private final JCheckBox bootsCanGlide = L10N.checkbox("elementgui.common.enable");
+
 	private LogicProcedureSelector helmetGlowCondition;
 	private LogicProcedureSelector bodyGlowCondition;
 	private LogicProcedureSelector leggingsGlowCondition;
@@ -377,6 +382,11 @@ public class ArmorGUI extends ModElementGUI<Armor> {
 		leggingsImmuneToFire.setOpaque(false);
 		bootsImmuneToFire.setOpaque(false);
 
+		helmetCanGlide.setOpaque(false);
+		bodyCanGlide.setOpaque(false);
+		leggingsCanGlide.setOpaque(false);
+		bootsCanGlide.setOpaque(false);
+
 		JPanel helmetSubPanel = new JPanel(new GridLayout(5, 2, 2, 2));
 		helmetSubPanel.setOpaque(false);
 
@@ -394,9 +404,18 @@ public class ArmorGUI extends ModElementGUI<Armor> {
 				HelpUtils.wrapWithHelpButton(this.withEntry("item/model"), L10N.label("elementgui.common.item_model")));
 		helmetSubPanel.add(helmetItemRenderType);
 
-		helmetSubPanel.add(HelpUtils.wrapWithHelpButton(this.withEntry("item/immune_to_fire"),
+		JPanel helmetFlagsPanel = new JPanel(new GridLayout(2, 2, 2, 2));
+		helmetFlagsPanel.setOpaque(false);
+
+		helmetFlagsPanel.add(HelpUtils.wrapWithHelpButton(this.withEntry("item/immune_to_fire"),
 				L10N.label("elementgui.item.is_immune_to_fire")));
-		helmetSubPanel.add(helmetImmuneToFire);
+		helmetFlagsPanel.add(helmetImmuneToFire);
+
+		helmetFlagsPanel.add(HelpUtils.wrapWithHelpButton(this.withEntry("item/can_glide"),
+				L10N.label("elementgui.item.can_glide")));
+		helmetFlagsPanel.add(helmetCanGlide);
+
+		helmetSubPanel.add(helmetFlagsPanel);
 
 		helmetModel.addActionListener(e -> helmetTranslucency.setEnabled(helmetModel.getSelectedItem() != defaultModel));
 
@@ -451,9 +470,18 @@ public class ArmorGUI extends ModElementGUI<Armor> {
 				HelpUtils.wrapWithHelpButton(this.withEntry("item/model"), L10N.label("elementgui.common.item_model")));
 		bodySubPanel.add(bodyItemRenderType);
 
-		bodySubPanel.add(HelpUtils.wrapWithHelpButton(this.withEntry("item/immune_to_fire"),
+		JPanel bodyFlagsPanel = new JPanel(new GridLayout(2, 2, 2, 2));
+		bodyFlagsPanel.setOpaque(false);
+
+		bodyFlagsPanel.add(HelpUtils.wrapWithHelpButton(this.withEntry("item/immune_to_fire"),
 				L10N.label("elementgui.item.is_immune_to_fire")));
-		bodySubPanel.add(bodyImmuneToFire);
+		bodyFlagsPanel.add(bodyImmuneToFire);
+
+		bodyFlagsPanel.add(HelpUtils.wrapWithHelpButton(this.withEntry("item/can_glide"),
+				L10N.label("elementgui.item.can_glide")));
+		bodyFlagsPanel.add(bodyCanGlide);
+
+		bodySubPanel.add(bodyFlagsPanel);
 
 		bodyModel.addActionListener(e -> bodyTranslucency.setEnabled(bodyModel.getSelectedItem() != defaultModel));
 
@@ -502,9 +530,18 @@ public class ArmorGUI extends ModElementGUI<Armor> {
 				HelpUtils.wrapWithHelpButton(this.withEntry("item/model"), L10N.label("elementgui.common.item_model")));
 		leggingsSubPanel.add(leggingsItemRenderType);
 
-		leggingsSubPanel.add(HelpUtils.wrapWithHelpButton(this.withEntry("item/immune_to_fire"),
+		JPanel leggingsFlagsPanel = new JPanel(new GridLayout(2, 2, 2, 2));
+		leggingsFlagsPanel.setOpaque(false);
+
+		leggingsFlagsPanel.add(HelpUtils.wrapWithHelpButton(this.withEntry("item/immune_to_fire"),
 				L10N.label("elementgui.item.is_immune_to_fire")));
-		leggingsSubPanel.add(leggingsImmuneToFire);
+		leggingsFlagsPanel.add(leggingsImmuneToFire);
+
+		leggingsFlagsPanel.add(HelpUtils.wrapWithHelpButton(this.withEntry("item/can_glide"),
+				L10N.label("elementgui.item.can_glide")));
+		leggingsFlagsPanel.add(leggingsCanGlide);
+
+		leggingsSubPanel.add(leggingsFlagsPanel);
 
 		leggingsModel.addActionListener(e -> leggingsTranslucency.setEnabled(leggingsModel.getSelectedItem() != defaultModel));
 
@@ -553,13 +590,22 @@ public class ArmorGUI extends ModElementGUI<Armor> {
 				HelpUtils.wrapWithHelpButton(this.withEntry("item/model"), L10N.label("elementgui.common.item_model")));
 		bootsSubPanel.add(bootsItemRenderType);
 
-		bootsSubPanel.add(HelpUtils.wrapWithHelpButton(this.withEntry("item/immune_to_fire"),
+		JPanel bootsFlagsPanel = new JPanel(new GridLayout(2, 2, 2, 2));
+		bootsFlagsPanel.setOpaque(false);
+
+		bootsFlagsPanel.add(HelpUtils.wrapWithHelpButton(this.withEntry("item/immune_to_fire"),
 				L10N.label("elementgui.item.is_immune_to_fire")));
-		bootsSubPanel.add(bootsImmuneToFire);
+		bootsFlagsPanel.add(bootsImmuneToFire);
+
+		bootsFlagsPanel.add(HelpUtils.wrapWithHelpButton(this.withEntry("item/can_glide"),
+				L10N.label("elementgui.item.can_glide")));
+		bootsFlagsPanel.add(bootsCanGlide);
+
+		bootsSubPanel.add(bootsFlagsPanel);
 
 		bootsModel.addActionListener(e -> bootsTranslucency.setEnabled(bootsModel.getSelectedItem() != defaultModel));
 
-		JPanel bootsConditionsPanel = new JPanel(new GridLayout(3, 1, 2, 2));
+		JPanel bootsConditionsPanel = new JPanel(new GridLayout(4, 1, 2, 2));
 		bootsConditionsPanel.setOpaque(false);
 		bootsConditionsPanel.add(bootsGlowCondition);
 		bootsConditionsPanel.add(bootsSpecialInformation);
@@ -964,6 +1010,11 @@ public class ArmorGUI extends ModElementGUI<Armor> {
 		leggingsImmuneToFire.setSelected(armor.leggingsImmuneToFire);
 		bootsImmuneToFire.setSelected(armor.bootsImmuneToFire);
 
+		helmetCanGlide.setSelected(armor.helmetCanGlide);
+		bodyCanGlide.setSelected(armor.bodyCanGlide);
+		leggingsCanGlide.setSelected(armor.leggingsCanGlide);
+		bootsCanGlide.setSelected(armor.bootsCanGlide);
+
 		helmetGlowCondition.setSelectedProcedure(armor.helmetGlowCondition);
 		bodyGlowCondition.setSelectedProcedure(armor.bodyGlowCondition);
 		leggingsGlowCondition.setSelectedProcedure(armor.leggingsGlowCondition);
@@ -1051,6 +1102,10 @@ public class ArmorGUI extends ModElementGUI<Armor> {
 		armor.bodyImmuneToFire = bodyImmuneToFire.isSelected();
 		armor.leggingsImmuneToFire = leggingsImmuneToFire.isSelected();
 		armor.bootsImmuneToFire = bootsImmuneToFire.isSelected();
+		armor.helmetCanGlide = helmetCanGlide.isSelected();
+		armor.bodyCanGlide = bodyCanGlide.isSelected();
+		armor.leggingsCanGlide = leggingsCanGlide.isSelected();
+		armor.bootsCanGlide = bootsCanGlide.isSelected();
 		armor.helmetGlowCondition = helmetGlowCondition.getSelectedProcedure();
 		armor.bodyGlowCondition = bodyGlowCondition.getSelectedProcedure();
 		armor.leggingsGlowCondition = leggingsGlowCondition.getSelectedProcedure();

--- a/src/test/java/net/mcreator/integration/TestWorkspaceDataProvider.java
+++ b/src/test/java/net/mcreator/integration/TestWorkspaceDataProvider.java
@@ -1044,6 +1044,10 @@ public class TestWorkspaceDataProvider {
 			armor.bodyImmuneToFire = !_true;
 			armor.leggingsImmuneToFire = _true;
 			armor.bootsImmuneToFire = !_true;
+			armor.helmetCanGlide = _true;
+			armor.bodyCanGlide = !_true;
+			armor.leggingsCanGlide = _true;
+			armor.bootsCanGlide = !_true;
 			armor.helmetGlowCondition = new LogicProcedure(_true ? "condition1" : null, _true);
 			armor.bodyGlowCondition = new LogicProcedure(_true ? "condition2" : null, _true);
 			armor.leggingsGlowCondition = new LogicProcedure(_true ? "condition3" : null, _true);


### PR DESCRIPTION
This adds the Glider component, allowing the armor piece to function like an elytra.

Allows the wearer of the armor-piece to glide with it like as if it were an elytra.

companion to Goldorion's pr

<img width="927" height="276" alt="Screenshot 2025-12-19 at 11 44 12 PM" src="https://github.com/user-attachments/assets/7a4a6351-b057-4fde-b8e1-0c491bb81fdc" />
