### PR TITLE
Fix #6426 - Ambient light not working in 26.1.2

### DIFF
--- a/plugins/generator-26.1.x/datapack-26.1.x/templates/dimension/dimension_type.json.ftl
+++ b/plugins/generator-26.1.x/datapack-26.1.x/templates/dimension/dimension_type.json.ftl
@@ -35,6 +35,9 @@
       <#if data.airColor?has_content>
       "minecraft:visual/fog_color": "${thelper.colorToHexString(data.airColor)}",
       "minecraft:visual/sky_color": "${thelper.colorToHexString(data.airColor)}",
+      "minecraft:visual/ambient_light_color": "${scaleAmbientLight("#0a0a0a", data.ambientLight, 0.0)}",
+      <#else>
+      "minecraft:visual/ambient_light_color": "${scaleAmbientLight("#0a0a0a", data.ambientLight, 0.0)}",
       </#if>
       <#if !data.sunHeightAffectsFog>
       "minecraft:visual/sunrise_sunset_color": {
@@ -45,15 +48,16 @@
     <#elseif data.defaultEffects == "overworld">
       "minecraft:visual/fog_color": "#c0d8ff",
       "minecraft:visual/sky_color": "#78a7ff",
+      "minecraft:visual/ambient_light_color": "${scaleAmbientLight("#0a0a0a", data.ambientLight, 0.0)}",
     <#elseif data.defaultEffects == "the_nether">
       "minecraft:visual/fog_start_distance": 10,
       "minecraft:visual/fog_end_distance": 96,
-      "minecraft:visual/ambient_light_color": "#302821",
+      "minecraft:visual/ambient_light_color": "${scaleAmbientLight("#302821", data.ambientLight, 0.1)}",
       "minecraft:visual/sky_light_color": "#7a7aff",
       "minecraft:visual/sky_light_factor": 0,
       "minecraft:gameplay/sky_light_level": 4.0,
     <#elseif data.defaultEffects == "the_end">
-      "minecraft:visual/ambient_light_color": "#3f473f",
+      "minecraft:visual/ambient_light_color": "${scaleAmbientLight("#3f473f", data.ambientLight, 0.25)}",
       "minecraft:visual/fog_color": "#181318",
       "minecraft:visual/sky_color": "#000000",
       "minecraft:visual/sky_light_color": "#ac60cd",
@@ -95,3 +99,12 @@
   "monster_spawn_block_light_limit": ${data.monsterSpawnBlockLightLimit},
   "skybox": "${data.skyType?lower_case?replace("normal", "overworld")}"
 }
+
+<#function scaleAmbientLight baseHexColor userAmbientLight vanillaAmbientLight>
+    <#assign baseColor = thelper.hexToDec(baseHexColor?substring(1))>
+    <#assign r = (baseColor / 65536)?floor % 256>
+    <#assign g = (baseColor / 256)?floor % 256>
+    <#assign b = baseColor % 256>
+    <#assign shift = ((userAmbientLight - vanillaAmbientLight) * 245)?floor>
+    <#return thelper.formatColor(thelper.clamp(r + shift, 0, 255), thelper.clamp(g + shift, 0, 255), thelper.clamp(b + shift, 0, 255), 255)>
+</#function>

--- a/plugins/mcreator-localization/help/default/dimension/ambient_light.md
+++ b/plugins/mcreator-localization/help/default/dimension/ambient_light.md
@@ -1,6 +1,4 @@
 This parameter controls how strong the ambient light is in this dimension.
 If set to 1, the dimension looks as if the player had night vision.
 
-This option is purely visual and doesn't affect gameplay logic such as mob spawning.
-
-Vanilla values are 0.1 for The Nether, 0 for other dimensions.
+Vanilla values are 0.1 for The Nether, 0.25 for The End, 0 for other dimensions.

--- a/src/main/java/net/mcreator/generator/template/TemplateHelper.java
+++ b/src/main/java/net/mcreator/generator/template/TemplateHelper.java
@@ -66,6 +66,26 @@ import java.util.Random;
 		return String.format("#%02x%02x%02x", color.getRed(), color.getGreen(), color.getBlue());
 	}
 
+	public int hexToDec(String hex) {
+		return Integer.parseInt(hex, 16);
+	}
+
+	public String decToHex(double dec) {
+		return String.format("%02x", (int) Math.floor(dec) % 256);
+	}
+
+	public String formatColor(double r, double g, double b, double a) {
+		String baseHex = "#" + decToHex(r) + decToHex(g) + decToHex(b);
+		if ((int) Math.floor(a) == 255) {
+			return baseHex;
+		}
+		return baseHex + decToHex(a);
+	}
+
+	public double clamp(double val, double min, double max) {
+		return Math.clamp(val, min, max);
+	}
+
 	public String obj2str(Object object) {
 		return new Gson().toJson(object);
 	}


### PR DESCRIPTION
Fix #6426 - [Bugfix, NF 26.1.2] Ambient light parameter of custom dimensions did not work correctly