### PR TITLE
Add an option to display a warning for nullable dependencies

### DIFF
--- a/plugins/mcreator-core/jstriggers/be_global_entity_dies.json
+++ b/plugins/mcreator-core/jstriggers/be_global_entity_dies.json
@@ -6,7 +6,8 @@
     },
     {
       "name": "sourceentity",
-      "type": "entity"
+      "type": "entity",
+      "can_be_null": true
     },
     {
       "name": "dimension",

--- a/plugins/mcreator-localization/lang/texts.properties
+++ b/plugins/mcreator-localization/lang/texts.properties
@@ -2471,6 +2471,7 @@ elementgui.common.attribute_modifier.chestplate=Chestplate
 elementgui.common.attribute_modifier.leggings=Leggings
 elementgui.common.attribute_modifier.boots=Boots
 elementgui.common.attribute_modifier.error_attributes_must_be_unique=Multiple attribute modifiers cannot modify the same attribute
+elementgui.common.provided_dependency_can_be_null=This dependency can be null in some cases. Make sure to keep this in mind when using it
 elementgui.advancement.name=Advancement GUI name: 
 elementgui.advancement.description=Advancement description: 
 elementgui.advancement.icon=Advancement icon: 

--- a/src/main/java/net/mcreator/blockly/data/Dependency.java
+++ b/src/main/java/net/mcreator/blockly/data/Dependency.java
@@ -31,7 +31,7 @@ import java.awt.*;
 import java.util.ArrayList;
 import java.util.List;
 
-public record Dependency(String name, String type, boolean canBeNull) implements Comparable<Dependency> {
+public record Dependency(String name, String type, boolean can_be_null) implements Comparable<Dependency> {
 
 	public Dependency(String name, String type) {
 		this(name, type, false);

--- a/src/main/java/net/mcreator/blockly/data/Dependency.java
+++ b/src/main/java/net/mcreator/blockly/data/Dependency.java
@@ -31,7 +31,11 @@ import java.awt.*;
 import java.util.ArrayList;
 import java.util.List;
 
-public record Dependency(String name, String type) implements Comparable<Dependency> {
+public record Dependency(String name, String type, boolean canBeNull) implements Comparable<Dependency> {
+
+	public Dependency(String name, String type) {
+		this(name, type, false);
+	}
 
 	@Override public int compareTo(Dependency o) {
 		return (type + ":" + name).compareTo(o.type + ":" + o.name);

--- a/src/main/java/net/mcreator/ui/modgui/ProcedureGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/ProcedureGUI.java
@@ -308,7 +308,13 @@ public class ProcedureGUI extends ModElementGUI<net.mcreator.element.types.Proce
 			setForeground(isSelected ? Theme.current().getForegroundColor() : col.brighter());
 			ComponentUtils.deriveFont(this, 14);
 			setText(value.name());
-			setToolTipText(value.toString());
+			if (value.canBeNull()) {
+				setToolTipText(L10N.t("elementgui.common.provided_dependency_can_be_null"));
+				setIcon(UIRES.get("18px.warning"));
+			} else {
+				setToolTipText(value.toString());
+				setIcon(null);
+			}
 			return this;
 		}
 	}

--- a/src/main/java/net/mcreator/ui/modgui/ProcedureGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/ProcedureGUI.java
@@ -308,7 +308,7 @@ public class ProcedureGUI extends ModElementGUI<net.mcreator.element.types.Proce
 			setForeground(isSelected ? Theme.current().getForegroundColor() : col.brighter());
 			ComponentUtils.deriveFont(this, 14);
 			setText(value.name());
-			if (value.canBeNull()) {
+			if (value.can_be_null()) {
 				setToolTipText(L10N.t("elementgui.common.provided_dependency_can_be_null"));
 				setIcon(UIRES.get("18px.warning"));
 			} else {

--- a/src/main/java/net/mcreator/ui/modgui/bedrock/BEScriptGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/bedrock/BEScriptGUI.java
@@ -244,7 +244,13 @@ public class BEScriptGUI extends ModElementGUI<BEScript>
 			setForeground(isSelected ? Theme.current().getForegroundColor() : col.brighter());
 			ComponentUtils.deriveFont(this, 14);
 			setText(value.name());
-			setToolTipText(value.toString());
+			if (value.canBeNull()) {
+				setToolTipText(L10N.t("elementgui.common.provided_dependency_can_be_null"));
+				setIcon(UIRES.get("18px.warning"));
+			} else {
+				setToolTipText(value.toString());
+				setIcon(null);
+			}
 			return this;
 		}
 	}

--- a/src/main/java/net/mcreator/ui/modgui/bedrock/BEScriptGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/bedrock/BEScriptGUI.java
@@ -244,7 +244,7 @@ public class BEScriptGUI extends ModElementGUI<BEScript>
 			setForeground(isSelected ? Theme.current().getForegroundColor() : col.brighter());
 			ComponentUtils.deriveFont(this, 14);
 			setText(value.name());
-			if (value.canBeNull()) {
+			if (value.can_be_null()) {
 				setToolTipText(L10N.t("elementgui.common.provided_dependency_can_be_null"));
 				setIcon(UIRES.get("18px.warning"));
 			} else {


### PR DESCRIPTION
I was thinking about your comment of an optional dependency in a Bedrock global trigger (https://github.com/MCreator/MCreator/pull/6408#discussion_r3545899130) for a solution, so users can know which provided dependencies can be null. I came up witht his idea of displaying a warning icon next to the dependency's name and add a tooltip explaining the precaution. I put this warning text in a tooltip, but I can also put it with the warning/error list at the bottom if this is preferable.

<img width="2560" height="1380" alt="image" src="https://github.com/user-attachments/assets/4bfc86cf-fd56-4c70-b30a-9bb7e111065e" />
