### PR TITLE
Prevent adding too many blockstate properties by disabling the "Add property" buttons

### DIFF
--- a/src/main/java/net/mcreator/ui/minecraft/states/block/JBlockStatePropertiesList.java
+++ b/src/main/java/net/mcreator/ui/minecraft/states/block/JBlockStatePropertiesList.java
@@ -77,9 +77,9 @@ public class JBlockStatePropertiesList extends JEntriesList {
 		propertyEntries.setOpaque(false);
 
 		addProperty.setText(L10N.t("elementgui.block.custom_properties.add"));
-		addProperty.addActionListener(e -> createPropertiesEntry());
+		addProperty.addActionListener(_ -> createPropertiesEntry());
 		addExisting.setText(L10N.t("elementgui.block.custom_properties.add_existing"));
-		addExisting.addActionListener(e -> addPropertyFromDataList());
+		addExisting.addActionListener(_ -> addPropertyFromDataList());
 
 		JScrollPane scrollProperties = new JScrollPane(PanelUtils.pullElementUp(propertyEntries)) {
 			@Override protected void paintComponent(Graphics g) {
@@ -136,6 +136,13 @@ public class JBlockStatePropertiesList extends JEntriesList {
 		}
 
 		propertiesCapLabel.setText(String.valueOf(propertyCombinations));
+		if (propertyCombinations > MAX_PROPERTY_COMBINATIONS / 2) {
+			addProperty.setEnabled(false);
+			addExisting.setEnabled(false);
+		} else {
+			addProperty.setEnabled(this.isEnabled());
+			addExisting.setEnabled(this.isEnabled());
+		}
 	}
 
 	@Override public void setEnabled(boolean enabled) {


### PR DESCRIPTION
This PR disables the "Add property" buttons once the user has reached more than half the property cap, to prevent possible overflows when adding too many properties