### PR TITLE
Fix edge case where GUI tests could fail if slot-specific code needed to be generated

### DIFF
--- a/src/test/java/net/mcreator/integration/TestWorkspaceDataProvider.java
+++ b/src/test/java/net/mcreator/integration/TestWorkspaceDataProvider.java
@@ -738,24 +738,26 @@ public class TestWorkspaceDataProvider {
 				components.add(new Slider(80, 110, 30, 10, "slider4", 1.0, 10.0, 4.8, 0.1, "", "",
 						new Procedure("procedure11")));
 				components.add(new Slider(80, 120, 30, 10, "slider5", 1.0, 10.0, 4.8, 0.1, "Be", "Af", null));
-				components.add(new InputSlot(0, 20, 30, Color.red, new LogicProcedure("condition1", true),
-						new LogicProcedure("condition1", true), _true, new Procedure("procedure3"),
-						new Procedure("procedure10"), new Procedure("procedure2"),
-						new MItemBlock(modElement.getWorkspace(), "")));
-				components.add(new InputSlot(3, 20, 30, Color.white, new LogicProcedure(null, true),
-						new LogicProcedure("condition1", true), !_true, new Procedure("procedure4"), null, null,
-						new MItemBlock(modElement.getWorkspace(), getRandomMCItem(random, blocksAndItems).getName())));
-				new InputSlot(5, 20, 30, Color.white, new LogicProcedure("condition1", true),
-						new LogicProcedure(null, true), !_true, new Procedure("procedure4"), null, null,
-						new MItemBlock(modElement.getWorkspace(), getRandomMCItem(random, blocksAndItems).getName()));
-				components.add(new InputSlot(4, 20, 30, Color.green, new LogicProcedure(null, _true),
-						new LogicProcedure("condition1", !_true), _true, new Procedure("procedure5"), null, null,
-						new MItemBlock(modElement.getWorkspace(), "TAG:walls")));
-				components.add(new OutputSlot(5, 10, 20, Color.black, new LogicProcedure("condition2", _true), !_true,
-						new Procedure("procedure10"), new Procedure("procedure2"), new Procedure("procedure3")));
-				components.add(
-						new OutputSlot(6, 243, 563, Color.black, new LogicProcedure("condition2", true), _true, null,
-								null, null));
+				if (gui.type == 1) {
+					components.add(new InputSlot(0, 20, 30, Color.red, new LogicProcedure("condition1", true),
+							new LogicProcedure("condition1", true), _true, new Procedure("procedure3"),
+							new Procedure("procedure10"), new Procedure("procedure2"),
+							new MItemBlock(modElement.getWorkspace(), "")));
+					components.add(new InputSlot(3, 20, 30, Color.white, new LogicProcedure(null, true),
+							new LogicProcedure("condition1", true), !_true, new Procedure("procedure4"), null, null,
+							new MItemBlock(modElement.getWorkspace(), getRandomMCItem(random, blocksAndItems).getName())));
+					new InputSlot(5, 20, 30, Color.white, new LogicProcedure("condition1", true),
+							new LogicProcedure(null, true), !_true, new Procedure("procedure4"), null, null,
+							new MItemBlock(modElement.getWorkspace(), getRandomMCItem(random, blocksAndItems).getName()));
+					components.add(new InputSlot(4, 20, 30, Color.green, new LogicProcedure(null, _true),
+							new LogicProcedure("condition1", !_true), _true, new Procedure("procedure5"), null, null,
+							new MItemBlock(modElement.getWorkspace(), "TAG:walls")));
+					components.add(new OutputSlot(5, 10, 20, Color.black, new LogicProcedure("condition2", _true), !_true,
+							new Procedure("procedure10"), new Procedure("procedure2"), new Procedure("procedure3")));
+					components.add(
+							new OutputSlot(6, 243, 563, Color.black, new LogicProcedure("condition2", true), _true, null,
+									null, null));
+				}
 				components.add(new TextField("text1", 0, 10, 100, 20, "Input value ..."));
 				components.add(new TextField("text2", 55, 231, 90, 20, ""));
 				components.add(new Checkbox("checkbox1", 100, 100, "Text", new Procedure("condition1")));


### PR DESCRIPTION
Tests used to add slots even in case the GUI was of no slots type. This is impossible in MCreator as slots are deleted and not able to be added when switching to no slots type.