### PR TITLE
Enable creative tab by default for BEBlock

### DIFF
--- a/src/main/java/net/mcreator/ui/modgui/bedrock/BEBlockGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/bedrock/BEBlockGUI.java
@@ -255,6 +255,7 @@ public class BEBlockGUI extends ModElementGUI<BEBlock> {
 
 		if (!isEditingMode()) {
 			name.setText(StringUtils.machineToReadableName(modElement.getName()));
+			enableCreativeTab.setSelected(true);
 		}
 		updateTextureOptions();
 		updateCreativeTab();


### PR DESCRIPTION
I forgot to add this line when making #6097, so now users will have the same behaviour as the JE Block MET GUI.