### PR TITLE
Close FileInputStream in loadFromFile

### DIFF
--- a/src/main/java/net/mcreator/ui/views/NBTEditorView.java
+++ b/src/main/java/net/mcreator/ui/views/NBTEditorView.java
@@ -63,8 +63,7 @@ public class NBTEditorView extends ViewBase {
 	}
 
 	private void loadFromFile() {
-		try {
-			FileInputStream fis = new FileInputStream(file);
+		try (FileInputStream fis = new FileInputStream(file)) {
 			NBTInputStream nbt = new NBTInputStream(fis);
 			Tag tag = nbt.readTag();
 


### PR DESCRIPTION
Kept looking at loadFromFile in src/main/java/net/mcreator/ui/views/NBTEditorView.java and wanted to flag something: The resource opened there can leak if loadFromFile exits on an error path. this patch moves the allocation into try-with-resources so cleanup happens on every exit path.

Happy to revise the approach or close this if it doesn’t fit — you know the codebase far better than I do.