### PR TITLE
Clean up the sound definitions template in addon generator

### DIFF
--- a/plugins/generator-addon-1.21.x/addon-1.21.x/templates/resourcepack/sound_definitions.json.ftl
+++ b/plugins/generator-addon-1.21.x/addon-1.21.x/templates/resourcepack/sound_definitions.json.ftl
@@ -1,16 +1,16 @@
 {
-<#list sounds as sound>
-"${modid}:${sound.getName()}": {
-  "category": "${sound.getCategory()?replace("master", "neutral")?replace("master", "neutral")?replace("voice", "ui")?replace("ambient", "weather")}",
-  <#if sound.getSubtitle()?has_content>"subtitle": "subtitles.${sound.getName()}",</#if>
-  "sounds": [
-    <#list sound.getFiles() as file>
-    {
-      "name": "sounds/${file}",
-      "volume": 1
-    }<#if file?has_next>,</#if>
-    </#list>
-  ]
-}<#if sound?has_next>,</#if>
-</#list>
+  <#list sounds as sound>
+    "${modid}:${sound.getName()}": {
+      "category": "${sound.getCategory()?replace("master", "neutral")?replace("master", "neutral")?replace("voice", "ui")?replace("ambient", "weather")}",
+      <#if sound.getSubtitle()?has_content>"subtitle": "subtitles.${sound.getName()}",</#if>
+        "sounds": [
+          <#list sound.getFiles() as file>
+            {
+              "name": "sounds/${file}",
+              "volume": 1
+            }<#sep>,
+          </#list>
+        ]
+    }<#sep>,
+  </#list>
 }


### PR DESCRIPTION
This PR fixes indentation and uses <#sep> for commas in sound_definitions.json in addon generator