### PR TITLE
Include sounds under the music category in music_definitions.json for bedrock addons

### DIFF
--- a/plugins/generator-addon-1.21.x/addon-1.21.x/generator.yaml
+++ b/plugins/generator-addon-1.21.x/addon-1.21.x/generator.yaml
@@ -31,6 +31,9 @@ base_templates:
   - template: resourcepack/sound_definitions.json.ftl
     writer: json
     name: "@RESROOT/sounds/sound_definitions.json"
+  - template: resourcepack/music_definitions.json.ftl
+    writer: json
+    name: "@RESROOT/sounds/music_definitions.json"
   - template: resourcepack/blocks.json.ftl
     writer: json
     name: "@RESROOT/blocks.json"

--- a/plugins/generator-addon-1.21.x/addon-1.21.x/templates/resourcepack/music_definitions.json.ftl
+++ b/plugins/generator-addon-1.21.x/addon-1.21.x/templates/resourcepack/music_definitions.json.ftl
@@ -1,0 +1,9 @@
+{
+  <#list sounds?filter(e -> e.getCategory() == "music") as sound>
+  	"${modid}:${sound.getName()}": {
+	  "event_name": "${modid}:${sound.getName()}",
+	  "min_delay": 60,
+	  "max_delay": 180
+  	}<#sep>,
+  </#list>
+}


### PR DESCRIPTION
In this PR, imported sounds under the music category are included in the music_definitions json so they can be used by elements that require a music definition for a sound.