### PR TITLE
Fix #6449 - Sky was black when sky type none was used

### DIFF
--- a/plugins/generator-26.1.x/datapack-26.1.x/dimension.definition.yaml
+++ b/plugins/generator-26.1.x/datapack-26.1.x/dimension.definition.yaml
@@ -4,7 +4,7 @@ templates:
     name: "@MODDATAROOT/dimension_type/@registryname.json"
   - template: dimension/fixed_timeline.json.ftl
     writer: json
-    condition: hasFixedTime
+    condition: hasFixedTimeAndNeedsCustomTimeline()
     name: "@MODDATAROOT/timeline/@registryname_fixed.json"
   - template: dimension/dimension_overworld.json.ftl
     writer: json

--- a/plugins/generator-26.1.x/datapack-26.1.x/templates/dimension/dimension_type.json.ftl
+++ b/plugins/generator-26.1.x/datapack-26.1.x/templates/dimension/dimension_type.json.ftl
@@ -77,15 +77,19 @@
   "coordinate_scale": ${data.coordinateScale},
   "ambient_light": ${data.ambientLight},
   "infiniburn": "#${data.infiniburnTag}",
-  <#if data.defaultEffects == "the_end">
+  <#if data.useCustomEffects>
+  <#-- no timelines or clock if useCustomEffects is true -->
+  <#elseif data.defaultEffects == "the_end">
+  "has_fixed_time": true,
   "timelines": "#minecraft:in_end",
   <#elseif data.defaultEffects == "the_nether">
+  "has_fixed_time": true,
   "timelines": "#minecraft:in_nether",
-  <#elseif data.hasFixedTime>
+  <#elseif data.hasFixedTimeAndNeedsCustomTimeline()>
   "has_fixed_time": true,
   "timelines": "${modid}:${registryname}_fixed",
   "default_clock": "minecraft:overworld",
-  <#else>
+  <#elseif data.defaultEffects == "overworld">
   "timelines": "#minecraft:in_overworld",
   "default_clock": "minecraft:overworld",
   </#if>

--- a/plugins/generator-26.1.x/neoforge-26.1.2/dimension.definition.yaml
+++ b/plugins/generator-26.1.x/neoforge-26.1.2/dimension.definition.yaml
@@ -20,7 +20,7 @@ templates:
     name: "@MODDATAROOT/dimension_type/@registryname.json"
   - template: dimension/fixed_timeline.json.ftl # loaded from datapack generator
     writer: json
-    condition: hasFixedTime
+    condition: hasFixedTimeAndNeedsCustomTimeline()
     name: "@MODDATAROOT/timeline/@registryname_fixed.json"
   - template: dimension/dimension_overworld.json.ftl # loaded from datapack generator
     writer: json

--- a/plugins/mcreator-localization/help/default/dimension/fixed_time_value.md
+++ b/plugins/mcreator-localization/help/default/dimension/fixed_time_value.md
@@ -1,2 +1,3 @@
-This is the value (measured in ticks) at which the time is frozen.
-For example, if this value is 18000, time will be frozen at midnight.
+This is the value (measured in ticks) at which the time is frozen for visual effects.
+
+For example, if this value is 18000, dimension visual effects will be frozen at midnight.

--- a/src/main/java/net/mcreator/element/types/Dimension.java
+++ b/src/main/java/net/mcreator/element/types/Dimension.java
@@ -166,6 +166,10 @@ import java.util.List;
 		return onPlayerEntersDimension != null || onPlayerLeavesDimension != null;
 	}
 
+	public boolean hasFixedTimeAndNeedsCustomTimeline() {
+		return !useCustomEffects && "overworld".equals(defaultEffects) && hasFixedTime;
+	}
+
 	public Set<String> getWorldgenBlocks() {
 		Set<String> retval = new HashSet<>();
 		retval.add(mainFillerBlock.getUnmappedValue());


### PR DESCRIPTION
Changelog:

* [Bugfix, NF 26.1.2] The sky was black when sky type none was used with custom effects