### PR TITLE
Fix incorrect name for amount dependency causing a build error when used

### DIFF
--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/potioneffect.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/potioneffect.java.ftl
@@ -125,7 +125,7 @@ public class ${name}MobEffect extends <#if data.isInstant>Instantenous</#if>MobE
 				"entity": "entity",
 				"amplifier": "amplifier",
 				"damagesource": "damagesource",
-				"damage": "damage"
+				"amount": "damage"
 			}/>
 		}
 	</#if>

--- a/plugins/generator-1.21.8/neoforge-1.21.8/templates/potioneffect.java.ftl
+++ b/plugins/generator-1.21.8/neoforge-1.21.8/templates/potioneffect.java.ftl
@@ -111,7 +111,7 @@ public class ${name}MobEffect extends <#if data.isInstant>Instantenous</#if>MobE
 				"entity": "entity",
 				"amplifier": "amplifier",
 				"damagesource": "damagesource",
-				"damage": "damage"
+				"amount": "damage"
 			}/>
 		}
 	</#if>


### PR DESCRIPTION
This fixes the potion effect's hurt trigger amount dependency's value being assigned to the name "damage" which meant the dependency wasn't included in the procedure call when it used it, leading to a build error

<img width="269" height="119" alt="image" src="https://github.com/user-attachments/assets/111850a1-d282-4530-8c19-48515b613a10" />
