### PR TITLE
[NF 26.1.2] ItemOwner could be null crashing the game

### DIFF
--- a/plugins/generator-26.1.x/neoforge-26.1.2/templates/item/item.java.ftl
+++ b/plugins/generator-26.1.x/neoforge-26.1.2/templates/item/item.java.ftl
@@ -367,7 +367,7 @@ public class ${name}Item extends Item {
 					"y": "owner != null ? owner.position().y() : 0",
 					"z": "owner != null ? owner.position().z() : 0",
 					"world": "owner != null ? owner.level() : clientWorld",
-					"entity": "owner.asLivingEntity()",
+					"entity": "owner != null ? owner.asLivingEntity() : null",
 					"itemstack": "itemStackToRender"
 				}, false/>;
 				<#else>


### PR DESCRIPTION
This fixes #6495 by adding a small null check that seems to have been forgotten.

---

Changelog:

* [Bugfix, NF 26.1.2] Item state conditions with entity dependency crash the game on item drop