### PR TITLE
Make all templates part of a single tabbed pane page

### DIFF
--- a/plugins/mcreator-localization/lang/texts.properties
+++ b/plugins/mcreator-localization/lang/texts.properties
@@ -490,6 +490,7 @@ dialog.preferences.page_aitasks_templates=AI builder templates
 dialog.preferences.page_cmdargs_templates=Command templates
 dialog.preferences.page_features_templates=Feature templates
 dialog.preferences.page_texture_templates=Texture templates
+dialog.preferences.page_templates=Templates
 dialog.preferences.page_armor_templates=Armor templates
 dialog.preferences.java_plugins=<html>Enable Java plugins<br><small>\
   Check this to enable loading of Java plugins. Java plugins have full access to your workspaces and computer, so be careful with this option.\

--- a/src/main/java/net/mcreator/ui/dialogs/preferences/EditTemplatesPanel.java
+++ b/src/main/java/net/mcreator/ui/dialogs/preferences/EditTemplatesPanel.java
@@ -40,9 +40,7 @@ class EditTemplatesPanel {
 	private final CardLayout cardLayout = new CardLayout();
 	private final JPanel panel = new JPanel(cardLayout);
 
-	EditTemplatesPanel(PreferencesDialog preferencesDialog, String name, String templatesFolder, String templateExt) {
-		preferencesDialog.model.addElement(name);
-
+	EditTemplatesPanel(JTabbedPane tabbedPane, PreferencesDialog preferencesDialog, String name, String templatesFolder, String templateExt) {
 		JPanel sectionPanel = new JPanel(new BorderLayout(0, 0));
 
 		JComponent titlebar = L10N.label("dialog.preferences.change_language", name.toLowerCase(), templateExt);
@@ -107,7 +105,7 @@ class EditTemplatesPanel {
 
 		sectionPanel.add("Center", PanelUtils.northAndCenterElement(opts, panel, 5, 5));
 
-		preferencesDialog.preferences.add(sectionPanel, name);
+		tabbedPane.addTab(name, sectionPanel);
 
 		updateVisibility(tmodel);
 	}

--- a/src/main/java/net/mcreator/ui/dialogs/preferences/PreferencesDialog.java
+++ b/src/main/java/net/mcreator/ui/dialogs/preferences/PreferencesDialog.java
@@ -18,6 +18,7 @@
 
 package net.mcreator.ui.dialogs.preferences;
 
+import com.formdev.flatlaf.ui.FlatTabbedPaneUI;
 import net.mcreator.blockly.data.BlocklyLoader;
 import net.mcreator.plugin.MCREvent;
 import net.mcreator.plugin.events.ui.PreferencesDialogEvent;
@@ -46,6 +47,8 @@ public class PreferencesDialog extends MCreatorDialog {
 
 	private final JList<String> sections = new JList<>(model);
 	private final CardLayout preferencesLayout = new CardLayout();
+
+	private final JTabbedPane templatesTabbedPane = new JTabbedPane();
 
 	private final Map<PreferencesEntry<?>, JComponent> entries = new HashMap<>();
 
@@ -165,6 +168,14 @@ public class PreferencesDialog extends MCreatorDialog {
 		BlocklyLoader.INSTANCE.getAllBlockLoaders().keySet().stream().filter(type -> type.extension() != null)
 				.forEach(this::addEditTemplatesPanel);
 
+		templatesTabbedPane.setUI(new FlatTabbedPaneUI() {
+			@Override protected boolean shouldRotateTabRuns(int tabPlacement) {
+				return false;
+			}
+		});
+		preferences.add(templatesTabbedPane, L10N.t("dialog.preferences.page_templates"));
+		model.addElement(L10N.t("dialog.preferences.page_templates"));
+
 		MCREvent.event(new PreferencesDialogEvent.SectionsLoaded(this));
 
 		sections.setSelectedIndex(0);
@@ -175,7 +186,7 @@ public class PreferencesDialog extends MCreatorDialog {
 	}
 
 	public void addEditTemplatesPanel(String translationKey, String folder, String extension) {
-		new EditTemplatesPanel(this, L10N.t("dialog.preferences.page_" + translationKey), folder, extension);
+		new EditTemplatesPanel(templatesTabbedPane, this, L10N.t("dialog.preferences.page_" + translationKey), folder, extension);
 	}
 
 	private void createPreferenceSection(String section) {


### PR DESCRIPTION
It's been sometimes now that I think that the side bar of the preferences dialog is becoming too long due to the constant additions of new Blockly editor with their own templates format. As they are all similar and their purpose is the same, I got the idea they could maybe fit under a single page with different tabs. I tried it and this is the global result. I think it makes the dialog cleaner and more understandable.

<img width="1177" height="722" alt="image" src="https://github.com/user-attachments/assets/93c1c09d-67b4-4e86-843a-c158dd0c7e6c" />

If this is not something you like/want for MCreator, I can totally understand it. It might be more of a preference.
