### PR TITLE
Make workspace tab reloads EDT-safe and harden ResourceFilterModel

### DIFF
--- a/src/main/java/net/mcreator/ui/workspace/AbstractMainWorkspacePanel.java
+++ b/src/main/java/net/mcreator/ui/workspace/AbstractMainWorkspacePanel.java
@@ -24,6 +24,7 @@ import net.mcreator.ui.MCreator;
 import net.mcreator.ui.component.JEmptyBox;
 import net.mcreator.ui.component.TransparentToolBar;
 import net.mcreator.ui.component.util.ComponentUtils;
+import net.mcreator.ui.component.util.ThreadUtil;
 import net.mcreator.ui.init.L10N;
 import net.mcreator.ui.laf.themes.Theme;
 import net.mcreator.ui.search.ITextFieldSearchable;
@@ -257,15 +258,17 @@ public abstract class AbstractMainWorkspacePanel extends JPanel implements IText
 	protected void afterVerticalTabChanged() {
 	}
 
-	public synchronized final void reloadWorkspaceTab() {
-		reloadToolBarComponents();
+	public final void reloadWorkspaceTab() {
+		ThreadUtil.runOnSwingThread(() -> {
+			reloadToolBarComponents();
 
-		if (currentTabPanel != null)
-			currentTabPanel.reloadElements();
+			if (currentTabPanel != null)
+				currentTabPanel.reloadElements();
+		});
 	}
 
-	public synchronized void refilterWorkspaceTab() {
-		sectionTabs.values().forEach(IReloadableFilterable::refilterElements);
+	public final void refilterWorkspaceTab() {
+		ThreadUtil.runOnSwingThread(() -> sectionTabs.values().forEach(IReloadableFilterable::refilterElements));
 	}
 
 	@Override public JTextComponent getSearchTextField() {

--- a/src/main/java/net/mcreator/ui/workspace/resources/ResourceFilterModel.java
+++ b/src/main/java/net/mcreator/ui/workspace/resources/ResourceFilterModel.java
@@ -91,15 +91,22 @@ public class ResourceFilterModel<T> extends DefaultListModel<T> {
 
 	@Override public void removeAllElements() {
 		super.removeAllElements();
+		int oldSize = filterItems.size();
 		items.clear();
 		filterItems.clear();
+		if (oldSize > 0)
+			fireIntervalRemoved(this, 0, oldSize - 1);
 	}
 
 	@SuppressWarnings("SuspiciousMethodCalls") @Override public boolean removeElement(Object a) {
 		if (a != null) {
 			try {
 				items.remove(a);
-				filterItems.remove(a);
+				int index = filterItems.indexOf(a);
+				if (index >= 0) {
+					filterItems.remove(index);
+					fireIntervalRemoved(this, index, index);
+				}
 			} catch (ClassCastException ignored) {
 			}
 		}
@@ -107,15 +114,20 @@ public class ResourceFilterModel<T> extends DefaultListModel<T> {
 	}
 
 	protected void refilter() {
-		filterItems.clear();
-		filterItems.addAll(items.stream().filter(Objects::nonNull).filter(item -> refilterItemsFilter.apply(item,
-				workspacePanel.getSearchTerm().toLowerCase(Locale.ENGLISH))).toList());
+		String query = workspacePanel.getSearchTerm().toLowerCase(Locale.ENGLISH);
+
+		// Build the new filtered list into a temporary list first
+		List<T> newFilterItems = new ArrayList<>(new ArrayList<>(items).stream().filter(Objects::nonNull)
+				.filter(item -> refilterItemsFilter.apply(item, query)).toList());
 
 		if (workspacePanel.sortName.isSelected())
-			filterItems.sort(Comparator.comparing(resourceNameSupplier));
+			newFilterItems.sort(Comparator.comparing(resourceNameSupplier));
 
 		if (workspacePanel.desc.isSelected())
-			Collections.reverse(filterItems);
+			Collections.reverse(newFilterItems);
+
+		filterItems.clear();
+		filterItems.addAll(newFilterItems);
 
 		fireContentsChanged(this, 0, getSize());
 	}


### PR DESCRIPTION
Workspace tab reloads could be triggered from background threads (e.g. code lock/unlock and code regeneration worker threads) while the EDT was reloading or repainting the same non-thread-safe list models. This race could leave resource tabs (textures, sounds, etc.) empty until the next successful reload, which explains sporadic reports of the resource interface not showing any resources (#6520).