### PR TITLE
Fix wrong dependency type in "Player deals critical hit" trigger

### DIFF
--- a/plugins/mcreator-core/triggers/player_critical_hit.json
+++ b/plugins/mcreator-core/triggers/player_critical_hit.json
@@ -30,7 +30,7 @@
     },
     {
       "name": "isvanillacritical",
-      "type": "boolean"
+      "type": "logic"
     }
   ],
   "has_result": "true"


### PR DESCRIPTION
Fixes #6600 