### PR TITLE
Fix int provider validators not working anymore

### DIFF
--- a/plugins/mcreator-core/blockly/js/int_provider_validators.js
+++ b/plugins/mcreator-core/blockly/js/int_provider_validators.js
@@ -77,11 +77,13 @@ function validateIntProviderInputs(...inputs) {
             }
             let isValid = true;
             // For each passed input, we check if it's within bounds
-            for (let i = 0; i < inputs.length; i++) {
+            let i = 0;
+            while (i < inputs.length) {
                 const countValue = this.getInput(inputs[i][0]).connection.targetBlock();
                 isValid = isIntProviderWithinBounds(countValue, inputs[i][1], inputs[i][2]);
                 if (!isValid)
                     break; // Stop checking as soon as one input isn't valid
+                i++;
             }
             if (!this.isInFlyout) {
                 // Add a warning for the first non-valid input


### PR DESCRIPTION
Fixes a bug introduced in #6348 which stopped validators from disabling blocks with OOB inputs. 
Note that disabled blocks still generate code due to #6490 