### PR TITLE
Fix #6435 - [26.1.2] Hostile mobs did not despawn in peaceful mode

### DIFF
--- a/plugins/generator-26.1.x/neoforge-26.1.2/templates/elementinits/entities.java.ftl
+++ b/plugins/generator-26.1.x/neoforge-26.1.2/templates/elementinits/entities.java.ftl
@@ -59,6 +59,7 @@ public class ${JavaModName}Entities {
 							.setShouldReceiveVelocityUpdates(true).setTrackingRange(${entity.trackingRange}).setUpdateInterval(3)
 							<#if entity.immuneToFire>.fireImmune()</#if>
 							<#if entity.mobModelName == "Biped">.ridingOffset(-0.6f)</#if>
+							<#if entity.mobBehaviourType != "Creature">.notInPeaceful()</#if>
 							.sized(${entity.modelWidth}f, ${entity.modelHeight}f)
 						);
 			<#if entity.hasCustomProjectile()>


### PR DESCRIPTION
Fix #6435 - [Bugfix, NF 26.1.2] Hostile mobs did not despawn in peaceful mode