### PR TITLE
[26.1] Remove the gamerule's definition file from the ref generator

### DIFF
--- a/plugins/ref-generator-1.21.8/neoforge-1.21.8/gamerule.definition.yaml
+++ b/plugins/ref-generator-1.21.8/neoforge-1.21.8/gamerule.definition.yaml
@@ -1,9 +1,0 @@
-global_templates:
-  - template: elementinits/gamerules.java.ftl
-    name: "@SRCROOT/@BASEPACKAGEPATH/init/@JavaModNameGameRules.java"
-
-localizationkeys:
-  - key: gamerule.@lc1_name
-    mapto: displayName
-  - key: gamerule.@lc1_name.description
-    mapto: description


### PR DESCRIPTION
I noticed while looking at the remaining mod elements to port I forgot to delete the gamerule.definition.yaml file inside the ref folder when porting the gamerule mod element. This PR simply removes this file.