### PR TITLE
Fix blocks with # in datalist name mapping to Air in AI task item inputs

### DIFF
--- a/plugins/generator-1.21.1/neoforge-1.21.1/aitasks/_mcitem.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/aitasks/_mcitem.java.ftl
@@ -1,2 +1,2 @@
 <#include "mcitems.ftl">
-(Ingredient.of(${mappedMCItemToItem(w.itemBlock(item))}))
+(Ingredient.of(${mappedMCItemToItem(item)}))

--- a/plugins/generator-26.1.x/neoforge-26.1.2/aitasks/_mcitem.java.ftl
+++ b/plugins/generator-26.1.x/neoforge-26.1.2/aitasks/_mcitem.java.ftl
@@ -1,2 +1,2 @@
 <#include "mcitems.ftl">
-(Ingredient.of(${mappedMCItemToItem(w.itemBlock(item))}))
+(Ingredient.of(${mappedMCItemToItem(item)}))


### PR DESCRIPTION
The _mcitem.java.ftl template wrapped the MItemBlock from the data model with w.itemBlock(), which made mapping system run twice

Fixes #6493

Changelog:

* [Bugfix] Certain blocks and items with variants could not be used in the follow item AI task