### PR TITLE
Add "Hide tab title" option to Creative Tab

### DIFF
--- a/plugins/generator-1.21.1/neoforge-1.21.1/templates/elementinits/tabs.java.ftl
+++ b/plugins/generator-1.21.1/neoforge-1.21.1/templates/elementinits/tabs.java.ftl
@@ -63,6 +63,7 @@ public class ${JavaModName}Tabs {
 							</#list>
 						})
 						<#if tab.showSearch>.withSearchBar()</#if>
+						<#if tab.hideTitle>.hideTitle()</#if>
 						<#if prevTab??>.withTabsBefore(${prevTab}.getId())</#if>
 						.build()
 				);

--- a/plugins/generator-26.1.x/neoforge-26.1.2/templates/elementinits/tabs.java.ftl
+++ b/plugins/generator-26.1.x/neoforge-26.1.2/templates/elementinits/tabs.java.ftl
@@ -63,6 +63,7 @@ public class ${JavaModName}Tabs {
 							</#list>
 						})
 						<#if tab.showSearch>.withSearchBar()</#if>
+						<#if tab.hideTitle>.hideTitle()</#if>
 						<#if prevTab??>.withTabsBefore(${prevTab}.getId())</#if>
 						.build()
 				);

--- a/plugins/mcreator-localization/help/default/tab/hide_title.md
+++ b/plugins/mcreator-localization/help/default/tab/hide_title.md
@@ -1,0 +1,1 @@
+Check this box to hide the tab title.

--- a/plugins/mcreator-localization/lang/texts.properties
+++ b/plugins/mcreator-localization/lang/texts.properties
@@ -3547,6 +3547,7 @@ elementgui.structuregen.page_jigsaw=Jigsaw
 elementgui.tab.name=Creative tab name: 
 elementgui.tab.icon=Tab icon: 
 elementgui.tab.search_bar=Show search bar: 
+elementgui.tab.hide_title=Hide tab title: 
 elementgui.tab.add_stuff_tip=To add blocks/items to this tab, make new element and set this tab as inventory tab.
 elementgui.tab.error_needs_name=Creative tab needs a name
 elementgui.tab.error_tab_needs_icon=Creative tab needs an icon

--- a/src/main/java/net/mcreator/element/types/Tab.java
+++ b/src/main/java/net/mcreator/element/types/Tab.java
@@ -29,7 +29,9 @@ import java.awt.image.BufferedImage;
 
 	public String name;
 	public MItemBlock icon;
+
 	public boolean showSearch;
+	public boolean hideTitle;
 
 	private Tab() {
 		this(null);

--- a/src/main/java/net/mcreator/ui/modgui/TabGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/TabGUI.java
@@ -43,7 +43,9 @@ public class TabGUI extends ModElementGUI<Tab> {
 	private final VTextField name = new VTextField(20).requireValue("elementgui.tab.error_needs_name")
 			.enableRealtimeValidation();
 	private MCItemHolder icon;
+
 	private final JCheckBox showSearch = L10N.checkbox("elementgui.common.enable");
+	private final JCheckBox hideTitle = L10N.checkbox("elementgui.common.enable");
 
 	private final ValidationGroup page1group = new ValidationGroup();
 
@@ -58,7 +60,7 @@ public class TabGUI extends ModElementGUI<Tab> {
 				"elementgui.tab.error_tab_needs_icon");
 
 		JPanel pane3 = new JPanel(new BorderLayout());
-		JPanel selp = new JPanel(new GridLayout(3, 2, 100, 1));
+		JPanel selp = new JPanel(new GridLayout(4, 2, 100, 1));
 
 		ComponentUtils.deriveFont(name, 16);
 
@@ -72,7 +74,12 @@ public class TabGUI extends ModElementGUI<Tab> {
 				L10N.label("elementgui.tab.search_bar")));
 		selp.add(showSearch);
 
+		selp.add(HelpUtils.wrapWithHelpButton(this.withEntry("tab/hide_title"),
+				L10N.label("elementgui.tab.hide_title")));
+		selp.add(hideTitle);
+
 		showSearch.setOpaque(false);
+		hideTitle.setOpaque(false);
 
 		selp.setOpaque(false);
 
@@ -104,6 +111,7 @@ public class TabGUI extends ModElementGUI<Tab> {
 		name.setText(tab.name);
 		icon.setBlock(tab.icon);
 		showSearch.setSelected(tab.showSearch);
+		hideTitle.setSelected(tab.hideTitle);
 	}
 
 	@Override public Tab getElementFromGUI() {
@@ -111,6 +119,7 @@ public class TabGUI extends ModElementGUI<Tab> {
 		tab.name = name.getText();
 		tab.icon = icon.getBlock();
 		tab.showSearch = showSearch.isSelected();
+		tab.hideTitle = hideTitle.isSelected();
 		return tab;
 	}
 

--- a/src/test/java/net/mcreator/integration/TestWorkspaceDataProvider.java
+++ b/src/test/java/net/mcreator/integration/TestWorkspaceDataProvider.java
@@ -688,6 +688,7 @@ public class TestWorkspaceDataProvider {
 			tab.name = modElement.getName();
 			tab.icon = new MItemBlock(modElement.getWorkspace(), getRandomMCItem(random, blocksAndItems).getName());
 			tab.showSearch = _true;
+			tab.hideTitle = _true;
 			return tab;
 		} else if (ModElementType.OVERLAY.equals(modElement.getType())) {
 			Overlay overlay = new Overlay(modElement);


### PR DESCRIPTION
This PR adds a new "Hide tab title" checkbox to the Creative Tab mod element, allowing for more customization.
<img width="810" height="862" alt="image" src="https://github.com/user-attachments/assets/5271ac94-a27b-48b1-bd6f-93d336f83774" />
