### PR TITLE
Fix #6521 - Add amount dependency to when entity is hurt trigger

### DIFF
--- a/src/main/java/net/mcreator/ui/modgui/LivingEntityGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/LivingEntityGUI.java
@@ -322,7 +322,7 @@ public class LivingEntityGUI extends ModElementGUI<LivingEntity> implements IBlo
 		whenMobIsHurt = new ProcedureSelector(this.withEntry("entity/when_hurt"), mcreator,
 				L10N.t("elementgui.living_entity.event_mob_is_hurt"), AbstractProcedureSelector.Side.SERVER, true,
 				VariableTypeLoader.BuiltInTypes.LOGIC, Dependency.fromString(
-				"x:number/y:number/z:number/world:world/entity:entity/sourceentity:entity/immediatesourceentity:entity/damagesource:damagesource")).makeReturnValueOptional();
+				"x:number/y:number/z:number/world:world/entity:entity/sourceentity:entity/immediatesourceentity:entity/damagesource:damagesource/amount:number")).makeReturnValueOptional();
 		onRightClickedOn = new ProcedureSelector(this.withEntry("entity/when_right_clicked"), mcreator,
 				L10N.t("elementgui.living_entity.event_mob_right_clicked"),
 				VariableTypeLoader.BuiltInTypes.ACTIONRESULTTYPE, Dependency.fromString(


### PR DESCRIPTION
Fix #6521 - Add amount dependency to when the entity is hurt trigger

---

Changelog:

* [Bugfix] Entity hurt procedure trigger was missing amount dependency