### PR TITLE
Searchable selector improvements

### DIFF
--- a/plugins/mcreator-core/blockly/js/field_data_list_selector.js
+++ b/plugins/mcreator-core/blockly/js/field_data_list_selector.js
@@ -62,7 +62,7 @@ class FieldDataListSelector extends Blockly.Field {
                 let customEntryProviders = typeof this.customEntryProviders === 'function' ?
                     this.customEntryProviders() :
                     this.customEntryProviders;
-                javabridge.openEntrySelector(this.type, this.typeFilter, customEntryProviders, {
+                javabridge.openEntrySelector(this.type, this.typeFilter, customEntryProviders, this.getValue(), {
                     'callback': function (value, readableName) {
                         thisField.cachedReadableName = readableName || value;
                         const group = Blockly.Events.getGroup();

--- a/plugins/mcreator-core/blockly/js/field_mcitem_selector.js
+++ b/plugins/mcreator-core/blockly/js/field_mcitem_selector.js
@@ -51,7 +51,7 @@ class FieldMCItemSelector extends Blockly.FieldImage {
             if (this.lastClickTime !== -1 && ((new Date().getTime() - this.lastClickTime) < 500)) {
                 e.stopPropagation(); // fix so the block does not "stick" to the mouse when the field is clicked
                 let thisField = this; // reference to this field, to use in the callback function
-                javabridge.openMCItemSelector(this.supported_mcitems, {
+                javabridge.openMCItemSelector(this.supported_mcitems, this.value_, {
                     'callback': function (selected) {
                         const group = Blockly.Events.getGroup();
                         Blockly.Events.setGroup(true);

--- a/src/main/java/net/mcreator/ui/blockly/BlocklyJavascriptBridge.java
+++ b/src/main/java/net/mcreator/ui/blockly/BlocklyJavascriptBridge.java
@@ -106,8 +106,7 @@ public final class BlocklyJavascriptBridge {
 	private String[] openDataListEntrySelector(Function<Workspace, Collection<DataListEntry>> entryProvider,
 			String selectedEntry, String type) {
 		String[] retval = new String[] { "", L10N.t("blockly.extension.data_list_selector.no_entry") };
-		DataListEntry toSelect = selectedEntry == null ? null : new DataListEntry.Dummy(selectedEntry);
-		DataListEntry selected = DataListSelectorDialog.openSelectorDialog(mcreator, entryProvider, toSelect,
+		DataListEntry selected = DataListSelectorDialog.openSelectorDialog(mcreator, entryProvider, selectedEntry,
 				L10N.t("dialog.selector.title"), L10N.t("dialog.selector." + type + ".message"));
 		if (selected != null) {
 			retval[0] = selected.getName();

--- a/src/main/java/net/mcreator/ui/blockly/BlocklyJavascriptBridge.java
+++ b/src/main/java/net/mcreator/ui/blockly/BlocklyJavascriptBridge.java
@@ -98,13 +98,15 @@ public final class BlocklyJavascriptBridge {
 	 * Opens a data list selector window for the searchable Blockly selectors
 	 *
 	 * @param entryProvider The function that provides the entries from a given workspace
+	 * @param selectedEntry Current value of this field, which will already be selected when the dialog is opened
 	 * @param type          The type of the data list, used for the selector title and message
 	 * @return A {"value", "readable name"} pair, or the default entry if no entry was selected
 	 */
 	private String[] openDataListEntrySelector(Function<Workspace, Collection<DataListEntry>> entryProvider,
-			String type) {
+			String selectedEntry, String type) {
 		String[] retval = new String[] { "", L10N.t("blockly.extension.data_list_selector.no_entry") };
-		DataListEntry selected = DataListSelectorDialog.openSelectorDialog(mcreator, entryProvider,
+		DataListEntry toSelect = selectedEntry == null ? null : new DataListEntry.Dummy(selectedEntry);
+		DataListEntry selected = DataListSelectorDialog.openSelectorDialog(mcreator, entryProvider, toSelect,
 				L10N.t("dialog.selector.title"), L10N.t("dialog.selector." + type + ".message"));
 		if (selected != null) {
 			retval[0] = selected.getName();
@@ -117,12 +119,14 @@ public final class BlocklyJavascriptBridge {
 	 * Opens a string selector window for the searchable Blockly selectors
 	 *
 	 * @param entryProvider The function that provides the strings from a given workspace
+	 * @param selectedEntry Current value of this field, which will already be selected when the dialog is opened
 	 * @param type          The type of the data list, used for the selector title and message
 	 * @return A {"value", "value"} pair (strings don't have readable names!), or the default entry if no string was selected
 	 */
-	private String[] openStringEntrySelector(Function<Workspace, String[]> entryProvider, String type) {
+	private String[] openStringEntrySelector(Function<Workspace, String[]> entryProvider, String selectedEntry,
+			String type) {
 		String[] retval = new String[] { "", L10N.t("blockly.extension.data_list_selector.no_entry") };
-		String selected = StringSelectorDialog.openSelectorDialog(mcreator, entryProvider,
+		String selected = StringSelectorDialog.openSelectorDialog(mcreator, entryProvider, selectedEntry,
 				L10N.t("dialog.selector.title"), L10N.t("dialog.selector." + type + ".message"));
 		if (selected != null) {
 			retval[0] = selected;
@@ -152,17 +156,18 @@ public final class BlocklyJavascriptBridge {
 	 * @param type                 The type of selector to open
 	 * @param typeFilter           If present, only entries whose type matches this parameter are loaded
 	 * @param customEntryProviders If present, the types of the mod elements that provide custom entries
-	 * @param callback             The Javascript object that passes the {"value", "readable name"} pair to the Blockly editor
+	 * @param currentValue         If present, the currently selected item in the entry selector
+	 * @param callback             The JavaScript object that passes the {"value", "readable name"} pair to the Blockly editor
 	 */
 	@SuppressWarnings("unused") public void openEntrySelector(@Nonnull String type, @Nullable String typeFilter,
-			@Nullable String customEntryProviders, Consumer<String[]> callback) {
+			@Nullable String customEntryProviders, @Nullable String currentValue, Consumer<String[]> callback) {
 		SwingUtilities.invokeLater(() -> {
 			String[] retval;
 			if ("global_triggers".equals(type)) {
 				String[] selectedEntry = openDataListEntrySelector(w -> ext_triggers.entrySet().stream()
 						.map(entry -> (DataListEntry) new DataListEntry.Dummy(entry.getKey()) {{
 							setReadableName(entry.getValue());
-						}}).toList(), "global_trigger");
+						}}).toList(), currentValue, "global_trigger");
 
 				// Legacy: for global triggers, "no_ext_trigger" is used to indicate no selected value, whereas normally it is ""
 				if (selectedEntry[0].isEmpty()) {
@@ -172,16 +177,18 @@ public final class BlocklyJavascriptBridge {
 			} else if (type.startsWith("procedure_retval_")) {
 				var variableType = VariableTypeLoader.INSTANCE.fromName(
 						Strings.CS.removeStart(type, "procedure_retval_"));
-				retval = openStringEntrySelector(w -> ElementUtil.getProceduresOfType(w, variableType), "procedure");
+				retval = openStringEntrySelector(w -> ElementUtil.getProceduresOfType(w, variableType),
+						currentValue, "procedure");
 			} else {
 				String[] arrayList = BlocklyElementUtil.getStringArrayForEntrySelector(mcreator.getWorkspace(), type,
 						customEntryProviders);
 				if (arrayList != null) {
-					retval = openStringEntrySelector(w -> arrayList, getEntrySelectorDialogLangKeyType(type));
+					retval = openStringEntrySelector(w -> arrayList, currentValue,
+							getEntrySelectorDialogLangKeyType(type));
 				} else {
 					retval = openDataListEntrySelector(
 							w -> BlocklyElementUtil.getDataListEntriesForEntrySelector(w, type, typeFilter,
-									customEntryProviders), getEntrySelectorDialogLangKeyType(type));
+									customEntryProviders), currentValue, getEntrySelectorDialogLangKeyType(type));
 				}
 			}
 			callback.accept(retval);

--- a/src/main/java/net/mcreator/ui/blockly/BlocklyJavascriptBridge.java
+++ b/src/main/java/net/mcreator/ui/blockly/BlocklyJavascriptBridge.java
@@ -79,10 +79,11 @@ public final class BlocklyJavascriptBridge {
 		});
 	}
 
-	@SuppressWarnings("unused") public void openMCItemSelector(String type, Consumer<String> callback) {
+	@SuppressWarnings("unused") public void openMCItemSelector(String type, String currentValue, Consumer<String> callback) {
 		SwingUtilities.invokeLater(() -> {
 			MCItem selected = MCItemSelectorDialog.openSelectorDialog(mcreator,
-					"allblocks".equals(type) ? ElementUtil::loadBlocks : ElementUtil::loadBlocksAndItems);
+					"allblocks".equals(type) ? ElementUtil::loadBlocks : ElementUtil::loadBlocksAndItems,
+					currentValue == null ? null : new MCItem(new DataListEntry.Dummy(currentValue)));
 			callback.accept(selected == null ? null : selected.getName());
 		});
 	}

--- a/src/main/java/net/mcreator/ui/dialogs/DataListSelectorDialog.java
+++ b/src/main/java/net/mcreator/ui/dialogs/DataListSelectorDialog.java
@@ -49,7 +49,14 @@ public class DataListSelectorDialog extends ListSelectorDialog<DataListEntry> {
 
 	public static DataListEntry openSelectorDialog(MCreator mcreator,
 			Function<Workspace, Collection<DataListEntry>> entryProvider, String title, String message) {
-		return openSelectorDialog(mcreator, entryProvider, null, title, message);
+		return openSelectorDialog(mcreator, entryProvider, (DataListEntry) null, title, message);
+	}
+
+	public static DataListEntry openSelectorDialog(MCreator mcreator,
+			Function<Workspace, Collection<DataListEntry>> entryProvider, String selectedEntry, String title,
+			String message) {
+		return openSelectorDialog(mcreator, entryProvider,
+				selectedEntry == null ? null : new DataListEntry.Dummy(selectedEntry), title, message);
 	}
 
 	public static DataListEntry openSelectorDialog(MCreator mcreator,

--- a/src/main/java/net/mcreator/ui/dialogs/DataListSelectorDialog.java
+++ b/src/main/java/net/mcreator/ui/dialogs/DataListSelectorDialog.java
@@ -35,10 +35,11 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 
 public class DataListSelectorDialog extends ListSelectorDialog<DataListEntry> {
-	public DataListSelectorDialog(MCreator mcreator, Function<Workspace, Collection<DataListEntry>> entryProvider) {
+	public DataListSelectorDialog(MCreator mcreator, Function<Workspace, Collection<DataListEntry>> entryProvider,
+			List<DataListEntry> selectedEntries) {
 		super(mcreator,
 				workspace -> entryProvider.apply(workspace).stream().filter(e -> e.isSupportedInWorkspace(workspace))
-						.toList());
+						.toList(), selectedEntries);
 		list.setCellRenderer(new DataListCellRenderer());
 	}
 
@@ -48,7 +49,14 @@ public class DataListSelectorDialog extends ListSelectorDialog<DataListEntry> {
 
 	public static DataListEntry openSelectorDialog(MCreator mcreator,
 			Function<Workspace, Collection<DataListEntry>> entryProvider, String title, String message) {
-		var dataListSelector = new DataListSelectorDialog(mcreator, entryProvider);
+		return openSelectorDialog(mcreator, entryProvider, null, title, message);
+	}
+
+	public static DataListEntry openSelectorDialog(MCreator mcreator,
+			Function<Workspace, Collection<DataListEntry>> entryProvider, DataListEntry selectedEntry,
+			String title, String message) {
+		var dataListSelector = new DataListSelectorDialog(mcreator, entryProvider,
+				selectedEntry == null ? null : List.of(selectedEntry));
 		dataListSelector.setMessage(message);
 		dataListSelector.setTitle(title);
 		dataListSelector.setVisible(true);
@@ -57,7 +65,13 @@ public class DataListSelectorDialog extends ListSelectorDialog<DataListEntry> {
 
 	public static List<DataListEntry> openMultiSelectorDialog(MCreator mcreator,
 			Function<Workspace, Collection<DataListEntry>> entryProvider, String title, String message) {
-		var dataListSelector = new DataListSelectorDialog(mcreator, entryProvider);
+		return openMultiSelectorDialog(mcreator, entryProvider, null, title, message);
+	}
+
+	public static List<DataListEntry> openMultiSelectorDialog(MCreator mcreator,
+			Function<Workspace, Collection<DataListEntry>> entryProvider, List<DataListEntry> selectedEntries,
+			String title, String message) {
+		var dataListSelector = new DataListSelectorDialog(mcreator, entryProvider, selectedEntries);
 		dataListSelector.setMessage(message);
 		dataListSelector.list.setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
 		dataListSelector.setTitle(title);

--- a/src/main/java/net/mcreator/ui/dialogs/ListSelectorDialog.java
+++ b/src/main/java/net/mcreator/ui/dialogs/ListSelectorDialog.java
@@ -56,7 +56,7 @@ public abstract class ListSelectorDialog<T> extends SearchableSelectorDialog<T> 
 		});
 
 		JButton selectButton = L10N.button("dialog.item_selector.use_selected");
-		selectButton.addActionListener(e -> dispose());
+		selectButton.addActionListener(_ -> dispose());
 
 		message.setBorder(BorderFactory.createEmptyBorder(4, 4, 2, 0));
 

--- a/src/main/java/net/mcreator/ui/dialogs/ListSelectorDialog.java
+++ b/src/main/java/net/mcreator/ui/dialogs/ListSelectorDialog.java
@@ -40,7 +40,7 @@ import java.util.function.Function;
  * @param <T> The type of elements contained in the list
  */
 public abstract class ListSelectorDialog<T> extends SearchableSelectorDialog<T> {
-	final JList<T> list = new JList<>(model);
+
 	final JLabel message = new JLabel("");
 
 	public ListSelectorDialog(MCreator mcreator, Function<Workspace, List<T>> entryProvider) {

--- a/src/main/java/net/mcreator/ui/dialogs/ListSelectorDialog.java
+++ b/src/main/java/net/mcreator/ui/dialogs/ListSelectorDialog.java
@@ -43,8 +43,8 @@ public abstract class ListSelectorDialog<T> extends SearchableSelectorDialog<T> 
 
 	final JLabel message = new JLabel("");
 
-	public ListSelectorDialog(MCreator mcreator, Function<Workspace, List<T>> entryProvider) {
-		super(mcreator, entryProvider);
+	public ListSelectorDialog(MCreator mcreator, Function<Workspace, List<T>> entryProvider, List<T> selectedEntries) {
+		super(mcreator, entryProvider, selectedEntries);
 
 		list.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
 		list.addMouseListener(new MouseAdapter() {

--- a/src/main/java/net/mcreator/ui/dialogs/MCItemSelectorDialog.java
+++ b/src/main/java/net/mcreator/ui/dialogs/MCItemSelectorDialog.java
@@ -36,7 +36,6 @@ import java.util.function.Predicate;
 
 public class MCItemSelectorDialog extends SearchableSelectorDialog<MCItem> {
 
-	private final JList<MCItem> list = new JList<>(model);
 	private final JTextField jtf = new JTextField(16);
 
 	private ActionListener itemSelectedListener;

--- a/src/main/java/net/mcreator/ui/dialogs/MCItemSelectorDialog.java
+++ b/src/main/java/net/mcreator/ui/dialogs/MCItemSelectorDialog.java
@@ -74,7 +74,7 @@ public class MCItemSelectorDialog extends SearchableSelectorDialog<MCItem> {
 		JButton cancelButton = new JButton(UIManager.getString("OptionPane.cancelButtonText"));
 
 		JButton useSelectedButton = L10N.button("dialog.item_selector.use_selected");
-		useSelectedButton.addActionListener(e -> {
+		useSelectedButton.addActionListener(_ -> {
 			dispose();
 			if (itemSelectedListener != null)
 				itemSelectedListener.actionPerformed(new ActionEvent(this, 0, ""));
@@ -83,7 +83,7 @@ public class MCItemSelectorDialog extends SearchableSelectorDialog<MCItem> {
 		if (supportTags) {
 			JButton useTags = L10N.button("dialog.item_selector.use_tag");
 			buttons.add(useTags);
-			useTags.addActionListener(e -> {
+			useTags.addActionListener(_ -> {
 				TagType tagType = TagType.BLOCKS;
 				List<MCItem> items = supplier.provide(mcreator.getWorkspace());
 				for (MCItem item : items) {
@@ -112,30 +112,30 @@ public class MCItemSelectorDialog extends SearchableSelectorDialog<MCItem> {
 		list.setLayoutOrientation(JList.VERTICAL_WRAP);
 		list.setVisibleRowCount(0);
 
-		list.addListSelectionListener(event -> {
+		list.addListSelectionListener(_ -> {
 			MCItem bl = list.getSelectedValue();
 			if (bl != null)
 				jtf.setText(bl.getReadableName());
 		});
 
-		cancelButton.addActionListener(event -> {
+		cancelButton.addActionListener(_ -> {
 			list.clearSelection();
 			dispose();
 		});
 
 		JComponent top;
 		JButton all = L10N.button("dialog.item_selector.all");
-		all.addActionListener(event -> filterField.setText(""));
+		all.addActionListener(_ -> filterField.setText(""));
 		JButton blocks = L10N.button("dialog.item_selector.blocks");
-		blocks.addActionListener(event -> filterField.setText("block"));
+		blocks.addActionListener(_ -> filterField.setText("block"));
 		JButton items = L10N.button("dialog.item_selector.items");
-		items.addActionListener(event -> filterField.setText("item"));
+		items.addActionListener(_ -> filterField.setText("item"));
 		JButton mods = L10N.button("dialog.item_selector.custom_elements");
-		mods.addActionListener(event -> filterField.setText("custom"));
+		mods.addActionListener(_ -> filterField.setText("custom"));
 
 		if (hasPotions) {
 			JButton potions = L10N.button("dialog.item_selector.potions");
-			potions.addActionListener(event -> filterField.setText("potion:"));
+			potions.addActionListener(_ -> filterField.setText("potion:"));
 			top = PanelUtils.join(FlowLayout.LEFT, 2, 2, L10N.label("dialog.item_selector.name"), jtf,
 					new JEmptyBox(2, 2), L10N.label("dialog.item_selector.display_filter"), filterField,
 					new JEmptyBox(2, 2), all, blocks, items, potions, mods);

--- a/src/main/java/net/mcreator/ui/dialogs/MCItemSelectorDialog.java
+++ b/src/main/java/net/mcreator/ui/dialogs/MCItemSelectorDialog.java
@@ -41,12 +41,17 @@ public class MCItemSelectorDialog extends SearchableSelectorDialog<MCItem> {
 	private ActionListener itemSelectedListener;
 
 	public MCItemSelectorDialog(MCreator mcreator, MCItem.ListProvider supplier, boolean supportTags) {
-		this(mcreator, supplier, supportTags, false);
+		this(mcreator, supplier, null, supportTags, false);
 	}
 
 	public MCItemSelectorDialog(MCreator mcreator, MCItem.ListProvider supplier, boolean supportTags,
 			boolean hasPotions) {
-		super(mcreator, supplier::provide);
+		this(mcreator, supplier, null, supportTags, hasPotions);
+	}
+
+	public MCItemSelectorDialog(MCreator mcreator, MCItem.ListProvider supplier, MCItem selectedEntry,
+			boolean supportTags, boolean hasPotions) {
+		super(mcreator, supplier::provide, selectedEntry);
 
 		setTitle(L10N.t("dialog.item_selector.title"));
 		list.setCellRenderer(new Render());
@@ -202,8 +207,8 @@ public class MCItemSelectorDialog extends SearchableSelectorDialog<MCItem> {
 		return list.getSelectedValue();
 	}
 
-	public static MCItem openSelectorDialog(MCreator parent, MCItem.ListProvider blocks) {
-		MCItemSelectorDialog bsd = new MCItemSelectorDialog(parent, blocks, false);
+	public static MCItem openSelectorDialog(MCreator parent, MCItem.ListProvider blocks, MCItem selectedItem) {
+		MCItemSelectorDialog bsd = new MCItemSelectorDialog(parent, blocks, selectedItem, false, false);
 		bsd.setVisible(true);
 		return bsd.list.getSelectedValue();
 	}

--- a/src/main/java/net/mcreator/ui/dialogs/SearchableSelectorDialog.java
+++ b/src/main/java/net/mcreator/ui/dialogs/SearchableSelectorDialog.java
@@ -22,12 +22,14 @@ package net.mcreator.ui.dialogs;
 import net.mcreator.ui.MCreator;
 import net.mcreator.workspace.Workspace;
 
+import javax.annotation.Nonnull;
 import javax.swing.*;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -40,6 +42,7 @@ import java.util.function.Predicate;
 public abstract class SearchableSelectorDialog<T> extends MCreatorDialog {
 	final MCreator mcreator;
 	final Function<Workspace, List<T>> provider;
+	final @Nonnull List<T> selectedEntries;
 
 	final FilterModel model = new FilterModel();
 	final JTextField filterField = new JTextField(14);
@@ -47,9 +50,14 @@ public abstract class SearchableSelectorDialog<T> extends MCreatorDialog {
 	final JList<T> list = new JList<>(model);
 
 	public SearchableSelectorDialog(MCreator mcreator, Function<Workspace, List<T>> provider) {
+		this(mcreator, provider, Collections.emptyList());
+	}
+
+	public SearchableSelectorDialog(MCreator mcreator, Function<Workspace, List<T>> provider, List<T> selectedEntries) {
 		super(mcreator);
 		this.mcreator = mcreator;
 		this.provider = provider;
+		this.selectedEntries = selectedEntries == null ? Collections.emptyList() : selectedEntries;
 
 		setModalityType(ModalityType.APPLICATION_MODAL);
 
@@ -134,5 +142,20 @@ public abstract class SearchableSelectorDialog<T> extends MCreatorDialog {
 	void reloadElements() {
 		model.removeAllElements();
 		provider.apply(this.mcreator.getWorkspace()).forEach(model::addElement);
+		selectEntries();
+	}
+
+	protected void selectEntries() {
+		if (!selectedEntries.isEmpty()) {
+			List<Integer> indicesToSelect = new ArrayList<>();
+			for (int i = 0; i < list.getModel().getSize(); i++) {
+				if (selectedEntries.contains(list.getModel().getElementAt(i)))
+					indicesToSelect.add(i);
+			}
+			if (!indicesToSelect.isEmpty()) {
+				list.setSelectedIndices(indicesToSelect.stream().mapToInt(i -> i).toArray());
+				list.ensureIndexIsVisible(indicesToSelect.getFirst());
+			}
+		}
 	}
 }

--- a/src/main/java/net/mcreator/ui/dialogs/SearchableSelectorDialog.java
+++ b/src/main/java/net/mcreator/ui/dialogs/SearchableSelectorDialog.java
@@ -44,6 +44,8 @@ public abstract class SearchableSelectorDialog<T> extends MCreatorDialog {
 	final FilterModel model = new FilterModel();
 	final JTextField filterField = new JTextField(14);
 
+	final JList<T> list = new JList<>(model);
+
 	public SearchableSelectorDialog(MCreator mcreator, Function<Workspace, List<T>> provider) {
 		super(mcreator);
 		this.mcreator = mcreator;

--- a/src/main/java/net/mcreator/ui/dialogs/SearchableSelectorDialog.java
+++ b/src/main/java/net/mcreator/ui/dialogs/SearchableSelectorDialog.java
@@ -53,6 +53,10 @@ public abstract class SearchableSelectorDialog<T> extends MCreatorDialog {
 		this(mcreator, provider, Collections.emptyList());
 	}
 
+	public SearchableSelectorDialog(MCreator mcreator, Function<Workspace, List<T>> provider, T selectedEntry) {
+		this(mcreator, provider, selectedEntry == null ? null : List.of(selectedEntry));
+	}
+
 	public SearchableSelectorDialog(MCreator mcreator, Function<Workspace, List<T>> provider, List<T> selectedEntries) {
 		super(mcreator);
 		this.mcreator = mcreator;

--- a/src/main/java/net/mcreator/ui/dialogs/StringSelectorDialog.java
+++ b/src/main/java/net/mcreator/ui/dialogs/StringSelectorDialog.java
@@ -33,8 +33,9 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 
 public class StringSelectorDialog extends ListSelectorDialog<String> {
-	public StringSelectorDialog(MCreator mcreator, Function<Workspace, String[]> entryProvider) {
-		super(mcreator, entryProvider.andThen(Arrays::asList));
+	public StringSelectorDialog(MCreator mcreator, Function<Workspace, String[]> entryProvider,
+			List<String> selectedEntries) {
+		super(mcreator, entryProvider.andThen(Arrays::asList), selectedEntries);
 		list.setCellRenderer(new StringListCellRenderer());
 	}
 
@@ -44,7 +45,13 @@ public class StringSelectorDialog extends ListSelectorDialog<String> {
 
 	public static String openSelectorDialog(MCreator mcreator, Function<Workspace, String[]> entryProvider,
 			String title, String message) {
-		var stringSelector = new StringSelectorDialog(mcreator, entryProvider);
+		return openSelectorDialog(mcreator, entryProvider, null, title, message);
+	}
+
+	public static String openSelectorDialog(MCreator mcreator, Function<Workspace, String[]> entryProvider,
+			String selectedEntry, String title, String message) {
+		var stringSelector = new StringSelectorDialog(mcreator, entryProvider,
+				selectedEntry == null ? null : List.of(selectedEntry));
 		stringSelector.setMessage(message);
 		stringSelector.setTitle(title);
 		stringSelector.setVisible(true);
@@ -53,7 +60,12 @@ public class StringSelectorDialog extends ListSelectorDialog<String> {
 
 	public static List<String> openMultiSelectorDialog(MCreator mcreator, Function<Workspace, String[]> entryProvider,
 			String title, String message) {
-		var dataListSelector = new StringSelectorDialog(mcreator, entryProvider);
+		return openMultiSelectorDialog(mcreator, entryProvider, null, title, message);
+	}
+
+	public static List<String> openMultiSelectorDialog(MCreator mcreator, Function<Workspace, String[]> entryProvider,
+			List<String> selectedEntries, String title, String message) {
+		var dataListSelector = new StringSelectorDialog(mcreator, entryProvider, selectedEntries);
 		dataListSelector.setMessage(message);
 		dataListSelector.list.setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
 		dataListSelector.setTitle(title);

--- a/src/main/java/net/mcreator/ui/minecraft/SingleConfiguredFeatureField.java
+++ b/src/main/java/net/mcreator/ui/minecraft/SingleConfiguredFeatureField.java
@@ -34,6 +34,7 @@ public class SingleConfiguredFeatureField extends JSingleEntrySelector<Configure
 
 	@Override protected ConfiguredFeatureEntry openEntrySelector() {
 		var entry = DataListSelectorDialog.openSelectorDialog(mcreator, ElementUtil::loadAllConfiguredFeatures,
+				this.getEntry() == null ? null : this.getEntry().getUnmappedValue(),
 				L10N.t("dialog.list_field.configured_feature_title"),
 				L10N.t("dialog.list_field.configured_feature_message"));
 		return entry == null ? null : new ConfiguredFeatureEntry(mcreator.getWorkspace(), entry);

--- a/src/main/java/net/mcreator/ui/minecraft/SingleModElementSelector.java
+++ b/src/main/java/net/mcreator/ui/minecraft/SingleModElementSelector.java
@@ -40,6 +40,7 @@ public class SingleModElementSelector extends JSingleEntrySelector<String> {
 	@Override protected String openEntrySelector() {
 		return StringSelectorDialog.openSelectorDialog(mcreator,
 				w -> w.getModElementsByType(type).stream().map(ModElement::getName).toList().toArray(String[]::new),
+				this.currentEntry,
 				L10N.t("dialog.selector.mod_element_title", type.getReadableName().toLowerCase(Locale.ENGLISH)),
 				L10N.t("dialog.selector.mod_element_message", type.getReadableName().toLowerCase(Locale.ENGLISH)));
 	}

--- a/src/main/java/net/mcreator/ui/minecraft/SingleParticleEntryField.java
+++ b/src/main/java/net/mcreator/ui/minecraft/SingleParticleEntryField.java
@@ -34,6 +34,7 @@ public class SingleParticleEntryField extends JSingleEntrySelector<ParticleEntry
 
 	@Override protected ParticleEntry openEntrySelector() {
 		var entry = DataListSelectorDialog.openSelectorDialog(mcreator, ElementUtil::loadAllParticles,
+				this.getEntry() == null ? null : this.getEntry().getUnmappedValue(),
 				L10N.t("dialog.selector.title"), L10N.t("dialog.selector.particles.message"));
 		return entry == null ? null : new ParticleEntry(mcreator.getWorkspace(), entry);
 	}

--- a/src/main/java/net/mcreator/ui/minecraft/SingleSpawnableEntitySelector.java
+++ b/src/main/java/net/mcreator/ui/minecraft/SingleSpawnableEntitySelector.java
@@ -34,6 +34,7 @@ public class SingleSpawnableEntitySelector extends JSingleEntrySelector<EntityEn
 
 	@Override protected EntityEntry openEntrySelector() {
 		var entry = DataListSelectorDialog.openSelectorDialog(mcreator, ElementUtil::loadAllSpawnableEntities,
+				this.getEntry() == null ? null : this.getEntry().getUnmappedValue(),
 				L10N.t("dialog.selector.title"), L10N.t("dialog.selector.entity.message"));
 		return entry == null ? null : new EntityEntry(mcreator.getWorkspace(), entry);
 	}

--- a/src/test/java/net/mcreator/integration/ui/DialogsTest.java
+++ b/src/test/java/net/mcreator/integration/ui/DialogsTest.java
@@ -111,7 +111,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 	@Test public void testMCItemSelector() throws Throwable {
 		UITestUtil.waitUntilWindowIsOpen(mcreator,
-				() -> MCItemSelectorDialog.openSelectorDialog(mcreator, ElementUtil::loadBlocksAndItems));
+				() -> MCItemSelectorDialog.openSelectorDialog(mcreator, ElementUtil::loadBlocksAndItems, null));
 	}
 
 	@Test public void testElementOrderEditor() throws Throwable {


### PR DESCRIPTION
- Searchable selectors can now specify pre-selected entries when opening the dialog
- Single entry selectors and Blockly datalist/MCItem fields will have their value already selected when opening the dialog