### PR TITLE
Fix #6413

### DIFF
--- a/plugins/generator-26.1.x/neoforge-26.1.2/templates/livingentity/livingentity_renderer.java.ftl
+++ b/plugins/generator-26.1.x/neoforge-26.1.2/templates/livingentity/livingentity_renderer.java.ftl
@@ -300,8 +300,8 @@ public class ${name}Renderer extends <#if humanoid>Humanoid</#if>MobRenderer<${n
 			<#assign needsEntityInState = true>
 			this.keyframeAnimation${animation?index}.apply(entity.animationState${animation?index}, state.ageInTicks, ${animation.speed}f);
 		<#else>
-			<#if hasProcedure(animation.condition)>
 			<#assign needsEntityInState = true>
+			<#if hasProcedure(animation.condition)>
 			if (<@procedureCode animation.condition, {
 				"x": "entity.getX()",
 				"y": "entity.getY()",


### PR DESCRIPTION
This fixes #6413 by moving the assign value outside the if statement for the procedure.

Changelog:
- [NF 26.1.2] Living entities with only a walk animation failed to build