### PR TITLE
Cache entity model layer model

### DIFF
--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/livingentity/livingentity_renderer.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/livingentity/livingentity_renderer.java.ftl
@@ -109,7 +109,7 @@ public class ${name}Renderer extends <#if humanoid>Humanoid</#if>MobRenderer<${n
 		this.addLayer(new RenderLayer<${name}Entity, ${model}>(this) {
 			final ResourceLocation LAYER_TEXTURE = ResourceLocation.parse("${modid}:textures/entities/${layer.texture}");
 			<#if layer.model != "Default">
-				final EntityModel LAYER_MODEL = model = new ${layer.model}(Minecraft.getInstance().getEntityModels().bakeLayer(${layer.model}.LAYER_LOCATION));
+				final EntityModel LAYER_MODEL = new ${layer.model}(Minecraft.getInstance().getEntityModels().bakeLayer(${layer.model}.LAYER_LOCATION));
 			</#if>
 
 			<@javacompress>

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/livingentity/livingentity_renderer.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/livingentity/livingentity_renderer.java.ftl
@@ -108,6 +108,9 @@ public class ${name}Renderer extends <#if humanoid>Humanoid</#if>MobRenderer<${n
 		<#list data.modelLayers as layer>
 		this.addLayer(new RenderLayer<${name}Entity, ${model}>(this) {
 			final ResourceLocation LAYER_TEXTURE = ResourceLocation.parse("${modid}:textures/entities/${layer.texture}");
+			<#if layer.model != "Default">
+				EntityModel model = null;
+			</#if>
 
 			<@javacompress>
 			@Override public void render(PoseStack poseStack, MultiBufferSource bufferSource, int light,
@@ -122,7 +125,8 @@ public class ${name}Renderer extends <#if humanoid>Humanoid</#if>MobRenderer<${n
 
 				VertexConsumer vertexConsumer = bufferSource.getBuffer(RenderType.<#if layer.glow>eyes<#else>entityCutoutNoCull</#if>(LAYER_TEXTURE));
 				<#if layer.model != "Default">
-					EntityModel model = new ${layer.model}(Minecraft.getInstance().getEntityModels().bakeLayer(${layer.model}.LAYER_LOCATION));
+					if (model == null)
+						model = new ${layer.model}(Minecraft.getInstance().getEntityModels().bakeLayer(${layer.model}.LAYER_LOCATION));
 					this.getParentModel().copyPropertiesTo(model);
 					model.prepareMobModel(entity, limbSwing, limbSwingAmount, partialTicks);
 					model.setupAnim(entity, limbSwing, limbSwingAmount, ageInTicks, netHeadYaw, headPitch);

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/livingentity/livingentity_renderer.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/livingentity/livingentity_renderer.java.ftl
@@ -109,7 +109,7 @@ public class ${name}Renderer extends <#if humanoid>Humanoid</#if>MobRenderer<${n
 		this.addLayer(new RenderLayer<${name}Entity, ${model}>(this) {
 			final ResourceLocation LAYER_TEXTURE = ResourceLocation.parse("${modid}:textures/entities/${layer.texture}");
 			<#if layer.model != "Default">
-				EntityModel model = null;
+				final EntityModel LAYER_MODEL = model = new ${layer.model}(Minecraft.getInstance().getEntityModels().bakeLayer(${layer.model}.LAYER_LOCATION));
 			</#if>
 
 			<@javacompress>
@@ -125,12 +125,10 @@ public class ${name}Renderer extends <#if humanoid>Humanoid</#if>MobRenderer<${n
 
 				VertexConsumer vertexConsumer = bufferSource.getBuffer(RenderType.<#if layer.glow>eyes<#else>entityCutoutNoCull</#if>(LAYER_TEXTURE));
 				<#if layer.model != "Default">
-					if (model == null)
-						model = new ${layer.model}(Minecraft.getInstance().getEntityModels().bakeLayer(${layer.model}.LAYER_LOCATION));
-					this.getParentModel().copyPropertiesTo(model);
-					model.prepareMobModel(entity, limbSwing, limbSwingAmount, partialTicks);
-					model.setupAnim(entity, limbSwing, limbSwingAmount, ageInTicks, netHeadYaw, headPitch);
-					model.renderToBuffer(poseStack, vertexConsumer, light,
+					this.getParentModel().copyPropertiesTo(LAYER_MODEL);
+					LAYER_MODEL.prepareMobModel(entity, limbSwing, limbSwingAmount, partialTicks);
+					LAYER_MODEL.setupAnim(entity, limbSwing, limbSwingAmount, ageInTicks, netHeadYaw, headPitch);
+					LAYER_MODEL.renderToBuffer(poseStack, vertexConsumer, light,
 						<#if layer.disableHurtOverlay>OverlayTexture.NO_OVERLAY<#else>LivingEntityRenderer.getOverlayCoords(entity, 0)</#if>);
 				<#else>
 					this.getParentModel().renderToBuffer(poseStack, vertexConsumer, light,

--- a/plugins/generator-26.1.x/neoforge-26.1.2/templates/livingentity/livingentity_renderer.java.ftl
+++ b/plugins/generator-26.1.x/neoforge-26.1.2/templates/livingentity/livingentity_renderer.java.ftl
@@ -129,8 +129,9 @@ public class ${name}Renderer extends <#if humanoid>Humanoid</#if>MobRenderer<${n
 		<#list data.modelLayers as layer>
 		this.addLayer(new RenderLayer<>(this) {
 			final Identifier LAYER_TEXTURE = Identifier.parse("${modid}:textures/entities/${layer.texture}");
+			final RenderType RENDER_TYPE = RenderTypes.<#if layer.glow>eyes<#else>entityCutout</#if>(LAYER_TEXTURE);
 			<#if layer.model != "Default">
-				EntityModel model = null;
+				final EntityModel LAYER_MODEL = new ${layer.model}(Minecraft.getInstance().getEntityModels().bakeLayer(${layer.model}.LAYER_LOCATION));
 			</#if>
 
 			<@javacompress>
@@ -145,17 +146,13 @@ public class ${name}Renderer extends <#if humanoid>Humanoid</#if>MobRenderer<${n
 				if (<@procedureOBJToConditionCode layer.condition/>) {
 				</#if>
 
-				Minecraft mc = Minecraft.getInstance();
-				VertexConsumer vertexConsumer = mc.renderBuffers().bufferSource().getBuffer(RenderTypes.<#if layer.glow>eyes<#else>entityCutout</#if>(LAYER_TEXTURE));
 				<#if layer.model != "Default">
-					if (model == null)
-						model = new ${layer.model}(mc.getEntityModels().bakeLayer(${layer.model}.LAYER_LOCATION));
-					model.setupAnim(state);
-					model.renderToBuffer(poseStack, vertexConsumer, light,
-						<#if layer.disableHurtOverlay>OverlayTexture.NO_OVERLAY<#else>LivingEntityRenderer.getOverlayCoords(state, 0)</#if>);
+					LAYER_MODEL.setupAnim(state);
+					submitNodeCollector.submitModel(LAYER_MODEL, state, poseStack, RENDER_TYPE, light,
+						<#if layer.disableHurtOverlay>OverlayTexture.NO_OVERLAY<#else>LivingEntityRenderer.getOverlayCoords(state, 0)</#if>, state.outlineColor, null);
 				<#else>
-					this.getParentModel().renderToBuffer(poseStack, vertexConsumer, light,
-						<#if layer.disableHurtOverlay>OverlayTexture.NO_OVERLAY<#else>LivingEntityRenderer.getOverlayCoords(state, 0)</#if>);
+					submitNodeCollector.submitModel(this.getParentModel(), state, poseStack, RENDER_TYPE, light,
+						<#if layer.disableHurtOverlay>OverlayTexture.NO_OVERLAY<#else>LivingEntityRenderer.getOverlayCoords(state, 0)</#if>, state.outlineColor, null);
 				</#if>
 
 				<#if hasProcedure(layer.condition)>}</#if>

--- a/plugins/generator-26.1.x/neoforge-26.1.2/templates/livingentity/livingentity_renderer.java.ftl
+++ b/plugins/generator-26.1.x/neoforge-26.1.2/templates/livingentity/livingentity_renderer.java.ftl
@@ -129,7 +129,9 @@ public class ${name}Renderer extends <#if humanoid>Humanoid</#if>MobRenderer<${n
 		<#list data.modelLayers as layer>
 		this.addLayer(new RenderLayer<>(this) {
 			final Identifier LAYER_TEXTURE = Identifier.parse("${modid}:textures/entities/${layer.texture}");
-			final RenderType RENDER_TYPE = RenderTypes.<#if layer.glow>eyes<#else>entityCutout</#if>(LAYER_TEXTURE);
+			<#if layer.model != "Default">
+				EntityModel model = null;
+			</#if>
 
 			<@javacompress>
 			@Override public void submit(PoseStack poseStack, SubmitNodeCollector submitNodeCollector, int light, ${renderState} state, float headYaw, float headPitch) {
@@ -143,14 +145,17 @@ public class ${name}Renderer extends <#if humanoid>Humanoid</#if>MobRenderer<${n
 				if (<@procedureOBJToConditionCode layer.condition/>) {
 				</#if>
 
+				Minecraft mc = Minecraft.getInstance();
+				VertexConsumer vertexConsumer = mc.renderBuffers().bufferSource().getBuffer(RenderTypes.<#if layer.glow>eyes<#else>entityCutout</#if>(LAYER_TEXTURE));
 				<#if layer.model != "Default">
-					EntityModel model = new ${layer.model}(Minecraft.getInstance().getEntityModels().bakeLayer(${layer.model}.LAYER_LOCATION));
+					if (model == null)
+						model = new ${layer.model}(mc.getEntityModels().bakeLayer(${layer.model}.LAYER_LOCATION));
 					model.setupAnim(state);
-					submitNodeCollector.submitModel(model, state, poseStack, RENDER_TYPE, light,
-						<#if layer.disableHurtOverlay>OverlayTexture.NO_OVERLAY<#else>LivingEntityRenderer.getOverlayCoords(state, 0)</#if>, state.outlineColor, null);
+					model.renderToBuffer(poseStack, vertexConsumer, light,
+						<#if layer.disableHurtOverlay>OverlayTexture.NO_OVERLAY<#else>LivingEntityRenderer.getOverlayCoords(state, 0)</#if>);
 				<#else>
-					submitNodeCollector.submitModel(this.getParentModel(), state, poseStack, RENDER_TYPE, light,
-						<#if layer.disableHurtOverlay>OverlayTexture.NO_OVERLAY<#else>LivingEntityRenderer.getOverlayCoords(state, 0)</#if>, state.outlineColor, null);
+					this.getParentModel().renderToBuffer(poseStack, vertexConsumer, light,
+						<#if layer.disableHurtOverlay>OverlayTexture.NO_OVERLAY<#else>LivingEntityRenderer.getOverlayCoords(state, 0)</#if>);
 				</#if>
 
 				<#if hasProcedure(layer.condition)>}</#if>


### PR DESCRIPTION
In this PR I cache the model instance in the model layer similar to the custom armor java model caching for HumanoidModels.

~~In 26.1.2, I replaced the SubmitNodeCollector calls with the old renderToBuffer rendering since SubmitNodeCollector does not seem to respect rendering order and has a random order every time the game is opened.~~