### PR TITLE
Adding support for tooltip and labels with several line in one component

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="VcsDirectoryMappings">
-    <mapping directory="" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
   </component>
 </project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+    <mapping directory="" vcs="Git" />
   </component>
 </project>

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/gui/gui_window.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/gui/gui_window.java.ftl
@@ -254,19 +254,19 @@ public class ${name}Screen extends AbstractContainerScreen<${name}Menu> implemen
 	</#if>
 
 	@Override protected void renderLabels(GuiGraphics guiGraphics, int mouseX, int mouseY) {
-		int BaseSpaceBetweenLine = 0;
+		int heightPadding = 0;
+        int yOffset = 0;
 		<#list data.getComponentsOfType("Label") as component>
 			<#if hasProcedure(component.displayCondition)>
 				if (<@procedureOBJToConditionCode component.displayCondition/>)
 			</#if>
 			<#assign LabelText><#if hasProcedure(component.text)><@procedureOBJToStringCode component.text/><#else>Component.translatable("gui.${modid}.${registryname}.${component.getName()}").getString()</#if></#assign>
             <#assign ListComponentsLabel>Arrays.stream(${LabelText}.split("\\\\n")).map(Component::literal).collect(Collectors.toList())</#assign>
-			BaseSpaceBetweenLine = 0;
+			yOffset = 0;
 			for(Component actualComponent : ${ListComponentsLabel}){
-				guiGraphics.drawString(this.font,
-								actualComponent,
-								${component.gx(data.width)}, ${component.gy(data.height)} + BaseSpaceBetweenLine, ${component.color.getRGB()}, ${component.hasShadow});
-				BaseSpaceBetweenLine += 10;
+				guiGraphics.drawString(this.font,actualComponent,${component.gx(data.width)}, ${component.gy(data.height)} + yOffset, ${component.color.getRGB()}, ${component.hasShadow});
+				heightPadding = 2;
+                yOffset += this.font.lineHeight + heightPadding;
 			}
 		</#list>
 	}

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/gui/gui_window.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/gui/gui_window.java.ftl
@@ -164,13 +164,13 @@ public class ${name}Screen extends AbstractContainerScreen<${name}Menu> implemen
 				if (mouseX > leftPos + ${x} && mouseX < leftPos + ${x + component.width} && mouseY > topPos + ${y} && mouseY < topPos + ${y + component.height}) {
 					<#if hasProcedure(component.text)>
 						<#assign hoverText><@procedureOBJToStringCode component.text/></#assign>
-						<#assign listComponentsTooltip>Arrays.stream(${hoverText}.split("%nl")).map(Component::literal).collect(Collectors.toList())</#assign>
+						<#assign listComponentsTooltip>Arrays.stream(${hoverText}.split("\\\\n")).map(Component::literal).collect(Collectors.toList())</#assign>
 						if (${hoverText} != null) {
 							guiGraphics.renderComponentTooltip(font, ${listComponentsTooltip}, mouseX, mouseY);
 						}
 					<#else>
 						<#assign hoverText>Component.translatable("gui.${modid}.${registryname}.${component.getName()}").getString()</#assign>
-						<#assign listComponentsTooltip>Arrays.stream(${hoverText}.split("%nl")).map(Component::literal).collect(Collectors.toList())</#assign>
+						<#assign listComponentsTooltip>Arrays.stream(${hoverText}.split("\\\\n")).map(Component::literal).collect(Collectors.toList())</#assign>
 						if (${hoverText} != null) {
 							guiGraphics.renderComponentTooltip(font, ${listComponentsTooltip}, mouseX, mouseY);
 						}
@@ -260,7 +260,7 @@ public class ${name}Screen extends AbstractContainerScreen<${name}Menu> implemen
 				if (<@procedureOBJToConditionCode component.displayCondition/>)
 			</#if>
 			<#assign LabelText><#if hasProcedure(component.text)><@procedureOBJToStringCode component.text/><#else>Component.translatable("gui.${modid}.${registryname}.${component.getName()}").getString()</#if></#assign>
-            <#assign ListComponentsLabel>Arrays.stream(${LabelText}.split("%nl")).map(Component::literal).collect(Collectors.toList())</#assign>
+            <#assign ListComponentsLabel>Arrays.stream(${LabelText}.split("\\\\n")).map(Component::literal).collect(Collectors.toList())</#assign>
 			BaseSpaceBetweenLine = 0;
 			for(Component actualComponent : ${ListComponentsLabel}){
 				guiGraphics.drawString(this.font,

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/gui/gui_window.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/gui/gui_window.java.ftl
@@ -164,11 +164,20 @@ public class ${name}Screen extends AbstractContainerScreen<${name}Menu> implemen
 				if (mouseX > leftPos + ${x} && mouseX < leftPos + ${x + component.width} && mouseY > topPos + ${y} && mouseY < topPos + ${y + component.height}) {
 					<#if hasProcedure(component.text)>
 					String hoverText = <@procedureOBJToStringCode component.text/>;
+					List<Component> listComponents = Arrays.stream(hoverText.getString().split("%nl"))
+                                                    .map(Component::literal)
+                                                    .collect(Collectors.toList());
 					if (hoverText != null) {
-						guiGraphics.renderComponentTooltip(font, Arrays.stream(hoverText.split("\n")).map(Component::literal).collect(Collectors.toList()), mouseX, mouseY);
+						guiGraphics.renderComponentTooltip(font, listComponent, mouseX, mouseY);
 					}
 					<#else>
-						guiGraphics.renderTooltip(font, Component.translatable("gui.${modid}.${registryname}.${component.getName()}"), mouseX, mouseY);
+						String hoverText = Component.translatable("gui.${modid}.${registryname}.${component.getName()}").getString();
+						List<Component> listComponent = Arrays.stream(hoverText.split("%nl"))
+                                                        .map(Component::literal)
+                                                     	.collect(Collectors.toList());
+						if (hoverText != null) {
+							guiGraphics.renderComponentTooltip(font, listComponent, mouseX, mouseY);
+						}
 					</#if>
 					customTooltipShown = true;
 				}
@@ -253,9 +262,18 @@ public class ${name}Screen extends AbstractContainerScreen<${name}Menu> implemen
 			<#if hasProcedure(component.displayCondition)>
 				if (<@procedureOBJToConditionCode component.displayCondition/>)
 			</#if>
-			guiGraphics.drawString(this.font,
-				<#if hasProcedure(component.text)><@procedureOBJToStringCode component.text/><#else>Component.translatable("gui.${modid}.${registryname}.${component.getName()}")</#if>,
-				${component.gx(data.width)}, ${component.gy(data.height)}, ${component.color.getRGB()}, ${component.hasShadow});
+			String LabelText = <#if hasProcedure(component.text)><@procedureOBJToStringCode component.text/><#else>Component.translatable("gui.${modid}.${registryname}.${component.getName()}").getString()</#if>;
+            			List<Component> listComponents = Arrays.stream(LabelText.split("%nl"))
+                                                        .map(Component::literal)
+                                                     	.collect(Collectors.toList());
+            			height = ${component.gy(data.height)};
+            			int BaseSpaceBetweenLine = 10;
+            			for(Component actualComponent : listComponents){
+            				guiGraphics.drawString(this.font,
+                            				actualComponent,
+                            				${component.gx(data.width)}, ${component.gy(data.height)} + BaseSpaceBetweenLine, ${component.color.getRGB()}, ${component.hasShadow});
+            				BaseSpaceBetweenLine += 10;
+						}
 		</#list>
 	}
 

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/gui/gui_window.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/gui/gui_window.java.ftl
@@ -163,20 +163,16 @@ public class ${name}Screen extends AbstractContainerScreen<${name}Menu> implemen
 			</#if>
 				if (mouseX > leftPos + ${x} && mouseX < leftPos + ${x + component.width} && mouseY > topPos + ${y} && mouseY < topPos + ${y + component.height}) {
 					<#if hasProcedure(component.text)>
-					String hoverText = <@procedureOBJToStringCode component.text/>;
-					List<Component> listComponents = Arrays.stream(hoverText.getString().split("%nl"))
-                                                    .map(Component::literal)
-                                                    .collect(Collectors.toList());
-					if (hoverText != null) {
-						guiGraphics.renderComponentTooltip(font, listComponent, mouseX, mouseY);
-					}
+						<#assign hoverText><@procedureOBJToStringCode component.text/></#assign>
+						<#assign listComponentsTooltip>Arrays.stream(${hoverText}.split("%nl")).map(Component::literal).collect(Collectors.toList())</#assign>
+						if (${hoverText} != null) {
+							guiGraphics.renderComponentTooltip(font, ${listComponentsTooltip}, mouseX, mouseY);
+						}
 					<#else>
-						String hoverText = Component.translatable("gui.${modid}.${registryname}.${component.getName()}").getString();
-						List<Component> listComponent = Arrays.stream(hoverText.split("%nl"))
-                                                        .map(Component::literal)
-                                                     	.collect(Collectors.toList());
-						if (hoverText != null) {
-							guiGraphics.renderComponentTooltip(font, listComponent, mouseX, mouseY);
+						<#assign hoverText>Component.translatable("gui.${modid}.${registryname}.${component.getName()}").getString()</#assign>
+						<#assign listComponentsTooltip>Arrays.stream(${hoverText}.split("%nl")).map(Component::literal).collect(Collectors.toList())</#assign>
+						if (${hoverText} != null) {
+							guiGraphics.renderComponentTooltip(font, ${listComponentsTooltip}, mouseX, mouseY);
 						}
 					</#if>
 					customTooltipShown = true;
@@ -258,22 +254,20 @@ public class ${name}Screen extends AbstractContainerScreen<${name}Menu> implemen
 	</#if>
 
 	@Override protected void renderLabels(GuiGraphics guiGraphics, int mouseX, int mouseY) {
+		int BaseSpaceBetweenLine = 0;
 		<#list data.getComponentsOfType("Label") as component>
 			<#if hasProcedure(component.displayCondition)>
 				if (<@procedureOBJToConditionCode component.displayCondition/>)
 			</#if>
-			String LabelText = <#if hasProcedure(component.text)><@procedureOBJToStringCode component.text/><#else>Component.translatable("gui.${modid}.${registryname}.${component.getName()}").getString()</#if>;
-            			List<Component> listComponents = Arrays.stream(LabelText.split("%nl"))
-                                                        .map(Component::literal)
-                                                     	.collect(Collectors.toList());
-            			height = ${component.gy(data.height)};
-            			int BaseSpaceBetweenLine = 10;
-            			for(Component actualComponent : listComponents){
-            				guiGraphics.drawString(this.font,
-                            				actualComponent,
-                            				${component.gx(data.width)}, ${component.gy(data.height)} + BaseSpaceBetweenLine, ${component.color.getRGB()}, ${component.hasShadow});
-            				BaseSpaceBetweenLine += 10;
-						}
+			<#assign LabelText><#if hasProcedure(component.text)><@procedureOBJToStringCode component.text/><#else>Component.translatable("gui.${modid}.${registryname}.${component.getName()}").getString()</#if></#assign>
+            <#assign ListComponentsLabel>Arrays.stream(${LabelText}.split("%nl")).map(Component::literal).collect(Collectors.toList())</#assign>
+			BaseSpaceBetweenLine = 0;
+			for(Component actualComponent : ${ListComponentsLabel}){
+				guiGraphics.drawString(this.font,
+								actualComponent,
+								${component.gx(data.width)}, ${component.gy(data.height)} + BaseSpaceBetweenLine, ${component.color.getRGB()}, ${component.hasShadow});
+				BaseSpaceBetweenLine += 10;
+			}
 		</#list>
 	}
 

--- a/plugins/generator-26.1.x/neoforge-26.1.2/templates/gui/gui_window.java.ftl
+++ b/plugins/generator-26.1.x/neoforge-26.1.2/templates/gui/gui_window.java.ftl
@@ -129,7 +129,7 @@ public class ${name}Screen extends AbstractContainerScreen<${name}Menu> implemen
 	}
 	</#if>
 
-		@Override public void extractRenderState(GuiGraphicsExtractor guiGraphics, int mouseX, int mouseY, float partialTicks) {
+	@Override public void extractRenderState(GuiGraphicsExtractor guiGraphics, int mouseX, int mouseY, float partialTicks) {
 		<#list tooltips as component>
 			<#assign x = component.gx(data.width)>
 			<#assign y = component.gy(data.height)>
@@ -139,13 +139,13 @@ public class ${name}Screen extends AbstractContainerScreen<${name}Menu> implemen
 				if (mouseX > leftPos + ${x} && mouseX < leftPos + ${x + component.width} && mouseY > topPos + ${y} && mouseY < topPos + ${y + component.height}) {
 					<#if hasProcedure(component.text)>
 					<#assign hoverText><@procedureOBJToStringCode component.text/></#assign>
-					<#assign listComponentTooltip>Arrays.stream(${hoverText}.split("%nl")).map(Component::literal).collect(Collectors.toList())</#assign>
+					<#assign listComponentTooltip>Arrays.stream(${hoverText}.split("\\\\n")).map(Component::literal).collect(Collectors.toList())</#assign>
 					if (${hoverText} != null) {
 						guiGraphics.setComponentTooltipForNextFrame( font, ${listComponentTooltip}, mouseX, mouseY);
 					}
 					<#else>
 					<#assign hoverText>Component.translatable("gui.${modid}.${registryname}.${component.getName()}").getString()</#assign>
-					<#assign listComponentTooltip>Arrays.stream(${hoverText}.split("%nl")).map(Component::literal).collect(Collectors.toList())</#assign>
+					<#assign listComponentTooltip>Arrays.stream(${hoverText}.split("\\\\n")).map(Component::literal).collect(Collectors.toList())</#assign>
 					if (${hoverText} != null) {
 						guiGraphics.setComponentTooltipForNextFrame( font, ${listComponentTooltip}, mouseX, mouseY);
                     }
@@ -244,7 +244,7 @@ public class ${name}Screen extends AbstractContainerScreen<${name}Menu> implemen
 				if (<@procedureOBJToConditionCode component.displayCondition/>)
 			</#if>
 			<#assign LabelText><#if hasProcedure(component.text)><@procedureOBJToStringCode component.text/><#else>Component.translatable("gui.${modid}.${registryname}.${component.getName()}").getString()</#if></#assign>
-			<#assign listComponentsLabel>Arrays.stream(${LabelText}.split("%nl")).map(Component::literal).collect(Collectors.toList())</#assign>
+			<#assign listComponentsLabel>Arrays.stream(${LabelText}.split("\\\\n")).map(Component::literal).collect(Collectors.toList())</#assign>
 			height = ${component.gy(data.height)};
 			BaseSpaceBetweenLine = 0;
 			for(Component actualComponent : ${listComponentsLabel}){

--- a/plugins/generator-26.1.x/neoforge-26.1.2/templates/gui/gui_window.java.ftl
+++ b/plugins/generator-26.1.x/neoforge-26.1.2/templates/gui/gui_window.java.ftl
@@ -138,20 +138,16 @@ public class ${name}Screen extends AbstractContainerScreen<${name}Menu> implemen
 			</#if>
 				if (mouseX > leftPos + ${x} && mouseX < leftPos + ${x + component.width} && mouseY > topPos + ${y} && mouseY < topPos + ${y + component.height}) {
 					<#if hasProcedure(component.text)>
-					String hoverText = <@procedureOBJToStringCode component.text/>;
-					List<Component> listComponents = Arrays.stream(hoverText.getString().split("%nl"))
-                                .map(Component::literal) // Convertit chaque String en Component
-                                .collect(Collectors.toList());
-					if (hoverText != null) {
-						guiGraphics.setComponentTooltipForNextFrame(font,listComponent , mouseX, mouseY);
+					<#assign hoverText><@procedureOBJToStringCode component.text/></#assign>
+					<#assign listComponentTooltip>Arrays.stream(${hoverText}.split("%nl")).map(Component::literal).collect(Collectors.toList())</#assign>
+					if (${hoverText} != null) {
+						guiGraphics.setComponentTooltipForNextFrame( font, ${listComponentTooltip}, mouseX, mouseY);
 					}
 					<#else>
-					String hoverText = Component.translatable("gui.${modid}.${registryname}.${component.getName()}").getString();
-					List<Component> listComponent = Arrays.stream(hoverText.split("%nl"))
-                                .map(Component::literal) // Convertit chaque String en Component
-                             	.collect(Collectors.toList());
-					if (hoverText != null) {
-						guiGraphics.setComponentTooltipForNextFrame(font,listComponent , mouseX, mouseY);
+					<#assign hoverText>Component.translatable("gui.${modid}.${registryname}.${component.getName()}").getString()</#assign>
+					<#assign listComponentTooltip>Arrays.stream(${hoverText}.split("%nl")).map(Component::literal).collect(Collectors.toList())</#assign>
+					if (${hoverText} != null) {
+						guiGraphics.setComponentTooltipForNextFrame( font, ${listComponentTooltip}, mouseX, mouseY);
                     }
 					</#if>
 				}
@@ -241,19 +237,19 @@ public class ${name}Screen extends AbstractContainerScreen<${name}Menu> implemen
 	</#if>
 
 	@Override protected void extractLabels(GuiGraphicsExtractor guiGraphics, int mouseX, int mouseY) {
+		int BaseSpaceBetweenLine;
+		int height;
 		<#list data.getComponentsOfType("Label") as component>
 			<#if hasProcedure(component.displayCondition)>
 				if (<@procedureOBJToConditionCode component.displayCondition/>)
 			</#if>
-			String LabelText = <#if hasProcedure(component.text)><@procedureOBJToStringCode component.text/><#else>Component.translatable("gui.${modid}.${registryname}.${component.getName()}").getString()</#if>;
-			List<Component> listComponents = Arrays.stream(LabelText.split("%nl"))
-                                            .map(Component::literal)
-                                         	.collect(Collectors.toList());
+			<#assign LabelText><#if hasProcedure(component.text)><@procedureOBJToStringCode component.text/><#else>Component.translatable("gui.${modid}.${registryname}.${component.getName()}").getString()</#if></#assign>
+			<#assign listComponentsLabel>Arrays.stream(${LabelText}.split("%nl")).map(Component::literal).collect(Collectors.toList())</#assign>
 			height = ${component.gy(data.height)};
-			int BaseSpaceBetweenLine = 10;
-			for(Component actualComponent : listComponents){
+			BaseSpaceBetweenLine = 0;
+			for(Component actualComponent : ${listComponentsLabel}){
 				guiGraphics.text(this.font,actualComponent,${component.gx(data.width)}, ${component.gy(data.height)} +  BaseSpaceBetweenLine, ${component.color.getRGB()}, ${component.hasShadow});
-				BaseSpaceBetweenLine += 10;
+				BaseSpaceBetweenLine+=10;
 			}
 		</#list>
 	}

--- a/plugins/generator-26.1.x/neoforge-26.1.2/templates/gui/gui_window.java.ftl
+++ b/plugins/generator-26.1.x/neoforge-26.1.2/templates/gui/gui_window.java.ftl
@@ -237,19 +237,19 @@ public class ${name}Screen extends AbstractContainerScreen<${name}Menu> implemen
 	</#if>
 
 	@Override protected void extractLabels(GuiGraphicsExtractor guiGraphics, int mouseX, int mouseY) {
-		int BaseSpaceBetweenLine;
-		int height;
+		int heightPadding = 0;
+		int yOffset = 0;
 		<#list data.getComponentsOfType("Label") as component>
 			<#if hasProcedure(component.displayCondition)>
 				if (<@procedureOBJToConditionCode component.displayCondition/>)
 			</#if>
 			<#assign LabelText><#if hasProcedure(component.text)><@procedureOBJToStringCode component.text/><#else>Component.translatable("gui.${modid}.${registryname}.${component.getName()}").getString()</#if></#assign>
 			<#assign listComponentsLabel>Arrays.stream(${LabelText}.split("\\\\n")).map(Component::literal).collect(Collectors.toList())</#assign>
-			height = ${component.gy(data.height)};
-			BaseSpaceBetweenLine = 0;
+			yOffset = 0;
 			for(Component actualComponent : ${listComponentsLabel}){
-				guiGraphics.text(this.font,actualComponent,${component.gx(data.width)}, ${component.gy(data.height)} +  BaseSpaceBetweenLine, ${component.color.getRGB()}, ${component.hasShadow});
-				BaseSpaceBetweenLine+=10;
+				guiGraphics.text(this.font,actualComponent,${component.gx(data.width)}, ${component.gy(data.height)} + yOffset, ${component.color.getRGB()}, ${component.hasShadow});
+				heightPadding = 2;
+				yOffset += this.font.lineHeight + heightPadding;
 			}
 		</#list>
 	}

--- a/plugins/generator-26.1.x/neoforge-26.1.2/templates/gui/gui_window.java.ftl
+++ b/plugins/generator-26.1.x/neoforge-26.1.2/templates/gui/gui_window.java.ftl
@@ -139,7 +139,7 @@ public class ${name}Screen extends AbstractContainerScreen<${name}Menu> implemen
 				if (mouseX > leftPos + ${x} && mouseX < leftPos + ${x + component.width} && mouseY > topPos + ${y} && mouseY < topPos + ${y + component.height}) {
 					<#if hasProcedure(component.text)>
 					String hoverText = <@procedureOBJToStringCode component.text/>;
-					List<Component> listComponents = Arrays.stream(hoverText.getString().split("%nl")) // \\R gère tous les sauts de ligne
+					List<Component> listComponents = Arrays.stream(hoverText.getString().split("%nl"))
                                 .map(Component::literal) // Convertit chaque String en Component
                                 .collect(Collectors.toList());
 					if (hoverText != null) {
@@ -147,7 +147,7 @@ public class ${name}Screen extends AbstractContainerScreen<${name}Menu> implemen
 					}
 					<#else>
 					String hoverText = Component.translatable("gui.${modid}.${registryname}.${component.getName()}").getString();
-					List<Component> listComponent = Arrays.stream(hoverText.split("%nl")) // \\R gère tous les sauts de ligne
+					List<Component> listComponent = Arrays.stream(hoverText.split("%nl"))
                                 .map(Component::literal) // Convertit chaque String en Component
                              	.collect(Collectors.toList());
 					if (hoverText != null) {

--- a/plugins/generator-26.1.x/neoforge-26.1.2/templates/gui/gui_window.java.ftl
+++ b/plugins/generator-26.1.x/neoforge-26.1.2/templates/gui/gui_window.java.ftl
@@ -129,7 +129,7 @@ public class ${name}Screen extends AbstractContainerScreen<${name}Menu> implemen
 	}
 	</#if>
 
-	@Override public void extractRenderState(GuiGraphicsExtractor guiGraphics, int mouseX, int mouseY, float partialTicks) {
+		@Override public void extractRenderState(GuiGraphicsExtractor guiGraphics, int mouseX, int mouseY, float partialTicks) {
 		<#list tooltips as component>
 			<#assign x = component.gx(data.width)>
 			<#assign y = component.gy(data.height)>
@@ -139,11 +139,20 @@ public class ${name}Screen extends AbstractContainerScreen<${name}Menu> implemen
 				if (mouseX > leftPos + ${x} && mouseX < leftPos + ${x + component.width} && mouseY > topPos + ${y} && mouseY < topPos + ${y + component.height}) {
 					<#if hasProcedure(component.text)>
 					String hoverText = <@procedureOBJToStringCode component.text/>;
+					List<Component> listComponents = Arrays.stream(hoverText.getString().split("%nl")) // \\R gère tous les sauts de ligne
+                                .map(Component::literal) // Convertit chaque String en Component
+                                .collect(Collectors.toList());
 					if (hoverText != null) {
-						guiGraphics.setComponentTooltipForNextFrame(font, Arrays.stream(hoverText.split("\n")).map(Component::literal).collect(Collectors.toList()), mouseX, mouseY);
+						guiGraphics.setComponentTooltipForNextFrame(font,listComponent , mouseX, mouseY);
 					}
 					<#else>
-						guiGraphics.setTooltipForNextFrame(font, Component.translatable("gui.${modid}.${registryname}.${component.getName()}"), mouseX, mouseY);
+					String hoverText = Component.translatable("gui.${modid}.${registryname}.${component.getName()}").getString();
+					List<Component> listComponent = Arrays.stream(hoverText.split("%nl")) // \\R gère tous les sauts de ligne
+                                .map(Component::literal) // Convertit chaque String en Component
+                             	.collect(Collectors.toList());
+					if (hoverText != null) {
+						guiGraphics.setComponentTooltipForNextFrame(font,listComponent , mouseX, mouseY);
+                    }
 					</#if>
 				}
 		</#list>
@@ -236,9 +245,16 @@ public class ${name}Screen extends AbstractContainerScreen<${name}Menu> implemen
 			<#if hasProcedure(component.displayCondition)>
 				if (<@procedureOBJToConditionCode component.displayCondition/>)
 			</#if>
-			guiGraphics.text(this.font,
-				<#if hasProcedure(component.text)><@procedureOBJToStringCode component.text/><#else>Component.translatable("gui.${modid}.${registryname}.${component.getName()}")</#if>,
-				${component.gx(data.width)}, ${component.gy(data.height)}, ${component.color.getRGB()}, ${component.hasShadow});
+			String LabelText = <#if hasProcedure(component.text)><@procedureOBJToStringCode component.text/><#else>Component.translatable("gui.${modid}.${registryname}.${component.getName()}").getString()</#if>;
+			List<Component> listComponents = Arrays.stream(LabelText.split("%nl"))
+                                            .map(Component::literal)
+                                         	.collect(Collectors.toList());
+			height = ${component.gy(data.height)};
+			int BaseSpaceBetweenLine = 10;
+			for(Component actualComponent : listComponents){
+				guiGraphics.text(this.font,actualComponent,${component.gx(data.width)}, ${component.gy(data.height)} +  BaseSpaceBetweenLine, ${component.color.getRGB()}, ${component.hasShadow});
+				BaseSpaceBetweenLine += 10;
+			}
 		</#list>
 	}
 


### PR DESCRIPTION
I added the possibility to make serverals lines with Tooltips and Labels with the %nl ( new line ) separator in one single component
This might be use for writing paragraph with Labels or just showing a large amount of text in a tooltip
The commit do not touch any UI/UX element so it might useful to add a tip section to tell the modders it is possible to do that


 



In Mcreator | In game preview
<img width="288" height="256" alt="image" src="https://github.com/user-attachments/assets/30087209-e56b-482c-83bd-6efc097c0f5c" />
I tested the code the code on MCreator-2026.2.22416 and move the 2 files on the new version of the repo because of jcef witch do not work in newer version of the repo