### PR TITLE
Fix blockstate variable used for luminance control in 1.21.1 being named 's' causing build error

### DIFF
--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/block/block.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/block/block.java.ftl
@@ -141,7 +141,7 @@ public class ${getClassName()}Block extends ${getBlockClass(data.blockBase)}
 			.strength(${data.hardness}f, ${data.resistance}f)
 		</#if>
 		<#if hasProcedure(data.luminance) || data.luminance.getFixedValue() != 0>
-			.lightLevel(s -> <#if hasProcedure(data.luminance)>(int) <@procedureOBJToNumberCode data.luminance/><#else>${data.luminance.getFixedValue()}</#if>)
+			.lightLevel(blockstate -> <#if hasProcedure(data.luminance)>(int) <@procedureOBJToNumberCode data.luminance/><#else>${data.luminance.getFixedValue()}</#if>)
 		</#if>
 		<#if data.requiresCorrectTool>
 			.requiresCorrectToolForDrops()


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/bd82fd24-8d31-4a4e-b453-62b3cae93320)

This is causing luminance procedures in 1.21.1 to cause a build error