### PR TITLE
Fix itemstack nbt blocks & global variables not reading/saving itemstacks with enchantments in 26.1.2

### DIFF
--- a/plugins/generator-26.1.x/neoforge-26.1.2/procedures/block_nbt_itemstack_set.java.ftl
+++ b/plugins/generator-26.1.x/neoforge-26.1.2/procedures/block_nbt_itemstack_set.java.ftl
@@ -8,7 +8,7 @@ if (!world.isClientSide()) {
 	if(_blockEntity != null) {
 </@head>
 		_blockEntity.getPersistentData().put(${input$tagName}, (CompoundTag) ItemStack.OPTIONAL_CODEC.encode(${mappedMCItemToItemStackCode(input$tagValue, 1)},
-			NbtOps.INSTANCE, new CompoundTag()).result().orElseGet(CompoundTag::new));
+			world.registryAccess().createSerializationContext(NbtOps.INSTANCE), new CompoundTag()).result().orElseGet(CompoundTag::new));
 <@tail>
 	}
 	if(world instanceof Level _level)

--- a/plugins/generator-26.1.x/neoforge-26.1.2/procedures/entity_nbt_itemstack_get.java.ftl
+++ b/plugins/generator-26.1.x/neoforge-26.1.2/procedures/entity_nbt_itemstack_get.java.ftl
@@ -1,1 +1,2 @@
-/*@ItemStack*/(ItemStack.OPTIONAL_CODEC.parse(NbtOps.INSTANCE, ${input$entity}.getPersistentData().getCompoundOrEmpty(${input$tagName})).result().orElse(ItemStack.EMPTY))
+<@addTemplate file="utils/entity/entity_get_itemstack_nbt.java.ftl"/>
+/*@ItemStack*/(getItemStackNbtFromEntity(${input$entity}, ${input$tagName}))

--- a/plugins/generator-26.1.x/neoforge-26.1.2/procedures/entity_nbt_itemstack_set.java.ftl
+++ b/plugins/generator-26.1.x/neoforge-26.1.2/procedures/entity_nbt_itemstack_set.java.ftl
@@ -1,2 +1,3 @@
 <#include "mcitems.ftl">
-${input$entity}.getPersistentData().put(${input$tagName}, (CompoundTag) ItemStack.OPTIONAL_CODEC.encode(${mappedMCItemToItemStackCode(input$tagValue, 1)}, NbtOps.INSTANCE, new CompoundTag()).result().orElseGet(CompoundTag::new));
+Entity _entity${cbi} = ${input$entity};
+_entity${cbi}.getPersistentData().put(${input$tagName}, (CompoundTag) ItemStack.OPTIONAL_CODEC.encode(${mappedMCItemToItemStackCode(input$tagValue, 1)}, _entity${cbi}.registryAccess().createSerializationContext(NbtOps.INSTANCE), new CompoundTag()).result().orElseGet(CompoundTag::new));

--- a/plugins/generator-26.1.x/neoforge-26.1.2/procedures/item_nbt_itemstack_get.java.ftl
+++ b/plugins/generator-26.1.x/neoforge-26.1.2/procedures/item_nbt_itemstack_get.java.ftl
@@ -1,3 +1,3 @@
 <#include "mcitems.ftl">
-/*@ItemStack*/(ItemStack.OPTIONAL_CODEC.parse(NbtOps.INSTANCE, ${mappedMCItemToItemStackCode(input$item, 1)}
+/*@ItemStack*/(ItemStack.OPTIONAL_CODEC.parse(world.registryAccess().createSerializationContext(NbtOps.INSTANCE), ${mappedMCItemToItemStackCode(input$item, 1)}
 	.getOrDefault(DataComponents.CUSTOM_DATA, CustomData.EMPTY).copyTag().getCompoundOrEmpty(${input$tagName})).result().orElse(ItemStack.EMPTY))

--- a/plugins/generator-26.1.x/neoforge-26.1.2/procedures/item_nbt_itemstack_set.java.ftl
+++ b/plugins/generator-26.1.x/neoforge-26.1.2/procedures/item_nbt_itemstack_set.java.ftl
@@ -3,5 +3,5 @@
 	final String _tagName = ${input$tagName};
 	final ItemStack _tagValue = ${mappedMCItemToItemStackCode(input$tagValue, 1)};
 	CustomData.update(DataComponents.CUSTOM_DATA, ${mappedMCItemToItemStackCode(input$item, 1)},
-		tag -> tag.put(_tagName, (CompoundTag) ItemStack.OPTIONAL_CODEC.encode(_tagValue, NbtOps.INSTANCE, new CompoundTag()).result().orElseGet(CompoundTag::new)));
+		tag -> tag.put(_tagName, (CompoundTag) ItemStack.OPTIONAL_CODEC.encode(_tagValue, world.registryAccess().createSerializationContext(NbtOps.INSTANCE), new CompoundTag()).result().orElseGet(CompoundTag::new)));
 }

--- a/plugins/generator-26.1.x/neoforge-26.1.2/procedures/utils/block_nbt/get_itemstack.java.ftl
+++ b/plugins/generator-26.1.x/neoforge-26.1.2/procedures/utils/block_nbt/get_itemstack.java.ftl
@@ -1,6 +1,6 @@
 private static ItemStack getBlockNBTItemStack(LevelAccessor world, BlockPos pos, String tag) {
 	BlockEntity blockEntity = world.getBlockEntity(pos);
 	if (blockEntity != null)
-		return ItemStack.OPTIONAL_CODEC.parse(NbtOps.INSTANCE, blockEntity.getPersistentData().getCompoundOrEmpty(tag)).result().orElse(ItemStack.EMPTY);
+		return ItemStack.OPTIONAL_CODEC.parse(world.registryAccess().createSerializationContext(NbtOps.INSTANCE), blockEntity.getPersistentData().getCompoundOrEmpty(tag)).result().orElse(ItemStack.EMPTY);
 	return ItemStack.EMPTY;
 }

--- a/plugins/generator-26.1.x/neoforge-26.1.2/procedures/utils/entity/entity_get_itemstack_nbt.java.ftl
+++ b/plugins/generator-26.1.x/neoforge-26.1.2/procedures/utils/entity/entity_get_itemstack_nbt.java.ftl
@@ -1,0 +1,3 @@
+private static ItemStack getItemStackNbtFromEntity(Entity entity, String tagName) {
+	return ItemStack.OPTIONAL_CODEC.parse(entity.level().registryAccess().createSerializationContext(NbtOps.INSTANCE), entity.getPersistentData().getCompoundOrEmpty(tagName)).result().orElse(ItemStack.EMPTY);
+}

--- a/plugins/generator-26.1.x/neoforge-26.1.2/templates/modbase/variableslist.java.ftl
+++ b/plugins/generator-26.1.x/neoforge-26.1.2/templates/modbase/variableslist.java.ftl
@@ -311,7 +311,7 @@ import ${package}.${JavaModName};
 
 		public static final StreamCodec<RegistryFriendlyByteBuf, PlayerVariablesSyncMessage> STREAM_CODEC = StreamCodec.of(
 				(RegistryFriendlyByteBuf buffer, PlayerVariablesSyncMessage message) -> {
-					TagValueOutput output = TagValueOutput.createWithoutContext(ProblemReporter.DISCARDING);
+					TagValueOutput output = TagValueOutput.createWithContext(ProblemReporter.DISCARDING, buffer.registryAccess());
 					message.data.serialize(output);
 					buffer.writeNbt(output.buildResult());
 				},

--- a/plugins/generator-26.1.x/neoforge-26.1.2/variables/itemstack.yaml
+++ b/plugins/generator-26.1.x/neoforge-26.1.2/variables/itemstack.yaml
@@ -10,8 +10,8 @@ scopes:
     set: <#include "mcitems.ftl"> ${JavaModName}Variables.${name} = ${mappedMCItemToItemStackCode(value, 1)}.copy();
   global_world:
     init: public ItemStack ${var.getName()} = ItemStack.EMPTY;
-    read: ${var.getName()} = ItemStack.OPTIONAL_CODEC.parse(NbtOps.INSTANCE, nbt.getCompoundOrEmpty("${var.getName()}")).result().orElse(ItemStack.EMPTY);
-    write: nbt.put("${var.getName()}", (CompoundTag) ItemStack.OPTIONAL_CODEC.encode(${var.getName()}, NbtOps.INSTANCE, new CompoundTag()).result().orElseGet(CompoundTag::new));
+    read: ${var.getName()} = ItemStack.OPTIONAL_CODEC.parse(lookupProvider.createSerializationContext(NbtOps.INSTANCE), nbt.getCompoundOrEmpty("${var.getName()}")).result().orElse(ItemStack.EMPTY);
+    write: nbt.put("${var.getName()}", (CompoundTag) ItemStack.OPTIONAL_CODEC.encode(${var.getName()}, lookupProvider.createSerializationContext(NbtOps.INSTANCE), new CompoundTag()).result().orElseGet(CompoundTag::new));
     get: /*@ItemStack*/${JavaModName}Variables.WorldVariables.get(world).${name}
     set: |
       <#include "mcitems.ftl">
@@ -19,8 +19,8 @@ scopes:
       <@tail>${JavaModName}Variables.WorldVariables.get(world).markSyncDirty();</@tail>
   global_map:
     init: public ItemStack ${var.getName()} = ItemStack.EMPTY;
-    read: ${var.getName()} = ItemStack.OPTIONAL_CODEC.parse(NbtOps.INSTANCE, nbt.getCompoundOrEmpty("${var.getName()}")).result().orElse(ItemStack.EMPTY);
-    write: nbt.put("${var.getName()}", (CompoundTag) ItemStack.OPTIONAL_CODEC.encode(${var.getName()}, NbtOps.INSTANCE, new CompoundTag()).result().orElseGet(CompoundTag::new));
+    read: ${var.getName()} = ItemStack.OPTIONAL_CODEC.parse(lookupProvider.createSerializationContext(NbtOps.INSTANCE), nbt.getCompoundOrEmpty("${var.getName()}")).result().orElse(ItemStack.EMPTY);
+    write: nbt.put("${var.getName()}", (CompoundTag) ItemStack.OPTIONAL_CODEC.encode(${var.getName()}, lookupProvider.createSerializationContext(NbtOps.INSTANCE), new CompoundTag()).result().orElseGet(CompoundTag::new));
     get: /*@ItemStack*/${JavaModName}Variables.MapVariables.get(world).${name}
     set: |
       <#include "mcitems.ftl">


### PR DESCRIPTION
This issue also existed in 1.21.8, but not in 1.21.1.

~~Global variables use the same code but don't have the issue, I don't know why. However, with these changes, the procedure blocks work with enchanted items again.~~

Both global variables and nbt itemstack procedure blocks have this issue.