### PR TITLE
Fix #6502 - Harden localized strings against HTML formatting mistakes

### DIFF
--- a/src/main/java/net/mcreator/ui/init/L10N.java
+++ b/src/main/java/net/mcreator/ui/init/L10N.java
@@ -29,9 +29,11 @@ import net.mcreator.util.locale.UTF8Control;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import javax.annotation.Nullable;
 import javax.swing.*;
 import java.text.MessageFormat;
 import java.util.*;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public class L10N {
@@ -39,6 +41,8 @@ public class L10N {
 	private static final Logger LOG = LogManager.getLogger("L10N");
 
 	public static final Locale DEFAULT_LOCALE = Locale.of("en", "US");
+
+	private static final Pattern NEWLINES = Pattern.compile("[\r\n]+");
 
 	private static ResourceBundle rb;
 	private static ResourceBundle rb_en;
@@ -149,7 +153,8 @@ public class L10N {
 			return null;
 
 		if (resourceBundle.containsKey(key)) {
-			return MessageFormat.format(resourceBundle.getString(key), parameters);
+			String value = hardenHTMLString(resourceBundle.getString(key), rb_en.containsKey(key) ? rb_en.getString(key) : null);
+			return MessageFormat.format(value, parameters);
 		} else if (key.startsWith("blockly.") && (key.endsWith(".tooltip") || key.endsWith(".tip") || key.endsWith(
 				".description"))) {
 			return null;
@@ -160,6 +165,31 @@ public class L10N {
 		} else {
 			return key;
 		}
+	}
+
+	/**
+	 * <p>Hardens localized strings against common translation mistakes that break HTML rendering in Swing components:
+	 * leading whitespace before the opening html tag, html tag present in the source string but missing in the
+	 * localized one, and literal newline characters inside HTML strings. Newlines carry no meaning in rendered HTML,
+	 * but cause components such as JOptionPane to split the message into multiple parts, in which case only the
+	 * first part is rendered as HTML.</p>
+	 *
+	 * @param value       The localized string to harden
+	 * @param sourceValue The source (English) string for the same key, or null if not known
+	 * @return Localized string safe to use in Swing components
+	 */
+	private static String hardenHTMLString(String value, @Nullable String sourceValue) {
+		String stripped = value.stripLeading();
+		boolean isHTML = stripped.regionMatches(true, 0, "<html>", 0, 6);
+
+		if (!isHTML && sourceValue != null && sourceValue.regionMatches(true, 0, "<html>", 0, 6)) {
+			// Source string is HTML, so the localized string must be HTML too, otherwise
+			// HTML tags contained in it would render as plain text
+			stripped = "<html>" + stripped;
+			isHTML = true;
+		}
+
+		return isHTML ? NEWLINES.matcher(stripped).replaceAll(" ") : value;
 	}
 
 	public static JLabel label(String key, Object... parameter) {


### PR DESCRIPTION
Translations can contain literal newlines inside <html> strings, lack the <html> tag present in the source string, or have leading whitespace before it. All of these break HTML rendering in Swing components (e.g. JOptionPane splits messages at newlines and only renders the first part as HTML). L10N now repairs such strings at lookup time.

Fix #6502