### PR TITLE
Add new block/fluid modes to raytracing blocks

### DIFF
--- a/plugins/mcreator-core/procedures/entity_look_face.json
+++ b/plugins/mcreator-core/procedures/entity_look_face.json
@@ -25,6 +25,10 @@
         [
           "ANY",
           "ANY"
+        ],
+        [
+          "WATER",
+          "WATER"
         ]
       ]
     },
@@ -43,6 +47,10 @@
         [
           "VISUAL",
           "VISUAL"
+        ],
+        [
+          "FALLDAMAGE_RESETTING",
+          "FALLDAMAGE_RESETTING"
         ]
       ]
     }

--- a/plugins/mcreator-core/procedures/entity_looking_at_block.json
+++ b/plugins/mcreator-core/procedures/entity_looking_at_block.json
@@ -25,6 +25,10 @@
         [
           "ANY",
           "ANY"
+        ],
+        [
+          "WATER",
+          "WATER"
         ]
       ]
     },
@@ -43,6 +47,10 @@
         [
           "VISUAL",
           "VISUAL"
+        ],
+        [
+          "FALLDAMAGE_RESETTING",
+          "FALLDAMAGE_RESETTING"
         ]
       ]
     }

--- a/plugins/mcreator-core/procedures/entity_lookpos.json
+++ b/plugins/mcreator-core/procedures/entity_lookpos.json
@@ -25,6 +25,10 @@
         [
           "ANY",
           "ANY"
+        ],
+        [
+          "WATER",
+          "WATER"
         ]
       ]
     },
@@ -43,6 +47,10 @@
         [
           "VISUAL",
           "VISUAL"
+        ],
+        [
+          "FALLDAMAGE_RESETTING",
+          "FALLDAMAGE_RESETTING"
         ]
       ]
     }

--- a/plugins/mcreator-core/procedures/entity_lookpos_x.json
+++ b/plugins/mcreator-core/procedures/entity_lookpos_x.json
@@ -25,6 +25,10 @@
         [
           "ANY",
           "ANY"
+        ],
+        [
+          "WATER",
+          "WATER"
         ]
       ]
     },
@@ -43,6 +47,10 @@
         [
           "VISUAL",
           "VISUAL"
+        ],
+        [
+          "FALLDAMAGE_RESETTING",
+          "FALLDAMAGE_RESETTING"
         ]
       ]
     }

--- a/plugins/mcreator-core/procedures/entity_lookpos_y.json
+++ b/plugins/mcreator-core/procedures/entity_lookpos_y.json
@@ -25,6 +25,10 @@
         [
           "ANY",
           "ANY"
+        ],
+        [
+          "WATER",
+          "WATER"
         ]
       ]
     },
@@ -43,6 +47,10 @@
         [
           "VISUAL",
           "VISUAL"
+        ],
+        [
+          "FALLDAMAGE_RESETTING",
+          "FALLDAMAGE_RESETTING"
         ]
       ]
     }

--- a/plugins/mcreator-core/procedures/entity_lookpos_z.json
+++ b/plugins/mcreator-core/procedures/entity_lookpos_z.json
@@ -25,6 +25,10 @@
         [
           "ANY",
           "ANY"
+        ],
+        [
+          "WATER",
+          "WATER"
         ]
       ]
     },
@@ -43,6 +47,10 @@
         [
           "VISUAL",
           "VISUAL"
+        ],
+        [
+          "FALLDAMAGE_RESETTING",
+          "FALLDAMAGE_RESETTING"
         ]
       ]
     }


### PR DESCRIPTION
This PR adds a WATER fluid mode and a FALLDAMAGE_RESETTING block mode to raytracing procedure blocks

<img width="840" height="429" alt="ray modes" src="https://github.com/user-attachments/assets/aa463d72-9758-4d54-b989-f3160ca7a7c9" />
