### PR TITLE
Windows Defender auto-exclude

### DIFF
--- a/plugins/mcreator-localization/lang/texts.properties
+++ b/plugins/mcreator-localization/lang/texts.properties
@@ -4522,6 +4522,13 @@ notification.patch_available.msg=There is a more recent version of {0} available
   <br>Installed version: {0}.{1}\
   <br>New version: {0}.{2}
 notification.plugin_updates.msg=There are some plugin updates available
+notification.defender_exclusions.title=Windows Defender exclusions
+notification.defender_exclusions.msg=Windows Defender real-time scanning can slow down or break Gradle builds.<br>\
+  Do you want to add common MCreator folders to Windows Defender exclusions?
+notification.defender_exclusions.add=Add exclusions
+notification.defender_exclusions.skip=Skip
+notification.defender_exclusions.failed=<html><b>MCreator could not add Windows Defender exclusions.</b><br><br>\
+  You can add the following folders to Windows Defender exclusions manually:<br><br>{0}
 notification.news.title=News from the website: {0}
 notification.news.read_more=Read more about this
 notification.news.hide=Hide this notification

--- a/src/main/java/net/mcreator/io/WindowsDefenderUtil.java
+++ b/src/main/java/net/mcreator/io/WindowsDefenderUtil.java
@@ -1,0 +1,213 @@
+/*
+ * MCreator (https://mcreator.net/)
+ * Copyright (C) 2012-2020, Pylo
+ * Copyright (C) 2020-2026, Pylo, opensource contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package net.mcreator.io;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+public class WindowsDefenderUtil {
+
+	private static final Logger LOG = LogManager.getLogger("Windows Defender");
+
+	public enum ExclusionResult {
+		ADDED, DECLINED, FAILED
+	}
+
+	private static final int EXIT_ADDED = 0;
+	private static final int EXIT_ADD_FAILED = 2;
+	private static final int EXIT_VERIFICATION_FAILED = 3;
+	private static final int EXIT_DECLINED = 10;
+	private static final int EXIT_LAUNCH_FAILED = 11;
+
+	/**
+	 * Checks if Windows Defender real-time protection is enabled. This does not require elevation.
+	 *
+	 * @return true if real-time protection is enabled, false if it is disabled, if another antivirus is active,
+	 * if the status cannot be determined or if not running on Windows
+	 */
+	public static boolean isRealTimeProtectionEnabled() {
+		if (OS.getOS() != OS.WINDOWS)
+			return false;
+
+		try {
+			String output = runPowerShell("(Get-MpComputerStatus).RealTimeProtectionEnabled", Duration.ofSeconds(20));
+			return output.lines().anyMatch(line -> line.trim().equalsIgnoreCase("True"));
+		} catch (Exception e) {
+			LOG.warn("Failed to check Windows Defender status", e);
+			return false;
+		}
+	}
+
+	/**
+	 * Adds the given folders to Windows Defender exclusions. This shows the UAC prompt to the user. The exclusions
+	 * are verified in the same elevated session, so ADDED is only returned if the folders are really excluded.
+	 * Folders that are already excluded are left as they are.
+	 *
+	 * @param folders Folders to exclude from Windows Defender scanning
+	 * @return Result of the operation, DECLINED if the user declined the UAC prompt
+	 */
+	public static ExclusionResult addFolderExclusions(List<File> folders) {
+		if (OS.getOS() != OS.WINDOWS || folders.isEmpty())
+			return ExclusionResult.FAILED;
+
+		// Result is written to a file by the elevated process, as exit codes are not reliable across the
+		// elevation boundary and the elevated process may run as a different (administrator) user
+		File resultFile;
+		try {
+			resultFile = File.createTempFile("mcreator_defender_", ".result");
+		} catch (IOException e) {
+			LOG.warn("Failed to create Windows Defender result file", e);
+			return ExclusionResult.FAILED;
+		}
+
+		String paths = folders.stream().map(folder -> quote(normalizePath(folder))).collect(Collectors.joining(","));
+
+		String elevatedScript = """
+				function Finish($code) { Set-Content -LiteralPath %s -Value $code; exit $code }
+				$paths = @(%s)
+				try { Add-MpPreference -ExclusionPath $paths -ErrorAction Stop } catch { Finish %d }
+				$exclusions = (Get-MpPreference).ExclusionPath
+				foreach ($path in $paths) { if (-not ($exclusions -contains $path)) { Finish %d } }
+				Finish %d
+				""".formatted(quote(normalizePath(resultFile)), paths, EXIT_ADD_FAILED, EXIT_VERIFICATION_FAILED,
+				EXIT_ADDED);
+
+		// Process.Start is used instead of Start-Process as Start-Process in PowerShell 5.1 drops the Win32 error
+		// code of the failure, which we need to detect the declined UAC prompt (ERROR_CANCELLED, 1223).
+		// The launcher reports failures through the result file too (code on the first line, error details after it)
+		// so no output pipes are needed that could fill up and block the process.
+		String launcherScript = """
+				$startInfo = New-Object System.Diagnostics.ProcessStartInfo
+				$startInfo.FileName = %s
+				$startInfo.Arguments = '-NoProfile -NonInteractive -ExecutionPolicy Bypass -EncodedCommand %s'
+				$startInfo.Verb = 'runas'
+				$startInfo.UseShellExecute = $true
+				$startInfo.WindowStyle = [System.Diagnostics.ProcessWindowStyle]::Hidden
+				try {
+				    $process = [System.Diagnostics.Process]::Start($startInfo)
+				    if ($process) { $process.WaitForExit() }
+				    exit 0
+				} catch {
+				    $exception = $_.Exception
+				    while ($exception) {
+				        if ($exception -is [System.ComponentModel.Win32Exception] -and $exception.NativeErrorCode -eq 1223) {
+				            Set-Content -LiteralPath %s -Value %d
+				            exit %d
+				        }
+				        $exception = $exception.InnerException
+				    }
+				    Set-Content -LiteralPath %s -Value (@('%d', "$_") -join "`n")
+				    exit %d
+				}
+				""".formatted(quote(getPowerShellPath()), encodeCommand(elevatedScript), quote(normalizePath(resultFile)),
+				EXIT_DECLINED, EXIT_DECLINED, quote(normalizePath(resultFile)), EXIT_LAUNCH_FAILED, EXIT_LAUNCH_FAILED);
+
+		try {
+			ProcessBuilder processBuilder = new ProcessBuilder(getPowerShellPath(), "-NoProfile", "-NonInteractive",
+					"-ExecutionPolicy", "Bypass", "-EncodedCommand", encodeCommand(launcherScript));
+			processBuilder.redirectOutput(ProcessBuilder.Redirect.DISCARD);
+			processBuilder.redirectError(ProcessBuilder.Redirect.DISCARD);
+			Process process = processBuilder.start();
+
+			// the elevated process waits for the user to respond to the UAC prompt, so this can take a while
+			if (!process.waitFor(15, TimeUnit.MINUTES)) {
+				process.destroyForcibly();
+				LOG.warn("Timed out waiting for Windows Defender exclusions to be added, treating as declined");
+				return ExclusionResult.DECLINED; // no decision was made, so the user should be asked again
+			}
+
+			String[] result = FileIO.readFileToString(resultFile).trim().split("\n", 2);
+			int code;
+			try {
+				code = Integer.parseInt(result[0].trim());
+			} catch (NumberFormatException e) {
+				LOG.warn("Failed to add Windows Defender exclusions, no result reported, launcher exit code: {}",
+						process.exitValue());
+				return ExclusionResult.FAILED;
+			}
+
+			switch (code) {
+			case EXIT_ADDED -> {
+				LOG.info("Windows Defender exclusions added for {}", folders);
+				return ExclusionResult.ADDED;
+			}
+			case EXIT_DECLINED -> {
+				LOG.info("User declined adding Windows Defender exclusions");
+				return ExclusionResult.DECLINED;
+			}
+			default -> LOG.warn("Failed to add Windows Defender exclusions, result code: {}, details: {}", code,
+					result.length > 1 ? result[1].trim() : "");
+			}
+		} catch (Exception e) {
+			LOG.warn("Failed to add Windows Defender exclusions", e);
+		} finally {
+			resultFile.delete();
+		}
+
+		return ExclusionResult.FAILED;
+	}
+
+	private static String runPowerShell(String command, Duration timeout) throws Exception {
+		ProcessBuilder processBuilder = new ProcessBuilder(getPowerShellPath(), "-NoProfile", "-NonInteractive",
+				"-ExecutionPolicy", "Bypass", "-EncodedCommand", encodeCommand(command));
+		// PowerShell writes progress records to stderr when it is redirected, so we only read stdout
+		processBuilder.redirectError(ProcessBuilder.Redirect.DISCARD);
+		Process process = processBuilder.start();
+
+		if (!process.waitFor(timeout.toMillis(), TimeUnit.MILLISECONDS)) {
+			process.destroyForcibly();
+			throw new RuntimeException("Timed out running PowerShell command: " + command);
+		}
+
+		return new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+	}
+
+	private static String getPowerShellPath() {
+		String systemRoot = System.getenv("SystemRoot");
+		if (systemRoot != null) {
+			File powerShell = new File(systemRoot, "System32/WindowsPowerShell/v1.0/powershell.exe");
+			if (powerShell.isFile())
+				return powerShell.getAbsolutePath();
+		}
+		return "powershell.exe";
+	}
+
+	private static String encodeCommand(String script) {
+		return Base64.getEncoder().encodeToString(script.getBytes(StandardCharsets.UTF_16LE));
+	}
+
+	private static String normalizePath(File file) {
+		return file.toPath().toAbsolutePath().normalize().toString();
+	}
+
+	private static String quote(String value) {
+		return "'" + value.replace("'", "''") + "'";
+	}
+
+}

--- a/src/main/java/net/mcreator/preferences/data/HiddenSection.java
+++ b/src/main/java/net/mcreator/preferences/data/HiddenSection.java
@@ -36,6 +36,7 @@ public class HiddenSection extends PreferencesSection {
 	public final PreferencesEntry<File> java_home;
 	public final StringEntry uiTheme;
 	public final StringEntry lastWebsiteNewsRead;
+	public final StringEntry defenderExclusions;
 
 	HiddenSection(String preferencesIdentifier) {
 		super(preferencesIdentifier);
@@ -56,6 +57,8 @@ public class HiddenSection extends PreferencesSection {
 		});
 		uiTheme = addEntry(new StringEntry("uiTheme", "default_dark"));
 		lastWebsiteNewsRead = addEntry(new StringEntry("lastWebsiteNewsRead", ""));
+		defenderExclusions = addEntry(new StringEntry("defenderExclusions",
+				"")); // empty if user was not asked yet, otherwise "added", "skipped" or "failed"
 	}
 
 	@Override public boolean isVisible() {

--- a/src/main/java/net/mcreator/ui/notifications/StartupNotifications.java
+++ b/src/main/java/net/mcreator/ui/notifications/StartupNotifications.java
@@ -20,6 +20,9 @@
 package net.mcreator.ui.notifications;
 
 import net.mcreator.Launcher;
+import net.mcreator.io.OS;
+import net.mcreator.io.UserFolderManager;
+import net.mcreator.io.WindowsDefenderUtil;
 import net.mcreator.io.net.api.update.UpdateInfo;
 import net.mcreator.plugin.PluginLoadFailure;
 import net.mcreator.plugin.PluginLoader;
@@ -33,10 +36,13 @@ import net.mcreator.ui.init.L10N;
 import net.mcreator.ui.init.UIRES;
 import net.mcreator.util.DesktopUtils;
 import net.mcreator.util.StringUtils;
+import net.mcreator.workspace.WorkspaceFolderManager;
 
 import javax.swing.*;
 import java.awt.*;
+import java.io.File;
 import java.util.Collection;
+import java.util.List;
 import java.util.stream.Collectors;
 
 public class StartupNotifications {
@@ -52,10 +58,49 @@ public class StartupNotifications {
 
 				// dialog if enabled, otherwise last in chain so this notification is on the top
 				handleUpdatesCore(parent);
+
+				// check for defender exclusions
+				handleWindowsDefender(parent);
 			});
 
 			notificationsHandled = true;
 		}
+	}
+
+	private static <T extends Window & INotificationConsumer> void handleWindowsDefender(T parent) {
+		if (OS.getOS() != OS.WINDOWS || !PreferencesManager.PREFERENCES.hidden.defenderExclusions.get().isEmpty())
+			return;
+
+		new Thread(() -> {
+			if (!WindowsDefenderUtil.isRealTimeProtectionEnabled())
+				return;
+
+			ThreadUtil.runOnSwingThread(() -> parent.addNotification(UIRES.get("18px.warning"),
+					L10N.t("notification.defender_exclusions.msg"),
+					new NotificationsRenderer.ActionButton(L10N.t("notification.defender_exclusions.add"), _ -> {
+						List<File> folders = List.of(UserFolderManager.getFileFromUserFolder("/"),
+								WorkspaceFolderManager.getSuggestedWorkspaceFoldersRoot());
+
+						new Thread(() -> {
+							WindowsDefenderUtil.ExclusionResult result = WindowsDefenderUtil.addFolderExclusions(
+									folders);
+							switch (result) {
+							case ADDED -> PreferencesManager.PREFERENCES.hidden.defenderExclusions.set("added");
+							case FAILED -> { // remember the failure so the user is not asked again, warning explains manual steps
+								PreferencesManager.PREFERENCES.hidden.defenderExclusions.set("failed");
+								ThreadUtil.runOnSwingThread(() -> JOptionPane.showMessageDialog(parent,
+										L10N.t("notification.defender_exclusions.failed",
+												folders.stream().map(File::getAbsolutePath)
+														.collect(Collectors.joining("<br>"))),
+										L10N.t("notification.defender_exclusions.title"), JOptionPane.WARNING_MESSAGE));
+							}
+							case DECLINED -> { // user will be asked again on the next launch
+							}
+							}
+						}, "WindowsDefenderExclusions").start();
+					}), new NotificationsRenderer.ActionButton(L10N.t("notification.defender_exclusions.skip"),
+							_ -> PreferencesManager.PREFERENCES.hidden.defenderExclusions.set("skipped"))));
+		}, "WindowsDefenderCheck").start();
 	}
 
 	private static <T extends Window & INotificationConsumer> void handleUpdatesCore(T parent) {

--- a/src/main/java/net/mcreator/ui/notifications/StartupNotifications.java
+++ b/src/main/java/net/mcreator/ui/notifications/StartupNotifications.java
@@ -78,7 +78,7 @@ public class StartupNotifications {
 			ThreadUtil.runOnSwingThread(() -> parent.addNotification(UIRES.get("18px.warning"),
 					L10N.t("notification.defender_exclusions.msg"),
 					new NotificationsRenderer.ActionButton(L10N.t("notification.defender_exclusions.add"), _ -> {
-						List<File> folders = List.of(UserFolderManager.getFileFromUserFolder("/"),
+						List<File> folders = List.of(UserFolderManager.getGradleHome(),
 								WorkspaceFolderManager.getSuggestedWorkspaceFoldersRoot());
 
 						new Thread(() -> {


### PR DESCRIPTION
Added Windows Defender auto-exclude. On Windows OS, if Defender is active, this PR makes MCreator prompt the user to add exclusions or skip it. This will likely reduce problems with Gradle and make builds faster on such systems.