### PR TITLE
Revert RSTA to 3.6.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -129,7 +129,7 @@ dependencies {
     implementation "com.atlassian.commonmark:commonmark:0.17.0"
     implementation "com.atlassian.commonmark:commonmark-ext-autolink:0.17.0"
     implementation "com.atlassian.commonmark:commonmark-ext-gfm-tables:0.17.0"
-    implementation "com.fifesoft:rsyntaxtextarea:4.0.1"
+    implementation "com.fifesoft:rsyntaxtextarea:3.6.3"
     implementation "com.fifesoft:autocomplete:3.3.3"
     implementation("com.fifesoft:languagesupport:3.4.1") {
         dep -> dep.exclude group: 'org.mozilla', module: 'rhino-all'


### PR DESCRIPTION
Revert RSTA to 3.6.3 until https://github.com/bobbylight/AutoComplete/pull/122 is present in a release