### PR TITLE
[26.1.2] Set items in block inventories with the vanilla Container instead of ResourceHandler

### DIFF
--- a/plugins/generator-26.1.x/neoforge-26.1.2/procedures/block_inv_clear_slot.java.ftl
+++ b/plugins/generator-26.1.x/neoforge-26.1.2/procedures/block_inv_clear_slot.java.ftl
@@ -1,8 +1,8 @@
 <#include "mcelements.ftl">
 <#-- @formatter:off -->
 if (world instanceof ServerLevel _serverLevel) {
-	BlockEntity be = _serverLevel.getBlockEntity(${toBlockPos(input$x,input$y,input$z)});
-	if (be instanceof Container container) {
+	BlockEntity _be = _serverLevel.getBlockEntity(${toBlockPos(input$x,input$y,input$z)});
+	if (_be instanceof Container container) {
 		container.setItem(${opt.toInt(input$slotid)}, ItemStack.EMPTY);
 	}
 }

--- a/plugins/generator-26.1.x/neoforge-26.1.2/procedures/block_inv_clear_slot.java.ftl
+++ b/plugins/generator-26.1.x/neoforge-26.1.2/procedures/block_inv_clear_slot.java.ftl
@@ -2,8 +2,8 @@
 <#-- @formatter:off -->
 if (world instanceof ServerLevel _serverLevel) {
 	BlockEntity _be = _serverLevel.getBlockEntity(${toBlockPos(input$x,input$y,input$z)});
-	if (_be instanceof Container container) {
-		container.setItem(${opt.toInt(input$slotid)}, ItemStack.EMPTY);
+	if (_be instanceof Container _container) {
+		_container.setItem(${opt.toInt(input$slotid)}, ItemStack.EMPTY);
 	}
 }
 <#-- @formatter:on -->

--- a/plugins/generator-26.1.x/neoforge-26.1.2/procedures/block_inv_clear_slot.java.ftl
+++ b/plugins/generator-26.1.x/neoforge-26.1.2/procedures/block_inv_clear_slot.java.ftl
@@ -1,6 +1,9 @@
 <#include "mcelements.ftl">
-<@addTemplate file="utils/item/itemhandler_set_slot.java.ftl"/>
 <#-- @formatter:off -->
-if (world instanceof ILevelExtension _ext && _ext.getCapability(Capabilities.Item.BLOCK, ${toBlockPos(input$x,input$y,input$z)}, null) instanceof ResourceHandler<ItemResource> _resourceHandler)
-	setStackInSlot(_resourceHandler, ${opt.toInt(input$slotid)}, ItemResource.EMPTY, 0);
+if (world instanceof ServerLevel _serverLevel) {
+	BlockEntity be = _serverLevel.getBlockEntity(${toBlockPos(input$x,input$y,input$z)});
+	if (be instanceof Container container) {
+		container.setItem(${opt.toInt(input$slotid)}, ItemStack.EMPTY);
+	}
+}
 <#-- @formatter:on -->

--- a/plugins/generator-26.1.x/neoforge-26.1.2/procedures/block_inv_damage_item.java.ftl
+++ b/plugins/generator-26.1.x/neoforge-26.1.2/procedures/block_inv_damage_item.java.ftl
@@ -2,8 +2,8 @@
 <#-- @formatter:off -->
 if (world instanceof ServerLevel _serverLevel) {
 	BlockEntity _be = _serverLevel.getBlockEntity(${toBlockPos(input$x,input$y,input$z)});
-	if (_be instanceof Container container) {
-		container.getItem(${opt.toInt(input$slotid)}).hurtAndBreak(${opt.toInt(input$amount)}, _serverLevel, null, _stkprov -> {});
+	if (_be instanceof Container _container) {
+		_container.getItem(${opt.toInt(input$slotid)}).hurtAndBreak(${opt.toInt(input$amount)}, _serverLevel, null, _stkprov -> {});
 	}
 }
 <#-- @formatter:on -->

--- a/plugins/generator-26.1.x/neoforge-26.1.2/procedures/block_inv_damage_item.java.ftl
+++ b/plugins/generator-26.1.x/neoforge-26.1.2/procedures/block_inv_damage_item.java.ftl
@@ -1,11 +1,9 @@
 <#include "mcelements.ftl">
-<@addTemplate file="utils/item/itemhandler_set_slot.java.ftl"/>
 <#-- @formatter:off -->
-if (world instanceof ILevelExtension _ext && world instanceof ServerLevel _serverLevel &&
-	_ext.getCapability(Capabilities.Item.BLOCK, ${toBlockPos(input$x,input$y,input$z)}, null) instanceof ResourceHandler<ItemResource> _resourceHandler) {
-	int _slotid = ${opt.toInt(input$slotid)};
-	ItemStack _stk = ItemUtil.getStack(_resourceHandler, _slotid);
-	_stk.hurtAndBreak(${opt.toInt(input$amount)}, _serverLevel, null, _stkprov -> {});
-	setStackInSlot(_resourceHandler, _slotid, ItemResource.of(_stk), _stk.getCount());
+if (world instanceof ServerLevel _serverLevel) {
+	BlockEntity be = _serverLevel.getBlockEntity(${toBlockPos(input$x,input$y,input$z)});
+	if (be instanceof Container container) {
+		container.getItem(${opt.toInt(input$slotid)}).hurtAndBreak(${opt.toInt(input$amount)}, _serverLevel, null, _stkprov -> {});
+	}
 }
 <#-- @formatter:on -->

--- a/plugins/generator-26.1.x/neoforge-26.1.2/procedures/block_inv_damage_item.java.ftl
+++ b/plugins/generator-26.1.x/neoforge-26.1.2/procedures/block_inv_damage_item.java.ftl
@@ -1,8 +1,8 @@
 <#include "mcelements.ftl">
 <#-- @formatter:off -->
 if (world instanceof ServerLevel _serverLevel) {
-	BlockEntity be = _serverLevel.getBlockEntity(${toBlockPos(input$x,input$y,input$z)});
-	if (be instanceof Container container) {
+	BlockEntity _be = _serverLevel.getBlockEntity(${toBlockPos(input$x,input$y,input$z)});
+	if (_be instanceof Container container) {
 		container.getItem(${opt.toInt(input$slotid)}).hurtAndBreak(${opt.toInt(input$amount)}, _serverLevel, null, _stkprov -> {});
 	}
 }

--- a/plugins/generator-26.1.x/neoforge-26.1.2/procedures/block_inv_remove_items.java.ftl
+++ b/plugins/generator-26.1.x/neoforge-26.1.2/procedures/block_inv_remove_items.java.ftl
@@ -1,8 +1,8 @@
 <#include "mcelements.ftl">
 <#-- @formatter:off -->
 if (world instanceof ServerLevel _serverLevel) {
-	BlockEntity be = _serverLevel.getBlockEntity(${toBlockPos(input$x,input$y,input$z)});
-	if (be instanceof Container container) {
+	BlockEntity _be = _serverLevel.getBlockEntity(${toBlockPos(input$x,input$y,input$z)});
+	if (_be instanceof Container container) {
 		container.getItem(${opt.toInt(input$slotid)}).shrink(${opt.toInt(input$amount)});
 	}
 }

--- a/plugins/generator-26.1.x/neoforge-26.1.2/procedures/block_inv_remove_items.java.ftl
+++ b/plugins/generator-26.1.x/neoforge-26.1.2/procedures/block_inv_remove_items.java.ftl
@@ -1,8 +1,9 @@
 <#include "mcelements.ftl">
-<@addTemplate file="utils/item/itemhandler_set_slot.java.ftl"/>
 <#-- @formatter:off -->
-if (world instanceof ILevelExtension _ext && _ext.getCapability(Capabilities.Item.BLOCK, ${toBlockPos(input$x,input$y,input$z)}, null) instanceof ResourceHandler<ItemResource> _resourceHandler) {
-	int _slotid = ${opt.toInt(input$slotid)};
-	setStackInSlot(_resourceHandler, _slotid, _resourceHandler.getResource(_slotid), _resourceHandler.getAmountAsInt(_slotid) - ${opt.toInt(input$amount)});
+if (world instanceof ServerLevel _serverLevel) {
+	BlockEntity be = _serverLevel.getBlockEntity(${toBlockPos(input$x,input$y,input$z)});
+	if (be instanceof Container container) {
+		container.getItem(${opt.toInt(input$slotid)}).shrink(${opt.toInt(input$amount)});
+	}
 }
 <#-- @formatter:on -->

--- a/plugins/generator-26.1.x/neoforge-26.1.2/procedures/block_inv_remove_items.java.ftl
+++ b/plugins/generator-26.1.x/neoforge-26.1.2/procedures/block_inv_remove_items.java.ftl
@@ -2,8 +2,8 @@
 <#-- @formatter:off -->
 if (world instanceof ServerLevel _serverLevel) {
 	BlockEntity _be = _serverLevel.getBlockEntity(${toBlockPos(input$x,input$y,input$z)});
-	if (_be instanceof Container container) {
-		container.getItem(${opt.toInt(input$slotid)}).shrink(${opt.toInt(input$amount)});
+	if (_be instanceof Container _container) {
+		_container.getItem(${opt.toInt(input$slotid)}).shrink(${opt.toInt(input$amount)});
 	}
 }
 <#-- @formatter:on -->

--- a/plugins/generator-26.1.x/neoforge-26.1.2/procedures/block_inv_set_items.java.ftl
+++ b/plugins/generator-26.1.x/neoforge-26.1.2/procedures/block_inv_set_items.java.ftl
@@ -3,10 +3,10 @@
 <#-- @formatter:off -->
 if (world instanceof ServerLevel _serverLevel) {
 	BlockEntity _be = _serverLevel.getBlockEntity(${toBlockPos(input$x,input$y,input$z)});
-	if (_be instanceof Container container) {
+	if (_be instanceof Container _container) {
 		ItemStack _setstack = ${mappedMCItemToItemStackCode(input$item, 1)}.copy();
         _setstack.setCount(${opt.toInt(input$amount)});
-		container.setItem(${opt.toInt(input$slotid)}, _setstack);
+		_container.setItem(${opt.toInt(input$slotid)}, _setstack);
 	}
 }
 <#-- @formatter:on -->

--- a/plugins/generator-26.1.x/neoforge-26.1.2/procedures/block_inv_set_items.java.ftl
+++ b/plugins/generator-26.1.x/neoforge-26.1.2/procedures/block_inv_set_items.java.ftl
@@ -1,8 +1,12 @@
 <#include "mcelements.ftl">
 <#include "mcitems.ftl">
-<@addTemplate file="utils/item/itemhandler_set_slot.java.ftl"/>
 <#-- @formatter:off -->
-if (world instanceof ILevelExtension _ext && _ext.getCapability(Capabilities.Item.BLOCK, ${toBlockPos(input$x,input$y,input$z)}, null) instanceof ResourceHandler<ItemResource> _resourceHandler) {
-	setStackInSlot(_resourceHandler, ${opt.toInt(input$slotid)}, ItemResource.of(${mappedMCItemToItemStackCode(input$item, 1)}), ${opt.toInt(input$amount)});  
+if (world instanceof ServerLevel _serverLevel) {
+	BlockEntity be = _serverLevel.getBlockEntity(${toBlockPos(input$x,input$y,input$z)});
+	if (be instanceof Container container) {
+		ItemStack _setstack = ${mappedMCItemToItemStackCode(input$item, 1)}.copy();
+        _setstack.setCount(${opt.toInt(input$amount)});
+		container.setItem(${opt.toInt(input$slotid)}, _setstack);
+	}
 }
 <#-- @formatter:on -->

--- a/plugins/generator-26.1.x/neoforge-26.1.2/procedures/block_inv_set_items.java.ftl
+++ b/plugins/generator-26.1.x/neoforge-26.1.2/procedures/block_inv_set_items.java.ftl
@@ -2,8 +2,8 @@
 <#include "mcitems.ftl">
 <#-- @formatter:off -->
 if (world instanceof ServerLevel _serverLevel) {
-	BlockEntity be = _serverLevel.getBlockEntity(${toBlockPos(input$x,input$y,input$z)});
-	if (be instanceof Container container) {
+	BlockEntity _be = _serverLevel.getBlockEntity(${toBlockPos(input$x,input$y,input$z)});
+	if (_be instanceof Container container) {
 		ItemStack _setstack = ${mappedMCItemToItemStackCode(input$item, 1)}.copy();
         _setstack.setCount(${opt.toInt(input$amount)});
 		container.setItem(${opt.toInt(input$slotid)}, _setstack);


### PR DESCRIPTION
In this PR, I replace setStackInSlot that uses ResourceHandler insert and extract for block inventory procedure blocks so we can get around the restrictions on insert, which prevents it from setting items in a slot that returns false on canPlaceItem. This is what IItemHandlerModifiable did, it set the item in a slot directly like these procedure blocks do now. Unfortunately, there is no equivalent for this in ResourceHandlers.