### PR TITLE
[1.21.8] Fix painting title/author colors

### DIFF
--- a/plugins/generator-1.21.8/neoforge-1.21.8/templates/json/painting.json.ftl
+++ b/plugins/generator-1.21.8/neoforge-1.21.8/templates/json/painting.json.ftl
@@ -3,9 +3,11 @@
   "height": ${(data.height / 16)?int},
   "width": ${(data.width / 16)?int},
   "title": {
+    "color": "yellow",
     "translate": "painting.${modid}.${registryname}.title"
   },
   "author": {
+    "color": "gray",
     "translate": "painting.${modid}.${registryname}.author"
   }
 }


### PR DESCRIPTION
Fixes a bug in 1.21.8 where custom paintings in the creative inventory would use the wrong colors for title and author strings