### PR TITLE
Add backgroundColor token to words replaced in RSyntactTextAreaStyler fallback

### DIFF
--- a/src/main/java/net/mcreator/ui/ide/RSyntaxTextAreaStyler.java
+++ b/src/main/java/net/mcreator/ui/ide/RSyntaxTextAreaStyler.java
@@ -38,6 +38,18 @@ public class RSyntaxTextAreaStyler {
 
 	private static final Logger LOG = LogManager.getLogger(RSyntaxTextAreaStyler.class);
 
+	private static String replaceXMLTokens(String themeXML) {
+		return themeXML
+				//@formatter:off
+				.replace("${backgroundColor}", Integer.toHexString((net.mcreator.ui.laf.themes.Theme.current().getBackgroundColor()).getRGB()).substring(2))
+				.replace("${altBackgroundColor}", Integer.toHexString((net.mcreator.ui.laf.themes.Theme.current().getAltBackgroundColor()).getRGB()).substring(2))
+				.replace("${secondAltBackgroundColor}", Integer.toHexString((net.mcreator.ui.laf.themes.Theme.current().getSecondAltBackgroundColor()).getRGB()).substring(2))
+				.replace("${foregroundColor}", Integer.toHexString((net.mcreator.ui.laf.themes.Theme.current().getForegroundColor()).getRGB()).substring(2))
+				.replace("${mainTint}", Integer.toHexString((net.mcreator.ui.laf.themes.Theme.current().getInterfaceAccentColor()).getRGB()).substring(2))
+				.replace("${altForegroundColor}", Integer.toHexString((net.mcreator.ui.laf.themes.Theme.current().getAltForegroundColor()).getRGB()).substring(2));
+		//@formatter:on
+	}
+
 	public static void style(RSyntaxTextArea te, RTextScrollPane sp, int initialFontSize) {
 		try {
 			Theme theme;
@@ -47,26 +59,12 @@ public class RSyntaxTextAreaStyler {
 					!= null) {
 				String themeXML = FileIO.readResourceToString(PluginLoader.INSTANCE,
 						"themes/" + net.mcreator.ui.laf.themes.Theme.current().getID() + "/styles/code_editor.xml");
-				themeXML = themeXML
-						//@formatter:off
-				.replace("${backgroundColor}", Integer.toHexString((net.mcreator.ui.laf.themes.Theme.current().getBackgroundColor()).getRGB()).substring(2))
-				.replace("${altBackgroundColor}", Integer.toHexString((net.mcreator.ui.laf.themes.Theme.current().getAltBackgroundColor()).getRGB()).substring(2))
-				.replace("${secondAltBackgroundColor}", Integer.toHexString((net.mcreator.ui.laf.themes.Theme.current().getSecondAltBackgroundColor()).getRGB()).substring(2))
-				.replace("${foregroundColor}", Integer.toHexString((net.mcreator.ui.laf.themes.Theme.current().getForegroundColor()).getRGB()).substring(2))
-				.replace("${mainTint}", Integer.toHexString((net.mcreator.ui.laf.themes.Theme.current().getInterfaceAccentColor()).getRGB()).substring(2))
-				.replace("${altForegroundColor}", Integer.toHexString((net.mcreator.ui.laf.themes.Theme.current().getAltForegroundColor()).getRGB()).substring(2))
-				//@formatter:on
-				;
+				themeXML = replaceXMLTokens(themeXML);
 				theme = Theme.load(new ByteArrayInputStream(themeXML.getBytes(StandardCharsets.UTF_8)));
 			} else {
 				String themeXML = FileIO.readResourceToString(PluginLoader.INSTANCE,
 						"themes/default_dark/styles/code_editor.xml");
-				themeXML = themeXML
-						//@formatter:off
-						.replace("${backgroundColor}", Integer.toHexString((net.mcreator.ui.laf.themes.Theme.current().getBackgroundColor()).getRGB()).substring(2))
-						.replace("${mainTint}", Integer.toHexString((net.mcreator.ui.laf.themes.Theme.current().getInterfaceAccentColor()).getRGB()).substring(2))
-				//@formatter:on
-				;
+				themeXML = replaceXMLTokens(themeXML);
 				theme = Theme.load(new ByteArrayInputStream(themeXML.getBytes(StandardCharsets.UTF_8)));
 			}
 

--- a/src/main/java/net/mcreator/ui/ide/RSyntaxTextAreaStyler.java
+++ b/src/main/java/net/mcreator/ui/ide/RSyntaxTextAreaStyler.java
@@ -61,8 +61,12 @@ public class RSyntaxTextAreaStyler {
 			} else {
 				String themeXML = FileIO.readResourceToString(PluginLoader.INSTANCE,
 						"themes/default_dark/styles/code_editor.xml");
-				themeXML = themeXML.replace("${mainTint}", Integer.toHexString(
-						(net.mcreator.ui.laf.themes.Theme.current().getInterfaceAccentColor()).getRGB()).substring(2));
+				themeXML = themeXML
+						//@formatter:off
+						.replace("${backgroundColor}", Integer.toHexString((net.mcreator.ui.laf.themes.Theme.current().getBackgroundColor()).getRGB()).substring(2))
+						.replace("${mainTint}", Integer.toHexString((net.mcreator.ui.laf.themes.Theme.current().getInterfaceAccentColor()).getRGB()).substring(2))
+				//@formatter:on
+				;
 				theme = Theme.load(new ByteArrayInputStream(themeXML.getBytes(StandardCharsets.UTF_8)));
 			}
 


### PR DESCRIPTION
As reported by someone on the forums ([here](https://mcreator.net/forum/123895/matrix-interface-theme-prevents-copy-and-cut)), when a UI theme does not define a code_editor.xml style file, so uses the file from default_dark, it will not be possible to cut (CTRL + X) a portion of the code inside the IDE. This seems to have been caused when the `${backgroundColor}` token was added to the default_dark's file in [this commit](https://github.com/MCreator/MCreator/commit/dfd9d744c464f4fdfc7b12800449d4abdf6501e3) as Klemen replaced the token when the file is taken from the current UI theme, but not when the file is used as a fallback option (so in the else statement).