### PR TITLE
Do not show Blockly info/warning notes in validation errors dialog

### DIFF
--- a/src/main/java/net/mcreator/ui/blockly/BlocklyAggregatedValidationResult.java
+++ b/src/main/java/net/mcreator/ui/blockly/BlocklyAggregatedValidationResult.java
@@ -43,7 +43,8 @@ public class BlocklyAggregatedValidationResult extends AggregatedValidationResul
 	}
 
 	@Override public List<ValidationResult> getGroupedValidationResults() {
-		return compileNotes.stream().map(note -> new ValidationResult(note.getValidationResultType(),
+		return compileNotes.stream().filter(note -> note.type() == BlocklyCompileNote.Type.ERROR)
+				.map(note -> new ValidationResult(note.getValidationResultType(),
 						messageFormatter != null ? messageFormatter.apply(note.message()) : note.message(), true))
 				.collect(Collectors.toList());
 	}


### PR DESCRIPTION
This PR fixes a bug where warning/info compile notes could appear in the validation errors dialog:
<img width="1613" height="614" alt="info warning" src="https://github.com/user-attachments/assets/f234a415-1ceb-4e8d-bbf7-b0bd5947adca" />
