### PR TITLE
Fix #6459 - Game rule names and descriptions showed translation keys

### DIFF
--- a/plugins/generator-26.1.x/neoforge-26.1.2/gamerule.definition.yaml
+++ b/plugins/generator-26.1.x/neoforge-26.1.2/gamerule.definition.yaml
@@ -3,7 +3,7 @@ global_templates:
     name: "@SRCROOT/@BASEPACKAGEPATH/init/@JavaModNameGameRules.java"
 
 localizationkeys:
-  - key: gamerule.@modid.@lc1_name
+  - key: gamerule.@modid.@registryname
     mapto: displayName
-  - key: gamerule.@modid.@lc1_name.description
+  - key: gamerule.@modid.@registryname.description
     mapto: description

--- a/plugins/generator-26.1.x/neoforge-26.1.2/templates/elementinits/gamerules.java.ftl
+++ b/plugins/generator-26.1.x/neoforge-26.1.2/templates/elementinits/gamerules.java.ftl
@@ -46,10 +46,10 @@ public class ${JavaModName}GameRules {
 	<#list gamerules as gamerule>
 		<#if gamerule.type == "Number">
 		<#assign hasNumberRules = true>
-		public static DeferredHolder<GameRule<?>, GameRule<Integer>> ${gamerule.getModElement().getRegistryNameUpper()} = registerInteger("${StringUtils.camelToSnake(gamerule.getModElement().getName())?lower_case}", GameRuleCategory.${gamerule.category}, ${gamerule.defaultValueNumber});
+		public static DeferredHolder<GameRule<?>, GameRule<Integer>> ${gamerule.getModElement().getRegistryNameUpper()} = registerInteger("${gamerule.getModElement().getRegistryName()}", GameRuleCategory.${gamerule.category}, ${gamerule.defaultValueNumber});
 		<#else>
 		<#assign hasLogicRules = true>
-		public static DeferredHolder<GameRule<?>, GameRule<Boolean>> ${gamerule.getModElement().getRegistryNameUpper()} = registerBoolean("${StringUtils.camelToSnake(gamerule.getModElement().getName())?lower_case}", GameRuleCategory.${gamerule.category}, ${gamerule.defaultValueLogic});
+		public static DeferredHolder<GameRule<?>, GameRule<Boolean>> ${gamerule.getModElement().getRegistryNameUpper()} = registerBoolean("${gamerule.getModElement().getRegistryName()}", GameRuleCategory.${gamerule.category}, ${gamerule.defaultValueLogic});
 		</#if>
 	</#list>
 


### PR DESCRIPTION
Changelog:

* [Bugfix, NF 26.1.2] Game rule names and descriptions showed translation keys