### PR TITLE
Fix resource leaks in StructureUtils and potential crash in LocalizationUtils

### DIFF
--- a/src/main/java/net/mcreator/generator/LocalizationUtils.java
+++ b/src/main/java/net/mcreator/generator/LocalizationUtils.java
@@ -56,8 +56,10 @@ public class LocalizationUtils {
 				langFileContent.append(lang_entry.getKey()).append("=").append(lang_entry.getValue()).append("\n");
 			}
 
-			String uppercaseLangName =
-					entry.getKey().split("_")[0] + "_" + entry.getKey().split("_")[1].toUpperCase(Locale.ENGLISH);
+			String[] langParts = entry.getKey().split("_", 2);
+			String uppercaseLangName = langParts.length == 2
+					? langParts[0] + "_" + langParts[1].toUpperCase(Locale.ENGLISH)
+					: entry.getKey();
 
 			String fileName = GeneratorTokens.replaceTokens(workspace,
 					rawName.replace("@langname", entry.getKey()).replace("@lang_NAME", uppercaseLangName));

--- a/src/main/java/net/mcreator/minecraft/StructureUtils.java
+++ b/src/main/java/net/mcreator/minecraft/StructureUtils.java
@@ -36,14 +36,15 @@ public class StructureUtils {
 
 	public static void renamePrefixInStructures(File fileToFix, String oldmodid, String newmodid) {
 		try {
-			FileInputStream fis = new FileInputStream(fileToFix);
-			NBTInputStream nbt = new NBTInputStream(fis);
-			Tag tag = nbt.readTag();
+			Tag tag;
+			try (FileInputStream fis = new FileInputStream(fileToFix);
+					NBTInputStream nbt = new NBTInputStream(fis)) {
+				tag = nbt.readTag();
+			}
 			Tag out = replaceAllStringTags(tag, oldmodid + ":", newmodid + ":");
-			NBTOutputStream nbtOutputStream = new NBTOutputStream(new FileOutputStream(fileToFix));
-			nbtOutputStream.writeTag(out);
-			nbt.close();
-			nbtOutputStream.close();
+			try (NBTOutputStream nbtOutputStream = new NBTOutputStream(new FileOutputStream(fileToFix))) {
+				nbtOutputStream.writeTag(out);
+			}
 		} catch (Exception e) {
 			LOG.error(e.getMessage(), e);
 		}


### PR DESCRIPTION
## What this fixes

### `StructureUtils.renamePrefixInStructures` — resource leak

`FileInputStream`/`NBTInputStream` and `NBTOutputStream` were not guaranteed to close when an exception is thrown during read or write. The fix wraps each phase in a separate try-with-resources block. As a bonus, this also ensures the input stream is fully closed before the output stream opens on the same file, which avoids potential file descriptor conflicts on some platforms.

### `LocalizationUtils.generateKeyValueLanguageFiles` — `ArrayIndexOutOfBoundsException`

```java
// before
entry.getKey().split("_")[0] + "_" + entry.getKey().split("_")[1].toUpperCase(Locale.ENGLISH)
```

If a language map key contains no underscore (e.g. a bare `"en"` entry), `split("_")[1]` throws `ArrayIndexOutOfBoundsException`. The fix uses `split("_", 2)` and falls back to the original key when there is no region suffix.

## Testing

Both changes have no effect on the happy path for well-formed input. The `StructureUtils` change preserves existing behavior while guaranteeing cleanup. The `LocalizationUtils` change is a pure defensive guard — for standard `xx_YY` locale codes the output is identical to before.