### PR TITLE
Make eraser rendering mode follow selected layer

### DIFF
--- a/src/main/java/net/mcreator/ui/views/editor/image/tool/ToolPanel.java
+++ b/src/main/java/net/mcreator/ui/views/editor/image/tool/ToolPanel.java
@@ -196,8 +196,12 @@ public class ToolPanel extends JPanel {
 	}
 
 	public void setLayer(Layer layer) {
-		for (AbstractTool tool : toolList)
+		for (AbstractTool tool : toolList) {
+			Layer oldLayer = tool.getLayer();
 			tool.setLayer(layer);
+			if (tool == currentTool)
+				tool.layerChanged(oldLayer, layer);
+		}
 	}
 
 	public void setCanvas(Canvas canvas) {

--- a/src/main/java/net/mcreator/ui/views/editor/image/tool/tools/AbstractTool.java
+++ b/src/main/java/net/mcreator/ui/views/editor/image/tool/tools/AbstractTool.java
@@ -111,6 +111,15 @@ public abstract class AbstractTool implements MouseListener, MouseMotionListener
 		this.layer = layer;
 	}
 
+	/**
+	 * Called on the currently active tool when the selected layer changes.
+	 *
+	 * @param oldLayer The layer that was selected before the change; can be null
+	 * @param newLayer The newly selected layer
+	 */
+	public void layerChanged(Layer oldLayer, Layer newLayer) {
+	}
+
 	public Layer getLayer() {
 		return layer;
 	}

--- a/src/main/java/net/mcreator/ui/views/editor/image/tool/tools/EraserTool.java
+++ b/src/main/java/net/mcreator/ui/views/editor/image/tool/tools/EraserTool.java
@@ -21,6 +21,7 @@ package net.mcreator.ui.views.editor.image.tool.tools;
 import net.mcreator.ui.init.L10N;
 import net.mcreator.ui.init.UIRES;
 import net.mcreator.ui.views.editor.image.canvas.Canvas;
+import net.mcreator.ui.views.editor.image.layer.Layer;
 import net.mcreator.ui.views.editor.image.layer.LayerPanel;
 import net.mcreator.ui.views.editor.image.tool.component.ColorSelector;
 import net.mcreator.ui.views.editor.image.tool.tools.event.ToolActivationEvent;
@@ -43,5 +44,12 @@ public class EraserTool extends DrawingTool {
 	@Override public void toolDisabled(ToolActivationEvent e) {
 		layer.setRenderingMode(false);
 		super.toolDisabled(e);
+	}
+
+	@Override public void layerChanged(Layer oldLayer, Layer newLayer) {
+		if (oldLayer != null)
+			oldLayer.setRenderingMode(false);
+		if (newLayer != null)
+			newLayer.setRenderingMode(true);
 	}
 }


### PR DESCRIPTION
Fixes #6498

---

Changelog:

* [Bugfix] Eraser tool did not work correctly when the active layer was changed in the image editor