### PR TITLE
Make import map explicitly unmodifiable

### DIFF
--- a/src/main/java/net/mcreator/generator/GeneratorGradleCache.java
+++ b/src/main/java/net/mcreator/generator/GeneratorGradleCache.java
@@ -26,6 +26,7 @@ import net.mcreator.workspace.Workspace;
 
 import javax.annotation.Nullable;
 import java.io.File;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -53,7 +54,9 @@ public class GeneratorGradleCache {
 	}
 
 	public Map<String, List<String>> getImportTree() {
-		return importTree;
+		// Not redundant as GSON will return a mutable map, but we want to return an unmodifiable map
+		//noinspection RedundantUnmodifiable
+		return Collections.unmodifiableMap(importTree);
 	}
 
 	public static class ClasspathEntry {

--- a/src/main/java/net/mcreator/java/ImportTreeBuilder.java
+++ b/src/main/java/net/mcreator/java/ImportTreeBuilder.java
@@ -108,7 +108,7 @@ public class ImportTreeBuilder {
 				LOG.warn("Failed to load import format classes", e);
 			}
 		});
-		return retval;
+		return Collections.unmodifiableMap(retval);
 	}
 
 	static void reloadClassesFromMod(Generator generator, Map<String, List<String>> store) {


### PR DESCRIPTION
Make the import map explicitly unmodifiable to prevent modification by e.g. plugins or future changes