### PR TITLE
Fix imagebutton display conditions only visually hiding the button

### DIFF
--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/gui/gui_window.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/gui/gui_window.java.ftl
@@ -309,7 +309,7 @@ public class ${name}Screen extends AbstractContainerScreen<${name}Menu> implemen
 				<@buttonOnClick component/>
 			) {
 				@Override public void renderWidget(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTicks) {
-		            guiGraphics.blit(sprites.get(isActive(), isHoveredOrFocused()), getX(), getY(), 0, 0, width, height, width, height);
+					guiGraphics.blit(sprites.get(isActive(), isHoveredOrFocused()), getX(), getY(), 0, 0, width, height, width, height);
 				}
 			};
 
@@ -360,7 +360,7 @@ public class ${name}Screen extends AbstractContainerScreen<${name}Menu> implemen
 	}
 
 	<#if data.getComponentsOfType("Button")?filter(component -> hasProcedure(component.displayCondition))?size != 0
-	    || data.getComponentsOfType("ImageButton")?filter(component -> hasProcedure(component.displayCondition))?size != 0>
+		|| data.getComponentsOfType("ImageButton")?filter(component -> hasProcedure(component.displayCondition))?size != 0>
 	@Override protected void containerTick() {
 		super.containerTick();
 

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/gui/gui_window.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/gui/gui_window.java.ftl
@@ -309,12 +309,8 @@ public class ${name}Screen extends AbstractContainerScreen<${name}Menu> implemen
 				<@buttonOnClick component/>
 			) {
 				@Override public void renderWidget(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTicks) {
-					<#if hasProcedure(component.displayCondition)>
-					int x = ${name}Screen.this.x; <#-- x and y provided by buttons are in-GUI, not in-world coordinates -->
-					int y = ${name}Screen.this.y;
-					if (<@procedureOBJToConditionCode component.displayCondition/>)
-					</#if>
-					guiGraphics.blit(sprites.get(isActive(), isHoveredOrFocused()), getX(), getY(), 0, 0, width, height, width, height);
+				    if (this.visible)
+					    guiGraphics.blit(sprites.get(isActive(), isHoveredOrFocused()), getX(), getY(), 0, 0, width, height, width, height);
 				}
 			};
 
@@ -369,6 +365,12 @@ public class ${name}Screen extends AbstractContainerScreen<${name}Menu> implemen
 		super.containerTick();
 
 		<#list data.getComponentsOfType("Button") as component>
+			<#if hasProcedure(component.displayCondition)>
+				this.${component.getName()}.visible = <@procedureOBJToConditionCode component.displayCondition/>;
+			</#if>
+		</#list>
+
+		<#list data.getComponentsOfType("ImageButton") as component>
 			<#if hasProcedure(component.displayCondition)>
 				this.${component.getName()}.visible = <@procedureOBJToConditionCode component.displayCondition/>;
 			</#if>

--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/gui/gui_window.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/gui/gui_window.java.ftl
@@ -309,8 +309,7 @@ public class ${name}Screen extends AbstractContainerScreen<${name}Menu> implemen
 				<@buttonOnClick component/>
 			) {
 				@Override public void renderWidget(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTicks) {
-				    if (this.visible)
-					    guiGraphics.blit(sprites.get(isActive(), isHoveredOrFocused()), getX(), getY(), 0, 0, width, height, width, height);
+		            guiGraphics.blit(sprites.get(isActive(), isHoveredOrFocused()), getX(), getY(), 0, 0, width, height, width, height);
 				}
 			};
 
@@ -360,7 +359,8 @@ public class ${name}Screen extends AbstractContainerScreen<${name}Menu> implemen
 		</#list>
 	}
 
-	<#if data.getComponentsOfType("Button")?filter(component -> hasProcedure(component.displayCondition))?size != 0>
+	<#if data.getComponentsOfType("Button")?filter(component -> hasProcedure(component.displayCondition))?size != 0
+	    || data.getComponentsOfType("ImageButton")?filter(component -> hasProcedure(component.displayCondition))?size != 0>
 	@Override protected void containerTick() {
 		super.containerTick();
 

--- a/plugins/generator-26.1.x/neoforge-26.1.2/templates/gui/gui_window.java.ftl
+++ b/plugins/generator-26.1.x/neoforge-26.1.2/templates/gui/gui_window.java.ftl
@@ -292,7 +292,7 @@ public class ${name}Screen extends AbstractContainerScreen<${name}Menu> implemen
 				<@buttonOnClick component/>
 			) {
 				@Override public void extractContents(GuiGraphicsExtractor guiGraphics, int mouseX, int mouseY, float partialTicks) {
-	                guiGraphics.blit(RenderPipelines.GUI_TEXTURED, sprites.get(isActive(), isHoveredOrFocused()), getX(), getY(), 0, 0, width, height, width, height);
+					guiGraphics.blit(RenderPipelines.GUI_TEXTURED, sprites.get(isActive(), isHoveredOrFocused()), getX(), getY(), 0, 0, width, height, width, height);
 				}
 			};
 
@@ -343,7 +343,7 @@ public class ${name}Screen extends AbstractContainerScreen<${name}Menu> implemen
 	}
 
 	<#if data.getComponentsOfType("Button")?filter(component -> hasProcedure(component.displayCondition))?size != 0
-	    || data.getComponentsOfType("ImageButton")?filter(component -> hasProcedure(component.displayCondition))?size != 0>
+		|| data.getComponentsOfType("ImageButton")?filter(component -> hasProcedure(component.displayCondition))?size != 0>
 	@Override protected void containerTick() {
 		super.containerTick();
 

--- a/plugins/generator-26.1.x/neoforge-26.1.2/templates/gui/gui_window.java.ftl
+++ b/plugins/generator-26.1.x/neoforge-26.1.2/templates/gui/gui_window.java.ftl
@@ -292,12 +292,8 @@ public class ${name}Screen extends AbstractContainerScreen<${name}Menu> implemen
 				<@buttonOnClick component/>
 			) {
 				@Override public void extractContents(GuiGraphicsExtractor guiGraphics, int mouseX, int mouseY, float partialTicks) {
-					<#if hasProcedure(component.displayCondition)>
-					int x = ${name}Screen.this.x; <#-- x and y provided by buttons are in-GUI, not in-world coordinates -->
-					int y = ${name}Screen.this.y;
-					if (<@procedureOBJToConditionCode component.displayCondition/>)
-					</#if>
-					guiGraphics.blit(RenderPipelines.GUI_TEXTURED, sprites.get(isActive(), isHoveredOrFocused()), getX(), getY(), 0, 0, width, height, width, height);
+	                if (this.visible)
+					    guiGraphics.blit(RenderPipelines.GUI_TEXTURED, sprites.get(isActive(), isHoveredOrFocused()), getX(), getY(), 0, 0, width, height, width, height);
 				}
 			};
 
@@ -352,6 +348,12 @@ public class ${name}Screen extends AbstractContainerScreen<${name}Menu> implemen
 		super.containerTick();
 
 		<#list data.getComponentsOfType("Button") as component>
+			<#if hasProcedure(component.displayCondition)>
+				this.${component.getName()}.visible = <@procedureOBJToConditionCode component.displayCondition/>;
+			</#if>
+		</#list>
+
+		<#list data.getComponentsOfType("ImageButton") as component>
 			<#if hasProcedure(component.displayCondition)>
 				this.${component.getName()}.visible = <@procedureOBJToConditionCode component.displayCondition/>;
 			</#if>

--- a/plugins/generator-26.1.x/neoforge-26.1.2/templates/gui/gui_window.java.ftl
+++ b/plugins/generator-26.1.x/neoforge-26.1.2/templates/gui/gui_window.java.ftl
@@ -292,8 +292,7 @@ public class ${name}Screen extends AbstractContainerScreen<${name}Menu> implemen
 				<@buttonOnClick component/>
 			) {
 				@Override public void extractContents(GuiGraphicsExtractor guiGraphics, int mouseX, int mouseY, float partialTicks) {
-	                if (this.visible)
-					    guiGraphics.blit(RenderPipelines.GUI_TEXTURED, sprites.get(isActive(), isHoveredOrFocused()), getX(), getY(), 0, 0, width, height, width, height);
+	                guiGraphics.blit(RenderPipelines.GUI_TEXTURED, sprites.get(isActive(), isHoveredOrFocused()), getX(), getY(), 0, 0, width, height, width, height);
 				}
 			};
 
@@ -343,7 +342,8 @@ public class ${name}Screen extends AbstractContainerScreen<${name}Menu> implemen
 		</#list>
 	}
 
-	<#if data.getComponentsOfType("Button")?filter(component -> hasProcedure(component.displayCondition))?size != 0>
+	<#if data.getComponentsOfType("Button")?filter(component -> hasProcedure(component.displayCondition))?size != 0
+	    || data.getComponentsOfType("ImageButton")?filter(component -> hasProcedure(component.displayCondition))?size != 0>
 	@Override protected void containerTick() {
 		super.containerTick();
 


### PR DESCRIPTION
Imagebuttons didnt set .visible with their display conditions causing imagebuttons overlapping imagebuttons or other GUI components to not be clickable as the imagebutton was still there but invisible as far as the GUI was concerned.

Fixes #6535 