### PR TITLE
Fix JRT home path not working on some Windows devices

### DIFF
--- a/src/main/java/net/mcreator/gradle/GradleToolchainUtil.java
+++ b/src/main/java/net/mcreator/gradle/GradleToolchainUtil.java
@@ -105,7 +105,9 @@ public class GradleToolchainUtil {
 		for (String line : output.split("\n")) {
 			line = line.trim();
 			if (line.startsWith("TOOLCHAIN_JDK_HOME=")) {
-				return new File(line.substring("TOOLCHAIN_JDK_HOME=".length()).trim());
+				// Normalize path to ensure consistent representation
+				return new File(line.substring("TOOLCHAIN_JDK_HOME=".length()).strip()).toPath().toAbsolutePath()
+						.normalize().toFile();
 			}
 		}
 		throw new RuntimeException("Could not determine compileJava toolchain JDK home. Output: " + output);

--- a/src/main/java/net/mcreator/java/ModulesFileLibraryInfo.java
+++ b/src/main/java/net/mcreator/java/ModulesFileLibraryInfo.java
@@ -58,13 +58,15 @@ public class ModulesFileLibraryInfo extends LibraryInfo {
 	public FileSystem getJrtFileSystem() throws IOException {
 		if (jrtFileSystem == null || !jrtFileSystem.isOpen()) {
 			try {
-				ClassLoader classLoader = new URLClassLoader(
-						new URL[] { new File(jdkHome, "lib/jrt-fs.jar").toURI().toURL() },
+				Path jdkPath = jdkHome.toPath().toAbsolutePath().normalize();
+				Path jrtFsPath = jdkPath.resolve("lib").resolve("jrt-fs.jar");
+
+				ClassLoader classLoader = new URLClassLoader(new URL[] { jrtFsPath.toUri().toURL() },
 						ClassLoader.getPlatformClassLoader());
 
 				// Load the JRT FileSystem using the external provider
-				jrtFileSystem = FileSystems.newFileSystem(URI.create("jrt:/"),
-						Map.of("java.home", jdkHome.getAbsolutePath()), classLoader);
+				jrtFileSystem = FileSystems.newFileSystem(URI.create("jrt:/"), Map.of("java.home", jdkPath.toString()),
+						classLoader);
 			} catch (Exception e) {
 				throw new IOException("Failed to initialize JRT FileSystem", e);
 			}


### PR DESCRIPTION
Fix JRT home path not working on some Windows devices

Waiting on confirmation from @NerdyPuzzle and comparison of old and new path for java.home he has to understand why this fixes it.