### PR TITLE
Fix cancellable global trigger not being marked as such

### DIFF
--- a/plugins/mcreator-core/triggers/entity_sets_attack_target.json
+++ b/plugins/mcreator-core/triggers/entity_sets_attack_target.json
@@ -25,5 +25,6 @@
       "type": "number"
     }
   ],
+  "cancelable": "true",
   "side": "server"
 }


### PR DESCRIPTION
LivingChangeTargetEvent has been cancellable for a while but was not updated to allow for cancellation.

<img width="836" height="51" alt="image" src="https://github.com/user-attachments/assets/403f29cf-4c1a-451d-85bd-a168a0748b7d" />
