### PR TITLE
Fix #6432 - Add custom items with provided banner patterns to the vanilla tag

### DIFF
--- a/plugins/generator-26.1.x/neoforge-26.1.2/item.definition.yaml
+++ b/plugins/generator-26.1.x/neoforge-26.1.2/item.definition.yaml
@@ -82,6 +82,8 @@ tags:
       - isMeat
   - tag: ITEMS:minecraft:enchantable/durability
     condition: "!damageCount #= 0"
+  - tag: ITEMS:minecraft:loom_patterns
+    condition: hasBannerPatterns()
   - tag: ITEMS:minecraft:music_discs
     condition: isMusicDisc
   - tag: ITEMS:minecraft:piglin_loved


### PR DESCRIPTION
Fix #6432 - [Bugfix, NF 26.1.2] Custom items providing banner patterns could not be used inside the loom block