### PR TITLE
Fix Blockly code generator still generating disabled blocks (#6490)

### DIFF
--- a/src/main/java/net/mcreator/blockly/BlocklyToCode.java
+++ b/src/main/java/net/mcreator/blockly/BlocklyToCode.java
@@ -308,7 +308,8 @@ public abstract class BlocklyToCode implements IGeneratorProvider {
 
 			String type = block.getAttribute("type");
 
-			if (!block.getAttribute("disabled-reasons").isEmpty()) { // Skip disabled blocks
+			// Skip disabled blocks
+			if (!block.getAttribute("disabled-reasons").isEmpty() || block.getAttribute("disabled").equals("true")) {
 				addCompileNote(new BlocklyCompileNote(BlocklyCompileNote.Type.WARNING,
 						L10N.t("blockly.warnings.disabled_block_type.skip", type)));
 			} else {
@@ -353,7 +354,8 @@ public abstract class BlocklyToCode implements IGeneratorProvider {
 		Element block = conditionBlocks.getFirst();
 		String type = block.getAttribute("type");
 
-		if (!block.getAttribute("disabled-reasons").isEmpty()) { // Add compile error if block is disabled
+		// Add compile error if block is disabled
+		if (!block.getAttribute("disabled-reasons").isEmpty() || block.getAttribute("disabled").equals("true")) {
 			addCompileNote(new BlocklyCompileNote(BlocklyCompileNote.Type.ERROR,
 					L10N.t("blockly.errors.disabled_block_type.remove", type)));
 		} else {

--- a/src/main/java/net/mcreator/blockly/BlocklyToCode.java
+++ b/src/main/java/net/mcreator/blockly/BlocklyToCode.java
@@ -308,7 +308,7 @@ public abstract class BlocklyToCode implements IGeneratorProvider {
 
 			String type = block.getAttribute("type");
 
-			if (block.getAttribute("disabled").equals("true")) { // Skip disabled blocks
+			if (!block.getAttribute("disabled-reasons").isEmpty()) { // Skip disabled blocks
 				addCompileNote(new BlocklyCompileNote(BlocklyCompileNote.Type.WARNING,
 						L10N.t("blockly.warnings.disabled_block_type.skip", type)));
 			} else {
@@ -353,7 +353,7 @@ public abstract class BlocklyToCode implements IGeneratorProvider {
 		Element block = conditionBlocks.getFirst();
 		String type = block.getAttribute("type");
 
-		if (block.getAttribute("disabled").equals("true")) { // Add compile error if block is disabled
+		if (!block.getAttribute("disabled-reasons").isEmpty()) { // Add compile error if block is disabled
 			addCompileNote(new BlocklyCompileNote(BlocklyCompileNote.Type.ERROR,
 					L10N.t("blockly.errors.disabled_block_type.remove", type)));
 		} else {


### PR DESCRIPTION
Blockly ditched the `disabled` attribute in favor of `disabled-reasons`, but BlocklyToCode wasn't updated accordingly. Fixes #6490 

---

Changelog:

* [Bugfix] Disabled Blockly blocks still generated in the code