### PR TITLE
[26.1.x] Fix grass tint not applying to particles

### DIFF
--- a/plugins/generator-26.1.x/neoforge-26.1.2/templates/block/block.java.ftl
+++ b/plugins/generator-26.1.x/neoforge-26.1.2/templates/block/block.java.ftl
@@ -742,7 +742,7 @@ public class ${getClassName()}Block extends ${getBlockClass(data.blockBase)}
 				<#elseif data.tintType == "Spruce foliage">
 					List.of(BlockTintSources.constant(FoliageColor.FOLIAGE_EVERGREEN))
 				<#elseif data.tintType == "Grass">
-					List.of(BlockTintSources.grassBlock())
+					List.of(BlockTintSources.grass())
 				<#elseif data.tintType == "Foliage">
 					List.of(BlockTintSources.foliage())
 				<#elseif data.tintType == "Water">

--- a/plugins/generator-26.1.x/neoforge-26.1.2/templates/plant/plant.java.ftl
+++ b/plugins/generator-26.1.x/neoforge-26.1.2/templates/plant/plant.java.ftl
@@ -380,7 +380,7 @@ public class ${name}Block extends ${getPlantClass(data.plantType)}Block <#if int
 				<#elseif data.tintType == "Spruce foliage">
 					List.of(BlockTintSources.constant(FoliageColor.FOLIAGE_EVERGREEN))
 				<#elseif data.tintType == "Grass">
-					List.of(BlockTintSources.grassBlock())
+					List.of(BlockTintSources.grass())
 				<#elseif data.tintType == "Foliage">
 					List.of(BlockTintSources.foliage())
 				<#elseif data.tintType == "Water">


### PR DESCRIPTION
Changed the tint source to `grass()` so that breaking particles are also tinted (same behavior as in previous versions)