### PR TITLE
Fix white bed mapping missing in 1.21.1

### DIFF
--- a/plugins/generator-1.21.1/datapack-1.21.1/mappings/blocksitems.yaml
+++ b/plugins/generator-1.21.1/datapack-1.21.1/mappings/blocksitems.yaml
@@ -1687,6 +1687,9 @@ Blocks.STRIPPED_MANGROVE_WOOD:
 Blocks.STRIPPED_CHERRY_WOOD:
   - Blocks.STRIPPED_CHERRY_WOOD
   - "stripped_cherry_wood"
+Blocks.BED:
+  - Blocks.WHITE_BED
+  - "white_bed"
 Blocks.ORANGE_BED:
   - Blocks.ORANGE_BED
   - "orange_bed"
@@ -3869,9 +3872,6 @@ Items.SUGAR:
 Items.CAKE:
   - Items.CAKE
   - "cake"
-Items.BED:
-  - Items.WHITE_BED
-  - "white_bed"
 Items.COOKIE:
   - Items.COOKIE
   - "cookie"


### PR DESCRIPTION
This PR fixes the white bed block mapping missing in 1.21.1