### PR TITLE
Fix Windows Native file chooser not allowing multiple file extensions

### DIFF
--- a/src/main/java/net/mcreator/ui/dialogs/file/NativeFileDialogs.java
+++ b/src/main/java/net/mcreator/ui/dialogs/file/NativeFileDialogs.java
@@ -50,8 +50,8 @@ class NativeFileDialogs {
 
 		if (filters != null) {
 			fileChooser.setAcceptAllFileFilterUsed(false);
+			fileChooser.resetChoosableFileFilters();
 			for (ExtensionFilter filter : filters) {
-				fileChooser.resetChoosableFileFilters();
 				fileChooser.addChoosableFileFilter(new SystemFileChooser.FileNameExtensionFilter(filter.description(),
 						filter.extensions().stream().map(e -> e.replace("*.", "")).toArray(String[]::new)));
 			}


### PR DESCRIPTION
Fix #6422 by not reseting all choosable file extensions at every iteration of the loop, but before the loop