### PR TITLE
"Get block at vector" procedure block

### DIFF
--- a/plugins/generator-1.21.1/neoforge-1.21.1/procedures/world_data_blockatvector.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/procedures/world_data_blockatvector.java.ftl
@@ -1,0 +1,1 @@
+/*@BlockState*/(world.getBlockState(BlockPos.containing(${input$vector})))

--- a/plugins/generator-26.1.x/neoforge-26.1.2/procedures/world_data_blockatvector.java.ftl
+++ b/plugins/generator-26.1.x/neoforge-26.1.2/procedures/world_data_blockatvector.java.ftl
@@ -1,0 +1,1 @@
+/*@BlockState*/(world.getBlockState(BlockPos.containing(${input$vector})))

--- a/plugins/mcreator-core/procedures/world_data_blockatvector.json
+++ b/plugins/mcreator-core/procedures/world_data_blockatvector.json
@@ -1,0 +1,34 @@
+{
+  "args0": [
+    {
+      "type": "input_value",
+      "name": "vector",
+      "check": "Vector"
+    },
+    {
+      "type": "field_image",
+      "src": "./res/b.png",
+      "width": 8,
+      "height": 36
+    }
+  ],
+  "inputsInline": true,
+  "output": "MCItemBlock",
+  "colour": 60,
+  "mcreator": {
+    "group": "base",
+    "toolbox_id": "blockdata",
+    "toolbox_init": [
+      "<value name=\"vector\"><block type=\"vector_new_vector\"><value name=\"x\"><block type=\"coord_x\"></block></value><value name=\"y\"><block type=\"coord_y\"></block></value><value name=\"z\"><block type=\"coord_z\"></block></value></block></value>"
+    ],
+    "inputs": [
+      "vector"
+    ],
+    "dependencies": [
+      {
+        "name": "world",
+        "type": "world"
+      }
+    ]
+  }
+}

--- a/plugins/mcreator-localization/lang/texts.properties
+++ b/plugins/mcreator-localization/lang/texts.properties
@@ -1426,6 +1426,7 @@ blockly.block.world_data_biomeat=Is biome at x: %1 y: %2 z: %3 type %4
 blockly.block.world_data_biomeat_tag=Is biome at x: %1 y: %2 z: %3 tagged in biome tags as %4
 blockly.block.world_data_block_direction_at=Get block direction at x: %1 y: %2 z: %3
 blockly.block.world_data_blockat=Get block at x: %1 y: %2 z: %3 %4
+blockly.block.world_data_blockatvector=Get block at vector: %1 %2
 blockly.block.be_world_data_blockat=Get block at x: %1 y: %2 z: %3 %4
 blockly.block.world_data_canseesky=Can location at x: %1 y: %2 z: %3 see the sky
 blockly.block.world_data_checkdifficulty=Is difficulty in the provided world %1


### PR DESCRIPTION
Adds a new procedure block that accepts vectors and returns blockstate of the block at that position.

<img width="694" height="202" alt="image" src="https://github.com/user-attachments/assets/e6a1f3a6-16ba-4791-a9cd-e589e4b9e749" />


### Reason to add: 
- There are cases when calculating positions/vectors where you need to give the calculated vector to "Get block at".