### PR TITLE
Fix the disable_duplicate_input_type extension

### DIFF
--- a/plugins/mcreator-core/blockly/js/mcreator_extensions.js
+++ b/plugins/mcreator-core/blockly/js/mcreator_extensions.js
@@ -353,7 +353,7 @@ Blockly.Extensions.registerMixin('disable_duplicate_input_type',
                 const seenTypes = new Set();
 
                 for (const block of parentsChildren) {
-                    const realType = block.type.split("_")[2]; // We use this format: item_predicate_{typewithoutunderscores}_{optional_extra_data}
+                    const realType = block.type.split("_")[3]; // We use this format: data_component_predicate_{typewithoutunderscores}_{optional_extra_data}
                     if (!realType) continue;
                     if (block === this) {
                         if (seenTypes.has(realType))


### PR DESCRIPTION
I noticed while working on the next part of #5827 that I forgot to update the `disable_duplicate_input_type` extension after I changed the format for file's names. This is a simple fix to allow plugins to use the system in the (very probable) case the next part is not merged in time.

Without changing this, we can not add new item predicate component blocks because the extension compares `predicate` to `predicate` (instead of `damage` to `enchantments`).