### PR TITLE
Fix #6456 - Custom water entities drowned underwater

### DIFF
--- a/plugins/generator-26.1.x/neoforge-26.1.2/templates/livingentity/livingentity.java.ftl
+++ b/plugins/generator-26.1.x/neoforge-26.1.2/templates/livingentity/livingentity.java.ftl
@@ -762,6 +762,11 @@ public class ${name}Entity extends ${extendsClass} <#if interfaces?size gt 0>imp
 		Entity entity = this;
 		return <@procedureOBJToConditionCode data.breatheUnderwater false true/>;
 	}
+
+	<#-- Fix #6456 - NeoForge did not patch canDrownInFluidType yet, so we also need use canBreatheUnderwater -->
+	@Override public boolean canBreatheUnderwater() {
+		return !this.canDrownInFluidType(NeoForgeMod.WATER_TYPE.value());
+	}
 	</#if>
 
 	<#if data.pushedByFluids?? && (hasProcedure(data.pushedByFluids) || !data.pushedByFluids.getFixedValue())>


### PR DESCRIPTION
Changelog:

* [Bugfix, NF 26.1.2] Custom water entities drowned underwater