### PR TITLE
Improve JarManager loading for JPMS Java features to not fail on them

### DIFF
--- a/src/main/java/net/mcreator/java/JModLibraryInfo.java
+++ b/src/main/java/net/mcreator/java/JModLibraryInfo.java
@@ -111,8 +111,11 @@ public class JModLibraryInfo extends LibraryInfo {
 			while (e.hasMoreElements()) {
 				ZipEntry entry = e.nextElement();
 				String entryName = entry.getName();
-				if (entryName.endsWith(".class") && entryName.startsWith("classes/"))
-					root.add(StringUtils.stripStart(entryName, "classes/"));
+				if (entryName.endsWith(".class") && entryName.startsWith("classes/")) {
+					String className = StringUtils.stripStart(entryName, "classes/");
+					if (SafeJarLibraryInfo.isIndexableClassEntry(className))
+						root.add(className);
+				}
 			}
 		}
 		return root;

--- a/src/main/java/net/mcreator/java/ModulesFileLibraryInfo.java
+++ b/src/main/java/net/mcreator/java/ModulesFileLibraryInfo.java
@@ -85,12 +85,16 @@ public class ModulesFileLibraryInfo extends LibraryInfo {
 				// We need to strip the first two elements (/modules/module.name/)
 				if (path.getNameCount() > 2) {
 					String relativePath = path.subpath(2, path.getNameCount()).toString();
+					String lookupName = relativePath.replace('\\', '/');
+
+					if (!SafeJarLibraryInfo.isIndexableClassEntry(lookupName))
+						return;
 
 					// Populate the RSTA tree
 					root.add(relativePath);
 
 					// Populate our lookup cache for createClassFile
-					classPathCache.put(relativePath.replace('\\', '/'), path);
+					classPathCache.put(lookupName, path);
 				}
 			});
 		}

--- a/src/main/java/net/mcreator/java/ProjectJarManager.java
+++ b/src/main/java/net/mcreator/java/ProjectJarManager.java
@@ -167,7 +167,7 @@ public class ProjectJarManager extends JarManager {
 			throw new GradleCacheImportFailedException(new IOException("Failed to load cached library " + libString));
 		}
 
-		JarLibraryInfo libraryInfo = new JarLibraryInfo(libString);
+		JarLibraryInfo libraryInfo = new SafeJarLibraryInfo(libString);
 		String srcString = classpathEntry.getSrc(workspace);
 		if (srcString != null) {
 			File srcFile = new File(srcString);
@@ -230,7 +230,7 @@ public class ProjectJarManager extends JarManager {
 		} else if (classesArchive.getName().endsWith(".jmod")) {
 			return new JModLibraryInfo(classesArchive);
 		} else {
-			return new JarLibraryInfo(classesArchive);
+			return new SafeJarLibraryInfo(classesArchive);
 		}
 	}
 

--- a/src/main/java/net/mcreator/java/SafeJarLibraryInfo.java
+++ b/src/main/java/net/mcreator/java/SafeJarLibraryInfo.java
@@ -1,0 +1,65 @@
+/*
+ * MCreator (https://mcreator.net/)
+ * Copyright (C) 2012-2020, Pylo
+ * Copyright (C) 2020-2026, Pylo, opensource contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package net.mcreator.java;
+
+import org.fife.rsta.ac.java.PackageMapNode;
+import org.fife.rsta.ac.java.buildpath.JarLibraryInfo;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Enumeration;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+
+/**
+ * A {@link JarLibraryInfo} that excludes class files the RSTA class reader cannot parse from the
+ * package map. The reader predates JPMS, so module descriptors (constant pool tags 19/20) make class
+ * file parsing fail with an IOException that aborts the completion lookup in progress. Module
+ * descriptors ({@code module-info.class}) and multi-release {@code META-INF/versions} entries are
+ * useless for code completion anyway, so they are not indexed at all.
+ */
+public class SafeJarLibraryInfo extends JarLibraryInfo {
+
+	public SafeJarLibraryInfo(String jarFile) {
+		super(jarFile);
+	}
+
+	public SafeJarLibraryInfo(File jarFile) {
+		super(jarFile);
+	}
+
+	static boolean isIndexableClassEntry(String entryName) {
+		return !entryName.startsWith("META-INF/") && !entryName.endsWith("module-info.class");
+	}
+
+	@Override public PackageMapNode createPackageMap() throws IOException {
+		PackageMapNode packageMap = new PackageMapNode();
+		try (JarFile jar = new JarFile(getJarFile())) {
+			Enumeration<JarEntry> entries = jar.entries();
+			while (entries.hasMoreElements()) {
+				String entryName = entries.nextElement().getName();
+				if (entryName.endsWith(".class") && isIndexableClassEntry(entryName))
+					packageMap.add(entryName);
+			}
+		}
+		return packageMap;
+	}
+
+}


### PR DESCRIPTION
Improve JarManager loading for JPMS Java features to not fail on them

Prevents loading classes that result in errors being logged due to an unsupported format